### PR TITLE
feat(generator/rust): request builder get examples

### DIFF
--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -79,6 +79,36 @@ pub mod {{Codec.ModuleName}} {
     {{! TODO(#1813) - fix and generate builder docs for veneers }}
     {{^Codec.HasVeneer}}
     /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.Name}}][super::super::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use {{Model.Codec.PackageNamespace}}::builder;
+    /// use builder::{{Service.Codec.ModuleName}}::{{Codec.BuilderName}};
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    {{#OperationInfo}}
+    /// use {{Model.Codec.PackageNamespace}}::Poller;
+    /// let response = builder.poller().until_done().await?;
+    {{/OperationInfo}}
+    {{^OperationInfo}}
+    {{#Pagination}}
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    {{/Pagination}}
+    {{^Pagination}}
+    /// let response = builder.send().await?;
+    {{/Pagination}}
+    {{/OperationInfo}}
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> {{Codec.BuilderName}} {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     {{/Codec.HasVeneer}}
     #[derive(Clone, Debug)]
     pub struct {{Codec.BuilderName}}(RequestBuilder<{{InputType.Codec.QualifiedName}}>);

--- a/generator/internal/rust/templates/crate/src/transport.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/transport.rs.mustache
@@ -94,7 +94,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
                     },
                 {{/PathInfo.Codec.PathArgs}}
             );
-            {{/PathInfo.Codec.HasPathArgs}};
+            {{/PathInfo.Codec.HasPathArgs}}
         let builder = self
             .inner
             .builder(reqwest::Method::{{PathInfo.Codec.Method}}, path)

--- a/src/firestore/src/generated/gapic/builder.rs
+++ b/src/firestore/src/generated/gapic/builder.rs
@@ -69,6 +69,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::get_document][super::super::client::Firestore::get_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::GetDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDocument(RequestBuilder<crate::model::GetDocumentRequest>);
 
@@ -162,6 +177,25 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::list_documents][super::super::client::Firestore::list_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::ListDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDocuments(RequestBuilder<crate::model::ListDocumentsRequest>);
 
@@ -309,6 +343,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::update_document][super::super::client::Firestore::update_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::UpdateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDocument(RequestBuilder<crate::model::UpdateDocumentRequest>);
 
@@ -386,6 +435,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::delete_document][super::super::client::Firestore::delete_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::DeleteDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDocument(RequestBuilder<crate::model::DeleteDocumentRequest>);
 
@@ -442,6 +506,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::begin_transaction][super::super::client::Firestore::begin_transaction] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::BeginTransaction;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BeginTransaction {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BeginTransaction(RequestBuilder<crate::model::BeginTransactionRequest>);
 
@@ -501,6 +580,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::commit][super::super::client::Firestore::commit] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::Commit;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Commit {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Commit(RequestBuilder<crate::model::CommitRequest>);
 
@@ -565,6 +659,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::rollback][super::super::client::Firestore::rollback] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::Rollback;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Rollback {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Rollback(RequestBuilder<crate::model::RollbackRequest>);
 
@@ -620,6 +729,25 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::partition_query][super::super::client::Firestore::partition_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::PartitionQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PartitionQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PartitionQuery(RequestBuilder<crate::model::PartitionQueryRequest>);
 
@@ -763,6 +891,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::list_collection_ids][super::super::client::Firestore::list_collection_ids] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::ListCollectionIds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCollectionIds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCollectionIds(RequestBuilder<crate::model::ListCollectionIdsRequest>);
 
@@ -852,6 +995,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::batch_write][super::super::client::Firestore::batch_write] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::BatchWrite;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchWrite {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchWrite(RequestBuilder<crate::model::BatchWriteRequest>);
 
@@ -921,6 +1079,21 @@ pub mod firestore {
     }
 
     /// The request builder for [Firestore::create_document][super::super::client::Firestore::create_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore::builder;
+    /// use builder::firestore::CreateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDocument(RequestBuilder<crate::model::CreateDocumentRequest>);
 

--- a/src/generated/api/apikeys/v2/src/builder.rs
+++ b/src/generated/api/apikeys/v2/src/builder.rs
@@ -67,6 +67,22 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::create_key][super::super::client::ApiKeys::create_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::CreateKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apikeys_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateKey(RequestBuilder<crate::model::CreateKeyRequest>);
 
@@ -166,6 +182,25 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::list_keys][super::super::client::ApiKeys::list_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::ListKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListKeys(RequestBuilder<crate::model::ListKeysRequest>);
 
@@ -253,6 +288,21 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::get_key][super::super::client::ApiKeys::get_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::GetKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetKey(RequestBuilder<crate::model::GetKeyRequest>);
 
@@ -298,6 +348,21 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::get_key_string][super::super::client::ApiKeys::get_key_string] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::GetKeyString;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetKeyString {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetKeyString(RequestBuilder<crate::model::GetKeyStringRequest>);
 
@@ -343,6 +408,22 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::update_key][super::super::client::ApiKeys::update_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::UpdateKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apikeys_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateKey(RequestBuilder<crate::model::UpdateKeyRequest>);
 
@@ -437,6 +518,22 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::delete_key][super::super::client::ApiKeys::delete_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::DeleteKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apikeys_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteKey(RequestBuilder<crate::model::DeleteKeyRequest>);
 
@@ -528,6 +625,22 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::undelete_key][super::super::client::ApiKeys::undelete_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::UndeleteKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apikeys_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteKey(RequestBuilder<crate::model::UndeleteKeyRequest>);
 
@@ -613,6 +726,21 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::lookup_key][super::super::client::ApiKeys::lookup_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::LookupKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupKey(RequestBuilder<crate::model::LookupKeyRequest>);
 
@@ -658,6 +786,21 @@ pub mod api_keys {
     }
 
     /// The request builder for [ApiKeys::get_operation][super::super::client::ApiKeys::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apikeys_v2::builder;
+    /// use builder::api_keys::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/api/servicecontrol/v1/src/builder.rs
+++ b/src/generated/api/servicecontrol/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod quota_controller {
     }
 
     /// The request builder for [QuotaController::allocate_quota][super::super::client::QuotaController::allocate_quota] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicecontrol_v1::builder;
+    /// use builder::quota_controller::AllocateQuota;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AllocateQuota {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AllocateQuota(RequestBuilder<crate::model::AllocateQuotaRequest>);
 
@@ -186,6 +201,21 @@ pub mod service_controller {
     }
 
     /// The request builder for [ServiceController::check][super::super::client::ServiceController::check] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicecontrol_v1::builder;
+    /// use builder::service_controller::Check;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Check {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Check(RequestBuilder<crate::model::CheckRequest>);
 
@@ -246,6 +276,21 @@ pub mod service_controller {
     }
 
     /// The request builder for [ServiceController::report][super::super::client::ServiceController::report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicecontrol_v1::builder;
+    /// use builder::service_controller::Report;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Report {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Report(RequestBuilder<crate::model::ReportRequest>);
 

--- a/src/generated/api/servicecontrol/v2/src/builder.rs
+++ b/src/generated/api/servicecontrol/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod service_controller {
     }
 
     /// The request builder for [ServiceController::check][super::super::client::ServiceController::check] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicecontrol_v2::builder;
+    /// use builder::service_controller::Check;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Check {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Check(RequestBuilder<crate::model::CheckRequest>);
 
@@ -148,6 +163,21 @@ pub mod service_controller {
     }
 
     /// The request builder for [ServiceController::report][super::super::client::ServiceController::report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicecontrol_v2::builder;
+    /// use builder::service_controller::Report;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Report {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Report(RequestBuilder<crate::model::ReportRequest>);
 

--- a/src/generated/api/servicemanagement/v1/src/builder.rs
+++ b/src/generated/api/servicemanagement/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::list_services][super::super::client::ServiceManager::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -157,6 +176,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::get_service][super::super::client::ServiceManager::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -204,6 +238,22 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::create_service][super::super::client::ServiceManager::create_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::CreateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_servicemanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -295,6 +345,22 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::delete_service][super::super::client::ServiceManager::delete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::DeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_servicemanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -382,6 +448,22 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::undelete_service][super::super::client::ServiceManager::undelete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::UndeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_servicemanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteService(RequestBuilder<crate::model::UndeleteServiceRequest>);
 
@@ -470,6 +552,25 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::list_service_configs][super::super::client::ServiceManager::list_service_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::ListServiceConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceConfigs(RequestBuilder<crate::model::ListServiceConfigsRequest>);
 
@@ -558,6 +659,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::get_service_config][super::super::client::ServiceManager::get_service_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::GetServiceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceConfig(RequestBuilder<crate::model::GetServiceConfigRequest>);
 
@@ -625,6 +741,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::create_service_config][super::super::client::ServiceManager::create_service_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::CreateServiceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceConfig(RequestBuilder<crate::model::CreateServiceConfigRequest>);
 
@@ -686,6 +817,22 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::submit_config_source][super::super::client::ServiceManager::submit_config_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::SubmitConfigSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_servicemanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubmitConfigSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubmitConfigSource(RequestBuilder<crate::model::SubmitConfigSourceRequest>);
 
@@ -794,6 +941,25 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::list_service_rollouts][super::super::client::ServiceManager::list_service_rollouts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::ListServiceRollouts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceRollouts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceRollouts(RequestBuilder<crate::model::ListServiceRolloutsRequest>);
 
@@ -890,6 +1056,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::get_service_rollout][super::super::client::ServiceManager::get_service_rollout] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::GetServiceRollout;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceRollout {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceRollout(RequestBuilder<crate::model::GetServiceRolloutRequest>);
 
@@ -948,6 +1129,22 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::create_service_rollout][super::super::client::ServiceManager::create_service_rollout] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::CreateServiceRollout;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_servicemanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceRollout {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceRollout(RequestBuilder<crate::model::CreateServiceRolloutRequest>);
 
@@ -1047,6 +1244,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::generate_config_report][super::super::client::ServiceManager::generate_config_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::GenerateConfigReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateConfigReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateConfigReport(RequestBuilder<crate::model::GenerateConfigReportRequest>);
 
@@ -1103,6 +1315,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::set_iam_policy][super::super::client::ServiceManager::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1170,6 +1397,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::get_iam_policy][super::super::client::ServiceManager::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1226,6 +1468,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::test_iam_permissions][super::super::client::ServiceManager::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1289,6 +1546,25 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::list_operations][super::super::client::ServiceManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1381,6 +1657,21 @@ pub mod service_manager {
     }
 
     /// The request builder for [ServiceManager::get_operation][super::super::client::ServiceManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_servicemanagement_v1::builder;
+    /// use builder::service_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/api/serviceusage/v1/src/builder.rs
+++ b/src/generated/api/serviceusage/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::enable_service][super::super::client::ServiceUsage::enable_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::EnableService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_serviceusage_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableService(RequestBuilder<crate::model::EnableServiceRequest>);
 
@@ -155,6 +171,22 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::disable_service][super::super::client::ServiceUsage::disable_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::DisableService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_serviceusage_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableService(RequestBuilder<crate::model::DisableServiceRequest>);
 
@@ -258,6 +290,21 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::get_service][super::super::client::ServiceUsage::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -303,6 +350,25 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::list_services][super::super::client::ServiceUsage::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -390,6 +456,22 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::batch_enable_services][super::super::client::ServiceUsage::batch_enable_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::BatchEnableServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_api_serviceusage_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchEnableServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchEnableServices(RequestBuilder<crate::model::BatchEnableServicesRequest>);
 
@@ -490,6 +572,21 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::batch_get_services][super::super::client::ServiceUsage::batch_get_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::BatchGetServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchGetServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchGetServices(RequestBuilder<crate::model::BatchGetServicesRequest>);
 
@@ -549,6 +646,25 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::list_operations][super::super::client::ServiceUsage::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -641,6 +757,21 @@ pub mod service_usage {
     }
 
     /// The request builder for [ServiceUsage::get_operation][super::super::client::ServiceUsage::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_api_serviceusage_v1::builder;
+    /// use builder::service_usage::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/appengine/v1/src/builder.rs
+++ b/src/generated/appengine/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod applications {
     }
 
     /// The request builder for [Applications::get_application][super::super::client::Applications::get_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::applications::GetApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApplication(RequestBuilder<crate::model::GetApplicationRequest>);
 
@@ -114,6 +129,22 @@ pub mod applications {
     }
 
     /// The request builder for [Applications::create_application][super::super::client::Applications::create_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::applications::CreateApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateApplication(RequestBuilder<crate::model::CreateApplicationRequest>);
 
@@ -206,6 +237,22 @@ pub mod applications {
     }
 
     /// The request builder for [Applications::update_application][super::super::client::Applications::update_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::applications::UpdateApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateApplication(RequestBuilder<crate::model::UpdateApplicationRequest>);
 
@@ -313,6 +360,22 @@ pub mod applications {
     }
 
     /// The request builder for [Applications::repair_application][super::super::client::Applications::repair_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::applications::RepairApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepairApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepairApplication(RequestBuilder<crate::model::RepairApplicationRequest>);
 
@@ -402,6 +465,25 @@ pub mod applications {
     }
 
     /// The request builder for [Applications::list_operations][super::super::client::Applications::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::applications::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -494,6 +576,21 @@ pub mod applications {
     }
 
     /// The request builder for [Applications::get_operation][super::super::client::Applications::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::applications::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -595,6 +692,25 @@ pub mod services {
     }
 
     /// The request builder for [Services::list_services][super::super::client::Services::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::services::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -674,6 +790,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::get_service][super::super::client::Services::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::services::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -717,6 +848,22 @@ pub mod services {
     }
 
     /// The request builder for [Services::update_service][super::super::client::Services::update_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::services::UpdateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -822,6 +969,22 @@ pub mod services {
     }
 
     /// The request builder for [Services::delete_service][super::super::client::Services::delete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::services::DeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -906,6 +1069,25 @@ pub mod services {
     }
 
     /// The request builder for [Services::list_operations][super::super::client::Services::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::services::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -996,6 +1178,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::get_operation][super::super::client::Services::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::services::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1095,6 +1292,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::versions::ListVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -1180,6 +1396,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::versions::GetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -1229,6 +1460,22 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::versions::CreateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -1322,6 +1569,22 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::versions::UpdateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -1421,6 +1684,22 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::versions::DeleteVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -1505,6 +1784,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::versions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1595,6 +1893,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::versions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1696,6 +2009,25 @@ pub mod instances {
     }
 
     /// The request builder for [Instances::list_instances][super::super::client::Instances::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::instances::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -1777,6 +2109,21 @@ pub mod instances {
     }
 
     /// The request builder for [Instances::get_instance][super::super::client::Instances::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::instances::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -1822,6 +2169,22 @@ pub mod instances {
     }
 
     /// The request builder for [Instances::delete_instance][super::super::client::Instances::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::instances::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -1908,6 +2271,22 @@ pub mod instances {
     }
 
     /// The request builder for [Instances::debug_instance][super::super::client::Instances::debug_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::instances::DebugInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DebugInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DebugInstance(RequestBuilder<crate::model::DebugInstanceRequest>);
 
@@ -1997,6 +2376,25 @@ pub mod instances {
     }
 
     /// The request builder for [Instances::list_operations][super::super::client::Instances::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::instances::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2089,6 +2487,21 @@ pub mod instances {
     }
 
     /// The request builder for [Instances::get_operation][super::super::client::Instances::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::instances::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2190,6 +2603,25 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::list_ingress_rules][super::super::client::Firewall::list_ingress_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::ListIngressRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIngressRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIngressRules(RequestBuilder<crate::model::ListIngressRulesRequest>);
 
@@ -2278,6 +2710,21 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::batch_update_ingress_rules][super::super::client::Firewall::batch_update_ingress_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::BatchUpdateIngressRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchUpdateIngressRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchUpdateIngressRules(
         RequestBuilder<crate::model::BatchUpdateIngressRulesRequest>,
@@ -2337,6 +2784,21 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::create_ingress_rule][super::super::client::Firewall::create_ingress_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::CreateIngressRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIngressRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIngressRule(RequestBuilder<crate::model::CreateIngressRuleRequest>);
 
@@ -2392,6 +2854,21 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::get_ingress_rule][super::super::client::Firewall::get_ingress_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::GetIngressRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIngressRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIngressRule(RequestBuilder<crate::model::GetIngressRuleRequest>);
 
@@ -2435,6 +2912,21 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::update_ingress_rule][super::super::client::Firewall::update_ingress_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::UpdateIngressRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIngressRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIngressRule(RequestBuilder<crate::model::UpdateIngressRuleRequest>);
 
@@ -2499,6 +2991,21 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::delete_ingress_rule][super::super::client::Firewall::delete_ingress_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::DeleteIngressRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIngressRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIngressRule(RequestBuilder<crate::model::DeleteIngressRuleRequest>);
 
@@ -2545,6 +3052,25 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::list_operations][super::super::client::Firewall::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2635,6 +3161,21 @@ pub mod firewall {
     }
 
     /// The request builder for [Firewall::get_operation][super::super::client::Firewall::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::firewall::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2736,6 +3277,25 @@ pub mod authorized_domains {
     }
 
     /// The request builder for [AuthorizedDomains::list_authorized_domains][super::super::client::AuthorizedDomains::list_authorized_domains] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_domains::ListAuthorizedDomains;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAuthorizedDomains {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAuthorizedDomains(RequestBuilder<crate::model::ListAuthorizedDomainsRequest>);
 
@@ -2822,6 +3382,25 @@ pub mod authorized_domains {
     }
 
     /// The request builder for [AuthorizedDomains::list_operations][super::super::client::AuthorizedDomains::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_domains::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2914,6 +3493,21 @@ pub mod authorized_domains {
     }
 
     /// The request builder for [AuthorizedDomains::get_operation][super::super::client::AuthorizedDomains::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_domains::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3017,6 +3611,25 @@ pub mod authorized_certificates {
     }
 
     /// The request builder for [AuthorizedCertificates::list_authorized_certificates][super::super::client::AuthorizedCertificates::list_authorized_certificates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_certificates::ListAuthorizedCertificates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAuthorizedCertificates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAuthorizedCertificates(
         RequestBuilder<crate::model::ListAuthorizedCertificatesRequest>,
@@ -3113,6 +3726,21 @@ pub mod authorized_certificates {
     }
 
     /// The request builder for [AuthorizedCertificates::get_authorized_certificate][super::super::client::AuthorizedCertificates::get_authorized_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_certificates::GetAuthorizedCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAuthorizedCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAuthorizedCertificate(
         RequestBuilder<crate::model::GetAuthorizedCertificateRequest>,
@@ -3169,6 +3797,21 @@ pub mod authorized_certificates {
     }
 
     /// The request builder for [AuthorizedCertificates::create_authorized_certificate][super::super::client::AuthorizedCertificates::create_authorized_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_certificates::CreateAuthorizedCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAuthorizedCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAuthorizedCertificate(
         RequestBuilder<crate::model::CreateAuthorizedCertificateRequest>,
@@ -3230,6 +3873,21 @@ pub mod authorized_certificates {
     }
 
     /// The request builder for [AuthorizedCertificates::update_authorized_certificate][super::super::client::AuthorizedCertificates::update_authorized_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_certificates::UpdateAuthorizedCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAuthorizedCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAuthorizedCertificate(
         RequestBuilder<crate::model::UpdateAuthorizedCertificateRequest>,
@@ -3300,6 +3958,21 @@ pub mod authorized_certificates {
     }
 
     /// The request builder for [AuthorizedCertificates::delete_authorized_certificate][super::super::client::AuthorizedCertificates::delete_authorized_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_certificates::DeleteAuthorizedCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAuthorizedCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAuthorizedCertificate(
         RequestBuilder<crate::model::DeleteAuthorizedCertificateRequest>,
@@ -3350,6 +4023,25 @@ pub mod authorized_certificates {
     }
 
     /// The request builder for [AuthorizedCertificates::list_operations][super::super::client::AuthorizedCertificates::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_certificates::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3442,6 +4134,21 @@ pub mod authorized_certificates {
     }
 
     /// The request builder for [AuthorizedCertificates::get_operation][super::super::client::AuthorizedCertificates::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::authorized_certificates::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3545,6 +4252,25 @@ pub mod domain_mappings {
     }
 
     /// The request builder for [DomainMappings::list_domain_mappings][super::super::client::DomainMappings::list_domain_mappings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::domain_mappings::ListDomainMappings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDomainMappings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDomainMappings(RequestBuilder<crate::model::ListDomainMappingsRequest>);
 
@@ -3631,6 +4357,21 @@ pub mod domain_mappings {
     }
 
     /// The request builder for [DomainMappings::get_domain_mapping][super::super::client::DomainMappings::get_domain_mapping] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::domain_mappings::GetDomainMapping;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDomainMapping {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDomainMapping(RequestBuilder<crate::model::GetDomainMappingRequest>);
 
@@ -3679,6 +4420,22 @@ pub mod domain_mappings {
     }
 
     /// The request builder for [DomainMappings::create_domain_mapping][super::super::client::DomainMappings::create_domain_mapping] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::domain_mappings::CreateDomainMapping;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDomainMapping {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDomainMapping(RequestBuilder<crate::model::CreateDomainMappingRequest>);
 
@@ -3786,6 +4543,22 @@ pub mod domain_mappings {
     }
 
     /// The request builder for [DomainMappings::update_domain_mapping][super::super::client::DomainMappings::update_domain_mapping] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::domain_mappings::UpdateDomainMapping;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDomainMapping {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDomainMapping(RequestBuilder<crate::model::UpdateDomainMappingRequest>);
 
@@ -3893,6 +4666,22 @@ pub mod domain_mappings {
     }
 
     /// The request builder for [DomainMappings::delete_domain_mapping][super::super::client::DomainMappings::delete_domain_mapping] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::domain_mappings::DeleteDomainMapping;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_appengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDomainMapping {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDomainMapping(RequestBuilder<crate::model::DeleteDomainMappingRequest>);
 
@@ -3982,6 +4771,25 @@ pub mod domain_mappings {
     }
 
     /// The request builder for [DomainMappings::list_operations][super::super::client::DomainMappings::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::domain_mappings::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4074,6 +4882,21 @@ pub mod domain_mappings {
     }
 
     /// The request builder for [DomainMappings::get_operation][super::super::client::DomainMappings::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_appengine_v1::builder;
+    /// use builder::domain_mappings::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/bigtable/admin/v2/src/builder.rs
+++ b/src/generated/bigtable/admin/v2/src/builder.rs
@@ -69,6 +69,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::create_instance][super::super::client::BigtableInstanceAdmin::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -189,6 +205,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::get_instance][super::super::client::BigtableInstanceAdmin::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -236,6 +267,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::list_instances][super::super::client::BigtableInstanceAdmin::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -289,6 +335,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::update_instance][super::super::client::BigtableInstanceAdmin::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::Instance>);
 
@@ -386,6 +447,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::partial_update_instance][super::super::client::BigtableInstanceAdmin::partial_update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::PartialUpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PartialUpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PartialUpdateInstance(RequestBuilder<crate::model::PartialUpdateInstanceRequest>);
 
@@ -491,6 +568,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::delete_instance][super::super::client::BigtableInstanceAdmin::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -538,6 +630,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::create_cluster][super::super::client::BigtableInstanceAdmin::create_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::CreateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -644,6 +752,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::get_cluster][super::super::client::BigtableInstanceAdmin::get_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::GetCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -691,6 +814,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::list_clusters][super::super::client::BigtableInstanceAdmin::list_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::ListClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -744,6 +882,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::update_cluster][super::super::client::BigtableInstanceAdmin::update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::UpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::Cluster>);
 
@@ -900,6 +1054,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::partial_update_cluster][super::super::client::BigtableInstanceAdmin::partial_update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::PartialUpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PartialUpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PartialUpdateCluster(RequestBuilder<crate::model::PartialUpdateClusterRequest>);
 
@@ -1005,6 +1175,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::delete_cluster][super::super::client::BigtableInstanceAdmin::delete_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::DeleteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -1052,6 +1237,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::create_app_profile][super::super::client::BigtableInstanceAdmin::create_app_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::CreateAppProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAppProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAppProfile(RequestBuilder<crate::model::CreateAppProfileRequest>);
 
@@ -1127,6 +1327,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::get_app_profile][super::super::client::BigtableInstanceAdmin::get_app_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::GetAppProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAppProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAppProfile(RequestBuilder<crate::model::GetAppProfileRequest>);
 
@@ -1174,6 +1389,25 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::list_app_profiles][super::super::client::BigtableInstanceAdmin::list_app_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::ListAppProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAppProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAppProfiles(RequestBuilder<crate::model::ListAppProfilesRequest>);
 
@@ -1257,6 +1491,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::update_app_profile][super::super::client::BigtableInstanceAdmin::update_app_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::UpdateAppProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAppProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAppProfile(RequestBuilder<crate::model::UpdateAppProfileRequest>);
 
@@ -1368,6 +1618,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::delete_app_profile][super::super::client::BigtableInstanceAdmin::delete_app_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::DeleteAppProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAppProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAppProfile(RequestBuilder<crate::model::DeleteAppProfileRequest>);
 
@@ -1426,6 +1691,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::get_iam_policy][super::super::client::BigtableInstanceAdmin::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1482,6 +1762,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::set_iam_policy][super::super::client::BigtableInstanceAdmin::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1549,6 +1844,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::test_iam_permissions][super::super::client::BigtableInstanceAdmin::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1612,6 +1922,25 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::list_hot_tablets][super::super::client::BigtableInstanceAdmin::list_hot_tablets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::ListHotTablets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHotTablets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHotTablets(RequestBuilder<crate::model::ListHotTabletsRequest>);
 
@@ -1710,6 +2039,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::create_logical_view][super::super::client::BigtableInstanceAdmin::create_logical_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::CreateLogicalView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLogicalView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLogicalView(RequestBuilder<crate::model::CreateLogicalViewRequest>);
 
@@ -1820,6 +2165,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::get_logical_view][super::super::client::BigtableInstanceAdmin::get_logical_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::GetLogicalView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLogicalView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLogicalView(RequestBuilder<crate::model::GetLogicalViewRequest>);
 
@@ -1867,6 +2227,25 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::list_logical_views][super::super::client::BigtableInstanceAdmin::list_logical_views] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::ListLogicalViews;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLogicalViews {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLogicalViews(RequestBuilder<crate::model::ListLogicalViewsRequest>);
 
@@ -1953,6 +2332,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::update_logical_view][super::super::client::BigtableInstanceAdmin::update_logical_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::UpdateLogicalView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLogicalView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLogicalView(RequestBuilder<crate::model::UpdateLogicalViewRequest>);
 
@@ -2056,6 +2451,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::delete_logical_view][super::super::client::BigtableInstanceAdmin::delete_logical_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::DeleteLogicalView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLogicalView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLogicalView(RequestBuilder<crate::model::DeleteLogicalViewRequest>);
 
@@ -2112,6 +2522,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::create_materialized_view][super::super::client::BigtableInstanceAdmin::create_materialized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::CreateMaterializedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMaterializedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMaterializedView(RequestBuilder<crate::model::CreateMaterializedViewRequest>);
 
@@ -2224,6 +2650,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::get_materialized_view][super::super::client::BigtableInstanceAdmin::get_materialized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::GetMaterializedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMaterializedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMaterializedView(RequestBuilder<crate::model::GetMaterializedViewRequest>);
 
@@ -2274,6 +2715,25 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::list_materialized_views][super::super::client::BigtableInstanceAdmin::list_materialized_views] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::ListMaterializedViews;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMaterializedViews {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMaterializedViews(RequestBuilder<crate::model::ListMaterializedViewsRequest>);
 
@@ -2362,6 +2822,22 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::update_materialized_view][super::super::client::BigtableInstanceAdmin::update_materialized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::UpdateMaterializedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMaterializedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMaterializedView(RequestBuilder<crate::model::UpdateMaterializedViewRequest>);
 
@@ -2467,6 +2943,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::delete_materialized_view][super::super::client::BigtableInstanceAdmin::delete_materialized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::DeleteMaterializedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMaterializedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMaterializedView(RequestBuilder<crate::model::DeleteMaterializedViewRequest>);
 
@@ -2523,6 +3014,25 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::list_operations][super::super::client::BigtableInstanceAdmin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2615,6 +3125,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::get_operation][super::super::client::BigtableInstanceAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2663,6 +3188,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::delete_operation][super::super::client::BigtableInstanceAdmin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2711,6 +3251,21 @@ pub mod bigtable_instance_admin {
     }
 
     /// The request builder for [BigtableInstanceAdmin::cancel_operation][super::super::client::BigtableInstanceAdmin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_instance_admin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2814,6 +3369,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::create_table][super::super::client::BigtableTableAdmin::create_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::CreateTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTable(RequestBuilder<crate::model::CreateTableRequest>);
 
@@ -2891,6 +3461,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::create_table_from_snapshot][super::super::client::BigtableTableAdmin::create_table_from_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::CreateTableFromSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTableFromSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTableFromSnapshot(
         RequestBuilder<crate::model::CreateTableFromSnapshotRequest>,
@@ -3000,6 +3586,25 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::list_tables][super::super::client::BigtableTableAdmin::list_tables] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::ListTables;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTables {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTables(RequestBuilder<crate::model::ListTablesRequest>);
 
@@ -3089,6 +3694,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::get_table][super::super::client::BigtableTableAdmin::get_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::GetTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTable(RequestBuilder<crate::model::GetTableRequest>);
 
@@ -3142,6 +3762,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::update_table][super::super::client::BigtableTableAdmin::update_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::UpdateTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTable(RequestBuilder<crate::model::UpdateTableRequest>);
 
@@ -3247,6 +3883,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::delete_table][super::super::client::BigtableTableAdmin::delete_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::DeleteTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTable(RequestBuilder<crate::model::DeleteTableRequest>);
 
@@ -3294,6 +3945,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::undelete_table][super::super::client::BigtableTableAdmin::undelete_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::UndeleteTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteTable(RequestBuilder<crate::model::UndeleteTableRequest>);
 
@@ -3379,6 +4046,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::create_authorized_view][super::super::client::BigtableTableAdmin::create_authorized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::CreateAuthorizedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAuthorizedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAuthorizedView(RequestBuilder<crate::model::CreateAuthorizedViewRequest>);
 
@@ -3489,6 +4172,25 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::list_authorized_views][super::super::client::BigtableTableAdmin::list_authorized_views] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::ListAuthorizedViews;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAuthorizedViews {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAuthorizedViews(RequestBuilder<crate::model::ListAuthorizedViewsRequest>);
 
@@ -3586,6 +4288,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::get_authorized_view][super::super::client::BigtableTableAdmin::get_authorized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::GetAuthorizedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAuthorizedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAuthorizedView(RequestBuilder<crate::model::GetAuthorizedViewRequest>);
 
@@ -3645,6 +4362,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::update_authorized_view][super::super::client::BigtableTableAdmin::update_authorized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::UpdateAuthorizedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAuthorizedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAuthorizedView(RequestBuilder<crate::model::UpdateAuthorizedViewRequest>);
 
@@ -3754,6 +4487,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::delete_authorized_view][super::super::client::BigtableTableAdmin::delete_authorized_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::DeleteAuthorizedView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAuthorizedView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAuthorizedView(RequestBuilder<crate::model::DeleteAuthorizedViewRequest>);
 
@@ -3810,6 +4558,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::modify_column_families][super::super::client::BigtableTableAdmin::modify_column_families] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::ModifyColumnFamilies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ModifyColumnFamilies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ModifyColumnFamilies(RequestBuilder<crate::model::ModifyColumnFamiliesRequest>);
 
@@ -3879,6 +4642,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::drop_row_range][super::super::client::BigtableTableAdmin::drop_row_range] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::DropRowRange;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DropRowRange {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DropRowRange(RequestBuilder<crate::model::DropRowRangeRequest>);
 
@@ -3958,6 +4736,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::generate_consistency_token][super::super::client::BigtableTableAdmin::generate_consistency_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::GenerateConsistencyToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateConsistencyToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateConsistencyToken(
         RequestBuilder<crate::model::GenerateConsistencyTokenRequest>,
@@ -4010,6 +4803,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::check_consistency][super::super::client::BigtableTableAdmin::check_consistency] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::CheckConsistency;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckConsistency {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckConsistency(RequestBuilder<crate::model::CheckConsistencyRequest>);
 
@@ -4110,6 +4918,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::snapshot_table][super::super::client::BigtableTableAdmin::snapshot_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::SnapshotTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SnapshotTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SnapshotTable(RequestBuilder<crate::model::SnapshotTableRequest>);
 
@@ -4225,6 +5049,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::get_snapshot][super::super::client::BigtableTableAdmin::get_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::GetSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSnapshot(RequestBuilder<crate::model::GetSnapshotRequest>);
 
@@ -4272,6 +5111,25 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::list_snapshots][super::super::client::BigtableTableAdmin::list_snapshots] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::ListSnapshots;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSnapshots {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSnapshots(RequestBuilder<crate::model::ListSnapshotsRequest>);
 
@@ -4355,6 +5213,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::delete_snapshot][super::super::client::BigtableTableAdmin::delete_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::DeleteSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSnapshot(RequestBuilder<crate::model::DeleteSnapshotRequest>);
 
@@ -4402,6 +5275,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::create_backup][super::super::client::BigtableTableAdmin::create_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::CreateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -4506,6 +5395,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::get_backup][super::super::client::BigtableTableAdmin::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -4553,6 +5457,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::update_backup][super::super::client::BigtableTableAdmin::update_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::UpdateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -4614,6 +5533,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::delete_backup][super::super::client::BigtableTableAdmin::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -4661,6 +5595,25 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::list_backups][super::super::client::BigtableTableAdmin::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -4756,6 +5709,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::restore_table][super::super::client::BigtableTableAdmin::restore_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::RestoreTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreTable(RequestBuilder<crate::model::RestoreTableRequest>);
 
@@ -4871,6 +5840,22 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::copy_backup][super::super::client::BigtableTableAdmin::copy_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::CopyBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigtable_admin_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CopyBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CopyBackup(RequestBuilder<crate::model::CopyBackupRequest>);
 
@@ -4983,6 +5968,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::get_iam_policy][super::super::client::BigtableTableAdmin::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5039,6 +6039,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::set_iam_policy][super::super::client::BigtableTableAdmin::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5106,6 +6121,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::test_iam_permissions][super::super::client::BigtableTableAdmin::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5169,6 +6199,25 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::list_operations][super::super::client::BigtableTableAdmin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5261,6 +6310,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::get_operation][super::super::client::BigtableTableAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5309,6 +6373,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::delete_operation][super::super::client::BigtableTableAdmin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5357,6 +6436,21 @@ pub mod bigtable_table_admin {
     }
 
     /// The request builder for [BigtableTableAdmin::cancel_operation][super::super::client::BigtableTableAdmin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigtable_admin_v2::builder;
+    /// use builder::bigtable_table_admin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/accessapproval/v1/src/builder.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::list_approval_requests][super::super::client::AccessApproval::list_approval_requests] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::ListApprovalRequests;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListApprovalRequests {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListApprovalRequests(RequestBuilder<crate::model::ListApprovalRequestsMessage>);
 
@@ -161,6 +180,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::get_approval_request][super::super::client::AccessApproval::get_approval_request] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::GetApprovalRequest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApprovalRequest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApprovalRequest(RequestBuilder<crate::model::GetApprovalRequestMessage>);
 
@@ -209,6 +243,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::approve_approval_request][super::super::client::AccessApproval::approve_approval_request] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::ApproveApprovalRequest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApproveApprovalRequest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApproveApprovalRequest(RequestBuilder<crate::model::ApproveApprovalRequestMessage>);
 
@@ -266,6 +315,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::dismiss_approval_request][super::super::client::AccessApproval::dismiss_approval_request] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::DismissApprovalRequest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DismissApprovalRequest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DismissApprovalRequest(RequestBuilder<crate::model::DismissApprovalRequestMessage>);
 
@@ -314,6 +378,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::invalidate_approval_request][super::super::client::AccessApproval::invalidate_approval_request] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::InvalidateApprovalRequest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InvalidateApprovalRequest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InvalidateApprovalRequest(
         RequestBuilder<crate::model::InvalidateApprovalRequestMessage>,
@@ -364,6 +443,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::get_access_approval_settings][super::super::client::AccessApproval::get_access_approval_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::GetAccessApprovalSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAccessApprovalSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAccessApprovalSettings(
         RequestBuilder<crate::model::GetAccessApprovalSettingsMessage>,
@@ -414,6 +508,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::update_access_approval_settings][super::super::client::AccessApproval::update_access_approval_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::UpdateAccessApprovalSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAccessApprovalSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAccessApprovalSettings(
         RequestBuilder<crate::model::UpdateAccessApprovalSettingsMessage>,
@@ -476,6 +585,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::delete_access_approval_settings][super::super::client::AccessApproval::delete_access_approval_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::DeleteAccessApprovalSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAccessApprovalSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAccessApprovalSettings(
         RequestBuilder<crate::model::DeleteAccessApprovalSettingsMessage>,
@@ -526,6 +650,21 @@ pub mod access_approval {
     }
 
     /// The request builder for [AccessApproval::get_access_approval_service_account][super::super::client::AccessApproval::get_access_approval_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_accessapproval_v1::builder;
+    /// use builder::access_approval::GetAccessApprovalServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAccessApprovalServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAccessApprovalServiceAccount(
         RequestBuilder<crate::model::GetAccessApprovalServiceAccountMessage>,

--- a/src/generated/cloud/advisorynotifications/v1/src/builder.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod advisory_notifications_service {
     }
 
     /// The request builder for [AdvisoryNotificationsService::list_notifications][super::super::client::AdvisoryNotificationsService::list_notifications] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_advisorynotifications_v1::builder;
+    /// use builder::advisory_notifications_service::ListNotifications;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotifications {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotifications(RequestBuilder<crate::model::ListNotificationsRequest>);
 
@@ -167,6 +186,21 @@ pub mod advisory_notifications_service {
     }
 
     /// The request builder for [AdvisoryNotificationsService::get_notification][super::super::client::AdvisoryNotificationsService::get_notification] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_advisorynotifications_v1::builder;
+    /// use builder::advisory_notifications_service::GetNotification;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotification {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotification(RequestBuilder<crate::model::GetNotificationRequest>);
 
@@ -220,6 +254,21 @@ pub mod advisory_notifications_service {
     }
 
     /// The request builder for [AdvisoryNotificationsService::get_settings][super::super::client::AdvisoryNotificationsService::get_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_advisorynotifications_v1::builder;
+    /// use builder::advisory_notifications_service::GetSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -267,6 +316,21 @@ pub mod advisory_notifications_service {
     }
 
     /// The request builder for [AdvisoryNotificationsService::update_settings][super::super::client::AdvisoryNotificationsService::update_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_advisorynotifications_v1::builder;
+    /// use builder::advisory_notifications_service::UpdateSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -71,6 +71,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::create_dataset][super::super::client::DatasetService::create_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::CreateDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataset(RequestBuilder<crate::model::CreateDatasetRequest>);
 
@@ -170,6 +186,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::get_dataset][super::super::client::DatasetService::get_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::GetDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -223,6 +254,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::update_dataset][super::super::client::DatasetService::update_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::UpdateDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataset(RequestBuilder<crate::model::UpdateDatasetRequest>);
 
@@ -284,6 +330,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_datasets][super::super::client::DatasetService::list_datasets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ListDatasets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatasets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -385,6 +450,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::delete_dataset][super::super::client::DatasetService::delete_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::DeleteDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -473,6 +554,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::import_data][super::super::client::DatasetService::import_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ImportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportData(RequestBuilder<crate::model::ImportDataRequest>);
 
@@ -574,6 +671,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::export_data][super::super::client::DatasetService::export_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ExportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportData(RequestBuilder<crate::model::ExportDataRequest>);
 
@@ -673,6 +786,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::create_dataset_version][super::super::client::DatasetService::create_dataset_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::CreateDatasetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDatasetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDatasetVersion(RequestBuilder<crate::model::CreateDatasetVersionRequest>);
 
@@ -777,6 +906,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::update_dataset_version][super::super::client::DatasetService::update_dataset_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::UpdateDatasetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDatasetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDatasetVersion(RequestBuilder<crate::model::UpdateDatasetVersionRequest>);
 
@@ -841,6 +985,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::delete_dataset_version][super::super::client::DatasetService::delete_dataset_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::DeleteDatasetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDatasetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDatasetVersion(RequestBuilder<crate::model::DeleteDatasetVersionRequest>);
 
@@ -932,6 +1092,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::get_dataset_version][super::super::client::DatasetService::get_dataset_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::GetDatasetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDatasetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDatasetVersion(RequestBuilder<crate::model::GetDatasetVersionRequest>);
 
@@ -988,6 +1163,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_dataset_versions][super::super::client::DatasetService::list_dataset_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ListDatasetVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatasetVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatasetVersions(RequestBuilder<crate::model::ListDatasetVersionsRequest>);
 
@@ -1094,6 +1288,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::restore_dataset_version][super::super::client::DatasetService::restore_dataset_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::RestoreDatasetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreDatasetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreDatasetVersion(RequestBuilder<crate::model::RestoreDatasetVersionRequest>);
 
@@ -1187,6 +1397,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_data_items][super::super::client::DatasetService::list_data_items] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ListDataItems;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataItems {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataItems(RequestBuilder<crate::model::ListDataItemsRequest>);
 
@@ -1288,6 +1517,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::search_data_items][super::super::client::DatasetService::search_data_items] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::SearchDataItems;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchDataItems {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchDataItems(RequestBuilder<crate::model::SearchDataItemsRequest>);
 
@@ -1472,6 +1720,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_saved_queries][super::super::client::DatasetService::list_saved_queries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ListSavedQueries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSavedQueries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSavedQueries(RequestBuilder<crate::model::ListSavedQueriesRequest>);
 
@@ -1576,6 +1843,22 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::delete_saved_query][super::super::client::DatasetService::delete_saved_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::DeleteSavedQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSavedQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSavedQuery(RequestBuilder<crate::model::DeleteSavedQueryRequest>);
 
@@ -1667,6 +1950,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::get_annotation_spec][super::super::client::DatasetService::get_annotation_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::GetAnnotationSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAnnotationSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAnnotationSpec(RequestBuilder<crate::model::GetAnnotationSpecRequest>);
 
@@ -1723,6 +2021,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_annotations][super::super::client::DatasetService::list_annotations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ListAnnotations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAnnotations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAnnotations(RequestBuilder<crate::model::ListAnnotationsRequest>);
 
@@ -1824,6 +2141,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_locations][super::super::client::DatasetService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1914,6 +2250,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::get_location][super::super::client::DatasetService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1959,6 +2310,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::set_iam_policy][super::super::client::DatasetService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2026,6 +2392,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::get_iam_policy][super::super::client::DatasetService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2082,6 +2463,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::test_iam_permissions][super::super::client::DatasetService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2145,6 +2541,25 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_operations][super::super::client::DatasetService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2237,6 +2652,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::get_operation][super::super::client::DatasetService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2285,6 +2715,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::delete_operation][super::super::client::DatasetService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2333,6 +2778,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::cancel_operation][super::super::client::DatasetService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2381,6 +2841,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::wait_operation][super::super::client::DatasetService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::dataset_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -2492,6 +2967,22 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::create_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::create_deployment_resource_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::CreateDeploymentResourcePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeploymentResourcePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeploymentResourcePool(
         RequestBuilder<crate::model::CreateDeploymentResourcePoolRequest>,
@@ -2611,6 +3102,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::get_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::get_deployment_resource_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::GetDeploymentResourcePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeploymentResourcePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeploymentResourcePool(
         RequestBuilder<crate::model::GetDeploymentResourcePoolRequest>,
@@ -2663,6 +3169,25 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::list_deployment_resource_pools][super::super::client::DeploymentResourcePoolService::list_deployment_resource_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::ListDeploymentResourcePools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeploymentResourcePools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeploymentResourcePools(
         RequestBuilder<crate::model::ListDeploymentResourcePoolsRequest>,
@@ -2755,6 +3280,22 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::update_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::update_deployment_resource_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::UpdateDeploymentResourcePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDeploymentResourcePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDeploymentResourcePool(
         RequestBuilder<crate::model::UpdateDeploymentResourcePoolRequest>,
@@ -2866,6 +3407,22 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::delete_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::delete_deployment_resource_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::DeleteDeploymentResourcePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDeploymentResourcePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDeploymentResourcePool(
         RequestBuilder<crate::model::DeleteDeploymentResourcePoolRequest>,
@@ -2959,6 +3516,25 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::query_deployed_models][super::super::client::DeploymentResourcePoolService::query_deployed_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::QueryDeployedModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryDeployedModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryDeployedModels(RequestBuilder<crate::model::QueryDeployedModelsRequest>);
 
@@ -3047,6 +3623,25 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::list_locations][super::super::client::DeploymentResourcePoolService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3137,6 +3732,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::get_location][super::super::client::DeploymentResourcePoolService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3182,6 +3792,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::set_iam_policy][super::super::client::DeploymentResourcePoolService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3249,6 +3874,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::get_iam_policy][super::super::client::DeploymentResourcePoolService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3305,6 +3945,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::test_iam_permissions][super::super::client::DeploymentResourcePoolService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3368,6 +4023,25 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::list_operations][super::super::client::DeploymentResourcePoolService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3460,6 +4134,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::get_operation][super::super::client::DeploymentResourcePoolService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3508,6 +4197,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::delete_operation][super::super::client::DeploymentResourcePoolService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3556,6 +4260,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::cancel_operation][super::super::client::DeploymentResourcePoolService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3604,6 +4323,21 @@ pub mod deployment_resource_pool_service {
     }
 
     /// The request builder for [DeploymentResourcePoolService::wait_operation][super::super::client::DeploymentResourcePoolService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::deployment_resource_pool_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -3715,6 +4449,22 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::create_endpoint][super::super::client::EndpointService::create_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::CreateEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEndpoint(RequestBuilder<crate::model::CreateEndpointRequest>);
 
@@ -3820,6 +4570,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::get_endpoint][super::super::client::EndpointService::get_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::GetEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEndpoint(RequestBuilder<crate::model::GetEndpointRequest>);
 
@@ -3867,6 +4632,25 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::list_endpoints][super::super::client::EndpointService::list_endpoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::ListEndpoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEndpoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEndpoints(RequestBuilder<crate::model::ListEndpointsRequest>);
 
@@ -3968,6 +4752,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::update_endpoint][super::super::client::EndpointService::update_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::UpdateEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEndpoint(RequestBuilder<crate::model::UpdateEndpointRequest>);
 
@@ -4029,6 +4828,22 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::update_endpoint_long_running][super::super::client::EndpointService::update_endpoint_long_running] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::UpdateEndpointLongRunning;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEndpointLongRunning {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEndpointLongRunning(
         RequestBuilder<crate::model::UpdateEndpointLongRunningRequest>,
@@ -4125,6 +4940,22 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::delete_endpoint][super::super::client::EndpointService::delete_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::DeleteEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEndpoint(RequestBuilder<crate::model::DeleteEndpointRequest>);
 
@@ -4213,6 +5044,22 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::deploy_model][super::super::client::EndpointService::deploy_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::DeployModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeployModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeployModel(RequestBuilder<crate::model::DeployModelRequest>);
 
@@ -4326,6 +5173,22 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::undeploy_model][super::super::client::EndpointService::undeploy_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::UndeployModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeployModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeployModel(RequestBuilder<crate::model::UndeployModelRequest>);
 
@@ -4436,6 +5299,22 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::mutate_deployed_model][super::super::client::EndpointService::mutate_deployed_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::MutateDeployedModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MutateDeployedModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MutateDeployedModel(RequestBuilder<crate::model::MutateDeployedModelRequest>);
 
@@ -4551,6 +5430,25 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::list_locations][super::super::client::EndpointService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4641,6 +5539,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::get_location][super::super::client::EndpointService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4686,6 +5599,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::set_iam_policy][super::super::client::EndpointService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4753,6 +5681,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::get_iam_policy][super::super::client::EndpointService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4809,6 +5752,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::test_iam_permissions][super::super::client::EndpointService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4872,6 +5830,25 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::list_operations][super::super::client::EndpointService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4964,6 +5941,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::get_operation][super::super::client::EndpointService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5012,6 +6004,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::delete_operation][super::super::client::EndpointService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5060,6 +6067,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::cancel_operation][super::super::client::EndpointService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5108,6 +6130,21 @@ pub mod endpoint_service {
     }
 
     /// The request builder for [EndpointService::wait_operation][super::super::client::EndpointService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::endpoint_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -5219,6 +6256,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::evaluate_instances][super::super::client::EvaluationService::evaluate_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::EvaluateInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EvaluateInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EvaluateInstances(RequestBuilder<crate::model::EvaluateInstancesRequest>);
 
@@ -5657,6 +6709,25 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::list_locations][super::super::client::EvaluationService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5747,6 +6818,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::get_location][super::super::client::EvaluationService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5792,6 +6878,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::set_iam_policy][super::super::client::EvaluationService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5859,6 +6960,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::get_iam_policy][super::super::client::EvaluationService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5915,6 +7031,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::test_iam_permissions][super::super::client::EvaluationService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5978,6 +7109,25 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::list_operations][super::super::client::EvaluationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6070,6 +7220,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::get_operation][super::super::client::EvaluationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6118,6 +7283,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::delete_operation][super::super::client::EvaluationService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -6166,6 +7346,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::cancel_operation][super::super::client::EvaluationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6214,6 +7409,21 @@ pub mod evaluation_service {
     }
 
     /// The request builder for [EvaluationService::wait_operation][super::super::client::EvaluationService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::evaluation_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -6325,6 +7535,22 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::create_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::create_feature_online_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::CreateFeatureOnlineStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeatureOnlineStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeatureOnlineStore(
         RequestBuilder<crate::model::CreateFeatureOnlineStoreRequest>,
@@ -6441,6 +7667,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::get_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::get_feature_online_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::GetFeatureOnlineStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeatureOnlineStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeatureOnlineStore(RequestBuilder<crate::model::GetFeatureOnlineStoreRequest>);
 
@@ -6491,6 +7732,25 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::list_feature_online_stores][super::super::client::FeatureOnlineStoreAdminService::list_feature_online_stores] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::ListFeatureOnlineStores;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeatureOnlineStores {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeatureOnlineStores(
         RequestBuilder<crate::model::ListFeatureOnlineStoresRequest>,
@@ -6595,6 +7855,22 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::update_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::update_feature_online_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::UpdateFeatureOnlineStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeatureOnlineStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeatureOnlineStore(
         RequestBuilder<crate::model::UpdateFeatureOnlineStoreRequest>,
@@ -6704,6 +7980,22 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::delete_feature_online_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::DeleteFeatureOnlineStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeatureOnlineStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureOnlineStore(
         RequestBuilder<crate::model::DeleteFeatureOnlineStoreRequest>,
@@ -6803,6 +8095,22 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::create_feature_view][super::super::client::FeatureOnlineStoreAdminService::create_feature_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::CreateFeatureView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeatureView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeatureView(RequestBuilder<crate::model::CreateFeatureViewRequest>);
 
@@ -6919,6 +8227,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view][super::super::client::FeatureOnlineStoreAdminService::get_feature_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::GetFeatureView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeatureView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeatureView(RequestBuilder<crate::model::GetFeatureViewRequest>);
 
@@ -6966,6 +8289,25 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::list_feature_views][super::super::client::FeatureOnlineStoreAdminService::list_feature_views] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::ListFeatureViews;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeatureViews {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeatureViews(RequestBuilder<crate::model::ListFeatureViewsRequest>);
 
@@ -7064,6 +8406,22 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::update_feature_view][super::super::client::FeatureOnlineStoreAdminService::update_feature_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::UpdateFeatureView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeatureView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeatureView(RequestBuilder<crate::model::UpdateFeatureViewRequest>);
 
@@ -7167,6 +8525,22 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_view][super::super::client::FeatureOnlineStoreAdminService::delete_feature_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::DeleteFeatureView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeatureView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureView(RequestBuilder<crate::model::DeleteFeatureViewRequest>);
 
@@ -7258,6 +8632,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::sync_feature_view][super::super::client::FeatureOnlineStoreAdminService::sync_feature_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::SyncFeatureView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SyncFeatureView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SyncFeatureView(RequestBuilder<crate::model::SyncFeatureViewRequest>);
 
@@ -7305,6 +8694,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view_sync][super::super::client::FeatureOnlineStoreAdminService::get_feature_view_sync] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::GetFeatureViewSync;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeatureViewSync {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeatureViewSync(RequestBuilder<crate::model::GetFeatureViewSyncRequest>);
 
@@ -7355,6 +8759,25 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::list_feature_view_syncs][super::super::client::FeatureOnlineStoreAdminService::list_feature_view_syncs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::ListFeatureViewSyncs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeatureViewSyncs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeatureViewSyncs(RequestBuilder<crate::model::ListFeatureViewSyncsRequest>);
 
@@ -7455,6 +8878,25 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::list_locations][super::super::client::FeatureOnlineStoreAdminService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7545,6 +8987,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::get_location][super::super::client::FeatureOnlineStoreAdminService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -7590,6 +9047,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::set_iam_policy][super::super::client::FeatureOnlineStoreAdminService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -7657,6 +9129,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::get_iam_policy][super::super::client::FeatureOnlineStoreAdminService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -7713,6 +9200,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::test_iam_permissions][super::super::client::FeatureOnlineStoreAdminService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -7776,6 +9278,25 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::list_operations][super::super::client::FeatureOnlineStoreAdminService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7868,6 +9389,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::get_operation][super::super::client::FeatureOnlineStoreAdminService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7916,6 +9452,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::delete_operation][super::super::client::FeatureOnlineStoreAdminService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -7964,6 +9515,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::cancel_operation][super::super::client::FeatureOnlineStoreAdminService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8012,6 +9578,21 @@ pub mod feature_online_store_admin_service {
     }
 
     /// The request builder for [FeatureOnlineStoreAdminService::wait_operation][super::super::client::FeatureOnlineStoreAdminService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_admin_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -8123,6 +9704,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::fetch_feature_values][super::super::client::FeatureOnlineStoreService::fetch_feature_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::FetchFeatureValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchFeatureValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchFeatureValues(RequestBuilder<crate::model::FetchFeatureValuesRequest>);
 
@@ -8191,6 +9787,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::search_nearest_entities][super::super::client::FeatureOnlineStoreService::search_nearest_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::SearchNearestEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchNearestEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchNearestEntities(RequestBuilder<crate::model::SearchNearestEntitiesRequest>);
 
@@ -8258,6 +9869,25 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::list_locations][super::super::client::FeatureOnlineStoreService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8348,6 +9978,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::get_location][super::super::client::FeatureOnlineStoreService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8393,6 +10038,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::set_iam_policy][super::super::client::FeatureOnlineStoreService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -8460,6 +10120,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::get_iam_policy][super::super::client::FeatureOnlineStoreService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -8516,6 +10191,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::test_iam_permissions][super::super::client::FeatureOnlineStoreService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -8579,6 +10269,25 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::list_operations][super::super::client::FeatureOnlineStoreService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8671,6 +10380,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::get_operation][super::super::client::FeatureOnlineStoreService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8719,6 +10443,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::delete_operation][super::super::client::FeatureOnlineStoreService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -8767,6 +10506,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::cancel_operation][super::super::client::FeatureOnlineStoreService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8815,6 +10569,21 @@ pub mod feature_online_store_service {
     }
 
     /// The request builder for [FeatureOnlineStoreService::wait_operation][super::super::client::FeatureOnlineStoreService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_online_store_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -8926,6 +10695,22 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::create_feature_group][super::super::client::FeatureRegistryService::create_feature_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::CreateFeatureGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeatureGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeatureGroup(RequestBuilder<crate::model::CreateFeatureGroupRequest>);
 
@@ -9038,6 +10823,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::get_feature_group][super::super::client::FeatureRegistryService::get_feature_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::GetFeatureGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeatureGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeatureGroup(RequestBuilder<crate::model::GetFeatureGroupRequest>);
 
@@ -9085,6 +10885,25 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::list_feature_groups][super::super::client::FeatureRegistryService::list_feature_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::ListFeatureGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeatureGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeatureGroups(RequestBuilder<crate::model::ListFeatureGroupsRequest>);
 
@@ -9183,6 +11002,22 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::update_feature_group][super::super::client::FeatureRegistryService::update_feature_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::UpdateFeatureGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeatureGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeatureGroup(RequestBuilder<crate::model::UpdateFeatureGroupRequest>);
 
@@ -9288,6 +11123,22 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::delete_feature_group][super::super::client::FeatureRegistryService::delete_feature_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::DeleteFeatureGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeatureGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureGroup(RequestBuilder<crate::model::DeleteFeatureGroupRequest>);
 
@@ -9385,6 +11236,22 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::create_feature][super::super::client::FeatureRegistryService::create_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::CreateFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeature(RequestBuilder<crate::model::CreateFeatureRequest>);
 
@@ -9492,6 +11359,22 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::batch_create_features][super::super::client::FeatureRegistryService::batch_create_features] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::BatchCreateFeatures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateFeatures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateFeatures(RequestBuilder<crate::model::BatchCreateFeaturesRequest>);
 
@@ -9598,6 +11481,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::get_feature][super::super::client::FeatureRegistryService::get_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::GetFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeature(RequestBuilder<crate::model::GetFeatureRequest>);
 
@@ -9645,6 +11543,25 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::list_features][super::super::client::FeatureRegistryService::list_features] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::ListFeatures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeatures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeatures(RequestBuilder<crate::model::ListFeaturesRequest>);
 
@@ -9752,6 +11669,22 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::update_feature][super::super::client::FeatureRegistryService::update_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::UpdateFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeature(RequestBuilder<crate::model::UpdateFeatureRequest>);
 
@@ -9852,6 +11785,22 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::delete_feature][super::super::client::FeatureRegistryService::delete_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::DeleteFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeature(RequestBuilder<crate::model::DeleteFeatureRequest>);
 
@@ -9940,6 +11889,25 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::list_locations][super::super::client::FeatureRegistryService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10030,6 +11998,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::get_location][super::super::client::FeatureRegistryService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10075,6 +12058,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::set_iam_policy][super::super::client::FeatureRegistryService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -10142,6 +12140,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::get_iam_policy][super::super::client::FeatureRegistryService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -10198,6 +12211,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::test_iam_permissions][super::super::client::FeatureRegistryService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -10261,6 +12289,25 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::list_operations][super::super::client::FeatureRegistryService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10353,6 +12400,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::get_operation][super::super::client::FeatureRegistryService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10401,6 +12463,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::delete_operation][super::super::client::FeatureRegistryService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -10449,6 +12526,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::cancel_operation][super::super::client::FeatureRegistryService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -10497,6 +12589,21 @@ pub mod feature_registry_service {
     }
 
     /// The request builder for [FeatureRegistryService::wait_operation][super::super::client::FeatureRegistryService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::feature_registry_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -10608,6 +12715,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::read_feature_values][super::super::client::FeaturestoreOnlineServingService::read_feature_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::ReadFeatureValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReadFeatureValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReadFeatureValues(RequestBuilder<crate::model::ReadFeatureValuesRequest>);
 
@@ -10677,6 +12799,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::write_feature_values][super::super::client::FeaturestoreOnlineServingService::write_feature_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::WriteFeatureValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WriteFeatureValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WriteFeatureValues(RequestBuilder<crate::model::WriteFeatureValuesRequest>);
 
@@ -10740,6 +12877,25 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::list_locations][super::super::client::FeaturestoreOnlineServingService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10830,6 +12986,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::get_location][super::super::client::FeaturestoreOnlineServingService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10875,6 +13046,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::set_iam_policy][super::super::client::FeaturestoreOnlineServingService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -10942,6 +13128,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::get_iam_policy][super::super::client::FeaturestoreOnlineServingService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -10998,6 +13199,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::test_iam_permissions][super::super::client::FeaturestoreOnlineServingService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -11061,6 +13277,25 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::list_operations][super::super::client::FeaturestoreOnlineServingService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -11153,6 +13388,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::get_operation][super::super::client::FeaturestoreOnlineServingService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -11201,6 +13451,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::delete_operation][super::super::client::FeaturestoreOnlineServingService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -11249,6 +13514,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::cancel_operation][super::super::client::FeaturestoreOnlineServingService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -11297,6 +13577,21 @@ pub mod featurestore_online_serving_service {
     }
 
     /// The request builder for [FeaturestoreOnlineServingService::wait_operation][super::super::client::FeaturestoreOnlineServingService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_online_serving_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -11408,6 +13703,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::create_featurestore][super::super::client::FeaturestoreService::create_featurestore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::CreateFeaturestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeaturestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeaturestore(RequestBuilder<crate::model::CreateFeaturestoreRequest>);
 
@@ -11520,6 +13831,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::get_featurestore][super::super::client::FeaturestoreService::get_featurestore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::GetFeaturestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeaturestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeaturestore(RequestBuilder<crate::model::GetFeaturestoreRequest>);
 
@@ -11567,6 +13893,25 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::list_featurestores][super::super::client::FeaturestoreService::list_featurestores] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::ListFeaturestores;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeaturestores {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeaturestores(RequestBuilder<crate::model::ListFeaturestoresRequest>);
 
@@ -11671,6 +14016,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::update_featurestore][super::super::client::FeaturestoreService::update_featurestore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::UpdateFeaturestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeaturestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeaturestore(RequestBuilder<crate::model::UpdateFeaturestoreRequest>);
 
@@ -11776,6 +14137,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::delete_featurestore][super::super::client::FeaturestoreService::delete_featurestore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::DeleteFeaturestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeaturestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeaturestore(RequestBuilder<crate::model::DeleteFeaturestoreRequest>);
 
@@ -11873,6 +14250,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::create_entity_type][super::super::client::FeaturestoreService::create_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::CreateEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntityType(RequestBuilder<crate::model::CreateEntityTypeRequest>);
 
@@ -11981,6 +14374,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::get_entity_type][super::super::client::FeaturestoreService::get_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::GetEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntityType(RequestBuilder<crate::model::GetEntityTypeRequest>);
 
@@ -12028,6 +14436,25 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::list_entity_types][super::super::client::FeaturestoreService::list_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::ListEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntityTypes(RequestBuilder<crate::model::ListEntityTypesRequest>);
 
@@ -12129,6 +14556,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::update_entity_type][super::super::client::FeaturestoreService::update_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::UpdateEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntityType(RequestBuilder<crate::model::UpdateEntityTypeRequest>);
 
@@ -12191,6 +14633,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::delete_entity_type][super::super::client::FeaturestoreService::delete_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::DeleteEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntityType(RequestBuilder<crate::model::DeleteEntityTypeRequest>);
 
@@ -12288,6 +14746,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::create_feature][super::super::client::FeaturestoreService::create_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::CreateFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeature(RequestBuilder<crate::model::CreateFeatureRequest>);
 
@@ -12395,6 +14869,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::batch_create_features][super::super::client::FeaturestoreService::batch_create_features] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::BatchCreateFeatures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateFeatures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateFeatures(RequestBuilder<crate::model::BatchCreateFeaturesRequest>);
 
@@ -12501,6 +14991,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::get_feature][super::super::client::FeaturestoreService::get_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::GetFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeature(RequestBuilder<crate::model::GetFeatureRequest>);
 
@@ -12548,6 +15053,25 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::list_features][super::super::client::FeaturestoreService::list_features] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::ListFeatures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeatures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeatures(RequestBuilder<crate::model::ListFeaturesRequest>);
 
@@ -12655,6 +15179,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::update_feature][super::super::client::FeaturestoreService::update_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::UpdateFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeature(RequestBuilder<crate::model::UpdateFeatureRequest>);
 
@@ -12714,6 +15253,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::delete_feature][super::super::client::FeaturestoreService::delete_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::DeleteFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeature(RequestBuilder<crate::model::DeleteFeatureRequest>);
 
@@ -12802,6 +15357,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::import_feature_values][super::super::client::FeaturestoreService::import_feature_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::ImportFeatureValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportFeatureValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportFeatureValues(RequestBuilder<crate::model::ImportFeatureValuesRequest>);
 
@@ -13025,6 +15596,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::batch_read_feature_values][super::super::client::FeaturestoreService::batch_read_feature_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::BatchReadFeatureValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchReadFeatureValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchReadFeatureValues(RequestBuilder<crate::model::BatchReadFeatureValuesRequest>);
 
@@ -13210,6 +15797,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::export_feature_values][super::super::client::FeaturestoreService::export_feature_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::ExportFeatureValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportFeatureValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportFeatureValues(RequestBuilder<crate::model::ExportFeatureValuesRequest>);
 
@@ -13384,6 +15987,22 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::delete_feature_values][super::super::client::FeaturestoreService::delete_feature_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::DeleteFeatureValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeatureValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeatureValues(RequestBuilder<crate::model::DeleteFeatureValuesRequest>);
 
@@ -13527,6 +16146,25 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::search_features][super::super::client::FeaturestoreService::search_features] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::SearchFeatures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchFeatures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchFeatures(RequestBuilder<crate::model::SearchFeaturesRequest>);
 
@@ -13616,6 +16254,25 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::list_locations][super::super::client::FeaturestoreService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -13706,6 +16363,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::get_location][super::super::client::FeaturestoreService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -13751,6 +16423,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::set_iam_policy][super::super::client::FeaturestoreService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -13818,6 +16505,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::get_iam_policy][super::super::client::FeaturestoreService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -13874,6 +16576,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::test_iam_permissions][super::super::client::FeaturestoreService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -13937,6 +16654,25 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::list_operations][super::super::client::FeaturestoreService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -14029,6 +16765,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::get_operation][super::super::client::FeaturestoreService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -14077,6 +16828,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::delete_operation][super::super::client::FeaturestoreService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -14125,6 +16891,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::cancel_operation][super::super::client::FeaturestoreService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -14173,6 +16954,21 @@ pub mod featurestore_service {
     }
 
     /// The request builder for [FeaturestoreService::wait_operation][super::super::client::FeaturestoreService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::featurestore_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -14284,6 +17080,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::create_cached_content][super::super::client::GenAiCacheService::create_cached_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::CreateCachedContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCachedContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCachedContent(RequestBuilder<crate::model::CreateCachedContentRequest>);
 
@@ -14345,6 +17156,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::get_cached_content][super::super::client::GenAiCacheService::get_cached_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::GetCachedContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCachedContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCachedContent(RequestBuilder<crate::model::GetCachedContentRequest>);
 
@@ -14395,6 +17221,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::update_cached_content][super::super::client::GenAiCacheService::update_cached_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::UpdateCachedContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCachedContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCachedContent(RequestBuilder<crate::model::UpdateCachedContentRequest>);
 
@@ -14459,6 +17300,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::delete_cached_content][super::super::client::GenAiCacheService::delete_cached_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::DeleteCachedContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCachedContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCachedContent(RequestBuilder<crate::model::DeleteCachedContentRequest>);
 
@@ -14509,6 +17365,25 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::list_cached_contents][super::super::client::GenAiCacheService::list_cached_contents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::ListCachedContents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCachedContents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCachedContents(RequestBuilder<crate::model::ListCachedContentsRequest>);
 
@@ -14597,6 +17472,25 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::list_locations][super::super::client::GenAiCacheService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -14687,6 +17581,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::get_location][super::super::client::GenAiCacheService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -14732,6 +17641,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::set_iam_policy][super::super::client::GenAiCacheService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -14799,6 +17723,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::get_iam_policy][super::super::client::GenAiCacheService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -14855,6 +17794,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::test_iam_permissions][super::super::client::GenAiCacheService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -14918,6 +17872,25 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::list_operations][super::super::client::GenAiCacheService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -15010,6 +17983,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::get_operation][super::super::client::GenAiCacheService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -15058,6 +18046,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::delete_operation][super::super::client::GenAiCacheService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -15106,6 +18109,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::cancel_operation][super::super::client::GenAiCacheService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -15154,6 +18172,21 @@ pub mod gen_ai_cache_service {
     }
 
     /// The request builder for [GenAiCacheService::wait_operation][super::super::client::GenAiCacheService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_cache_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -15265,6 +18298,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::create_tuning_job][super::super::client::GenAiTuningService::create_tuning_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::CreateTuningJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTuningJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTuningJob(RequestBuilder<crate::model::CreateTuningJobRequest>);
 
@@ -15323,6 +18371,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::get_tuning_job][super::super::client::GenAiTuningService::get_tuning_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::GetTuningJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTuningJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTuningJob(RequestBuilder<crate::model::GetTuningJobRequest>);
 
@@ -15370,6 +18433,25 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::list_tuning_jobs][super::super::client::GenAiTuningService::list_tuning_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::ListTuningJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTuningJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTuningJobs(RequestBuilder<crate::model::ListTuningJobsRequest>);
 
@@ -15459,6 +18541,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::cancel_tuning_job][super::super::client::GenAiTuningService::cancel_tuning_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::CancelTuningJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelTuningJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelTuningJob(RequestBuilder<crate::model::CancelTuningJobRequest>);
 
@@ -15506,6 +18603,22 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::rebase_tuned_model][super::super::client::GenAiTuningService::rebase_tuned_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::RebaseTunedModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RebaseTunedModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RebaseTunedModel(RequestBuilder<crate::model::RebaseTunedModelRequest>);
 
@@ -15634,6 +18747,25 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::list_locations][super::super::client::GenAiTuningService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -15724,6 +18856,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::get_location][super::super::client::GenAiTuningService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -15769,6 +18916,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::set_iam_policy][super::super::client::GenAiTuningService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -15836,6 +18998,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::get_iam_policy][super::super::client::GenAiTuningService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -15892,6 +19069,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::test_iam_permissions][super::super::client::GenAiTuningService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -15955,6 +19147,25 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::list_operations][super::super::client::GenAiTuningService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -16047,6 +19258,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::get_operation][super::super::client::GenAiTuningService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -16095,6 +19321,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::delete_operation][super::super::client::GenAiTuningService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -16143,6 +19384,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::cancel_operation][super::super::client::GenAiTuningService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -16191,6 +19447,21 @@ pub mod gen_ai_tuning_service {
     }
 
     /// The request builder for [GenAiTuningService::wait_operation][super::super::client::GenAiTuningService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::gen_ai_tuning_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -16302,6 +19573,22 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::create_index_endpoint][super::super::client::IndexEndpointService::create_index_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::CreateIndexEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIndexEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIndexEndpoint(RequestBuilder<crate::model::CreateIndexEndpointRequest>);
 
@@ -16406,6 +19693,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::get_index_endpoint][super::super::client::IndexEndpointService::get_index_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::GetIndexEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIndexEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIndexEndpoint(RequestBuilder<crate::model::GetIndexEndpointRequest>);
 
@@ -16456,6 +19758,25 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::list_index_endpoints][super::super::client::IndexEndpointService::list_index_endpoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::ListIndexEndpoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIndexEndpoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIndexEndpoints(RequestBuilder<crate::model::ListIndexEndpointsRequest>);
 
@@ -16556,6 +19877,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::update_index_endpoint][super::super::client::IndexEndpointService::update_index_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::UpdateIndexEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIndexEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIndexEndpoint(RequestBuilder<crate::model::UpdateIndexEndpointRequest>);
 
@@ -16620,6 +19956,22 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::delete_index_endpoint][super::super::client::IndexEndpointService::delete_index_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::DeleteIndexEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIndexEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIndexEndpoint(RequestBuilder<crate::model::DeleteIndexEndpointRequest>);
 
@@ -16711,6 +20063,22 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::deploy_index][super::super::client::IndexEndpointService::deploy_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::DeployIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeployIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeployIndex(RequestBuilder<crate::model::DeployIndexRequest>);
 
@@ -16812,6 +20180,22 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::undeploy_index][super::super::client::IndexEndpointService::undeploy_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::UndeployIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeployIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeployIndex(RequestBuilder<crate::model::UndeployIndexRequest>);
 
@@ -16910,6 +20294,22 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::mutate_deployed_index][super::super::client::IndexEndpointService::mutate_deployed_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::MutateDeployedIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MutateDeployedIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MutateDeployedIndex(RequestBuilder<crate::model::MutateDeployedIndexRequest>);
 
@@ -17014,6 +20414,25 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::list_locations][super::super::client::IndexEndpointService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -17104,6 +20523,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::get_location][super::super::client::IndexEndpointService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -17149,6 +20583,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::set_iam_policy][super::super::client::IndexEndpointService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -17216,6 +20665,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::get_iam_policy][super::super::client::IndexEndpointService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -17272,6 +20736,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::test_iam_permissions][super::super::client::IndexEndpointService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -17335,6 +20814,25 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::list_operations][super::super::client::IndexEndpointService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -17427,6 +20925,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::get_operation][super::super::client::IndexEndpointService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -17475,6 +20988,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::delete_operation][super::super::client::IndexEndpointService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -17523,6 +21051,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::cancel_operation][super::super::client::IndexEndpointService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -17571,6 +21114,21 @@ pub mod index_endpoint_service {
     }
 
     /// The request builder for [IndexEndpointService::wait_operation][super::super::client::IndexEndpointService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_endpoint_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -17682,6 +21240,22 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::create_index][super::super::client::IndexService::create_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::CreateIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIndex(RequestBuilder<crate::model::CreateIndexRequest>);
 
@@ -17781,6 +21355,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::get_index][super::super::client::IndexService::get_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::GetIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIndex(RequestBuilder<crate::model::GetIndexRequest>);
 
@@ -17828,6 +21417,25 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::list_indexes][super::super::client::IndexService::list_indexes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::ListIndexes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIndexes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIndexes(RequestBuilder<crate::model::ListIndexesRequest>);
 
@@ -17923,6 +21531,22 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::update_index][super::super::client::IndexService::update_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::UpdateIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIndex(RequestBuilder<crate::model::UpdateIndexRequest>);
 
@@ -18023,6 +21647,22 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::delete_index][super::super::client::IndexService::delete_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::DeleteIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIndex(RequestBuilder<crate::model::DeleteIndexRequest>);
 
@@ -18111,6 +21751,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::upsert_datapoints][super::super::client::IndexService::upsert_datapoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::UpsertDatapoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpsertDatapoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpsertDatapoints(RequestBuilder<crate::model::UpsertDatapointsRequest>);
 
@@ -18181,6 +21836,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::remove_datapoints][super::super::client::IndexService::remove_datapoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::RemoveDatapoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveDatapoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveDatapoints(RequestBuilder<crate::model::RemoveDatapointsRequest>);
 
@@ -18242,6 +21912,25 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::list_locations][super::super::client::IndexService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -18332,6 +22021,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::get_location][super::super::client::IndexService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -18377,6 +22081,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::set_iam_policy][super::super::client::IndexService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -18444,6 +22163,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::get_iam_policy][super::super::client::IndexService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -18500,6 +22234,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::test_iam_permissions][super::super::client::IndexService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -18563,6 +22312,25 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::list_operations][super::super::client::IndexService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -18655,6 +22423,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::get_operation][super::super::client::IndexService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -18703,6 +22486,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::delete_operation][super::super::client::IndexService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -18751,6 +22549,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::cancel_operation][super::super::client::IndexService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -18799,6 +22612,21 @@ pub mod index_service {
     }
 
     /// The request builder for [IndexService::wait_operation][super::super::client::IndexService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::index_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -18910,6 +22738,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::create_custom_job][super::super::client::JobService::create_custom_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CreateCustomJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCustomJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCustomJob(RequestBuilder<crate::model::CreateCustomJobRequest>);
 
@@ -18968,6 +22811,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_custom_job][super::super::client::JobService::get_custom_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetCustomJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCustomJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCustomJob(RequestBuilder<crate::model::GetCustomJobRequest>);
 
@@ -19015,6 +22873,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_custom_jobs][super::super::client::JobService::list_custom_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListCustomJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCustomJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCustomJobs(RequestBuilder<crate::model::ListCustomJobsRequest>);
 
@@ -19110,6 +22987,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_custom_job][super::super::client::JobService::delete_custom_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::DeleteCustomJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCustomJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCustomJob(RequestBuilder<crate::model::DeleteCustomJobRequest>);
 
@@ -19198,6 +23091,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::cancel_custom_job][super::super::client::JobService::cancel_custom_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CancelCustomJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelCustomJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelCustomJob(RequestBuilder<crate::model::CancelCustomJobRequest>);
 
@@ -19245,6 +23153,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::create_data_labeling_job][super::super::client::JobService::create_data_labeling_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CreateDataLabelingJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataLabelingJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataLabelingJob(RequestBuilder<crate::model::CreateDataLabelingJobRequest>);
 
@@ -19308,6 +23231,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_data_labeling_job][super::super::client::JobService::get_data_labeling_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetDataLabelingJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataLabelingJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataLabelingJob(RequestBuilder<crate::model::GetDataLabelingJobRequest>);
 
@@ -19358,6 +23296,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_data_labeling_jobs][super::super::client::JobService::list_data_labeling_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListDataLabelingJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataLabelingJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataLabelingJobs(RequestBuilder<crate::model::ListDataLabelingJobsRequest>);
 
@@ -19464,6 +23421,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_data_labeling_job][super::super::client::JobService::delete_data_labeling_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::DeleteDataLabelingJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataLabelingJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataLabelingJob(RequestBuilder<crate::model::DeleteDataLabelingJobRequest>);
 
@@ -19555,6 +23528,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::cancel_data_labeling_job][super::super::client::JobService::cancel_data_labeling_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CancelDataLabelingJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelDataLabelingJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelDataLabelingJob(RequestBuilder<crate::model::CancelDataLabelingJobRequest>);
 
@@ -19605,6 +23593,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::create_hyperparameter_tuning_job][super::super::client::JobService::create_hyperparameter_tuning_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CreateHyperparameterTuningJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateHyperparameterTuningJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateHyperparameterTuningJob(
         RequestBuilder<crate::model::CreateHyperparameterTuningJobRequest>,
@@ -19670,6 +23673,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_hyperparameter_tuning_job][super::super::client::JobService::get_hyperparameter_tuning_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetHyperparameterTuningJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetHyperparameterTuningJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetHyperparameterTuningJob(
         RequestBuilder<crate::model::GetHyperparameterTuningJobRequest>,
@@ -19722,6 +23740,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_hyperparameter_tuning_jobs][super::super::client::JobService::list_hyperparameter_tuning_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListHyperparameterTuningJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHyperparameterTuningJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHyperparameterTuningJobs(
         RequestBuilder<crate::model::ListHyperparameterTuningJobsRequest>,
@@ -19826,6 +23863,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_hyperparameter_tuning_job][super::super::client::JobService::delete_hyperparameter_tuning_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::DeleteHyperparameterTuningJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteHyperparameterTuningJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteHyperparameterTuningJob(
         RequestBuilder<crate::model::DeleteHyperparameterTuningJobRequest>,
@@ -19919,6 +23972,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::cancel_hyperparameter_tuning_job][super::super::client::JobService::cancel_hyperparameter_tuning_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CancelHyperparameterTuningJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelHyperparameterTuningJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelHyperparameterTuningJob(
         RequestBuilder<crate::model::CancelHyperparameterTuningJobRequest>,
@@ -19971,6 +24039,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::create_nas_job][super::super::client::JobService::create_nas_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CreateNasJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNasJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNasJob(RequestBuilder<crate::model::CreateNasJobRequest>);
 
@@ -20029,6 +24112,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_nas_job][super::super::client::JobService::get_nas_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetNasJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNasJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNasJob(RequestBuilder<crate::model::GetNasJobRequest>);
 
@@ -20076,6 +24174,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_nas_jobs][super::super::client::JobService::list_nas_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListNasJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNasJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNasJobs(RequestBuilder<crate::model::ListNasJobsRequest>);
 
@@ -20171,6 +24288,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_nas_job][super::super::client::JobService::delete_nas_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::DeleteNasJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNasJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNasJob(RequestBuilder<crate::model::DeleteNasJobRequest>);
 
@@ -20259,6 +24392,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::cancel_nas_job][super::super::client::JobService::cancel_nas_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CancelNasJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelNasJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelNasJob(RequestBuilder<crate::model::CancelNasJobRequest>);
 
@@ -20306,6 +24454,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_nas_trial_detail][super::super::client::JobService::get_nas_trial_detail] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetNasTrialDetail;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNasTrialDetail {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNasTrialDetail(RequestBuilder<crate::model::GetNasTrialDetailRequest>);
 
@@ -20356,6 +24519,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_nas_trial_details][super::super::client::JobService::list_nas_trial_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListNasTrialDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNasTrialDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNasTrialDetails(RequestBuilder<crate::model::ListNasTrialDetailsRequest>);
 
@@ -20444,6 +24626,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::create_batch_prediction_job][super::super::client::JobService::create_batch_prediction_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CreateBatchPredictionJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBatchPredictionJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBatchPredictionJob(
         RequestBuilder<crate::model::CreateBatchPredictionJobRequest>,
@@ -20509,6 +24706,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_batch_prediction_job][super::super::client::JobService::get_batch_prediction_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetBatchPredictionJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBatchPredictionJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBatchPredictionJob(RequestBuilder<crate::model::GetBatchPredictionJobRequest>);
 
@@ -20559,6 +24771,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_batch_prediction_jobs][super::super::client::JobService::list_batch_prediction_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListBatchPredictionJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBatchPredictionJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBatchPredictionJobs(
         RequestBuilder<crate::model::ListBatchPredictionJobsRequest>,
@@ -20663,6 +24894,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_batch_prediction_job][super::super::client::JobService::delete_batch_prediction_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::DeleteBatchPredictionJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBatchPredictionJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBatchPredictionJob(
         RequestBuilder<crate::model::DeleteBatchPredictionJobRequest>,
@@ -20756,6 +25003,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::cancel_batch_prediction_job][super::super::client::JobService::cancel_batch_prediction_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CancelBatchPredictionJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelBatchPredictionJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelBatchPredictionJob(
         RequestBuilder<crate::model::CancelBatchPredictionJobRequest>,
@@ -20808,6 +25070,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::create_model_deployment_monitoring_job][super::super::client::JobService::create_model_deployment_monitoring_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CreateModelDeploymentMonitoringJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateModelDeploymentMonitoringJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::CreateModelDeploymentMonitoringJobRequest>,
@@ -20873,6 +25150,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::search_model_deployment_monitoring_stats_anomalies][super::super::client::JobService::search_model_deployment_monitoring_stats_anomalies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::SearchModelDeploymentMonitoringStatsAnomalies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchModelDeploymentMonitoringStatsAnomalies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchModelDeploymentMonitoringStatsAnomalies(
         RequestBuilder<crate::model::SearchModelDeploymentMonitoringStatsAnomaliesRequest>,
@@ -21014,6 +25310,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_model_deployment_monitoring_job][super::super::client::JobService::get_model_deployment_monitoring_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetModelDeploymentMonitoringJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModelDeploymentMonitoringJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::GetModelDeploymentMonitoringJobRequest>,
@@ -21066,6 +25377,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_model_deployment_monitoring_jobs][super::super::client::JobService::list_model_deployment_monitoring_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListModelDeploymentMonitoringJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModelDeploymentMonitoringJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModelDeploymentMonitoringJobs(
         RequestBuilder<crate::model::ListModelDeploymentMonitoringJobsRequest>,
@@ -21170,6 +25500,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::update_model_deployment_monitoring_job][super::super::client::JobService::update_model_deployment_monitoring_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::UpdateModelDeploymentMonitoringJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateModelDeploymentMonitoringJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::UpdateModelDeploymentMonitoringJobRequest>,
@@ -21281,6 +25627,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_model_deployment_monitoring_job][super::super::client::JobService::delete_model_deployment_monitoring_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::DeleteModelDeploymentMonitoringJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteModelDeploymentMonitoringJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::DeleteModelDeploymentMonitoringJobRequest>,
@@ -21374,6 +25736,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::pause_model_deployment_monitoring_job][super::super::client::JobService::pause_model_deployment_monitoring_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::PauseModelDeploymentMonitoringJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseModelDeploymentMonitoringJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::PauseModelDeploymentMonitoringJobRequest>,
@@ -21426,6 +25803,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::resume_model_deployment_monitoring_job][super::super::client::JobService::resume_model_deployment_monitoring_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ResumeModelDeploymentMonitoringJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeModelDeploymentMonitoringJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeModelDeploymentMonitoringJob(
         RequestBuilder<crate::model::ResumeModelDeploymentMonitoringJobRequest>,
@@ -21478,6 +25870,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_locations][super::super::client::JobService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -21568,6 +25979,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_location][super::super::client::JobService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -21613,6 +26039,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::set_iam_policy][super::super::client::JobService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -21680,6 +26121,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_iam_policy][super::super::client::JobService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -21736,6 +26192,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::test_iam_permissions][super::super::client::JobService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -21799,6 +26270,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_operations][super::super::client::JobService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -21891,6 +26381,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_operation][super::super::client::JobService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -21939,6 +26444,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_operation][super::super::client::JobService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -21987,6 +26507,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::cancel_operation][super::super::client::JobService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -22035,6 +26570,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::wait_operation][super::super::client::JobService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::job_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -22146,6 +26696,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::count_tokens][super::super::client::LlmUtilityService::count_tokens] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::CountTokens;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CountTokens {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CountTokens(RequestBuilder<crate::model::CountTokensRequest>);
 
@@ -22252,6 +26817,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::compute_tokens][super::super::client::LlmUtilityService::compute_tokens] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::ComputeTokens;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ComputeTokens {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ComputeTokens(RequestBuilder<crate::model::ComputeTokensRequest>);
 
@@ -22327,6 +26907,25 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::list_locations][super::super::client::LlmUtilityService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -22417,6 +27016,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::get_location][super::super::client::LlmUtilityService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -22462,6 +27076,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::set_iam_policy][super::super::client::LlmUtilityService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -22529,6 +27158,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::get_iam_policy][super::super::client::LlmUtilityService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -22585,6 +27229,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::test_iam_permissions][super::super::client::LlmUtilityService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -22648,6 +27307,25 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::list_operations][super::super::client::LlmUtilityService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -22740,6 +27418,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::get_operation][super::super::client::LlmUtilityService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -22788,6 +27481,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::delete_operation][super::super::client::LlmUtilityService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -22836,6 +27544,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::cancel_operation][super::super::client::LlmUtilityService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -22884,6 +27607,21 @@ pub mod llm_utility_service {
     }
 
     /// The request builder for [LlmUtilityService::wait_operation][super::super::client::LlmUtilityService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::llm_utility_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -22995,6 +27733,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::find_neighbors][super::super::client::MatchService::find_neighbors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::FindNeighbors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FindNeighbors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FindNeighbors(RequestBuilder<crate::model::FindNeighborsRequest>);
 
@@ -23065,6 +27818,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::read_index_datapoints][super::super::client::MatchService::read_index_datapoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::ReadIndexDatapoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReadIndexDatapoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReadIndexDatapoints(RequestBuilder<crate::model::ReadIndexDatapointsRequest>);
 
@@ -23132,6 +27900,25 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::list_locations][super::super::client::MatchService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -23222,6 +28009,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::get_location][super::super::client::MatchService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -23267,6 +28069,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::set_iam_policy][super::super::client::MatchService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -23334,6 +28151,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::get_iam_policy][super::super::client::MatchService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -23390,6 +28222,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::test_iam_permissions][super::super::client::MatchService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -23453,6 +28300,25 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::list_operations][super::super::client::MatchService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -23545,6 +28411,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::get_operation][super::super::client::MatchService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -23593,6 +28474,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::delete_operation][super::super::client::MatchService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -23641,6 +28537,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::cancel_operation][super::super::client::MatchService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -23689,6 +28600,21 @@ pub mod match_service {
     }
 
     /// The request builder for [MatchService::wait_operation][super::super::client::MatchService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::match_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -23800,6 +28726,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::create_metadata_store][super::super::client::MetadataService::create_metadata_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::CreateMetadataStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMetadataStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMetadataStore(RequestBuilder<crate::model::CreateMetadataStoreRequest>);
 
@@ -23910,6 +28852,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_metadata_store][super::super::client::MetadataService::get_metadata_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetMetadataStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMetadataStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMetadataStore(RequestBuilder<crate::model::GetMetadataStoreRequest>);
 
@@ -23960,6 +28917,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_metadata_stores][super::super::client::MetadataService::list_metadata_stores] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::ListMetadataStores;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMetadataStores {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMetadataStores(RequestBuilder<crate::model::ListMetadataStoresRequest>);
 
@@ -24048,6 +29024,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_metadata_store][super::super::client::MetadataService::delete_metadata_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::DeleteMetadataStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMetadataStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMetadataStore(RequestBuilder<crate::model::DeleteMetadataStoreRequest>);
 
@@ -24150,6 +29142,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::create_artifact][super::super::client::MetadataService::create_artifact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::CreateArtifact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateArtifact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateArtifact(RequestBuilder<crate::model::CreateArtifactRequest>);
 
@@ -24214,6 +29221,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_artifact][super::super::client::MetadataService::get_artifact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetArtifact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetArtifact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetArtifact(RequestBuilder<crate::model::GetArtifactRequest>);
 
@@ -24261,6 +29283,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_artifacts][super::super::client::MetadataService::list_artifacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::ListArtifacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListArtifacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListArtifacts(RequestBuilder<crate::model::ListArtifactsRequest>);
 
@@ -24356,6 +29397,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::update_artifact][super::super::client::MetadataService::update_artifact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::UpdateArtifact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateArtifact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateArtifact(RequestBuilder<crate::model::UpdateArtifactRequest>);
 
@@ -24421,6 +29477,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_artifact][super::super::client::MetadataService::delete_artifact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::DeleteArtifact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteArtifact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteArtifact(RequestBuilder<crate::model::DeleteArtifactRequest>);
 
@@ -24515,6 +29587,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::purge_artifacts][super::super::client::MetadataService::purge_artifacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::PurgeArtifacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeArtifacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeArtifacts(RequestBuilder<crate::model::PurgeArtifactsRequest>);
 
@@ -24617,6 +29705,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::create_context][super::super::client::MetadataService::create_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::CreateContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateContext(RequestBuilder<crate::model::CreateContextRequest>);
 
@@ -24681,6 +29784,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_context][super::super::client::MetadataService::get_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetContext(RequestBuilder<crate::model::GetContextRequest>);
 
@@ -24728,6 +29846,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_contexts][super::super::client::MetadataService::list_contexts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::ListContexts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListContexts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListContexts(RequestBuilder<crate::model::ListContextsRequest>);
 
@@ -24823,6 +29960,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::update_context][super::super::client::MetadataService::update_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::UpdateContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateContext(RequestBuilder<crate::model::UpdateContextRequest>);
 
@@ -24888,6 +30040,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_context][super::super::client::MetadataService::delete_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::DeleteContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteContext(RequestBuilder<crate::model::DeleteContextRequest>);
 
@@ -24988,6 +30156,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::purge_contexts][super::super::client::MetadataService::purge_contexts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::PurgeContexts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeContexts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeContexts(RequestBuilder<crate::model::PurgeContextsRequest>);
 
@@ -25090,6 +30274,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::add_context_artifacts_and_executions][super::super::client::MetadataService::add_context_artifacts_and_executions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::AddContextArtifactsAndExecutions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddContextArtifactsAndExecutions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddContextArtifactsAndExecutions(
         RequestBuilder<crate::model::AddContextArtifactsAndExecutionsRequest>,
@@ -25164,6 +30363,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::add_context_children][super::super::client::MetadataService::add_context_children] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::AddContextChildren;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddContextChildren {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddContextChildren(RequestBuilder<crate::model::AddContextChildrenRequest>);
 
@@ -25225,6 +30439,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::remove_context_children][super::super::client::MetadataService::remove_context_children] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::RemoveContextChildren;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveContextChildren {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveContextChildren(RequestBuilder<crate::model::RemoveContextChildrenRequest>);
 
@@ -25286,6 +30515,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::query_context_lineage_subgraph][super::super::client::MetadataService::query_context_lineage_subgraph] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::QueryContextLineageSubgraph;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryContextLineageSubgraph {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryContextLineageSubgraph(
         RequestBuilder<crate::model::QueryContextLineageSubgraphRequest>,
@@ -25338,6 +30582,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::create_execution][super::super::client::MetadataService::create_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::CreateExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExecution(RequestBuilder<crate::model::CreateExecutionRequest>);
 
@@ -25402,6 +30661,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_execution][super::super::client::MetadataService::get_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExecution(RequestBuilder<crate::model::GetExecutionRequest>);
 
@@ -25449,6 +30723,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_executions][super::super::client::MetadataService::list_executions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::ListExecutions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExecutions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExecutions(RequestBuilder<crate::model::ListExecutionsRequest>);
 
@@ -25544,6 +30837,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::update_execution][super::super::client::MetadataService::update_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::UpdateExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExecution(RequestBuilder<crate::model::UpdateExecutionRequest>);
 
@@ -25609,6 +30917,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_execution][super::super::client::MetadataService::delete_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::DeleteExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteExecution(RequestBuilder<crate::model::DeleteExecutionRequest>);
 
@@ -25703,6 +31027,22 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::purge_executions][super::super::client::MetadataService::purge_executions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::PurgeExecutions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeExecutions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeExecutions(RequestBuilder<crate::model::PurgeExecutionsRequest>);
 
@@ -25805,6 +31145,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::add_execution_events][super::super::client::MetadataService::add_execution_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::AddExecutionEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddExecutionEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddExecutionEvents(RequestBuilder<crate::model::AddExecutionEventsRequest>);
 
@@ -25866,6 +31221,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::query_execution_inputs_and_outputs][super::super::client::MetadataService::query_execution_inputs_and_outputs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::QueryExecutionInputsAndOutputs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryExecutionInputsAndOutputs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryExecutionInputsAndOutputs(
         RequestBuilder<crate::model::QueryExecutionInputsAndOutputsRequest>,
@@ -25918,6 +31288,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::create_metadata_schema][super::super::client::MetadataService::create_metadata_schema] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::CreateMetadataSchema;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMetadataSchema {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMetadataSchema(RequestBuilder<crate::model::CreateMetadataSchemaRequest>);
 
@@ -25985,6 +31370,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_metadata_schema][super::super::client::MetadataService::get_metadata_schema] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetMetadataSchema;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMetadataSchema {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMetadataSchema(RequestBuilder<crate::model::GetMetadataSchemaRequest>);
 
@@ -26035,6 +31435,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_metadata_schemas][super::super::client::MetadataService::list_metadata_schemas] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::ListMetadataSchemas;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMetadataSchemas {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMetadataSchemas(RequestBuilder<crate::model::ListMetadataSchemasRequest>);
 
@@ -26129,6 +31548,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::query_artifact_lineage_subgraph][super::super::client::MetadataService::query_artifact_lineage_subgraph] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::QueryArtifactLineageSubgraph;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryArtifactLineageSubgraph {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryArtifactLineageSubgraph(
         RequestBuilder<crate::model::QueryArtifactLineageSubgraphRequest>,
@@ -26193,6 +31627,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_locations][super::super::client::MetadataService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -26283,6 +31736,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_location][super::super::client::MetadataService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -26328,6 +31796,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::set_iam_policy][super::super::client::MetadataService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -26395,6 +31878,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_iam_policy][super::super::client::MetadataService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -26451,6 +31949,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::test_iam_permissions][super::super::client::MetadataService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -26514,6 +32027,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_operations][super::super::client::MetadataService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -26606,6 +32138,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_operation][super::super::client::MetadataService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -26654,6 +32201,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_operation][super::super::client::MetadataService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -26702,6 +32264,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::cancel_operation][super::super::client::MetadataService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -26750,6 +32327,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::wait_operation][super::super::client::MetadataService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::metadata_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -26861,6 +32453,25 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::search_migratable_resources][super::super::client::MigrationService::search_migratable_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::SearchMigratableResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchMigratableResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchMigratableResources(
         RequestBuilder<crate::model::SearchMigratableResourcesRequest>,
@@ -26959,6 +32570,22 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::batch_migrate_resources][super::super::client::MigrationService::batch_migrate_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::BatchMigrateResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchMigrateResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchMigrateResources(RequestBuilder<crate::model::BatchMigrateResourcesRequest>);
 
@@ -27065,6 +32692,25 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::list_locations][super::super::client::MigrationService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -27155,6 +32801,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::get_location][super::super::client::MigrationService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -27200,6 +32861,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::set_iam_policy][super::super::client::MigrationService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -27267,6 +32943,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::get_iam_policy][super::super::client::MigrationService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -27323,6 +33014,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::test_iam_permissions][super::super::client::MigrationService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -27386,6 +33092,25 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::list_operations][super::super::client::MigrationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -27478,6 +33203,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::get_operation][super::super::client::MigrationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -27526,6 +33266,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::delete_operation][super::super::client::MigrationService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -27574,6 +33329,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::cancel_operation][super::super::client::MigrationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -27622,6 +33392,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::wait_operation][super::super::client::MigrationService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::migration_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -27733,6 +33518,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::get_publisher_model][super::super::client::ModelGardenService::get_publisher_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::GetPublisherModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPublisherModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPublisherModel(RequestBuilder<crate::model::GetPublisherModelRequest>);
 
@@ -27807,6 +33607,25 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::list_locations][super::super::client::ModelGardenService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -27897,6 +33716,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::get_location][super::super::client::ModelGardenService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -27942,6 +33776,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::set_iam_policy][super::super::client::ModelGardenService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -28009,6 +33858,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::get_iam_policy][super::super::client::ModelGardenService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -28065,6 +33929,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::test_iam_permissions][super::super::client::ModelGardenService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -28128,6 +34007,25 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::list_operations][super::super::client::ModelGardenService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -28220,6 +34118,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::get_operation][super::super::client::ModelGardenService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -28268,6 +34181,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::delete_operation][super::super::client::ModelGardenService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -28316,6 +34244,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::cancel_operation][super::super::client::ModelGardenService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -28364,6 +34307,21 @@ pub mod model_garden_service {
     }
 
     /// The request builder for [ModelGardenService::wait_operation][super::super::client::ModelGardenService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_garden_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -28475,6 +34433,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::upload_model][super::super::client::ModelService::upload_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::UploadModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UploadModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UploadModel(RequestBuilder<crate::model::UploadModelRequest>);
 
@@ -28594,6 +34568,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::GetModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -28641,6 +34630,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ListModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -28742,6 +34750,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_model_versions][super::super::client::ModelService::list_model_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ListModelVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModelVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModelVersions(RequestBuilder<crate::model::ListModelVersionsRequest>);
 
@@ -28846,6 +34873,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_model_version_checkpoints][super::super::client::ModelService::list_model_version_checkpoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ListModelVersionCheckpoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModelVersionCheckpoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModelVersionCheckpoints(
         RequestBuilder<crate::model::ListModelVersionCheckpointsRequest>,
@@ -28938,6 +34984,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::update_model][super::super::client::ModelService::update_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::UpdateModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateModel(RequestBuilder<crate::model::UpdateModelRequest>);
 
@@ -28999,6 +35060,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::update_explanation_dataset][super::super::client::ModelService::update_explanation_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::UpdateExplanationDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExplanationDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExplanationDataset(
         RequestBuilder<crate::model::UpdateExplanationDatasetRequest>,
@@ -29103,6 +35180,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::DeleteModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -29191,6 +35284,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::delete_model_version][super::super::client::ModelService::delete_model_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::DeleteModelVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteModelVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteModelVersion(RequestBuilder<crate::model::DeleteModelVersionRequest>);
 
@@ -29282,6 +35391,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::merge_version_aliases][super::super::client::ModelService::merge_version_aliases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::MergeVersionAliases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MergeVersionAliases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MergeVersionAliases(RequestBuilder<crate::model::MergeVersionAliasesRequest>);
 
@@ -29345,6 +35469,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::export_model][super::super::client::ModelService::export_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ExportModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportModel(RequestBuilder<crate::model::ExportModelRequest>);
 
@@ -29448,6 +35588,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::copy_model][super::super::client::ModelService::copy_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::CopyModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CopyModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CopyModel(RequestBuilder<crate::model::CopyModelRequest>);
 
@@ -29590,6 +35746,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::import_model_evaluation][super::super::client::ModelService::import_model_evaluation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ImportModelEvaluation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportModelEvaluation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportModelEvaluation(RequestBuilder<crate::model::ImportModelEvaluationRequest>);
 
@@ -29651,6 +35822,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::batch_import_model_evaluation_slices][super::super::client::ModelService::batch_import_model_evaluation_slices] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::BatchImportModelEvaluationSlices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchImportModelEvaluationSlices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchImportModelEvaluationSlices(
         RequestBuilder<crate::model::BatchImportModelEvaluationSlicesRequest>,
@@ -29716,6 +35902,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::batch_import_evaluated_annotations][super::super::client::ModelService::batch_import_evaluated_annotations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::BatchImportEvaluatedAnnotations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchImportEvaluatedAnnotations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchImportEvaluatedAnnotations(
         RequestBuilder<crate::model::BatchImportEvaluatedAnnotationsRequest>,
@@ -29781,6 +35982,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_model_evaluation][super::super::client::ModelService::get_model_evaluation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::GetModelEvaluation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModelEvaluation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModelEvaluation(RequestBuilder<crate::model::GetModelEvaluationRequest>);
 
@@ -29831,6 +36047,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_model_evaluations][super::super::client::ModelService::list_model_evaluations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ListModelEvaluations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModelEvaluations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModelEvaluations(RequestBuilder<crate::model::ListModelEvaluationsRequest>);
 
@@ -29931,6 +36166,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_model_evaluation_slice][super::super::client::ModelService::get_model_evaluation_slice] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::GetModelEvaluationSlice;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModelEvaluationSlice {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModelEvaluationSlice(
         RequestBuilder<crate::model::GetModelEvaluationSliceRequest>,
@@ -29983,6 +36233,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_model_evaluation_slices][super::super::client::ModelService::list_model_evaluation_slices] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ListModelEvaluationSlices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModelEvaluationSlices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModelEvaluationSlices(
         RequestBuilder<crate::model::ListModelEvaluationSlicesRequest>,
@@ -30087,6 +36356,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_locations][super::super::client::ModelService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -30177,6 +36465,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_location][super::super::client::ModelService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -30222,6 +36525,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::set_iam_policy][super::super::client::ModelService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -30289,6 +36607,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_iam_policy][super::super::client::ModelService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -30345,6 +36678,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::test_iam_permissions][super::super::client::ModelService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -30408,6 +36756,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_operations][super::super::client::ModelService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -30500,6 +36867,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_operation][super::super::client::ModelService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -30548,6 +36930,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::delete_operation][super::super::client::ModelService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -30596,6 +36993,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::cancel_operation][super::super::client::ModelService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -30644,6 +37056,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::wait_operation][super::super::client::ModelService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::model_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -30755,6 +37182,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::create_notebook_runtime_template][super::super::client::NotebookService::create_notebook_runtime_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::CreateNotebookRuntimeTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNotebookRuntimeTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNotebookRuntimeTemplate(
         RequestBuilder<crate::model::CreateNotebookRuntimeTemplateRequest>,
@@ -30872,6 +37315,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_notebook_runtime_template][super::super::client::NotebookService::get_notebook_runtime_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::GetNotebookRuntimeTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotebookRuntimeTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotebookRuntimeTemplate(
         RequestBuilder<crate::model::GetNotebookRuntimeTemplateRequest>,
@@ -30924,6 +37382,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_notebook_runtime_templates][super::super::client::NotebookService::list_notebook_runtime_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::ListNotebookRuntimeTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotebookRuntimeTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotebookRuntimeTemplates(
         RequestBuilder<crate::model::ListNotebookRuntimeTemplatesRequest>,
@@ -31034,6 +37511,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::delete_notebook_runtime_template][super::super::client::NotebookService::delete_notebook_runtime_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::DeleteNotebookRuntimeTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNotebookRuntimeTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNotebookRuntimeTemplate(
         RequestBuilder<crate::model::DeleteNotebookRuntimeTemplateRequest>,
@@ -31127,6 +37620,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::update_notebook_runtime_template][super::super::client::NotebookService::update_notebook_runtime_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::UpdateNotebookRuntimeTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNotebookRuntimeTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNotebookRuntimeTemplate(
         RequestBuilder<crate::model::UpdateNotebookRuntimeTemplateRequest>,
@@ -31195,6 +37703,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::assign_notebook_runtime][super::super::client::NotebookService::assign_notebook_runtime] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::AssignNotebookRuntime;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AssignNotebookRuntime {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AssignNotebookRuntime(RequestBuilder<crate::model::AssignNotebookRuntimeRequest>);
 
@@ -31313,6 +37837,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_notebook_runtime][super::super::client::NotebookService::get_notebook_runtime] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::GetNotebookRuntime;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotebookRuntime {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotebookRuntime(RequestBuilder<crate::model::GetNotebookRuntimeRequest>);
 
@@ -31363,6 +37902,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_notebook_runtimes][super::super::client::NotebookService::list_notebook_runtimes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::ListNotebookRuntimes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotebookRuntimes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotebookRuntimes(RequestBuilder<crate::model::ListNotebookRuntimesRequest>);
 
@@ -31469,6 +38027,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::delete_notebook_runtime][super::super::client::NotebookService::delete_notebook_runtime] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::DeleteNotebookRuntime;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNotebookRuntime {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNotebookRuntime(RequestBuilder<crate::model::DeleteNotebookRuntimeRequest>);
 
@@ -31560,6 +38134,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::upgrade_notebook_runtime][super::super::client::NotebookService::upgrade_notebook_runtime] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::UpgradeNotebookRuntime;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpgradeNotebookRuntime {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpgradeNotebookRuntime(RequestBuilder<crate::model::UpgradeNotebookRuntimeRequest>);
 
@@ -31653,6 +38243,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::start_notebook_runtime][super::super::client::NotebookService::start_notebook_runtime] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::StartNotebookRuntime;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartNotebookRuntime {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartNotebookRuntime(RequestBuilder<crate::model::StartNotebookRuntimeRequest>);
 
@@ -31746,6 +38352,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::stop_notebook_runtime][super::super::client::NotebookService::stop_notebook_runtime] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::StopNotebookRuntime;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopNotebookRuntime {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopNotebookRuntime(RequestBuilder<crate::model::StopNotebookRuntimeRequest>);
 
@@ -31839,6 +38461,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::create_notebook_execution_job][super::super::client::NotebookService::create_notebook_execution_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::CreateNotebookExecutionJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNotebookExecutionJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNotebookExecutionJob(
         RequestBuilder<crate::model::CreateNotebookExecutionJobRequest>,
@@ -31953,6 +38591,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_notebook_execution_job][super::super::client::NotebookService::get_notebook_execution_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::GetNotebookExecutionJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotebookExecutionJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotebookExecutionJob(
         RequestBuilder<crate::model::GetNotebookExecutionJobRequest>,
@@ -32011,6 +38664,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_notebook_execution_jobs][super::super::client::NotebookService::list_notebook_execution_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::ListNotebookExecutionJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotebookExecutionJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotebookExecutionJobs(
         RequestBuilder<crate::model::ListNotebookExecutionJobsRequest>,
@@ -32121,6 +38793,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::delete_notebook_execution_job][super::super::client::NotebookService::delete_notebook_execution_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::DeleteNotebookExecutionJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNotebookExecutionJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNotebookExecutionJob(
         RequestBuilder<crate::model::DeleteNotebookExecutionJobRequest>,
@@ -32214,6 +38902,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_locations][super::super::client::NotebookService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -32304,6 +39011,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_location][super::super::client::NotebookService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -32349,6 +39071,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::set_iam_policy][super::super::client::NotebookService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -32416,6 +39153,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_iam_policy][super::super::client::NotebookService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -32472,6 +39224,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::test_iam_permissions][super::super::client::NotebookService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -32535,6 +39302,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_operations][super::super::client::NotebookService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -32627,6 +39413,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_operation][super::super::client::NotebookService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -32675,6 +39476,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::delete_operation][super::super::client::NotebookService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -32723,6 +39539,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::cancel_operation][super::super::client::NotebookService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -32771,6 +39602,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::wait_operation][super::super::client::NotebookService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::notebook_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -32882,6 +39728,22 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::create_persistent_resource][super::super::client::PersistentResourceService::create_persistent_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::CreatePersistentResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePersistentResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePersistentResource(
         RequestBuilder<crate::model::CreatePersistentResourceRequest>,
@@ -32998,6 +39860,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::get_persistent_resource][super::super::client::PersistentResourceService::get_persistent_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::GetPersistentResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPersistentResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPersistentResource(RequestBuilder<crate::model::GetPersistentResourceRequest>);
 
@@ -33048,6 +39925,25 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::list_persistent_resources][super::super::client::PersistentResourceService::list_persistent_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::ListPersistentResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPersistentResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPersistentResources(
         RequestBuilder<crate::model::ListPersistentResourcesRequest>,
@@ -33140,6 +40036,22 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::delete_persistent_resource][super::super::client::PersistentResourceService::delete_persistent_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::DeletePersistentResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePersistentResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePersistentResource(
         RequestBuilder<crate::model::DeletePersistentResourceRequest>,
@@ -33233,6 +40145,22 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::update_persistent_resource][super::super::client::PersistentResourceService::update_persistent_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::UpdatePersistentResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePersistentResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePersistentResource(
         RequestBuilder<crate::model::UpdatePersistentResourceRequest>,
@@ -33344,6 +40272,22 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::reboot_persistent_resource][super::super::client::PersistentResourceService::reboot_persistent_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::RebootPersistentResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RebootPersistentResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RebootPersistentResource(
         RequestBuilder<crate::model::RebootPersistentResourceRequest>,
@@ -33439,6 +40383,25 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::list_locations][super::super::client::PersistentResourceService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -33529,6 +40492,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::get_location][super::super::client::PersistentResourceService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -33574,6 +40552,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::set_iam_policy][super::super::client::PersistentResourceService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -33641,6 +40634,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::get_iam_policy][super::super::client::PersistentResourceService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -33697,6 +40705,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::test_iam_permissions][super::super::client::PersistentResourceService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -33760,6 +40783,25 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::list_operations][super::super::client::PersistentResourceService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -33852,6 +40894,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::get_operation][super::super::client::PersistentResourceService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -33900,6 +40957,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::delete_operation][super::super::client::PersistentResourceService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -33948,6 +41020,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::cancel_operation][super::super::client::PersistentResourceService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -33996,6 +41083,21 @@ pub mod persistent_resource_service {
     }
 
     /// The request builder for [PersistentResourceService::wait_operation][super::super::client::PersistentResourceService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::persistent_resource_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -34107,6 +41209,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::create_training_pipeline][super::super::client::PipelineService::create_training_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::CreateTrainingPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTrainingPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTrainingPipeline(RequestBuilder<crate::model::CreateTrainingPipelineRequest>);
 
@@ -34170,6 +41287,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::get_training_pipeline][super::super::client::PipelineService::get_training_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::GetTrainingPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTrainingPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTrainingPipeline(RequestBuilder<crate::model::GetTrainingPipelineRequest>);
 
@@ -34220,6 +41352,25 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::list_training_pipelines][super::super::client::PipelineService::list_training_pipelines] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::ListTrainingPipelines;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTrainingPipelines {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTrainingPipelines(RequestBuilder<crate::model::ListTrainingPipelinesRequest>);
 
@@ -34320,6 +41471,22 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::delete_training_pipeline][super::super::client::PipelineService::delete_training_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::DeleteTrainingPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTrainingPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTrainingPipeline(RequestBuilder<crate::model::DeleteTrainingPipelineRequest>);
 
@@ -34411,6 +41578,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::cancel_training_pipeline][super::super::client::PipelineService::cancel_training_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::CancelTrainingPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelTrainingPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelTrainingPipeline(RequestBuilder<crate::model::CancelTrainingPipelineRequest>);
 
@@ -34461,6 +41643,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::create_pipeline_job][super::super::client::PipelineService::create_pipeline_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::CreatePipelineJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePipelineJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePipelineJob(RequestBuilder<crate::model::CreatePipelineJobRequest>);
 
@@ -34528,6 +41725,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::get_pipeline_job][super::super::client::PipelineService::get_pipeline_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::GetPipelineJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPipelineJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPipelineJob(RequestBuilder<crate::model::GetPipelineJobRequest>);
 
@@ -34575,6 +41787,25 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::list_pipeline_jobs][super::super::client::PipelineService::list_pipeline_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::ListPipelineJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPipelineJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPipelineJobs(RequestBuilder<crate::model::ListPipelineJobsRequest>);
 
@@ -34679,6 +41910,22 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::delete_pipeline_job][super::super::client::PipelineService::delete_pipeline_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::DeletePipelineJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePipelineJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePipelineJob(RequestBuilder<crate::model::DeletePipelineJobRequest>);
 
@@ -34770,6 +42017,22 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::batch_delete_pipeline_jobs][super::super::client::PipelineService::batch_delete_pipeline_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::BatchDeletePipelineJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeletePipelineJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeletePipelineJobs(
         RequestBuilder<crate::model::BatchDeletePipelineJobsRequest>,
@@ -34878,6 +42141,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::cancel_pipeline_job][super::super::client::PipelineService::cancel_pipeline_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::CancelPipelineJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelPipelineJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelPipelineJob(RequestBuilder<crate::model::CancelPipelineJobRequest>);
 
@@ -34928,6 +42206,22 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::batch_cancel_pipeline_jobs][super::super::client::PipelineService::batch_cancel_pipeline_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::BatchCancelPipelineJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCancelPipelineJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCancelPipelineJobs(
         RequestBuilder<crate::model::BatchCancelPipelineJobsRequest>,
@@ -35036,6 +42330,25 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::list_locations][super::super::client::PipelineService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -35126,6 +42439,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::get_location][super::super::client::PipelineService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -35171,6 +42499,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::set_iam_policy][super::super::client::PipelineService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -35238,6 +42581,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::get_iam_policy][super::super::client::PipelineService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -35294,6 +42652,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::test_iam_permissions][super::super::client::PipelineService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -35357,6 +42730,25 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::list_operations][super::super::client::PipelineService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -35449,6 +42841,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::get_operation][super::super::client::PipelineService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -35497,6 +42904,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::delete_operation][super::super::client::PipelineService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -35545,6 +42967,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::cancel_operation][super::super::client::PipelineService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -35593,6 +43030,21 @@ pub mod pipeline_service {
     }
 
     /// The request builder for [PipelineService::wait_operation][super::super::client::PipelineService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::pipeline_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -35704,6 +43156,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::predict][super::super::client::PredictionService::predict] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::Predict;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Predict {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Predict(RequestBuilder<crate::model::PredictRequest>);
 
@@ -35770,6 +43237,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::raw_predict][super::super::client::PredictionService::raw_predict] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::RawPredict;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RawPredict {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RawPredict(RequestBuilder<crate::model::RawPredictRequest>);
 
@@ -35826,6 +43308,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::direct_predict][super::super::client::PredictionService::direct_predict] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::DirectPredict;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DirectPredict {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DirectPredict(RequestBuilder<crate::model::DirectPredictRequest>);
 
@@ -35893,6 +43390,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::direct_raw_predict][super::super::client::PredictionService::direct_raw_predict] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::DirectRawPredict;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DirectRawPredict {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DirectRawPredict(RequestBuilder<crate::model::DirectRawPredictRequest>);
 
@@ -35955,6 +43467,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::explain][super::super::client::PredictionService::explain] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::Explain;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Explain {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Explain(RequestBuilder<crate::model::ExplainRequest>);
 
@@ -36038,6 +43565,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::generate_content][super::super::client::PredictionService::generate_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::GenerateContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateContent(RequestBuilder<crate::model::GenerateContentRequest>);
 
@@ -36166,6 +43708,25 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::list_locations][super::super::client::PredictionService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -36256,6 +43817,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::get_location][super::super::client::PredictionService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -36301,6 +43877,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::set_iam_policy][super::super::client::PredictionService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -36368,6 +43959,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::get_iam_policy][super::super::client::PredictionService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -36424,6 +44030,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::test_iam_permissions][super::super::client::PredictionService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -36487,6 +44108,25 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::list_operations][super::super::client::PredictionService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -36579,6 +44219,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::get_operation][super::super::client::PredictionService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -36627,6 +44282,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::delete_operation][super::super::client::PredictionService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -36675,6 +44345,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::cancel_operation][super::super::client::PredictionService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -36723,6 +44408,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::wait_operation][super::super::client::PredictionService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::prediction_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -36834,6 +44534,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::query_reasoning_engine][super::super::client::ReasoningEngineExecutionService::query_reasoning_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::QueryReasoningEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryReasoningEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryReasoningEngine(RequestBuilder<crate::model::QueryReasoningEngineRequest>);
 
@@ -36896,6 +44611,25 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::list_locations][super::super::client::ReasoningEngineExecutionService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -36986,6 +44720,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::get_location][super::super::client::ReasoningEngineExecutionService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -37031,6 +44780,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::set_iam_policy][super::super::client::ReasoningEngineExecutionService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -37098,6 +44862,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::get_iam_policy][super::super::client::ReasoningEngineExecutionService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -37154,6 +44933,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::test_iam_permissions][super::super::client::ReasoningEngineExecutionService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -37217,6 +45011,25 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::list_operations][super::super::client::ReasoningEngineExecutionService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -37309,6 +45122,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::get_operation][super::super::client::ReasoningEngineExecutionService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -37357,6 +45185,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::delete_operation][super::super::client::ReasoningEngineExecutionService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -37405,6 +45248,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::cancel_operation][super::super::client::ReasoningEngineExecutionService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -37453,6 +45311,21 @@ pub mod reasoning_engine_execution_service {
     }
 
     /// The request builder for [ReasoningEngineExecutionService::wait_operation][super::super::client::ReasoningEngineExecutionService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_execution_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -37564,6 +45437,22 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::create_reasoning_engine][super::super::client::ReasoningEngineService::create_reasoning_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::CreateReasoningEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReasoningEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReasoningEngine(RequestBuilder<crate::model::CreateReasoningEngineRequest>);
 
@@ -37668,6 +45557,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::get_reasoning_engine][super::super::client::ReasoningEngineService::get_reasoning_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::GetReasoningEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReasoningEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReasoningEngine(RequestBuilder<crate::model::GetReasoningEngineRequest>);
 
@@ -37718,6 +45622,25 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::list_reasoning_engines][super::super::client::ReasoningEngineService::list_reasoning_engines] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::ListReasoningEngines;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReasoningEngines {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReasoningEngines(RequestBuilder<crate::model::ListReasoningEnginesRequest>);
 
@@ -37812,6 +45735,22 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::update_reasoning_engine][super::super::client::ReasoningEngineService::update_reasoning_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::UpdateReasoningEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateReasoningEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateReasoningEngine(RequestBuilder<crate::model::UpdateReasoningEngineRequest>);
 
@@ -37917,6 +45856,22 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::delete_reasoning_engine][super::super::client::ReasoningEngineService::delete_reasoning_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::DeleteReasoningEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteReasoningEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteReasoningEngine(RequestBuilder<crate::model::DeleteReasoningEngineRequest>);
 
@@ -38014,6 +45969,25 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::list_locations][super::super::client::ReasoningEngineService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -38104,6 +46078,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::get_location][super::super::client::ReasoningEngineService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -38149,6 +46138,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::set_iam_policy][super::super::client::ReasoningEngineService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -38216,6 +46220,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::get_iam_policy][super::super::client::ReasoningEngineService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -38272,6 +46291,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::test_iam_permissions][super::super::client::ReasoningEngineService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -38335,6 +46369,25 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::list_operations][super::super::client::ReasoningEngineService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -38427,6 +46480,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::get_operation][super::super::client::ReasoningEngineService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -38475,6 +46543,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::delete_operation][super::super::client::ReasoningEngineService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -38523,6 +46606,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::cancel_operation][super::super::client::ReasoningEngineService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -38571,6 +46669,21 @@ pub mod reasoning_engine_service {
     }
 
     /// The request builder for [ReasoningEngineService::wait_operation][super::super::client::ReasoningEngineService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::reasoning_engine_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -38682,6 +46795,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::create_schedule][super::super::client::ScheduleService::create_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::CreateSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSchedule(RequestBuilder<crate::model::CreateScheduleRequest>);
 
@@ -38740,6 +46868,22 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::delete_schedule][super::super::client::ScheduleService::delete_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::DeleteSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSchedule(RequestBuilder<crate::model::DeleteScheduleRequest>);
 
@@ -38828,6 +46972,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::get_schedule][super::super::client::ScheduleService::get_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::GetSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSchedule(RequestBuilder<crate::model::GetScheduleRequest>);
 
@@ -38875,6 +47034,25 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::list_schedules][super::super::client::ScheduleService::list_schedules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::ListSchedules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSchedules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSchedules(RequestBuilder<crate::model::ListSchedulesRequest>);
 
@@ -38970,6 +47148,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::pause_schedule][super::super::client::ScheduleService::pause_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::PauseSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseSchedule(RequestBuilder<crate::model::PauseScheduleRequest>);
 
@@ -39017,6 +47210,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::resume_schedule][super::super::client::ScheduleService::resume_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::ResumeSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeSchedule(RequestBuilder<crate::model::ResumeScheduleRequest>);
 
@@ -39070,6 +47278,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::update_schedule][super::super::client::ScheduleService::update_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::UpdateSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSchedule(RequestBuilder<crate::model::UpdateScheduleRequest>);
 
@@ -39131,6 +47354,25 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::list_locations][super::super::client::ScheduleService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -39221,6 +47463,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::get_location][super::super::client::ScheduleService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -39266,6 +47523,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::set_iam_policy][super::super::client::ScheduleService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -39333,6 +47605,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::get_iam_policy][super::super::client::ScheduleService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -39389,6 +47676,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::test_iam_permissions][super::super::client::ScheduleService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -39452,6 +47754,25 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::list_operations][super::super::client::ScheduleService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -39544,6 +47865,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::get_operation][super::super::client::ScheduleService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -39592,6 +47928,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::delete_operation][super::super::client::ScheduleService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -39640,6 +47991,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::cancel_operation][super::super::client::ScheduleService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -39688,6 +48054,21 @@ pub mod schedule_service {
     }
 
     /// The request builder for [ScheduleService::wait_operation][super::super::client::ScheduleService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::schedule_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -39799,6 +48180,22 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::create_specialist_pool][super::super::client::SpecialistPoolService::create_specialist_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::CreateSpecialistPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSpecialistPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSpecialistPool(RequestBuilder<crate::model::CreateSpecialistPoolRequest>);
 
@@ -39903,6 +48300,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::get_specialist_pool][super::super::client::SpecialistPoolService::get_specialist_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::GetSpecialistPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSpecialistPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSpecialistPool(RequestBuilder<crate::model::GetSpecialistPoolRequest>);
 
@@ -39953,6 +48365,25 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::list_specialist_pools][super::super::client::SpecialistPoolService::list_specialist_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::ListSpecialistPools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSpecialistPools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSpecialistPools(RequestBuilder<crate::model::ListSpecialistPoolsRequest>);
 
@@ -40047,6 +48478,22 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::delete_specialist_pool][super::super::client::SpecialistPoolService::delete_specialist_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::DeleteSpecialistPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSpecialistPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSpecialistPool(RequestBuilder<crate::model::DeleteSpecialistPoolRequest>);
 
@@ -40144,6 +48591,22 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::update_specialist_pool][super::super::client::SpecialistPoolService::update_specialist_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::UpdateSpecialistPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSpecialistPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSpecialistPool(RequestBuilder<crate::model::UpdateSpecialistPoolRequest>);
 
@@ -40251,6 +48714,25 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::list_locations][super::super::client::SpecialistPoolService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -40341,6 +48823,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::get_location][super::super::client::SpecialistPoolService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -40386,6 +48883,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::set_iam_policy][super::super::client::SpecialistPoolService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -40453,6 +48965,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::get_iam_policy][super::super::client::SpecialistPoolService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -40509,6 +49036,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::test_iam_permissions][super::super::client::SpecialistPoolService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -40572,6 +49114,25 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::list_operations][super::super::client::SpecialistPoolService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -40664,6 +49225,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::get_operation][super::super::client::SpecialistPoolService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -40712,6 +49288,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::delete_operation][super::super::client::SpecialistPoolService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -40760,6 +49351,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::cancel_operation][super::super::client::SpecialistPoolService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -40808,6 +49414,21 @@ pub mod specialist_pool_service {
     }
 
     /// The request builder for [SpecialistPoolService::wait_operation][super::super::client::SpecialistPoolService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::specialist_pool_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -40919,6 +49540,22 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::create_tensorboard][super::super::client::TensorboardService::create_tensorboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::CreateTensorboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTensorboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTensorboard(RequestBuilder<crate::model::CreateTensorboardRequest>);
 
@@ -41021,6 +49658,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::get_tensorboard][super::super::client::TensorboardService::get_tensorboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::GetTensorboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTensorboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTensorboard(RequestBuilder<crate::model::GetTensorboardRequest>);
 
@@ -41068,6 +49720,22 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::update_tensorboard][super::super::client::TensorboardService::update_tensorboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::UpdateTensorboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTensorboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboard(RequestBuilder<crate::model::UpdateTensorboardRequest>);
 
@@ -41173,6 +49841,25 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::list_tensorboards][super::super::client::TensorboardService::list_tensorboards] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ListTensorboards;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTensorboards {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTensorboards(RequestBuilder<crate::model::ListTensorboardsRequest>);
 
@@ -41277,6 +49964,22 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::delete_tensorboard][super::super::client::TensorboardService::delete_tensorboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::DeleteTensorboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTensorboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboard(RequestBuilder<crate::model::DeleteTensorboardRequest>);
 
@@ -41368,6 +50071,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::read_tensorboard_usage][super::super::client::TensorboardService::read_tensorboard_usage] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ReadTensorboardUsage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReadTensorboardUsage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReadTensorboardUsage(RequestBuilder<crate::model::ReadTensorboardUsageRequest>);
 
@@ -41418,6 +50136,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::read_tensorboard_size][super::super::client::TensorboardService::read_tensorboard_size] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ReadTensorboardSize;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReadTensorboardSize {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReadTensorboardSize(RequestBuilder<crate::model::ReadTensorboardSizeRequest>);
 
@@ -41468,6 +50201,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::create_tensorboard_experiment][super::super::client::TensorboardService::create_tensorboard_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::CreateTensorboardExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTensorboardExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTensorboardExperiment(
         RequestBuilder<crate::model::CreateTensorboardExperimentRequest>,
@@ -41539,6 +50287,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::get_tensorboard_experiment][super::super::client::TensorboardService::get_tensorboard_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::GetTensorboardExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTensorboardExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTensorboardExperiment(
         RequestBuilder<crate::model::GetTensorboardExperimentRequest>,
@@ -41591,6 +50354,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::update_tensorboard_experiment][super::super::client::TensorboardService::update_tensorboard_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::UpdateTensorboardExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTensorboardExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboardExperiment(
         RequestBuilder<crate::model::UpdateTensorboardExperimentRequest>,
@@ -41659,6 +50437,25 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::list_tensorboard_experiments][super::super::client::TensorboardService::list_tensorboard_experiments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ListTensorboardExperiments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTensorboardExperiments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTensorboardExperiments(
         RequestBuilder<crate::model::ListTensorboardExperimentsRequest>,
@@ -41769,6 +50566,22 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::delete_tensorboard_experiment][super::super::client::TensorboardService::delete_tensorboard_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::DeleteTensorboardExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTensorboardExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboardExperiment(
         RequestBuilder<crate::model::DeleteTensorboardExperimentRequest>,
@@ -41862,6 +50675,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::create_tensorboard_run][super::super::client::TensorboardService::create_tensorboard_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::CreateTensorboardRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTensorboardRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTensorboardRun(RequestBuilder<crate::model::CreateTensorboardRunRequest>);
 
@@ -41931,6 +50759,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::batch_create_tensorboard_runs][super::super::client::TensorboardService::batch_create_tensorboard_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::BatchCreateTensorboardRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateTensorboardRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateTensorboardRuns(
         RequestBuilder<crate::model::BatchCreateTensorboardRunsRequest>,
@@ -41996,6 +50839,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::get_tensorboard_run][super::super::client::TensorboardService::get_tensorboard_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::GetTensorboardRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTensorboardRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTensorboardRun(RequestBuilder<crate::model::GetTensorboardRunRequest>);
 
@@ -42046,6 +50904,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::update_tensorboard_run][super::super::client::TensorboardService::update_tensorboard_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::UpdateTensorboardRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTensorboardRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboardRun(RequestBuilder<crate::model::UpdateTensorboardRunRequest>);
 
@@ -42110,6 +50983,25 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::list_tensorboard_runs][super::super::client::TensorboardService::list_tensorboard_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ListTensorboardRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTensorboardRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTensorboardRuns(RequestBuilder<crate::model::ListTensorboardRunsRequest>);
 
@@ -42216,6 +51108,22 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::delete_tensorboard_run][super::super::client::TensorboardService::delete_tensorboard_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::DeleteTensorboardRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTensorboardRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboardRun(RequestBuilder<crate::model::DeleteTensorboardRunRequest>);
 
@@ -42307,6 +51215,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::batch_create_tensorboard_time_series][super::super::client::TensorboardService::batch_create_tensorboard_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::BatchCreateTensorboardTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateTensorboardTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateTensorboardTimeSeries(
         RequestBuilder<crate::model::BatchCreateTensorboardTimeSeriesRequest>,
@@ -42372,6 +51295,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::create_tensorboard_time_series][super::super::client::TensorboardService::create_tensorboard_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::CreateTensorboardTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTensorboardTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTensorboardTimeSeries(
         RequestBuilder<crate::model::CreateTensorboardTimeSeriesRequest>,
@@ -42446,6 +51384,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::get_tensorboard_time_series][super::super::client::TensorboardService::get_tensorboard_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::GetTensorboardTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTensorboardTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTensorboardTimeSeries(
         RequestBuilder<crate::model::GetTensorboardTimeSeriesRequest>,
@@ -42498,6 +51451,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::update_tensorboard_time_series][super::super::client::TensorboardService::update_tensorboard_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::UpdateTensorboardTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTensorboardTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTensorboardTimeSeries(
         RequestBuilder<crate::model::UpdateTensorboardTimeSeriesRequest>,
@@ -42566,6 +51534,25 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::list_tensorboard_time_series][super::super::client::TensorboardService::list_tensorboard_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ListTensorboardTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTensorboardTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTensorboardTimeSeries(
         RequestBuilder<crate::model::ListTensorboardTimeSeriesRequest>,
@@ -42676,6 +51663,22 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::delete_tensorboard_time_series][super::super::client::TensorboardService::delete_tensorboard_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::DeleteTensorboardTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTensorboardTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTensorboardTimeSeries(
         RequestBuilder<crate::model::DeleteTensorboardTimeSeriesRequest>,
@@ -42769,6 +51772,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::batch_read_tensorboard_time_series_data][super::super::client::TensorboardService::batch_read_tensorboard_time_series_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::BatchReadTensorboardTimeSeriesData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchReadTensorboardTimeSeriesData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchReadTensorboardTimeSeriesData(
         RequestBuilder<crate::model::BatchReadTensorboardTimeSeriesDataRequest>,
@@ -42836,6 +51854,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::read_tensorboard_time_series_data][super::super::client::TensorboardService::read_tensorboard_time_series_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ReadTensorboardTimeSeriesData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReadTensorboardTimeSeriesData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReadTensorboardTimeSeriesData(
         RequestBuilder<crate::model::ReadTensorboardTimeSeriesDataRequest>,
@@ -42900,6 +51933,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::write_tensorboard_experiment_data][super::super::client::TensorboardService::write_tensorboard_experiment_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::WriteTensorboardExperimentData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WriteTensorboardExperimentData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WriteTensorboardExperimentData(
         RequestBuilder<crate::model::WriteTensorboardExperimentDataRequest>,
@@ -42965,6 +52013,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::write_tensorboard_run_data][super::super::client::TensorboardService::write_tensorboard_run_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::WriteTensorboardRunData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WriteTensorboardRunData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WriteTensorboardRunData(
         RequestBuilder<crate::model::WriteTensorboardRunDataRequest>,
@@ -43030,6 +52093,25 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::export_tensorboard_time_series_data][super::super::client::TensorboardService::export_tensorboard_time_series_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ExportTensorboardTimeSeriesData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportTensorboardTimeSeriesData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportTensorboardTimeSeriesData(
         RequestBuilder<crate::model::ExportTensorboardTimeSeriesDataRequest>,
@@ -43134,6 +52216,25 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::list_locations][super::super::client::TensorboardService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -43224,6 +52325,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::get_location][super::super::client::TensorboardService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -43269,6 +52385,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::set_iam_policy][super::super::client::TensorboardService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -43336,6 +52467,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::get_iam_policy][super::super::client::TensorboardService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -43392,6 +52538,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::test_iam_permissions][super::super::client::TensorboardService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -43455,6 +52616,25 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::list_operations][super::super::client::TensorboardService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -43547,6 +52727,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::get_operation][super::super::client::TensorboardService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -43595,6 +52790,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::delete_operation][super::super::client::TensorboardService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -43643,6 +52853,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::cancel_operation][super::super::client::TensorboardService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -43691,6 +52916,21 @@ pub mod tensorboard_service {
     }
 
     /// The request builder for [TensorboardService::wait_operation][super::super::client::TensorboardService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::tensorboard_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -43802,6 +53042,22 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::create_rag_corpus][super::super::client::VertexRagDataService::create_rag_corpus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::CreateRagCorpus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRagCorpus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRagCorpus(RequestBuilder<crate::model::CreateRagCorpusRequest>);
 
@@ -43901,6 +53157,22 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::update_rag_corpus][super::super::client::VertexRagDataService::update_rag_corpus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::UpdateRagCorpus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRagCorpus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRagCorpus(RequestBuilder<crate::model::UpdateRagCorpusRequest>);
 
@@ -43992,6 +53264,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::get_rag_corpus][super::super::client::VertexRagDataService::get_rag_corpus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::GetRagCorpus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRagCorpus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRagCorpus(RequestBuilder<crate::model::GetRagCorpusRequest>);
 
@@ -44039,6 +53326,25 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::list_rag_corpora][super::super::client::VertexRagDataService::list_rag_corpora] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::ListRagCorpora;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRagCorpora {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRagCorpora(RequestBuilder<crate::model::ListRagCorporaRequest>);
 
@@ -44122,6 +53428,22 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::delete_rag_corpus][super::super::client::VertexRagDataService::delete_rag_corpus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::DeleteRagCorpus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRagCorpus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRagCorpus(RequestBuilder<crate::model::DeleteRagCorpusRequest>);
 
@@ -44216,6 +53538,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::upload_rag_file][super::super::client::VertexRagDataService::upload_rag_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::UploadRagFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UploadRagFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UploadRagFile(RequestBuilder<crate::model::UploadRagFileRequest>);
 
@@ -44287,6 +53624,22 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::import_rag_files][super::super::client::VertexRagDataService::import_rag_files] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::ImportRagFiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportRagFiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportRagFiles(RequestBuilder<crate::model::ImportRagFilesRequest>);
 
@@ -44390,6 +53743,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::get_rag_file][super::super::client::VertexRagDataService::get_rag_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::GetRagFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRagFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRagFile(RequestBuilder<crate::model::GetRagFileRequest>);
 
@@ -44437,6 +53805,25 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::list_rag_files][super::super::client::VertexRagDataService::list_rag_files] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::ListRagFiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRagFiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRagFiles(RequestBuilder<crate::model::ListRagFilesRequest>);
 
@@ -44520,6 +53907,22 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::delete_rag_file][super::super::client::VertexRagDataService::delete_rag_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::DeleteRagFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRagFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRagFile(RequestBuilder<crate::model::DeleteRagFileRequest>);
 
@@ -44608,6 +54011,25 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::list_locations][super::super::client::VertexRagDataService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -44698,6 +54120,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::get_location][super::super::client::VertexRagDataService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -44743,6 +54180,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::set_iam_policy][super::super::client::VertexRagDataService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -44810,6 +54262,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::get_iam_policy][super::super::client::VertexRagDataService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -44866,6 +54333,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::test_iam_permissions][super::super::client::VertexRagDataService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -44929,6 +54411,25 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::list_operations][super::super::client::VertexRagDataService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -45021,6 +54522,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::get_operation][super::super::client::VertexRagDataService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -45069,6 +54585,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::delete_operation][super::super::client::VertexRagDataService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -45117,6 +54648,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::cancel_operation][super::super::client::VertexRagDataService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -45165,6 +54711,21 @@ pub mod vertex_rag_data_service {
     }
 
     /// The request builder for [VertexRagDataService::wait_operation][super::super::client::VertexRagDataService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_data_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -45276,6 +54837,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::retrieve_contexts][super::super::client::VertexRagService::retrieve_contexts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::RetrieveContexts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetrieveContexts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetrieveContexts(RequestBuilder<crate::model::RetrieveContextsRequest>);
 
@@ -45368,6 +54944,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::augment_prompt][super::super::client::VertexRagService::augment_prompt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::AugmentPrompt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AugmentPrompt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AugmentPrompt(RequestBuilder<crate::model::AugmentPromptRequest>);
 
@@ -45466,6 +55057,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::corroborate_content][super::super::client::VertexRagService::corroborate_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::CorroborateContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CorroborateContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CorroborateContent(RequestBuilder<crate::model::CorroborateContentRequest>);
 
@@ -45547,6 +55153,25 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::list_locations][super::super::client::VertexRagService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -45637,6 +55262,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::get_location][super::super::client::VertexRagService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -45682,6 +55322,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::set_iam_policy][super::super::client::VertexRagService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -45749,6 +55404,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::get_iam_policy][super::super::client::VertexRagService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -45805,6 +55475,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::test_iam_permissions][super::super::client::VertexRagService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -45868,6 +55553,25 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::list_operations][super::super::client::VertexRagService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -45960,6 +55664,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::get_operation][super::super::client::VertexRagService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -46008,6 +55727,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::delete_operation][super::super::client::VertexRagService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -46056,6 +55790,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::cancel_operation][super::super::client::VertexRagService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -46104,6 +55853,21 @@ pub mod vertex_rag_service {
     }
 
     /// The request builder for [VertexRagService::wait_operation][super::super::client::VertexRagService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vertex_rag_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -46215,6 +55979,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::create_study][super::super::client::VizierService::create_study] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::CreateStudy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateStudy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateStudy(RequestBuilder<crate::model::CreateStudyRequest>);
 
@@ -46273,6 +56052,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::get_study][super::super::client::VizierService::get_study] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::GetStudy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStudy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStudy(RequestBuilder<crate::model::GetStudyRequest>);
 
@@ -46320,6 +56114,25 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::list_studies][super::super::client::VizierService::list_studies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::ListStudies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListStudies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListStudies(RequestBuilder<crate::model::ListStudiesRequest>);
 
@@ -46403,6 +56216,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::delete_study][super::super::client::VizierService::delete_study] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::DeleteStudy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteStudy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteStudy(RequestBuilder<crate::model::DeleteStudyRequest>);
 
@@ -46450,6 +56278,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::lookup_study][super::super::client::VizierService::lookup_study] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::LookupStudy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupStudy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupStudy(RequestBuilder<crate::model::LookupStudyRequest>);
 
@@ -46505,6 +56348,22 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::suggest_trials][super::super::client::VizierService::suggest_trials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::SuggestTrials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SuggestTrials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SuggestTrials(RequestBuilder<crate::model::SuggestTrialsRequest>);
 
@@ -46620,6 +56479,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::create_trial][super::super::client::VizierService::create_trial] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::CreateTrial;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTrial {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTrial(RequestBuilder<crate::model::CreateTrialRequest>);
 
@@ -46678,6 +56552,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::get_trial][super::super::client::VizierService::get_trial] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::GetTrial;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTrial {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTrial(RequestBuilder<crate::model::GetTrialRequest>);
 
@@ -46725,6 +56614,25 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::list_trials][super::super::client::VizierService::list_trials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::ListTrials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTrials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTrials(RequestBuilder<crate::model::ListTrialsRequest>);
 
@@ -46808,6 +56716,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::add_trial_measurement][super::super::client::VizierService::add_trial_measurement] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::AddTrialMeasurement;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddTrialMeasurement {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddTrialMeasurement(RequestBuilder<crate::model::AddTrialMeasurementRequest>);
 
@@ -46869,6 +56792,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::complete_trial][super::super::client::VizierService::complete_trial] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::CompleteTrial;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompleteTrial {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompleteTrial(RequestBuilder<crate::model::CompleteTrialRequest>);
 
@@ -46937,6 +56875,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::delete_trial][super::super::client::VizierService::delete_trial] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::DeleteTrial;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTrial {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTrial(RequestBuilder<crate::model::DeleteTrialRequest>);
 
@@ -46984,6 +56937,22 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::check_trial_early_stopping_state][super::super::client::VizierService::check_trial_early_stopping_state] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::CheckTrialEarlyStoppingState;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_aiplatform_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckTrialEarlyStoppingState {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckTrialEarlyStoppingState(
         RequestBuilder<crate::model::CheckTrialEarlyStoppingStateRequest>,
@@ -47079,6 +57048,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::stop_trial][super::super::client::VizierService::stop_trial] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::StopTrial;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopTrial {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopTrial(RequestBuilder<crate::model::StopTrialRequest>);
 
@@ -47126,6 +57110,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::list_optimal_trials][super::super::client::VizierService::list_optimal_trials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::ListOptimalTrials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOptimalTrials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOptimalTrials(RequestBuilder<crate::model::ListOptimalTrialsRequest>);
 
@@ -47176,6 +57175,25 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::list_locations][super::super::client::VizierService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -47266,6 +57284,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::get_location][super::super::client::VizierService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -47311,6 +57344,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::set_iam_policy][super::super::client::VizierService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -47378,6 +57426,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::get_iam_policy][super::super::client::VizierService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -47434,6 +57497,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::test_iam_permissions][super::super::client::VizierService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -47497,6 +57575,25 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::list_operations][super::super::client::VizierService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -47589,6 +57686,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::get_operation][super::super::client::VizierService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -47637,6 +57749,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::delete_operation][super::super::client::VizierService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -47685,6 +57812,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::cancel_operation][super::super::client::VizierService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -47733,6 +57875,21 @@ pub mod vizier_service {
     }
 
     /// The request builder for [VizierService::wait_operation][super::super::client::VizierService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_aiplatform_v1::builder;
+    /// use builder::vizier_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 

--- a/src/generated/cloud/alloydb/v1/src/builder.rs
+++ b/src/generated/cloud/alloydb/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_clusters][super::super::client::AlloyDBAdmin::list_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -164,6 +183,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::get_cluster][super::super::client::AlloyDBAdmin::get_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GetCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -217,6 +251,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::create_cluster][super::super::client::AlloyDBAdmin::create_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::CreateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -333,6 +383,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::update_cluster][super::super::client::AlloyDBAdmin::update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::UpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -448,6 +514,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::delete_cluster][super::super::client::AlloyDBAdmin::delete_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::DeleteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -559,6 +641,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::promote_cluster][super::super::client::AlloyDBAdmin::promote_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::PromoteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PromoteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PromoteCluster(RequestBuilder<crate::model::PromoteClusterRequest>);
 
@@ -662,6 +760,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::switchover_cluster][super::super::client::AlloyDBAdmin::switchover_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::SwitchoverCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SwitchoverCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SwitchoverCluster(RequestBuilder<crate::model::SwitchoverClusterRequest>);
 
@@ -762,6 +876,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::restore_cluster][super::super::client::AlloyDBAdmin::restore_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::RestoreCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreCluster(RequestBuilder<crate::model::RestoreClusterRequest>);
 
@@ -920,6 +1050,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::create_secondary_cluster][super::super::client::AlloyDBAdmin::create_secondary_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::CreateSecondaryCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSecondaryCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSecondaryCluster(RequestBuilder<crate::model::CreateSecondaryClusterRequest>);
 
@@ -1039,6 +1185,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_instances][super::super::client::AlloyDBAdmin::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -1134,6 +1299,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::get_instance][super::super::client::AlloyDBAdmin::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -1187,6 +1367,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::create_instance][super::super::client::AlloyDBAdmin::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -1303,6 +1499,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::create_secondary_instance][super::super::client::AlloyDBAdmin::create_secondary_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::CreateSecondaryInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSecondaryInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSecondaryInstance(
         RequestBuilder<crate::model::CreateSecondaryInstanceRequest>,
@@ -1424,6 +1636,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::batch_create_instances][super::super::client::AlloyDBAdmin::batch_create_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::BatchCreateInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateInstances(RequestBuilder<crate::model::BatchCreateInstancesRequest>);
 
@@ -1532,6 +1760,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::update_instance][super::super::client::AlloyDBAdmin::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -1647,6 +1891,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::delete_instance][super::super::client::AlloyDBAdmin::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -1752,6 +2012,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::failover_instance][super::super::client::AlloyDBAdmin::failover_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::FailoverInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FailoverInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FailoverInstance(RequestBuilder<crate::model::FailoverInstanceRequest>);
 
@@ -1852,6 +2128,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::inject_fault][super::super::client::AlloyDBAdmin::inject_fault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::InjectFault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InjectFault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InjectFault(RequestBuilder<crate::model::InjectFaultRequest>);
 
@@ -1960,6 +2252,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::restart_instance][super::super::client::AlloyDBAdmin::restart_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::RestartInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestartInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestartInstance(RequestBuilder<crate::model::RestartInstanceRequest>);
 
@@ -2068,6 +2376,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::execute_sql][super::super::client::AlloyDBAdmin::execute_sql] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ExecuteSql;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExecuteSql {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExecuteSql(RequestBuilder<crate::model::ExecuteSqlRequest>);
 
@@ -2163,6 +2486,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_backups][super::super::client::AlloyDBAdmin::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -2258,6 +2600,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::get_backup][super::super::client::AlloyDBAdmin::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -2305,6 +2662,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::create_backup][super::super::client::AlloyDBAdmin::create_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::CreateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -2421,6 +2794,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::update_backup][super::super::client::AlloyDBAdmin::update_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::UpdateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -2536,6 +2925,22 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::delete_backup][super::super::client::AlloyDBAdmin::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_alloydb_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -2641,6 +3046,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_supported_database_flags][super::super::client::AlloyDBAdmin::list_supported_database_flags] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListSupportedDatabaseFlags;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSupportedDatabaseFlags {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSupportedDatabaseFlags(
         RequestBuilder<crate::model::ListSupportedDatabaseFlagsRequest>,
@@ -2733,6 +3157,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::generate_client_certificate][super::super::client::AlloyDBAdmin::generate_client_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GenerateClientCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateClientCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateClientCertificate(
         RequestBuilder<crate::model::GenerateClientCertificateRequest>,
@@ -2812,6 +3251,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::get_connection_info][super::super::client::AlloyDBAdmin::get_connection_info] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GetConnectionInfo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnectionInfo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnectionInfo(RequestBuilder<crate::model::GetConnectionInfoRequest>);
 
@@ -2868,6 +3322,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_users][super::super::client::AlloyDBAdmin::list_users] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListUsers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUsers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUsers(RequestBuilder<crate::model::ListUsersRequest>);
 
@@ -2963,6 +3436,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::get_user][super::super::client::AlloyDBAdmin::get_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GetUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetUser(RequestBuilder<crate::model::GetUserRequest>);
 
@@ -3010,6 +3498,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::create_user][super::super::client::AlloyDBAdmin::create_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::CreateUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateUser(RequestBuilder<crate::model::CreateUserRequest>);
 
@@ -3085,6 +3588,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::update_user][super::super::client::AlloyDBAdmin::update_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::UpdateUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateUser(RequestBuilder<crate::model::UpdateUserRequest>);
 
@@ -3159,6 +3677,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::delete_user][super::super::client::AlloyDBAdmin::delete_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::DeleteUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteUser(RequestBuilder<crate::model::DeleteUserRequest>);
 
@@ -3218,6 +3751,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_databases][super::super::client::AlloyDBAdmin::list_databases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListDatabases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatabases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatabases(RequestBuilder<crate::model::ListDatabasesRequest>);
 
@@ -3307,6 +3859,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_locations][super::super::client::AlloyDBAdmin::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3397,6 +3968,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::get_location][super::super::client::AlloyDBAdmin::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3442,6 +4028,25 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::list_operations][super::super::client::AlloyDBAdmin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3534,6 +4139,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::get_operation][super::super::client::AlloyDBAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3582,6 +4202,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::delete_operation][super::super::client::AlloyDBAdmin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3630,6 +4265,21 @@ pub mod alloy_db_admin {
     }
 
     /// The request builder for [AlloyDBAdmin::cancel_operation][super::super::client::AlloyDBAdmin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_alloydb_v1::builder;
+    /// use builder::alloy_db_admin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/apigateway/v1/src/builder.rs
+++ b/src/generated/cloud/apigateway/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::list_gateways][super::super::client::ApiGatewayService::list_gateways] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::ListGateways;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGateways {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGateways(RequestBuilder<crate::model::ListGatewaysRequest>);
 
@@ -164,6 +183,21 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::get_gateway][super::super::client::ApiGatewayService::get_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::GetGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGateway(RequestBuilder<crate::model::GetGatewayRequest>);
 
@@ -211,6 +245,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::create_gateway][super::super::client::ApiGatewayService::create_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::CreateGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGateway(RequestBuilder<crate::model::CreateGatewayRequest>);
 
@@ -315,6 +365,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::update_gateway][super::super::client::ApiGatewayService::update_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::UpdateGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGateway(RequestBuilder<crate::model::UpdateGatewayRequest>);
 
@@ -412,6 +478,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::delete_gateway][super::super::client::ApiGatewayService::delete_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::DeleteGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGateway(RequestBuilder<crate::model::DeleteGatewayRequest>);
 
@@ -499,6 +581,25 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::list_apis][super::super::client::ApiGatewayService::list_apis] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::ListApis;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListApis {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListApis(RequestBuilder<crate::model::ListApisRequest>);
 
@@ -594,6 +695,21 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::get_api][super::super::client::ApiGatewayService::get_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::GetApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApi(RequestBuilder<crate::model::GetApiRequest>);
 
@@ -641,6 +757,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::create_api][super::super::client::ApiGatewayService::create_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::CreateApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateApi(RequestBuilder<crate::model::CreateApiRequest>);
 
@@ -742,6 +874,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::update_api][super::super::client::ApiGatewayService::update_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::UpdateApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateApi(RequestBuilder<crate::model::UpdateApiRequest>);
 
@@ -836,6 +984,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::delete_api][super::super::client::ApiGatewayService::delete_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::DeleteApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteApi(RequestBuilder<crate::model::DeleteApiRequest>);
 
@@ -923,6 +1087,25 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::list_api_configs][super::super::client::ApiGatewayService::list_api_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::ListApiConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListApiConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListApiConfigs(RequestBuilder<crate::model::ListApiConfigsRequest>);
 
@@ -1018,6 +1201,21 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::get_api_config][super::super::client::ApiGatewayService::get_api_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::GetApiConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApiConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApiConfig(RequestBuilder<crate::model::GetApiConfigRequest>);
 
@@ -1074,6 +1272,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::create_api_config][super::super::client::ApiGatewayService::create_api_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::CreateApiConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateApiConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateApiConfig(RequestBuilder<crate::model::CreateApiConfigRequest>);
 
@@ -1178,6 +1392,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::update_api_config][super::super::client::ApiGatewayService::update_api_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::UpdateApiConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateApiConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateApiConfig(RequestBuilder<crate::model::UpdateApiConfigRequest>);
 
@@ -1275,6 +1505,22 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::delete_api_config][super::super::client::ApiGatewayService::delete_api_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::DeleteApiConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apigateway_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteApiConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteApiConfig(RequestBuilder<crate::model::DeleteApiConfigRequest>);
 
@@ -1362,6 +1608,25 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::list_operations][super::super::client::ApiGatewayService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1454,6 +1719,21 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::get_operation][super::super::client::ApiGatewayService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1502,6 +1782,21 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::delete_operation][super::super::client::ApiGatewayService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1550,6 +1845,21 @@ pub mod api_gateway_service {
     }
 
     /// The request builder for [ApiGatewayService::cancel_operation][super::super::client::ApiGatewayService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigateway_v1::builder;
+    /// use builder::api_gateway_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/apigeeconnect/v1/src/builder.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::list_connections][super::super::client::ConnectionService::list_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apigeeconnect_v1::builder;
+    /// use builder::connection_service::ListConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 

--- a/src/generated/cloud/apihub/v1/src/builder.rs
+++ b/src/generated/cloud/apihub/v1/src/builder.rs
@@ -67,6 +67,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::create_api][super::super::client::ApiHub::create_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::CreateApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateApi(RequestBuilder<crate::model::CreateApiRequest>);
 
@@ -126,6 +141,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_api][super::super::client::ApiHub::get_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApi(RequestBuilder<crate::model::GetApiRequest>);
 
@@ -171,6 +201,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_apis][super::super::client::ApiHub::list_apis] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListApis;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListApis {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListApis(RequestBuilder<crate::model::ListApisRequest>);
 
@@ -258,6 +307,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::update_api][super::super::client::ApiHub::update_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::UpdateApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateApi(RequestBuilder<crate::model::UpdateApiRequest>);
 
@@ -314,6 +378,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::delete_api][super::super::client::ApiHub::delete_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::DeleteApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteApi(RequestBuilder<crate::model::DeleteApiRequest>);
 
@@ -365,6 +444,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::create_version][super::super::client::ApiHub::create_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::CreateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -427,6 +521,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_version][super::super::client::ApiHub::get_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -472,6 +581,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_versions][super::super::client::ApiHub::list_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -559,6 +687,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::update_version][super::super::client::ApiHub::update_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::UpdateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -618,6 +761,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::delete_version][super::super::client::ApiHub::delete_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::DeleteVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -669,6 +827,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::create_spec][super::super::client::ApiHub::create_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::CreateSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSpec(RequestBuilder<crate::model::CreateSpecRequest>);
 
@@ -728,6 +901,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_spec][super::super::client::ApiHub::get_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSpec(RequestBuilder<crate::model::GetSpecRequest>);
 
@@ -773,6 +961,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_spec_contents][super::super::client::ApiHub::get_spec_contents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetSpecContents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSpecContents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSpecContents(RequestBuilder<crate::model::GetSpecContentsRequest>);
 
@@ -818,6 +1021,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_specs][super::super::client::ApiHub::list_specs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListSpecs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSpecs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSpecs(RequestBuilder<crate::model::ListSpecsRequest>);
 
@@ -905,6 +1127,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::update_spec][super::super::client::ApiHub::update_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::UpdateSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSpec(RequestBuilder<crate::model::UpdateSpecRequest>);
 
@@ -961,6 +1198,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::delete_spec][super::super::client::ApiHub::delete_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::DeleteSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSpec(RequestBuilder<crate::model::DeleteSpecRequest>);
 
@@ -1006,6 +1258,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_api_operation][super::super::client::ApiHub::get_api_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetApiOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApiOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApiOperation(RequestBuilder<crate::model::GetApiOperationRequest>);
 
@@ -1051,6 +1318,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_api_operations][super::super::client::ApiHub::list_api_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListApiOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListApiOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListApiOperations(RequestBuilder<crate::model::ListApiOperationsRequest>);
 
@@ -1141,6 +1427,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_definition][super::super::client::ApiHub::get_definition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetDefinition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDefinition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDefinition(RequestBuilder<crate::model::GetDefinitionRequest>);
 
@@ -1186,6 +1487,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::create_deployment][super::super::client::ApiHub::create_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::CreateDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -1251,6 +1567,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_deployment][super::super::client::ApiHub::get_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -1296,6 +1627,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_deployments][super::super::client::ApiHub::list_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -1383,6 +1733,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::update_deployment][super::super::client::ApiHub::update_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::UpdateDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDeployment(RequestBuilder<crate::model::UpdateDeploymentRequest>);
 
@@ -1445,6 +1810,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::delete_deployment][super::super::client::ApiHub::delete_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::DeleteDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDeployment(RequestBuilder<crate::model::DeleteDeploymentRequest>);
 
@@ -1493,6 +1873,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::create_attribute][super::super::client::ApiHub::create_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::CreateAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAttribute(RequestBuilder<crate::model::CreateAttributeRequest>);
 
@@ -1555,6 +1950,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_attribute][super::super::client::ApiHub::get_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAttribute(RequestBuilder<crate::model::GetAttributeRequest>);
 
@@ -1600,6 +2010,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::update_attribute][super::super::client::ApiHub::update_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::UpdateAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAttribute(RequestBuilder<crate::model::UpdateAttributeRequest>);
 
@@ -1659,6 +2084,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::delete_attribute][super::super::client::ApiHub::delete_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::DeleteAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAttribute(RequestBuilder<crate::model::DeleteAttributeRequest>);
 
@@ -1704,6 +2144,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_attributes][super::super::client::ApiHub::list_attributes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListAttributes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAttributes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAttributes(RequestBuilder<crate::model::ListAttributesRequest>);
 
@@ -1791,6 +2250,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::search_resources][super::super::client::ApiHub::search_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::SearchResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchResources(RequestBuilder<crate::model::SearchResourcesRequest>);
 
@@ -1886,6 +2364,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::create_external_api][super::super::client::ApiHub::create_external_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::CreateExternalApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExternalApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExternalApi(RequestBuilder<crate::model::CreateExternalApiRequest>);
 
@@ -1951,6 +2444,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_external_api][super::super::client::ApiHub::get_external_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetExternalApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExternalApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExternalApi(RequestBuilder<crate::model::GetExternalApiRequest>);
 
@@ -1996,6 +2504,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::update_external_api][super::super::client::ApiHub::update_external_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::UpdateExternalApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExternalApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExternalApi(RequestBuilder<crate::model::UpdateExternalApiRequest>);
 
@@ -2058,6 +2581,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::delete_external_api][super::super::client::ApiHub::delete_external_api] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::DeleteExternalApi;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteExternalApi {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteExternalApi(RequestBuilder<crate::model::DeleteExternalApiRequest>);
 
@@ -2106,6 +2644,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_external_apis][super::super::client::ApiHub::list_external_apis] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListExternalApis;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExternalApis {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExternalApis(RequestBuilder<crate::model::ListExternalApisRequest>);
 
@@ -2190,6 +2747,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_locations][super::super::client::ApiHub::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2278,6 +2854,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_location][super::super::client::ApiHub::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2321,6 +2912,25 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::list_operations][super::super::client::ApiHub::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2411,6 +3021,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::get_operation][super::super::client::ApiHub::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2457,6 +3082,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::delete_operation][super::super::client::ApiHub::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2503,6 +3143,21 @@ pub mod api_hub {
     }
 
     /// The request builder for [ApiHub::cancel_operation][super::super::client::ApiHub::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2604,6 +3259,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::create_dependency][super::super::client::ApiHubDependencies::create_dependency] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::CreateDependency;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDependency {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDependency(RequestBuilder<crate::model::CreateDependencyRequest>);
 
@@ -2671,6 +3341,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::get_dependency][super::super::client::ApiHubDependencies::get_dependency] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::GetDependency;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDependency {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDependency(RequestBuilder<crate::model::GetDependencyRequest>);
 
@@ -2718,6 +3403,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::update_dependency][super::super::client::ApiHubDependencies::update_dependency] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::UpdateDependency;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDependency {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDependency(RequestBuilder<crate::model::UpdateDependencyRequest>);
 
@@ -2782,6 +3482,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::delete_dependency][super::super::client::ApiHubDependencies::delete_dependency] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::DeleteDependency;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDependency {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDependency(RequestBuilder<crate::model::DeleteDependencyRequest>);
 
@@ -2832,6 +3547,25 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::list_dependencies][super::super::client::ApiHubDependencies::list_dependencies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::ListDependencies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDependencies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDependencies(RequestBuilder<crate::model::ListDependenciesRequest>);
 
@@ -2924,6 +3658,25 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::list_locations][super::super::client::ApiHubDependencies::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3014,6 +3767,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::get_location][super::super::client::ApiHubDependencies::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3059,6 +3827,25 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::list_operations][super::super::client::ApiHubDependencies::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3151,6 +3938,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::get_operation][super::super::client::ApiHubDependencies::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3199,6 +4001,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::delete_operation][super::super::client::ApiHubDependencies::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3247,6 +4064,21 @@ pub mod api_hub_dependencies {
     }
 
     /// The request builder for [ApiHubDependencies::cancel_operation][super::super::client::ApiHubDependencies::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_dependencies::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3350,6 +4182,21 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::create_host_project_registration][super::super::client::HostProjectRegistrationService::create_host_project_registration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::CreateHostProjectRegistration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateHostProjectRegistration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateHostProjectRegistration(
         RequestBuilder<crate::model::CreateHostProjectRegistrationRequest>,
@@ -3426,6 +4273,21 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::get_host_project_registration][super::super::client::HostProjectRegistrationService::get_host_project_registration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::GetHostProjectRegistration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetHostProjectRegistration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetHostProjectRegistration(
         RequestBuilder<crate::model::GetHostProjectRegistrationRequest>,
@@ -3478,6 +4340,25 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::list_host_project_registrations][super::super::client::HostProjectRegistrationService::list_host_project_registrations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::ListHostProjectRegistrations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHostProjectRegistrations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHostProjectRegistrations(
         RequestBuilder<crate::model::ListHostProjectRegistrationsRequest>,
@@ -3582,6 +4463,25 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::list_locations][super::super::client::HostProjectRegistrationService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3672,6 +4572,21 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::get_location][super::super::client::HostProjectRegistrationService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3717,6 +4632,25 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::list_operations][super::super::client::HostProjectRegistrationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3809,6 +4743,21 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::get_operation][super::super::client::HostProjectRegistrationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3857,6 +4806,21 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::delete_operation][super::super::client::HostProjectRegistrationService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3905,6 +4869,21 @@ pub mod host_project_registration_service {
     }
 
     /// The request builder for [HostProjectRegistrationService::cancel_operation][super::super::client::HostProjectRegistrationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::host_project_registration_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4008,6 +4987,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::get_style_guide][super::super::client::LintingService::get_style_guide] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::GetStyleGuide;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStyleGuide {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStyleGuide(RequestBuilder<crate::model::GetStyleGuideRequest>);
 
@@ -4055,6 +5049,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::update_style_guide][super::super::client::LintingService::update_style_guide] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::UpdateStyleGuide;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateStyleGuide {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateStyleGuide(RequestBuilder<crate::model::UpdateStyleGuideRequest>);
 
@@ -4117,6 +5126,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::get_style_guide_contents][super::super::client::LintingService::get_style_guide_contents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::GetStyleGuideContents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStyleGuideContents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStyleGuideContents(RequestBuilder<crate::model::GetStyleGuideContentsRequest>);
 
@@ -4167,6 +5191,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::lint_spec][super::super::client::LintingService::lint_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::LintSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LintSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LintSpec(RequestBuilder<crate::model::LintSpecRequest>);
 
@@ -4214,6 +5253,25 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::list_locations][super::super::client::LintingService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4304,6 +5362,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::get_location][super::super::client::LintingService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4349,6 +5422,25 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::list_operations][super::super::client::LintingService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4441,6 +5533,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::get_operation][super::super::client::LintingService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4489,6 +5596,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::delete_operation][super::super::client::LintingService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4537,6 +5659,21 @@ pub mod linting_service {
     }
 
     /// The request builder for [LintingService::cancel_operation][super::super::client::LintingService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::linting_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4640,6 +5777,21 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::get_plugin][super::super::client::ApiHubPlugin::get_plugin] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::GetPlugin;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPlugin {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPlugin(RequestBuilder<crate::model::GetPluginRequest>);
 
@@ -4687,6 +5839,21 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::enable_plugin][super::super::client::ApiHubPlugin::enable_plugin] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::EnablePlugin;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnablePlugin {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnablePlugin(RequestBuilder<crate::model::EnablePluginRequest>);
 
@@ -4734,6 +5901,21 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::disable_plugin][super::super::client::ApiHubPlugin::disable_plugin] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::DisablePlugin;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisablePlugin {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisablePlugin(RequestBuilder<crate::model::DisablePluginRequest>);
 
@@ -4781,6 +5963,25 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::list_locations][super::super::client::ApiHubPlugin::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4871,6 +6072,21 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::get_location][super::super::client::ApiHubPlugin::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4916,6 +6132,25 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::list_operations][super::super::client::ApiHubPlugin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5008,6 +6243,21 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::get_operation][super::super::client::ApiHubPlugin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5056,6 +6306,21 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::delete_operation][super::super::client::ApiHubPlugin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5104,6 +6369,21 @@ pub mod api_hub_plugin {
     }
 
     /// The request builder for [ApiHubPlugin::cancel_operation][super::super::client::ApiHubPlugin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::api_hub_plugin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5207,6 +6487,22 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::create_api_hub_instance][super::super::client::Provisioning::create_api_hub_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::CreateApiHubInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apihub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateApiHubInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateApiHubInstance(RequestBuilder<crate::model::CreateApiHubInstanceRequest>);
 
@@ -5315,6 +6611,21 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::get_api_hub_instance][super::super::client::Provisioning::get_api_hub_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::GetApiHubInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApiHubInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApiHubInstance(RequestBuilder<crate::model::GetApiHubInstanceRequest>);
 
@@ -5365,6 +6676,21 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::lookup_api_hub_instance][super::super::client::Provisioning::lookup_api_hub_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::LookupApiHubInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupApiHubInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupApiHubInstance(RequestBuilder<crate::model::LookupApiHubInstanceRequest>);
 
@@ -5415,6 +6741,25 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::list_locations][super::super::client::Provisioning::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5505,6 +6850,21 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::get_location][super::super::client::Provisioning::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5550,6 +6910,25 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::list_operations][super::super::client::Provisioning::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5642,6 +7021,21 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::get_operation][super::super::client::Provisioning::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5690,6 +7084,21 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::delete_operation][super::super::client::Provisioning::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5738,6 +7147,21 @@ pub mod provisioning {
     }
 
     /// The request builder for [Provisioning::cancel_operation][super::super::client::Provisioning::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::provisioning::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5841,6 +7265,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::create_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::create_runtime_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::CreateRuntimeProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRuntimeProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRuntimeProjectAttachment(
         RequestBuilder<crate::model::CreateRuntimeProjectAttachmentRequest>,
@@ -5917,6 +7356,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::get_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::get_runtime_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::GetRuntimeProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRuntimeProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRuntimeProjectAttachment(
         RequestBuilder<crate::model::GetRuntimeProjectAttachmentRequest>,
@@ -5969,6 +7423,25 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::list_runtime_project_attachments][super::super::client::RuntimeProjectAttachmentService::list_runtime_project_attachments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::ListRuntimeProjectAttachments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuntimeProjectAttachments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuntimeProjectAttachments(
         RequestBuilder<crate::model::ListRuntimeProjectAttachmentsRequest>,
@@ -6073,6 +7546,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::delete_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::delete_runtime_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::DeleteRuntimeProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRuntimeProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRuntimeProjectAttachment(
         RequestBuilder<crate::model::DeleteRuntimeProjectAttachmentRequest>,
@@ -6125,6 +7613,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::lookup_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::lookup_runtime_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::LookupRuntimeProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupRuntimeProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupRuntimeProjectAttachment(
         RequestBuilder<crate::model::LookupRuntimeProjectAttachmentRequest>,
@@ -6177,6 +7680,25 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::list_locations][super::super::client::RuntimeProjectAttachmentService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6267,6 +7789,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::get_location][super::super::client::RuntimeProjectAttachmentService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6312,6 +7849,25 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::list_operations][super::super::client::RuntimeProjectAttachmentService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6404,6 +7960,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::get_operation][super::super::client::RuntimeProjectAttachmentService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6452,6 +8023,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::delete_operation][super::super::client::RuntimeProjectAttachmentService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -6500,6 +8086,21 @@ pub mod runtime_project_attachment_service {
     }
 
     /// The request builder for [RuntimeProjectAttachmentService::cancel_operation][super::super::client::RuntimeProjectAttachmentService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apihub_v1::builder;
+    /// use builder::runtime_project_attachment_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/apphub/v1/src/builder.rs
+++ b/src/generated/cloud/apphub/v1/src/builder.rs
@@ -67,6 +67,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::lookup_service_project_attachment][super::super::client::AppHub::lookup_service_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::LookupServiceProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupServiceProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupServiceProjectAttachment(
         RequestBuilder<crate::model::LookupServiceProjectAttachmentRequest>,
@@ -117,6 +132,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_service_project_attachments][super::super::client::AppHub::list_service_project_attachments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListServiceProjectAttachments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceProjectAttachments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceProjectAttachments(
         RequestBuilder<crate::model::ListServiceProjectAttachmentsRequest>,
@@ -219,6 +253,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::create_service_project_attachment][super::super::client::AppHub::create_service_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::CreateServiceProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceProjectAttachment(
         RequestBuilder<crate::model::CreateServiceProjectAttachmentRequest>,
@@ -340,6 +390,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_service_project_attachment][super::super::client::AppHub::get_service_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetServiceProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceProjectAttachment(
         RequestBuilder<crate::model::GetServiceProjectAttachmentRequest>,
@@ -390,6 +455,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::delete_service_project_attachment][super::super::client::AppHub::delete_service_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::DeleteServiceProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceProjectAttachment(
         RequestBuilder<crate::model::DeleteServiceProjectAttachmentRequest>,
@@ -486,6 +567,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::detach_service_project_attachment][super::super::client::AppHub::detach_service_project_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::DetachServiceProjectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DetachServiceProjectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DetachServiceProjectAttachment(
         RequestBuilder<crate::model::DetachServiceProjectAttachmentRequest>,
@@ -536,6 +632,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_discovered_services][super::super::client::AppHub::list_discovered_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListDiscoveredServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDiscoveredServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDiscoveredServices(RequestBuilder<crate::model::ListDiscoveredServicesRequest>);
 
@@ -636,6 +751,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_discovered_service][super::super::client::AppHub::get_discovered_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetDiscoveredService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDiscoveredService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDiscoveredService(RequestBuilder<crate::model::GetDiscoveredServiceRequest>);
 
@@ -684,6 +814,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::lookup_discovered_service][super::super::client::AppHub::lookup_discovered_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::LookupDiscoveredService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupDiscoveredService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupDiscoveredService(
         RequestBuilder<crate::model::LookupDiscoveredServiceRequest>,
@@ -742,6 +887,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_services][super::super::client::AppHub::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -835,6 +999,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::create_service][super::super::client::AppHub::create_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::CreateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -943,6 +1123,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_service][super::super::client::AppHub::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -988,6 +1183,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::update_service][super::super::client::AppHub::update_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::UpdateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -1091,6 +1302,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::delete_service][super::super::client::AppHub::delete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::DeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -1182,6 +1409,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_discovered_workloads][super::super::client::AppHub::list_discovered_workloads] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListDiscoveredWorkloads;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDiscoveredWorkloads {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDiscoveredWorkloads(
         RequestBuilder<crate::model::ListDiscoveredWorkloadsRequest>,
@@ -1284,6 +1530,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_discovered_workload][super::super::client::AppHub::get_discovered_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetDiscoveredWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDiscoveredWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDiscoveredWorkload(RequestBuilder<crate::model::GetDiscoveredWorkloadRequest>);
 
@@ -1332,6 +1593,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::lookup_discovered_workload][super::super::client::AppHub::lookup_discovered_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::LookupDiscoveredWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupDiscoveredWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupDiscoveredWorkload(
         RequestBuilder<crate::model::LookupDiscoveredWorkloadRequest>,
@@ -1390,6 +1666,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_workloads][super::super::client::AppHub::list_workloads] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListWorkloads;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkloads {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -1483,6 +1778,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::create_workload][super::super::client::AppHub::create_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::CreateWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkload(RequestBuilder<crate::model::CreateWorkloadRequest>);
 
@@ -1591,6 +1902,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_workload][super::super::client::AppHub::get_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkload(RequestBuilder<crate::model::GetWorkloadRequest>);
 
@@ -1636,6 +1962,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::update_workload][super::super::client::AppHub::update_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::UpdateWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkload(RequestBuilder<crate::model::UpdateWorkloadRequest>);
 
@@ -1739,6 +2081,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::delete_workload][super::super::client::AppHub::delete_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::DeleteWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkload(RequestBuilder<crate::model::DeleteWorkloadRequest>);
 
@@ -1830,6 +2188,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_applications][super::super::client::AppHub::list_applications] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListApplications;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListApplications {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListApplications(RequestBuilder<crate::model::ListApplicationsRequest>);
 
@@ -1926,6 +2303,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::create_application][super::super::client::AppHub::create_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::CreateApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateApplication(RequestBuilder<crate::model::CreateApplicationRequest>);
 
@@ -2039,6 +2432,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_application][super::super::client::AppHub::get_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetApplication(RequestBuilder<crate::model::GetApplicationRequest>);
 
@@ -2084,6 +2492,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::update_application][super::super::client::AppHub::update_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::UpdateApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateApplication(RequestBuilder<crate::model::UpdateApplicationRequest>);
 
@@ -2192,6 +2616,22 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::delete_application][super::super::client::AppHub::delete_application] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::DeleteApplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_apphub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteApplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteApplication(RequestBuilder<crate::model::DeleteApplicationRequest>);
 
@@ -2286,6 +2726,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_locations][super::super::client::AppHub::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2374,6 +2833,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_location][super::super::client::AppHub::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2417,6 +2891,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::set_iam_policy][super::super::client::AppHub::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2482,6 +2971,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_iam_policy][super::super::client::AppHub::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2536,6 +3040,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::test_iam_permissions][super::super::client::AppHub::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2597,6 +3116,25 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::list_operations][super::super::client::AppHub::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2687,6 +3225,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::get_operation][super::super::client::AppHub::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2733,6 +3286,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::delete_operation][super::super::client::AppHub::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2779,6 +3347,21 @@ pub mod app_hub {
     }
 
     /// The request builder for [AppHub::cancel_operation][super::super::client::AppHub::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_apphub_v1::builder;
+    /// use builder::app_hub::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/asset/v1/src/builder.rs
+++ b/src/generated/cloud/asset/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::export_assets][super::super::client::AssetService::export_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::ExportAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_asset_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportAssets(RequestBuilder<crate::model::ExportAssetsRequest>);
 
@@ -202,6 +218,25 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::list_assets][super::super::client::AssetService::list_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::ListAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAssets(RequestBuilder<crate::model::ListAssetsRequest>);
 
@@ -319,6 +354,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::batch_get_assets_history][super::super::client::AssetService::batch_get_assets_history] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::BatchGetAssetsHistory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchGetAssetsHistory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchGetAssetsHistory(RequestBuilder<crate::model::BatchGetAssetsHistoryRequest>);
 
@@ -406,6 +456,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::create_feed][super::super::client::AssetService::create_feed] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::CreateFeed;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeed {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeed(RequestBuilder<crate::model::CreateFeedRequest>);
 
@@ -469,6 +534,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::get_feed][super::super::client::AssetService::get_feed] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::GetFeed;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeed {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeed(RequestBuilder<crate::model::GetFeedRequest>);
 
@@ -516,6 +596,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::list_feeds][super::super::client::AssetService::list_feeds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::ListFeeds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeeds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeeds(RequestBuilder<crate::model::ListFeedsRequest>);
 
@@ -563,6 +658,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::update_feed][super::super::client::AssetService::update_feed] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::UpdateFeed;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeed {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeed(RequestBuilder<crate::model::UpdateFeedRequest>);
 
@@ -621,6 +731,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::delete_feed][super::super::client::AssetService::delete_feed] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::DeleteFeed;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeed {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeed(RequestBuilder<crate::model::DeleteFeedRequest>);
 
@@ -668,6 +793,25 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::search_all_resources][super::super::client::AssetService::search_all_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::SearchAllResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchAllResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchAllResources(RequestBuilder<crate::model::SearchAllResourcesRequest>);
 
@@ -785,6 +929,25 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::search_all_iam_policies][super::super::client::AssetService::search_all_iam_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::SearchAllIamPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchAllIamPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchAllIamPolicies(RequestBuilder<crate::model::SearchAllIamPoliciesRequest>);
 
@@ -896,6 +1059,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::analyze_iam_policy][super::super::client::AssetService::analyze_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::AnalyzeIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeIamPolicy(RequestBuilder<crate::model::AnalyzeIamPolicyRequest>);
 
@@ -966,6 +1144,22 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::analyze_iam_policy_longrunning][super::super::client::AssetService::analyze_iam_policy_longrunning] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::AnalyzeIamPolicyLongrunning;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_asset_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeIamPolicyLongrunning {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeIamPolicyLongrunning(
         RequestBuilder<crate::model::AnalyzeIamPolicyLongrunningRequest>,
@@ -1085,6 +1279,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::analyze_move][super::super::client::AssetService::analyze_move] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::AnalyzeMove;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeMove {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeMove(RequestBuilder<crate::model::AnalyzeMoveRequest>);
 
@@ -1149,6 +1358,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::query_assets][super::super::client::AssetService::query_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::QueryAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryAssets(RequestBuilder<crate::model::QueryAssetsRequest>);
 
@@ -1300,6 +1524,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::create_saved_query][super::super::client::AssetService::create_saved_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::CreateSavedQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSavedQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSavedQuery(RequestBuilder<crate::model::CreateSavedQueryRequest>);
 
@@ -1369,6 +1608,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::get_saved_query][super::super::client::AssetService::get_saved_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::GetSavedQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSavedQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSavedQuery(RequestBuilder<crate::model::GetSavedQueryRequest>);
 
@@ -1416,6 +1670,25 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::list_saved_queries][super::super::client::AssetService::list_saved_queries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::ListSavedQueries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSavedQueries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSavedQueries(RequestBuilder<crate::model::ListSavedQueriesRequest>);
 
@@ -1508,6 +1781,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::update_saved_query][super::super::client::AssetService::update_saved_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::UpdateSavedQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSavedQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSavedQuery(RequestBuilder<crate::model::UpdateSavedQueryRequest>);
 
@@ -1572,6 +1860,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::delete_saved_query][super::super::client::AssetService::delete_saved_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::DeleteSavedQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSavedQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSavedQuery(RequestBuilder<crate::model::DeleteSavedQueryRequest>);
 
@@ -1622,6 +1925,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::batch_get_effective_iam_policies][super::super::client::AssetService::batch_get_effective_iam_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::BatchGetEffectiveIamPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchGetEffectiveIamPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchGetEffectiveIamPolicies(
         RequestBuilder<crate::model::BatchGetEffectiveIamPoliciesRequest>,
@@ -1687,6 +2005,25 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::analyze_org_policies][super::super::client::AssetService::analyze_org_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::AnalyzeOrgPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeOrgPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeOrgPolicies(RequestBuilder<crate::model::AnalyzeOrgPoliciesRequest>);
 
@@ -1789,6 +2126,25 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::analyze_org_policy_governed_containers][super::super::client::AssetService::analyze_org_policy_governed_containers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::AnalyzeOrgPolicyGovernedContainers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeOrgPolicyGovernedContainers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeOrgPolicyGovernedContainers(
         RequestBuilder<crate::model::AnalyzeOrgPolicyGovernedContainersRequest>,
@@ -1897,6 +2253,25 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::analyze_org_policy_governed_assets][super::super::client::AssetService::analyze_org_policy_governed_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::AnalyzeOrgPolicyGovernedAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeOrgPolicyGovernedAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeOrgPolicyGovernedAssets(
         RequestBuilder<crate::model::AnalyzeOrgPolicyGovernedAssetsRequest>,
@@ -2003,6 +2378,21 @@ pub mod asset_service {
     }
 
     /// The request builder for [AssetService::get_operation][super::super::client::AssetService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_asset_v1::builder;
+    /// use builder::asset_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/assuredworkloads/v1/src/builder.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::create_workload][super::super::client::AssuredWorkloadsService::create_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::CreateWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_assuredworkloads_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkload(RequestBuilder<crate::model::CreateWorkloadRequest>);
 
@@ -174,6 +190,21 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::update_workload][super::super::client::AssuredWorkloadsService::update_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::UpdateWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkload(RequestBuilder<crate::model::UpdateWorkloadRequest>);
 
@@ -235,6 +266,21 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::restrict_allowed_resources][super::super::client::AssuredWorkloadsService::restrict_allowed_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::RestrictAllowedResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestrictAllowedResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestrictAllowedResources(
         RequestBuilder<crate::model::RestrictAllowedResourcesRequest>,
@@ -300,6 +346,21 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::delete_workload][super::super::client::AssuredWorkloadsService::delete_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::DeleteWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkload(RequestBuilder<crate::model::DeleteWorkloadRequest>);
 
@@ -353,6 +414,21 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::get_workload][super::super::client::AssuredWorkloadsService::get_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::GetWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkload(RequestBuilder<crate::model::GetWorkloadRequest>);
 
@@ -400,6 +476,25 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::list_workloads][super::super::client::AssuredWorkloadsService::list_workloads] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::ListWorkloads;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkloads {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -489,6 +584,25 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::list_operations][super::super::client::AssuredWorkloadsService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -581,6 +695,21 @@ pub mod assured_workloads_service {
     }
 
     /// The request builder for [AssuredWorkloadsService::get_operation][super::super::client::AssuredWorkloadsService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_assuredworkloads_v1::builder;
+    /// use builder::assured_workloads_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/backupdr/v1/src/builder.rs
+++ b/src/generated/cloud/backupdr/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_management_servers][super::super::client::BackupDR::list_management_servers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListManagementServers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListManagementServers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListManagementServers(RequestBuilder<crate::model::ListManagementServersRequest>);
 
@@ -171,6 +190,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_management_server][super::super::client::BackupDR::get_management_server] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetManagementServer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetManagementServer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetManagementServer(RequestBuilder<crate::model::GetManagementServerRequest>);
 
@@ -219,6 +253,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::create_management_server][super::super::client::BackupDR::create_management_server] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::CreateManagementServer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateManagementServer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateManagementServer(RequestBuilder<crate::model::CreateManagementServerRequest>);
 
@@ -335,6 +385,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::delete_management_server][super::super::client::BackupDR::delete_management_server] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::DeleteManagementServer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteManagementServer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteManagementServer(RequestBuilder<crate::model::DeleteManagementServerRequest>);
 
@@ -429,6 +495,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::create_backup_vault][super::super::client::BackupDR::create_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::CreateBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupVault(RequestBuilder<crate::model::CreateBackupVaultRequest>);
 
@@ -548,6 +630,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_backup_vaults][super::super::client::BackupDR::list_backup_vaults] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListBackupVaults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupVaults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupVaults(RequestBuilder<crate::model::ListBackupVaultsRequest>);
 
@@ -650,6 +751,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::fetch_usable_backup_vaults][super::super::client::BackupDR::fetch_usable_backup_vaults] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::FetchUsableBackupVaults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchUsableBackupVaults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchUsableBackupVaults(
         RequestBuilder<crate::model::FetchUsableBackupVaultsRequest>,
@@ -752,6 +872,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_backup_vault][super::super::client::BackupDR::get_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupVault(RequestBuilder<crate::model::GetBackupVaultRequest>);
 
@@ -803,6 +938,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::update_backup_vault][super::super::client::BackupDR::update_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::UpdateBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackupVault(RequestBuilder<crate::model::UpdateBackupVaultRequest>);
 
@@ -923,6 +1074,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::delete_backup_vault][super::super::client::BackupDR::delete_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::DeleteBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupVault(RequestBuilder<crate::model::DeleteBackupVaultRequest>);
 
@@ -1047,6 +1214,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_data_sources][super::super::client::BackupDR::list_data_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListDataSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataSources(RequestBuilder<crate::model::ListDataSourcesRequest>);
 
@@ -1140,6 +1326,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_data_source][super::super::client::BackupDR::get_data_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetDataSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataSource(RequestBuilder<crate::model::GetDataSourceRequest>);
 
@@ -1185,6 +1386,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::update_data_source][super::super::client::BackupDR::update_data_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::UpdateDataSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataSource(RequestBuilder<crate::model::UpdateDataSourceRequest>);
 
@@ -1297,6 +1514,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_backups][super::super::client::BackupDR::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1396,6 +1632,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_backup][super::super::client::BackupDR::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1447,6 +1698,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::update_backup][super::super::client::BackupDR::update_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::UpdateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -1550,6 +1817,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::delete_backup][super::super::client::BackupDR::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1639,6 +1922,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::restore_backup][super::super::client::BackupDR::restore_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::RestoreBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreBackup(RequestBuilder<crate::model::RestoreBackupRequest>);
 
@@ -1789,6 +2088,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::create_backup_plan][super::super::client::BackupDR::create_backup_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::CreateBackupPlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupPlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupPlan(RequestBuilder<crate::model::CreateBackupPlanRequest>);
 
@@ -1900,6 +2215,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_backup_plan][super::super::client::BackupDR::get_backup_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetBackupPlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupPlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupPlan(RequestBuilder<crate::model::GetBackupPlanRequest>);
 
@@ -1945,6 +2275,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_backup_plans][super::super::client::BackupDR::list_backup_plans] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListBackupPlans;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupPlans {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupPlans(RequestBuilder<crate::model::ListBackupPlansRequest>);
 
@@ -2038,6 +2387,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::delete_backup_plan][super::super::client::BackupDR::delete_backup_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::DeleteBackupPlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupPlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPlan(RequestBuilder<crate::model::DeleteBackupPlanRequest>);
 
@@ -2132,6 +2497,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::create_backup_plan_association][super::super::client::BackupDR::create_backup_plan_association] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::CreateBackupPlanAssociation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupPlanAssociation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupPlanAssociation(
         RequestBuilder<crate::model::CreateBackupPlanAssociationRequest>,
@@ -2253,6 +2634,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_backup_plan_association][super::super::client::BackupDR::get_backup_plan_association] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetBackupPlanAssociation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupPlanAssociation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupPlanAssociation(
         RequestBuilder<crate::model::GetBackupPlanAssociationRequest>,
@@ -2303,6 +2699,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_backup_plan_associations][super::super::client::BackupDR::list_backup_plan_associations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListBackupPlanAssociations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupPlanAssociations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupPlanAssociations(
         RequestBuilder<crate::model::ListBackupPlanAssociationsRequest>,
@@ -2399,6 +2814,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::delete_backup_plan_association][super::super::client::BackupDR::delete_backup_plan_association] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::DeleteBackupPlanAssociation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupPlanAssociation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPlanAssociation(
         RequestBuilder<crate::model::DeleteBackupPlanAssociationRequest>,
@@ -2495,6 +2926,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::trigger_backup][super::super::client::BackupDR::trigger_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::TriggerBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TriggerBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TriggerBackup(RequestBuilder<crate::model::TriggerBackupRequest>);
 
@@ -2595,6 +3042,22 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::initialize_service][super::super::client::BackupDR::initialize_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::InitializeService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_backupdr_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InitializeService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InitializeService(RequestBuilder<crate::model::InitializeServiceRequest>);
 
@@ -2698,6 +3161,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_locations][super::super::client::BackupDR::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2786,6 +3268,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_location][super::super::client::BackupDR::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2829,6 +3326,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::set_iam_policy][super::super::client::BackupDR::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2894,6 +3406,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_iam_policy][super::super::client::BackupDR::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2948,6 +3475,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::test_iam_permissions][super::super::client::BackupDR::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3009,6 +3551,25 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::list_operations][super::super::client::BackupDR::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3099,6 +3660,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::get_operation][super::super::client::BackupDR::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3145,6 +3721,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::delete_operation][super::super::client::BackupDR::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3191,6 +3782,21 @@ pub mod backup_dr {
     }
 
     /// The request builder for [BackupDR::cancel_operation][super::super::client::BackupDR::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_backupdr_v1::builder;
+    /// use builder::backup_dr::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/baremetalsolution/v2/src/builder.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builder.rs
@@ -69,6 +69,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_instances][super::super::client::BareMetalSolution::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -158,6 +177,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_instance][super::super::client::BareMetalSolution::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -205,6 +239,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::update_instance][super::super::client::BareMetalSolution::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -302,6 +352,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::rename_instance][super::super::client::BareMetalSolution::rename_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::RenameInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenameInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenameInstance(RequestBuilder<crate::model::RenameInstanceRequest>);
 
@@ -357,6 +422,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::reset_instance][super::super::client::BareMetalSolution::reset_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ResetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetInstance(RequestBuilder<crate::model::ResetInstanceRequest>);
 
@@ -445,6 +526,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::start_instance][super::super::client::BareMetalSolution::start_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::StartInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartInstance(RequestBuilder<crate::model::StartInstanceRequest>);
 
@@ -533,6 +630,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::stop_instance][super::super::client::BareMetalSolution::stop_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::StopInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopInstance(RequestBuilder<crate::model::StopInstanceRequest>);
 
@@ -621,6 +734,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::enable_interactive_serial_console][super::super::client::BareMetalSolution::enable_interactive_serial_console] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::EnableInteractiveSerialConsole;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableInteractiveSerialConsole {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableInteractiveSerialConsole(
         RequestBuilder<crate::model::EnableInteractiveSerialConsoleRequest>,
@@ -716,6 +845,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::disable_interactive_serial_console][super::super::client::BareMetalSolution::disable_interactive_serial_console] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::DisableInteractiveSerialConsole;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableInteractiveSerialConsole {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableInteractiveSerialConsole(
         RequestBuilder<crate::model::DisableInteractiveSerialConsoleRequest>,
@@ -811,6 +956,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::detach_lun][super::super::client::BareMetalSolution::detach_lun] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::DetachLun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DetachLun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DetachLun(RequestBuilder<crate::model::DetachLunRequest>);
 
@@ -910,6 +1071,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_ssh_keys][super::super::client::BareMetalSolution::list_ssh_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListSSHKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSSHKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSSHKeys(RequestBuilder<crate::model::ListSSHKeysRequest>);
 
@@ -993,6 +1173,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::create_ssh_key][super::super::client::BareMetalSolution::create_ssh_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::CreateSSHKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSSHKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSSHKey(RequestBuilder<crate::model::CreateSSHKeyRequest>);
 
@@ -1059,6 +1254,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::delete_ssh_key][super::super::client::BareMetalSolution::delete_ssh_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::DeleteSSHKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSSHKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSSHKey(RequestBuilder<crate::model::DeleteSSHKeyRequest>);
 
@@ -1106,6 +1316,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_volumes][super::super::client::BareMetalSolution::list_volumes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListVolumes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVolumes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVolumes(RequestBuilder<crate::model::ListVolumesRequest>);
 
@@ -1195,6 +1424,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_volume][super::super::client::BareMetalSolution::get_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVolume(RequestBuilder<crate::model::GetVolumeRequest>);
 
@@ -1242,6 +1486,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::update_volume][super::super::client::BareMetalSolution::update_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::UpdateVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVolume(RequestBuilder<crate::model::UpdateVolumeRequest>);
 
@@ -1339,6 +1599,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::rename_volume][super::super::client::BareMetalSolution::rename_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::RenameVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenameVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenameVolume(RequestBuilder<crate::model::RenameVolumeRequest>);
 
@@ -1394,6 +1669,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::evict_volume][super::super::client::BareMetalSolution::evict_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::EvictVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EvictVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EvictVolume(RequestBuilder<crate::model::EvictVolumeRequest>);
 
@@ -1481,6 +1772,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::resize_volume][super::super::client::BareMetalSolution::resize_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ResizeVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResizeVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResizeVolume(RequestBuilder<crate::model::ResizeVolumeRequest>);
 
@@ -1572,6 +1879,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_networks][super::super::client::BareMetalSolution::list_networks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListNetworks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNetworks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNetworks(RequestBuilder<crate::model::ListNetworksRequest>);
 
@@ -1661,6 +1987,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_network_usage][super::super::client::BareMetalSolution::list_network_usage] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListNetworkUsage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNetworkUsage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNetworkUsage(RequestBuilder<crate::model::ListNetworkUsageRequest>);
 
@@ -1711,6 +2052,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_network][super::super::client::BareMetalSolution::get_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNetwork(RequestBuilder<crate::model::GetNetworkRequest>);
 
@@ -1758,6 +2114,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::update_network][super::super::client::BareMetalSolution::update_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::UpdateNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNetwork(RequestBuilder<crate::model::UpdateNetworkRequest>);
 
@@ -1855,6 +2227,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::create_volume_snapshot][super::super::client::BareMetalSolution::create_volume_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::CreateVolumeSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVolumeSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVolumeSnapshot(RequestBuilder<crate::model::CreateVolumeSnapshotRequest>);
 
@@ -1916,6 +2303,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::restore_volume_snapshot][super::super::client::BareMetalSolution::restore_volume_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::RestoreVolumeSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreVolumeSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreVolumeSnapshot(RequestBuilder<crate::model::RestoreVolumeSnapshotRequest>);
 
@@ -2007,6 +2410,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::delete_volume_snapshot][super::super::client::BareMetalSolution::delete_volume_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::DeleteVolumeSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVolumeSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVolumeSnapshot(RequestBuilder<crate::model::DeleteVolumeSnapshotRequest>);
 
@@ -2057,6 +2475,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_volume_snapshot][super::super::client::BareMetalSolution::get_volume_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetVolumeSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVolumeSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVolumeSnapshot(RequestBuilder<crate::model::GetVolumeSnapshotRequest>);
 
@@ -2107,6 +2540,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_volume_snapshots][super::super::client::BareMetalSolution::list_volume_snapshots] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListVolumeSnapshots;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVolumeSnapshots {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVolumeSnapshots(RequestBuilder<crate::model::ListVolumeSnapshotsRequest>);
 
@@ -2195,6 +2647,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_lun][super::super::client::BareMetalSolution::get_lun] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetLun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLun(RequestBuilder<crate::model::GetLunRequest>);
 
@@ -2242,6 +2709,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_luns][super::super::client::BareMetalSolution::list_luns] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListLuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLuns(RequestBuilder<crate::model::ListLunsRequest>);
 
@@ -2325,6 +2811,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::evict_lun][super::super::client::BareMetalSolution::evict_lun] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::EvictLun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EvictLun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EvictLun(RequestBuilder<crate::model::EvictLunRequest>);
 
@@ -2412,6 +2914,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_nfs_share][super::super::client::BareMetalSolution::get_nfs_share] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetNfsShare;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNfsShare {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNfsShare(RequestBuilder<crate::model::GetNfsShareRequest>);
 
@@ -2459,6 +2976,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_nfs_shares][super::super::client::BareMetalSolution::list_nfs_shares] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListNfsShares;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNfsShares {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNfsShares(RequestBuilder<crate::model::ListNfsSharesRequest>);
 
@@ -2548,6 +3084,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::update_nfs_share][super::super::client::BareMetalSolution::update_nfs_share] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::UpdateNfsShare;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNfsShare {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNfsShare(RequestBuilder<crate::model::UpdateNfsShareRequest>);
 
@@ -2645,6 +3197,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::create_nfs_share][super::super::client::BareMetalSolution::create_nfs_share] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::CreateNfsShare;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNfsShare {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNfsShare(RequestBuilder<crate::model::CreateNfsShareRequest>);
 
@@ -2741,6 +3309,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::rename_nfs_share][super::super::client::BareMetalSolution::rename_nfs_share] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::RenameNfsShare;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenameNfsShare {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenameNfsShare(RequestBuilder<crate::model::RenameNfsShareRequest>);
 
@@ -2796,6 +3379,22 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::delete_nfs_share][super::super::client::BareMetalSolution::delete_nfs_share] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::DeleteNfsShare;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_baremetalsolution_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNfsShare {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNfsShare(RequestBuilder<crate::model::DeleteNfsShareRequest>);
 
@@ -2883,6 +3482,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_provisioning_quotas][super::super::client::BareMetalSolution::list_provisioning_quotas] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListProvisioningQuotas;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProvisioningQuotas {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProvisioningQuotas(RequestBuilder<crate::model::ListProvisioningQuotasRequest>);
 
@@ -2973,6 +3591,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::submit_provisioning_config][super::super::client::BareMetalSolution::submit_provisioning_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::SubmitProvisioningConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubmitProvisioningConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubmitProvisioningConfig(
         RequestBuilder<crate::model::SubmitProvisioningConfigRequest>,
@@ -3044,6 +3677,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_provisioning_config][super::super::client::BareMetalSolution::get_provisioning_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetProvisioningConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProvisioningConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProvisioningConfig(RequestBuilder<crate::model::GetProvisioningConfigRequest>);
 
@@ -3094,6 +3742,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::create_provisioning_config][super::super::client::BareMetalSolution::create_provisioning_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::CreateProvisioningConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProvisioningConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProvisioningConfig(
         RequestBuilder<crate::model::CreateProvisioningConfigRequest>,
@@ -3165,6 +3828,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::update_provisioning_config][super::super::client::BareMetalSolution::update_provisioning_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::UpdateProvisioningConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProvisioningConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProvisioningConfig(
         RequestBuilder<crate::model::UpdateProvisioningConfigRequest>,
@@ -3239,6 +3917,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::rename_network][super::super::client::BareMetalSolution::rename_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::RenameNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenameNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenameNetwork(RequestBuilder<crate::model::RenameNetworkRequest>);
 
@@ -3294,6 +3987,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_os_images][super::super::client::BareMetalSolution::list_os_images] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListOSImages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOSImages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOSImages(RequestBuilder<crate::model::ListOSImagesRequest>);
 
@@ -3377,6 +4089,25 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::list_locations][super::super::client::BareMetalSolution::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3467,6 +4198,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_location][super::super::client::BareMetalSolution::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3512,6 +4258,21 @@ pub mod bare_metal_solution {
     }
 
     /// The request builder for [BareMetalSolution::get_operation][super::super::client::BareMetalSolution::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_baremetalsolution_v2::builder;
+    /// use builder::bare_metal_solution::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::list_app_connections][super::super::client::AppConnectionsService::list_app_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::ListAppConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAppConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAppConnections(RequestBuilder<crate::model::ListAppConnectionsRequest>);
 
@@ -169,6 +188,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::get_app_connection][super::super::client::AppConnectionsService::get_app_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::GetAppConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAppConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAppConnection(RequestBuilder<crate::model::GetAppConnectionRequest>);
 
@@ -219,6 +253,22 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::create_app_connection][super::super::client::AppConnectionsService::create_app_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::CreateAppConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appconnections_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAppConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAppConnection(RequestBuilder<crate::model::CreateAppConnectionRequest>);
 
@@ -339,6 +389,22 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::update_app_connection][super::super::client::AppConnectionsService::update_app_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::UpdateAppConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appconnections_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAppConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAppConnection(RequestBuilder<crate::model::UpdateAppConnectionRequest>);
 
@@ -462,6 +528,22 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::delete_app_connection][super::super::client::AppConnectionsService::delete_app_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::DeleteAppConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appconnections_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAppConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAppConnection(RequestBuilder<crate::model::DeleteAppConnectionRequest>);
 
@@ -565,6 +647,25 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::resolve_app_connections][super::super::client::AppConnectionsService::resolve_app_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::ResolveAppConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResolveAppConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResolveAppConnections(RequestBuilder<crate::model::ResolveAppConnectionsRequest>);
 
@@ -661,6 +762,25 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::list_locations][super::super::client::AppConnectionsService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -751,6 +871,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::get_location][super::super::client::AppConnectionsService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -796,6 +931,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::set_iam_policy][super::super::client::AppConnectionsService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -863,6 +1013,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::get_iam_policy][super::super::client::AppConnectionsService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -919,6 +1084,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::test_iam_permissions][super::super::client::AppConnectionsService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -982,6 +1162,25 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::list_operations][super::super::client::AppConnectionsService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1074,6 +1273,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::get_operation][super::super::client::AppConnectionsService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1122,6 +1336,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::delete_operation][super::super::client::AppConnectionsService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1170,6 +1399,21 @@ pub mod app_connections_service {
     }
 
     /// The request builder for [AppConnectionsService::cancel_operation][super::super::client::AppConnectionsService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnections_v1::builder;
+    /// use builder::app_connections_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::list_app_connectors][super::super::client::AppConnectorsService::list_app_connectors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::ListAppConnectors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAppConnectors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAppConnectors(RequestBuilder<crate::model::ListAppConnectorsRequest>);
 
@@ -167,6 +186,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::get_app_connector][super::super::client::AppConnectorsService::get_app_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::GetAppConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAppConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAppConnector(RequestBuilder<crate::model::GetAppConnectorRequest>);
 
@@ -214,6 +248,22 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::create_app_connector][super::super::client::AppConnectorsService::create_app_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::CreateAppConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appconnectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAppConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAppConnector(RequestBuilder<crate::model::CreateAppConnectorRequest>);
 
@@ -334,6 +384,22 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::update_app_connector][super::super::client::AppConnectorsService::update_app_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::UpdateAppConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appconnectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAppConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAppConnector(RequestBuilder<crate::model::UpdateAppConnectorRequest>);
 
@@ -451,6 +517,22 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::delete_app_connector][super::super::client::AppConnectorsService::delete_app_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::DeleteAppConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appconnectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAppConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAppConnector(RequestBuilder<crate::model::DeleteAppConnectorRequest>);
 
@@ -554,6 +636,22 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::report_status][super::super::client::AppConnectorsService::report_status] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::ReportStatus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appconnectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReportStatus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReportStatus(RequestBuilder<crate::model::ReportStatusRequest>);
 
@@ -665,6 +763,25 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::list_locations][super::super::client::AppConnectorsService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -755,6 +872,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::get_location][super::super::client::AppConnectorsService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -800,6 +932,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::set_iam_policy][super::super::client::AppConnectorsService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -867,6 +1014,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::get_iam_policy][super::super::client::AppConnectorsService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -923,6 +1085,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::test_iam_permissions][super::super::client::AppConnectorsService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -986,6 +1163,25 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::list_operations][super::super::client::AppConnectorsService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1078,6 +1274,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::get_operation][super::super::client::AppConnectorsService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1126,6 +1337,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::delete_operation][super::super::client::AppConnectorsService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1174,6 +1400,21 @@ pub mod app_connectors_service {
     }
 
     /// The request builder for [AppConnectorsService::cancel_operation][super::super::client::AppConnectorsService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appconnectors_v1::builder;
+    /// use builder::app_connectors_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::list_app_gateways][super::super::client::AppGatewaysService::list_app_gateways] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::ListAppGateways;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAppGateways {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAppGateways(RequestBuilder<crate::model::ListAppGatewaysRequest>);
 
@@ -164,6 +183,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::get_app_gateway][super::super::client::AppGatewaysService::get_app_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::GetAppGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAppGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAppGateway(RequestBuilder<crate::model::GetAppGatewayRequest>);
 
@@ -211,6 +245,22 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::create_app_gateway][super::super::client::AppGatewaysService::create_app_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::CreateAppGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appgateways_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAppGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAppGateway(RequestBuilder<crate::model::CreateAppGatewayRequest>);
 
@@ -331,6 +381,22 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::delete_app_gateway][super::super::client::AppGatewaysService::delete_app_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::DeleteAppGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_appgateways_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAppGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAppGateway(RequestBuilder<crate::model::DeleteAppGatewayRequest>);
 
@@ -434,6 +500,25 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::list_locations][super::super::client::AppGatewaysService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -524,6 +609,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::get_location][super::super::client::AppGatewaysService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -569,6 +669,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::set_iam_policy][super::super::client::AppGatewaysService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -636,6 +751,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::get_iam_policy][super::super::client::AppGatewaysService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -692,6 +822,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::test_iam_permissions][super::super::client::AppGatewaysService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -755,6 +900,25 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::list_operations][super::super::client::AppGatewaysService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -847,6 +1011,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::get_operation][super::super::client::AppGatewaysService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -895,6 +1074,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::delete_operation][super::super::client::AppGatewaysService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -943,6 +1137,21 @@ pub mod app_gateways_service {
     }
 
     /// The request builder for [AppGatewaysService::cancel_operation][super::super::client::AppGatewaysService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_appgateways_v1::builder;
+    /// use builder::app_gateways_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::list_client_connector_services][super::super::client::ClientConnectorServicesService::list_client_connector_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::ListClientConnectorServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClientConnectorServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClientConnectorServices(
         RequestBuilder<crate::model::ListClientConnectorServicesRequest>,
@@ -173,6 +192,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::get_client_connector_service][super::super::client::ClientConnectorServicesService::get_client_connector_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::GetClientConnectorService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetClientConnectorService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetClientConnectorService(
         RequestBuilder<crate::model::GetClientConnectorServiceRequest>,
@@ -225,6 +259,22 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::create_client_connector_service][super::super::client::ClientConnectorServicesService::create_client_connector_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::CreateClientConnectorService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_clientconnectorservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateClientConnectorService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateClientConnectorService(
         RequestBuilder<crate::model::CreateClientConnectorServiceRequest>,
@@ -354,6 +404,22 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::update_client_connector_service][super::super::client::ClientConnectorServicesService::update_client_connector_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::UpdateClientConnectorService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_clientconnectorservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateClientConnectorService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateClientConnectorService(
         RequestBuilder<crate::model::UpdateClientConnectorServiceRequest>,
@@ -483,6 +549,22 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::delete_client_connector_service][super::super::client::ClientConnectorServicesService::delete_client_connector_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::DeleteClientConnectorService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_clientconnectorservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteClientConnectorService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteClientConnectorService(
         RequestBuilder<crate::model::DeleteClientConnectorServiceRequest>,
@@ -592,6 +674,25 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::list_locations][super::super::client::ClientConnectorServicesService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -682,6 +783,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::get_location][super::super::client::ClientConnectorServicesService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -727,6 +843,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::set_iam_policy][super::super::client::ClientConnectorServicesService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -794,6 +925,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::get_iam_policy][super::super::client::ClientConnectorServicesService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -850,6 +996,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::test_iam_permissions][super::super::client::ClientConnectorServicesService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -913,6 +1074,25 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::list_operations][super::super::client::ClientConnectorServicesService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1005,6 +1185,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::get_operation][super::super::client::ClientConnectorServicesService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1053,6 +1248,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::delete_operation][super::super::client::ClientConnectorServicesService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1101,6 +1311,21 @@ pub mod client_connector_services_service {
     }
 
     /// The request builder for [ClientConnectorServicesService::cancel_operation][super::super::client::ClientConnectorServicesService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientconnectorservices_v1::builder;
+    /// use builder::client_connector_services_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::list_client_gateways][super::super::client::ClientGatewaysService::list_client_gateways] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::ListClientGateways;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClientGateways {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClientGateways(RequestBuilder<crate::model::ListClientGatewaysRequest>);
 
@@ -169,6 +188,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::get_client_gateway][super::super::client::ClientGatewaysService::get_client_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::GetClientGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetClientGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetClientGateway(RequestBuilder<crate::model::GetClientGatewayRequest>);
 
@@ -219,6 +253,22 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::create_client_gateway][super::super::client::ClientGatewaysService::create_client_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::CreateClientGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_clientgateways_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateClientGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateClientGateway(RequestBuilder<crate::model::CreateClientGatewayRequest>);
 
@@ -339,6 +389,22 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::delete_client_gateway][super::super::client::ClientGatewaysService::delete_client_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::DeleteClientGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_beyondcorp_clientgateways_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteClientGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteClientGateway(RequestBuilder<crate::model::DeleteClientGatewayRequest>);
 
@@ -442,6 +508,25 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::list_locations][super::super::client::ClientGatewaysService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -532,6 +617,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::get_location][super::super::client::ClientGatewaysService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -577,6 +677,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::set_iam_policy][super::super::client::ClientGatewaysService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -644,6 +759,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::get_iam_policy][super::super::client::ClientGatewaysService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -700,6 +830,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::test_iam_permissions][super::super::client::ClientGatewaysService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -763,6 +908,25 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::list_operations][super::super::client::ClientGatewaysService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -855,6 +1019,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::get_operation][super::super::client::ClientGatewaysService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -903,6 +1082,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::delete_operation][super::super::client::ClientGatewaysService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -951,6 +1145,21 @@ pub mod client_gateways_service {
     }
 
     /// The request builder for [ClientGatewaysService::cancel_operation][super::super::client::ClientGatewaysService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_beyondcorp_clientgateways_v1::builder;
+    /// use builder::client_gateways_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::list_data_exchanges][super::super::client::AnalyticsHubService::list_data_exchanges] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::ListDataExchanges;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataExchanges {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataExchanges(RequestBuilder<crate::model::ListDataExchangesRequest>);
 
@@ -155,6 +174,25 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::list_org_data_exchanges][super::super::client::AnalyticsHubService::list_org_data_exchanges] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::ListOrgDataExchanges;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOrgDataExchanges {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOrgDataExchanges(RequestBuilder<crate::model::ListOrgDataExchangesRequest>);
 
@@ -243,6 +281,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::get_data_exchange][super::super::client::AnalyticsHubService::get_data_exchange] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::GetDataExchange;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataExchange {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataExchange(RequestBuilder<crate::model::GetDataExchangeRequest>);
 
@@ -290,6 +343,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::create_data_exchange][super::super::client::AnalyticsHubService::create_data_exchange] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::CreateDataExchange;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataExchange {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataExchange(RequestBuilder<crate::model::CreateDataExchangeRequest>);
 
@@ -359,6 +427,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::update_data_exchange][super::super::client::AnalyticsHubService::update_data_exchange] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::UpdateDataExchange;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataExchange {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataExchange(RequestBuilder<crate::model::UpdateDataExchangeRequest>);
 
@@ -423,6 +506,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::delete_data_exchange][super::super::client::AnalyticsHubService::delete_data_exchange] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::DeleteDataExchange;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataExchange {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataExchange(RequestBuilder<crate::model::DeleteDataExchangeRequest>);
 
@@ -473,6 +571,25 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::list_listings][super::super::client::AnalyticsHubService::list_listings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::ListListings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListListings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListListings(RequestBuilder<crate::model::ListListingsRequest>);
 
@@ -556,6 +673,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::get_listing][super::super::client::AnalyticsHubService::get_listing] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::GetListing;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetListing {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetListing(RequestBuilder<crate::model::GetListingRequest>);
 
@@ -603,6 +735,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::create_listing][super::super::client::AnalyticsHubService::create_listing] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::CreateListing;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateListing {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateListing(RequestBuilder<crate::model::CreateListingRequest>);
 
@@ -669,6 +816,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::update_listing][super::super::client::AnalyticsHubService::update_listing] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::UpdateListing;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateListing {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateListing(RequestBuilder<crate::model::UpdateListingRequest>);
 
@@ -730,6 +892,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::delete_listing][super::super::client::AnalyticsHubService::delete_listing] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::DeleteListing;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteListing {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteListing(RequestBuilder<crate::model::DeleteListingRequest>);
 
@@ -777,6 +954,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::subscribe_listing][super::super::client::AnalyticsHubService::subscribe_listing] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::SubscribeListing;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubscribeListing {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubscribeListing(RequestBuilder<crate::model::SubscribeListingRequest>);
 
@@ -871,6 +1063,22 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::subscribe_data_exchange][super::super::client::AnalyticsHubService::subscribe_data_exchange] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::SubscribeDataExchange;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigquery_analyticshub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubscribeDataExchange {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubscribeDataExchange(RequestBuilder<crate::model::SubscribeDataExchangeRequest>);
 
@@ -995,6 +1203,22 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::refresh_subscription][super::super::client::AnalyticsHubService::refresh_subscription] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::RefreshSubscription;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigquery_analyticshub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RefreshSubscription {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RefreshSubscription(RequestBuilder<crate::model::RefreshSubscriptionRequest>);
 
@@ -1086,6 +1310,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::get_subscription][super::super::client::AnalyticsHubService::get_subscription] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::GetSubscription;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSubscription {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSubscription(RequestBuilder<crate::model::GetSubscriptionRequest>);
 
@@ -1133,6 +1372,25 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::list_subscriptions][super::super::client::AnalyticsHubService::list_subscriptions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::ListSubscriptions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSubscriptions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSubscriptions(RequestBuilder<crate::model::ListSubscriptionsRequest>);
 
@@ -1225,6 +1483,25 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::list_shared_resource_subscriptions][super::super::client::AnalyticsHubService::list_shared_resource_subscriptions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::ListSharedResourceSubscriptions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSharedResourceSubscriptions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSharedResourceSubscriptions(
         RequestBuilder<crate::model::ListSharedResourceSubscriptionsRequest>,
@@ -1323,6 +1600,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::revoke_subscription][super::super::client::AnalyticsHubService::revoke_subscription] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::RevokeSubscription;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RevokeSubscription {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RevokeSubscription(RequestBuilder<crate::model::RevokeSubscriptionRequest>);
 
@@ -1373,6 +1665,22 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::delete_subscription][super::super::client::AnalyticsHubService::delete_subscription] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::DeleteSubscription;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_bigquery_analyticshub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSubscription {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSubscription(RequestBuilder<crate::model::DeleteSubscriptionRequest>);
 
@@ -1463,6 +1771,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::get_iam_policy][super::super::client::AnalyticsHubService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1519,6 +1842,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::set_iam_policy][super::super::client::AnalyticsHubService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1586,6 +1924,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::test_iam_permissions][super::super::client::AnalyticsHubService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1649,6 +2002,21 @@ pub mod analytics_hub_service {
     }
 
     /// The request builder for [AnalyticsHubService::get_operation][super::super::client::AnalyticsHubService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_analyticshub_v1::builder;
+    /// use builder::analytics_hub_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/bigquery/connection/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::create_connection][super::super::client::ConnectionService::create_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::CreateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -136,6 +151,21 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::get_connection][super::super::client::ConnectionService::get_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::GetConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -183,6 +213,25 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::list_connections][super::super::client::ConnectionService::list_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::ListConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -268,6 +317,21 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::update_connection][super::super::client::ConnectionService::update_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::UpdateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -340,6 +404,21 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::delete_connection][super::super::client::ConnectionService::delete_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::DeleteConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -390,6 +469,21 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::get_iam_policy][super::super::client::ConnectionService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -446,6 +540,21 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::set_iam_policy][super::super::client::ConnectionService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -513,6 +622,21 @@ pub mod connection_service {
     }
 
     /// The request builder for [ConnectionService::test_iam_permissions][super::super::client::ConnectionService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_connection_v1::builder;
+    /// use builder::connection_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::create_data_policy][super::super::client::DataPolicyService::create_data_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::CreateDataPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataPolicy(RequestBuilder<crate::model::CreateDataPolicyRequest>);
 
@@ -130,6 +145,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::update_data_policy][super::super::client::DataPolicyService::update_data_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::UpdateDataPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataPolicy(RequestBuilder<crate::model::UpdateDataPolicyRequest>);
 
@@ -192,6 +222,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::rename_data_policy][super::super::client::DataPolicyService::rename_data_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::RenameDataPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenameDataPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenameDataPolicy(RequestBuilder<crate::model::RenameDataPolicyRequest>);
 
@@ -250,6 +295,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::delete_data_policy][super::super::client::DataPolicyService::delete_data_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::DeleteDataPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataPolicy(RequestBuilder<crate::model::DeleteDataPolicyRequest>);
 
@@ -300,6 +360,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::get_data_policy][super::super::client::DataPolicyService::get_data_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::GetDataPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataPolicy(RequestBuilder<crate::model::GetDataPolicyRequest>);
 
@@ -347,6 +422,25 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::list_data_policies][super::super::client::DataPolicyService::list_data_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::ListDataPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataPolicies(RequestBuilder<crate::model::ListDataPoliciesRequest>);
 
@@ -439,6 +533,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::get_iam_policy][super::super::client::DataPolicyService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -495,6 +604,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::set_iam_policy][super::super::client::DataPolicyService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -562,6 +686,21 @@ pub mod data_policy_service {
     }
 
     /// The request builder for [DataPolicyService::test_iam_permissions][super::super::client::DataPolicyService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datapolicies_v1::builder;
+    /// use builder::data_policy_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::get_data_source][super::super::client::DataTransferService::get_data_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::GetDataSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataSource(RequestBuilder<crate::model::GetDataSourceRequest>);
 
@@ -116,6 +131,25 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::list_data_sources][super::super::client::DataTransferService::list_data_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::ListDataSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataSources(RequestBuilder<crate::model::ListDataSourcesRequest>);
 
@@ -199,6 +233,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::create_transfer_config][super::super::client::DataTransferService::create_transfer_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::CreateTransferConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTransferConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTransferConfig(RequestBuilder<crate::model::CreateTransferConfigRequest>);
 
@@ -279,6 +328,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::update_transfer_config][super::super::client::DataTransferService::update_transfer_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::UpdateTransferConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTransferConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTransferConfig(RequestBuilder<crate::model::UpdateTransferConfigRequest>);
 
@@ -362,6 +426,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::delete_transfer_config][super::super::client::DataTransferService::delete_transfer_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::DeleteTransferConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTransferConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTransferConfig(RequestBuilder<crate::model::DeleteTransferConfigRequest>);
 
@@ -412,6 +491,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::get_transfer_config][super::super::client::DataTransferService::get_transfer_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::GetTransferConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTransferConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTransferConfig(RequestBuilder<crate::model::GetTransferConfigRequest>);
 
@@ -462,6 +556,25 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::list_transfer_configs][super::super::client::DataTransferService::list_transfer_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::ListTransferConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTransferConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTransferConfigs(RequestBuilder<crate::model::ListTransferConfigsRequest>);
 
@@ -561,6 +674,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::schedule_transfer_runs][super::super::client::DataTransferService::schedule_transfer_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::ScheduleTransferRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ScheduleTransferRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ScheduleTransferRuns(RequestBuilder<crate::model::ScheduleTransferRunsRequest>);
 
@@ -630,6 +758,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::start_manual_transfer_runs][super::super::client::DataTransferService::start_manual_transfer_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::StartManualTransferRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartManualTransferRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartManualTransferRuns(
         RequestBuilder<crate::model::StartManualTransferRunsRequest>,
@@ -724,6 +867,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::get_transfer_run][super::super::client::DataTransferService::get_transfer_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::GetTransferRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTransferRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTransferRun(RequestBuilder<crate::model::GetTransferRunRequest>);
 
@@ -771,6 +929,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::delete_transfer_run][super::super::client::DataTransferService::delete_transfer_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::DeleteTransferRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTransferRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTransferRun(RequestBuilder<crate::model::DeleteTransferRunRequest>);
 
@@ -821,6 +994,25 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::list_transfer_runs][super::super::client::DataTransferService::list_transfer_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::ListTransferRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTransferRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTransferRuns(RequestBuilder<crate::model::ListTransferRunsRequest>);
 
@@ -927,6 +1119,25 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::list_transfer_logs][super::super::client::DataTransferService::list_transfer_logs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::ListTransferLogs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTransferLogs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTransferLogs(RequestBuilder<crate::model::ListTransferLogsRequest>);
 
@@ -1024,6 +1235,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::check_valid_creds][super::super::client::DataTransferService::check_valid_creds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::CheckValidCreds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckValidCreds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckValidCreds(RequestBuilder<crate::model::CheckValidCredsRequest>);
 
@@ -1071,6 +1297,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::enroll_data_sources][super::super::client::DataTransferService::enroll_data_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::EnrollDataSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnrollDataSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnrollDataSources(RequestBuilder<crate::model::EnrollDataSourcesRequest>);
 
@@ -1132,6 +1373,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::unenroll_data_sources][super::super::client::DataTransferService::unenroll_data_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::UnenrollDataSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UnenrollDataSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UnenrollDataSources(RequestBuilder<crate::model::UnenrollDataSourcesRequest>);
 
@@ -1193,6 +1449,25 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::list_locations][super::super::client::DataTransferService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1283,6 +1558,21 @@ pub mod data_transfer_service {
     }
 
     /// The request builder for [DataTransferService::get_location][super::super::client::DataTransferService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_datatransfer_v1::builder;
+    /// use builder::data_transfer_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/bigquery/migration/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::create_migration_workflow][super::super::client::MigrationService::create_migration_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_migration_v2::builder;
+    /// use builder::migration_service::CreateMigrationWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMigrationWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMigrationWorkflow(
         RequestBuilder<crate::model::CreateMigrationWorkflowRequest>,
@@ -134,6 +149,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::get_migration_workflow][super::super::client::MigrationService::get_migration_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_migration_v2::builder;
+    /// use builder::migration_service::GetMigrationWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMigrationWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMigrationWorkflow(RequestBuilder<crate::model::GetMigrationWorkflowRequest>);
 
@@ -190,6 +220,25 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::list_migration_workflows][super::super::client::MigrationService::list_migration_workflows] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_migration_v2::builder;
+    /// use builder::migration_service::ListMigrationWorkflows;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMigrationWorkflows {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMigrationWorkflows(RequestBuilder<crate::model::ListMigrationWorkflowsRequest>);
 
@@ -286,6 +335,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::delete_migration_workflow][super::super::client::MigrationService::delete_migration_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_migration_v2::builder;
+    /// use builder::migration_service::DeleteMigrationWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMigrationWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMigrationWorkflow(
         RequestBuilder<crate::model::DeleteMigrationWorkflowRequest>,
@@ -338,6 +402,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::start_migration_workflow][super::super::client::MigrationService::start_migration_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_migration_v2::builder;
+    /// use builder::migration_service::StartMigrationWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartMigrationWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartMigrationWorkflow(RequestBuilder<crate::model::StartMigrationWorkflowRequest>);
 
@@ -388,6 +467,21 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::get_migration_subtask][super::super::client::MigrationService::get_migration_subtask] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_migration_v2::builder;
+    /// use builder::migration_service::GetMigrationSubtask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMigrationSubtask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMigrationSubtask(RequestBuilder<crate::model::GetMigrationSubtaskRequest>);
 
@@ -444,6 +538,25 @@ pub mod migration_service {
     }
 
     /// The request builder for [MigrationService::list_migration_subtasks][super::super::client::MigrationService::list_migration_subtasks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_migration_v2::builder;
+    /// use builder::migration_service::ListMigrationSubtasks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMigrationSubtasks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMigrationSubtasks(RequestBuilder<crate::model::ListMigrationSubtasksRequest>);
 

--- a/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::create_reservation][super::super::client::ReservationService::create_reservation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::CreateReservation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReservation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReservation(RequestBuilder<crate::model::CreateReservationRequest>);
 
@@ -134,6 +149,25 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::list_reservations][super::super::client::ReservationService::list_reservations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::ListReservations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReservations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReservations(RequestBuilder<crate::model::ListReservationsRequest>);
 
@@ -220,6 +254,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::get_reservation][super::super::client::ReservationService::get_reservation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::GetReservation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReservation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReservation(RequestBuilder<crate::model::GetReservationRequest>);
 
@@ -267,6 +316,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::delete_reservation][super::super::client::ReservationService::delete_reservation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::DeleteReservation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteReservation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteReservation(RequestBuilder<crate::model::DeleteReservationRequest>);
 
@@ -317,6 +381,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::update_reservation][super::super::client::ReservationService::update_reservation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::UpdateReservation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateReservation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateReservation(RequestBuilder<crate::model::UpdateReservationRequest>);
 
@@ -377,6 +456,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::failover_reservation][super::super::client::ReservationService::failover_reservation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::FailoverReservation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FailoverReservation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FailoverReservation(RequestBuilder<crate::model::FailoverReservationRequest>);
 
@@ -427,6 +521,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::create_capacity_commitment][super::super::client::ReservationService::create_capacity_commitment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::CreateCapacityCommitment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCapacityCommitment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCapacityCommitment(
         RequestBuilder<crate::model::CreateCapacityCommitmentRequest>,
@@ -502,6 +611,25 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::list_capacity_commitments][super::super::client::ReservationService::list_capacity_commitments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::ListCapacityCommitments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCapacityCommitments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCapacityCommitments(
         RequestBuilder<crate::model::ListCapacityCommitmentsRequest>,
@@ -594,6 +722,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::get_capacity_commitment][super::super::client::ReservationService::get_capacity_commitment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::GetCapacityCommitment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCapacityCommitment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCapacityCommitment(RequestBuilder<crate::model::GetCapacityCommitmentRequest>);
 
@@ -644,6 +787,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::delete_capacity_commitment][super::super::client::ReservationService::delete_capacity_commitment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::DeleteCapacityCommitment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCapacityCommitment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCapacityCommitment(
         RequestBuilder<crate::model::DeleteCapacityCommitmentRequest>,
@@ -702,6 +860,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::update_capacity_commitment][super::super::client::ReservationService::update_capacity_commitment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::UpdateCapacityCommitment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCapacityCommitment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCapacityCommitment(
         RequestBuilder<crate::model::UpdateCapacityCommitmentRequest>,
@@ -766,6 +939,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::split_capacity_commitment][super::super::client::ReservationService::split_capacity_commitment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::SplitCapacityCommitment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SplitCapacityCommitment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SplitCapacityCommitment(
         RequestBuilder<crate::model::SplitCapacityCommitmentRequest>,
@@ -824,6 +1012,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::merge_capacity_commitments][super::super::client::ReservationService::merge_capacity_commitments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::MergeCapacityCommitments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MergeCapacityCommitments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MergeCapacityCommitments(
         RequestBuilder<crate::model::MergeCapacityCommitmentsRequest>,
@@ -885,6 +1088,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::create_assignment][super::super::client::ReservationService::create_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::CreateAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAssignment(RequestBuilder<crate::model::CreateAssignmentRequest>);
 
@@ -950,6 +1168,25 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::list_assignments][super::super::client::ReservationService::list_assignments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::ListAssignments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAssignments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAssignments(RequestBuilder<crate::model::ListAssignmentsRequest>);
 
@@ -1033,6 +1270,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::delete_assignment][super::super::client::ReservationService::delete_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::DeleteAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAssignment(RequestBuilder<crate::model::DeleteAssignmentRequest>);
 
@@ -1083,6 +1335,25 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::search_assignments][super::super::client::ReservationService::search_assignments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::SearchAssignments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchAssignments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchAssignments(RequestBuilder<crate::model::SearchAssignmentsRequest>);
 
@@ -1175,6 +1446,25 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::search_all_assignments][super::super::client::ReservationService::search_all_assignments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::SearchAllAssignments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchAllAssignments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchAllAssignments(RequestBuilder<crate::model::SearchAllAssignmentsRequest>);
 
@@ -1269,6 +1559,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::move_assignment][super::super::client::ReservationService::move_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::MoveAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MoveAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MoveAssignment(RequestBuilder<crate::model::MoveAssignmentRequest>);
 
@@ -1328,6 +1633,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::update_assignment][super::super::client::ReservationService::update_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::UpdateAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAssignment(RequestBuilder<crate::model::UpdateAssignmentRequest>);
 
@@ -1388,6 +1708,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::get_bi_reservation][super::super::client::ReservationService::get_bi_reservation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::GetBiReservation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBiReservation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBiReservation(RequestBuilder<crate::model::GetBiReservationRequest>);
 
@@ -1438,6 +1773,21 @@ pub mod reservation_service {
     }
 
     /// The request builder for [ReservationService::update_bi_reservation][super::super::client::ReservationService::update_bi_reservation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_reservation_v1::builder;
+    /// use builder::reservation_service::UpdateBiReservation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBiReservation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBiReservation(RequestBuilder<crate::model::UpdateBiReservationRequest>);
 

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::get_dataset][super::super::client::DatasetService::get_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::dataset_service::GetDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -139,6 +154,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::insert_dataset][super::super::client::DatasetService::insert_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::dataset_service::InsertDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InsertDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InsertDataset(RequestBuilder<crate::model::InsertDatasetRequest>);
 
@@ -203,6 +233,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::patch_dataset][super::super::client::DatasetService::patch_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::dataset_service::PatchDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PatchDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PatchDataset(RequestBuilder<crate::model::UpdateOrPatchDatasetRequest>);
 
@@ -289,6 +334,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::update_dataset][super::super::client::DatasetService::update_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::dataset_service::UpdateDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataset(RequestBuilder<crate::model::UpdateOrPatchDatasetRequest>);
 
@@ -375,6 +435,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::delete_dataset][super::super::client::DatasetService::delete_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::dataset_service::DeleteDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -436,6 +511,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::list_datasets][super::super::client::DatasetService::list_datasets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::dataset_service::ListDatasets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatasets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -510,6 +600,21 @@ pub mod dataset_service {
     }
 
     /// The request builder for [DatasetService::undelete_dataset][super::super::client::DatasetService::undelete_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::dataset_service::UndeleteDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteDataset(RequestBuilder<crate::model::UndeleteDatasetRequest>);
 
@@ -629,6 +734,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::model_service::GetModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -692,6 +812,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::model_service::ListModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -762,6 +897,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::patch_model][super::super::client::ModelService::patch_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::model_service::PatchModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PatchModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PatchModel(RequestBuilder<crate::model::PatchModelRequest>);
 
@@ -836,6 +986,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::model_service::DeleteModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -954,6 +1119,21 @@ pub mod project_service {
     }
 
     /// The request builder for [ProjectService::get_service_account][super::super::client::ProjectService::get_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::project_service::GetServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceAccount(RequestBuilder<crate::model::GetServiceAccountRequest>);
 
@@ -1059,6 +1239,21 @@ pub mod routine_service {
     }
 
     /// The request builder for [RoutineService::get_routine][super::super::client::RoutineService::get_routine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::routine_service::GetRoutine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRoutine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRoutine(RequestBuilder<crate::model::GetRoutineRequest>);
 
@@ -1122,6 +1317,21 @@ pub mod routine_service {
     }
 
     /// The request builder for [RoutineService::insert_routine][super::super::client::RoutineService::insert_routine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::routine_service::InsertRoutine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InsertRoutine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InsertRoutine(RequestBuilder<crate::model::InsertRoutineRequest>);
 
@@ -1188,6 +1398,21 @@ pub mod routine_service {
     }
 
     /// The request builder for [RoutineService::update_routine][super::super::client::RoutineService::update_routine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::routine_service::UpdateRoutine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRoutine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRoutine(RequestBuilder<crate::model::UpdateRoutineRequest>);
 
@@ -1262,6 +1487,21 @@ pub mod routine_service {
     }
 
     /// The request builder for [RoutineService::delete_routine][super::super::client::RoutineService::delete_routine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::routine_service::DeleteRoutine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRoutine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRoutine(RequestBuilder<crate::model::DeleteRoutineRequest>);
 
@@ -1325,6 +1565,21 @@ pub mod routine_service {
     }
 
     /// The request builder for [RoutineService::list_routines][super::super::client::RoutineService::list_routines] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::routine_service::ListRoutines;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRoutines {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRoutines(RequestBuilder<crate::model::ListRoutinesRequest>);
 
@@ -1456,6 +1711,25 @@ pub mod row_access_policy_service {
     }
 
     /// The request builder for [RowAccessPolicyService::list_row_access_policies][super::super::client::RowAccessPolicyService::list_row_access_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::row_access_policy_service::ListRowAccessPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRowAccessPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRowAccessPolicies(RequestBuilder<crate::model::ListRowAccessPoliciesRequest>);
 
@@ -1560,6 +1834,21 @@ pub mod row_access_policy_service {
     }
 
     /// The request builder for [RowAccessPolicyService::get_row_access_policy][super::super::client::RowAccessPolicyService::get_row_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::row_access_policy_service::GetRowAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRowAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRowAccessPolicy(RequestBuilder<crate::model::GetRowAccessPolicyRequest>);
 
@@ -1634,6 +1923,21 @@ pub mod row_access_policy_service {
     }
 
     /// The request builder for [RowAccessPolicyService::create_row_access_policy][super::super::client::RowAccessPolicyService::create_row_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::row_access_policy_service::CreateRowAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRowAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRowAccessPolicy(RequestBuilder<crate::model::CreateRowAccessPolicyRequest>);
 
@@ -1713,6 +2017,21 @@ pub mod row_access_policy_service {
     }
 
     /// The request builder for [RowAccessPolicyService::update_row_access_policy][super::super::client::RowAccessPolicyService::update_row_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::row_access_policy_service::UpdateRowAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRowAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRowAccessPolicy(RequestBuilder<crate::model::UpdateRowAccessPolicyRequest>);
 
@@ -1800,6 +2119,21 @@ pub mod row_access_policy_service {
     }
 
     /// The request builder for [RowAccessPolicyService::delete_row_access_policy][super::super::client::RowAccessPolicyService::delete_row_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::row_access_policy_service::DeleteRowAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRowAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRowAccessPolicy(RequestBuilder<crate::model::DeleteRowAccessPolicyRequest>);
 
@@ -1880,6 +2214,21 @@ pub mod row_access_policy_service {
     }
 
     /// The request builder for [RowAccessPolicyService::batch_delete_row_access_policies][super::super::client::RowAccessPolicyService::batch_delete_row_access_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::row_access_policy_service::BatchDeleteRowAccessPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteRowAccessPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteRowAccessPolicies(
         RequestBuilder<crate::model::BatchDeleteRowAccessPoliciesRequest>,
@@ -2022,6 +2371,21 @@ pub mod table_service {
     }
 
     /// The request builder for [TableService::get_table][super::super::client::TableService::get_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::table_service::GetTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTable(RequestBuilder<crate::model::GetTableRequest>);
 
@@ -2100,6 +2464,21 @@ pub mod table_service {
     }
 
     /// The request builder for [TableService::insert_table][super::super::client::TableService::insert_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::table_service::InsertTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InsertTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InsertTable(RequestBuilder<crate::model::InsertTableRequest>);
 
@@ -2166,6 +2545,21 @@ pub mod table_service {
     }
 
     /// The request builder for [TableService::patch_table][super::super::client::TableService::patch_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::table_service::PatchTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PatchTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PatchTable(RequestBuilder<crate::model::UpdateOrPatchTableRequest>);
 
@@ -2249,6 +2643,21 @@ pub mod table_service {
     }
 
     /// The request builder for [TableService::update_table][super::super::client::TableService::update_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::table_service::UpdateTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTable(RequestBuilder<crate::model::UpdateOrPatchTableRequest>);
 
@@ -2332,6 +2741,21 @@ pub mod table_service {
     }
 
     /// The request builder for [TableService::delete_table][super::super::client::TableService::delete_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::table_service::DeleteTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTable(RequestBuilder<crate::model::DeleteTableRequest>);
 
@@ -2395,6 +2819,21 @@ pub mod table_service {
     }
 
     /// The request builder for [TableService::list_tables][super::super::client::TableService::list_tables] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_bigquery_v2::builder;
+    /// use builder::table_service::ListTables;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTables {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTables(RequestBuilder<crate::model::ListTablesRequest>);
 

--- a/src/generated/cloud/billing/v1/src/builder.rs
+++ b/src/generated/cloud/billing/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::get_billing_account][super::super::client::CloudBilling::get_billing_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::GetBillingAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBillingAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBillingAccount(RequestBuilder<crate::model::GetBillingAccountRequest>);
 
@@ -119,6 +134,25 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::list_billing_accounts][super::super::client::CloudBilling::list_billing_accounts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::ListBillingAccounts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBillingAccounts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBillingAccounts(RequestBuilder<crate::model::ListBillingAccountsRequest>);
 
@@ -211,6 +245,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::update_billing_account][super::super::client::CloudBilling::update_billing_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::UpdateBillingAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBillingAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBillingAccount(RequestBuilder<crate::model::UpdateBillingAccountRequest>);
 
@@ -281,6 +330,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::create_billing_account][super::super::client::CloudBilling::create_billing_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::CreateBillingAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBillingAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBillingAccount(RequestBuilder<crate::model::CreateBillingAccountRequest>);
 
@@ -340,6 +404,25 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::list_project_billing_info][super::super::client::CloudBilling::list_project_billing_info] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::ListProjectBillingInfo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProjectBillingInfo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProjectBillingInfo(RequestBuilder<crate::model::ListProjectBillingInfoRequest>);
 
@@ -430,6 +513,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::get_project_billing_info][super::super::client::CloudBilling::get_project_billing_info] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::GetProjectBillingInfo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProjectBillingInfo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProjectBillingInfo(RequestBuilder<crate::model::GetProjectBillingInfoRequest>);
 
@@ -480,6 +578,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::update_project_billing_info][super::super::client::CloudBilling::update_project_billing_info] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::UpdateProjectBillingInfo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProjectBillingInfo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProjectBillingInfo(
         RequestBuilder<crate::model::UpdateProjectBillingInfoRequest>,
@@ -543,6 +656,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::get_iam_policy][super::super::client::CloudBilling::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -599,6 +727,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::set_iam_policy][super::super::client::CloudBilling::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -666,6 +809,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::test_iam_permissions][super::super::client::CloudBilling::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -729,6 +887,21 @@ pub mod cloud_billing {
     }
 
     /// The request builder for [CloudBilling::move_billing_account][super::super::client::CloudBilling::move_billing_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_billing::MoveBillingAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MoveBillingAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MoveBillingAccount(RequestBuilder<crate::model::MoveBillingAccountRequest>);
 
@@ -842,6 +1015,25 @@ pub mod cloud_catalog {
     }
 
     /// The request builder for [CloudCatalog::list_services][super::super::client::CloudCatalog::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_catalog::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -917,6 +1109,25 @@ pub mod cloud_catalog {
     }
 
     /// The request builder for [CloudCatalog::list_skus][super::super::client::CloudCatalog::list_skus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_billing_v1::builder;
+    /// use builder::cloud_catalog::ListSkus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSkus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSkus(RequestBuilder<crate::model::ListSkusRequest>);
 

--- a/src/generated/cloud/binaryauthorization/v1/src/builder.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod binauthz_management_service_v_1 {
     }
 
     /// The request builder for [BinauthzManagementServiceV1::get_policy][super::super::client::BinauthzManagementServiceV1::get_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::binauthz_management_service_v_1::GetPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPolicy(RequestBuilder<crate::model::GetPolicyRequest>);
 
@@ -116,6 +131,21 @@ pub mod binauthz_management_service_v_1 {
     }
 
     /// The request builder for [BinauthzManagementServiceV1::update_policy][super::super::client::BinauthzManagementServiceV1::update_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::binauthz_management_service_v_1::UpdatePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePolicy(RequestBuilder<crate::model::UpdatePolicyRequest>);
 
@@ -166,6 +196,21 @@ pub mod binauthz_management_service_v_1 {
     }
 
     /// The request builder for [BinauthzManagementServiceV1::create_attestor][super::super::client::BinauthzManagementServiceV1::create_attestor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::binauthz_management_service_v_1::CreateAttestor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAttestor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAttestor(RequestBuilder<crate::model::CreateAttestorRequest>);
 
@@ -232,6 +277,21 @@ pub mod binauthz_management_service_v_1 {
     }
 
     /// The request builder for [BinauthzManagementServiceV1::get_attestor][super::super::client::BinauthzManagementServiceV1::get_attestor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::binauthz_management_service_v_1::GetAttestor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAttestor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAttestor(RequestBuilder<crate::model::GetAttestorRequest>);
 
@@ -279,6 +339,21 @@ pub mod binauthz_management_service_v_1 {
     }
 
     /// The request builder for [BinauthzManagementServiceV1::update_attestor][super::super::client::BinauthzManagementServiceV1::update_attestor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::binauthz_management_service_v_1::UpdateAttestor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAttestor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAttestor(RequestBuilder<crate::model::UpdateAttestorRequest>);
 
@@ -329,6 +404,25 @@ pub mod binauthz_management_service_v_1 {
     }
 
     /// The request builder for [BinauthzManagementServiceV1::list_attestors][super::super::client::BinauthzManagementServiceV1::list_attestors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::binauthz_management_service_v_1::ListAttestors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAttestors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAttestors(RequestBuilder<crate::model::ListAttestorsRequest>);
 
@@ -412,6 +506,21 @@ pub mod binauthz_management_service_v_1 {
     }
 
     /// The request builder for [BinauthzManagementServiceV1::delete_attestor][super::super::client::BinauthzManagementServiceV1::delete_attestor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::binauthz_management_service_v_1::DeleteAttestor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAttestor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAttestor(RequestBuilder<crate::model::DeleteAttestorRequest>);
 
@@ -514,6 +623,21 @@ pub mod system_policy_v_1 {
     }
 
     /// The request builder for [SystemPolicyV1::get_system_policy][super::super::client::SystemPolicyV1::get_system_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::system_policy_v_1::GetSystemPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSystemPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSystemPolicy(RequestBuilder<crate::model::GetSystemPolicyRequest>);
 
@@ -616,6 +740,21 @@ pub mod validation_helper_v_1 {
     }
 
     /// The request builder for [ValidationHelperV1::validate_attestation_occurrence][super::super::client::ValidationHelperV1::validate_attestation_occurrence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_binaryauthorization_v1::builder;
+    /// use builder::validation_helper_v_1::ValidateAttestationOccurrence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ValidateAttestationOccurrence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ValidateAttestationOccurrence(
         RequestBuilder<crate::model::ValidateAttestationOccurrenceRequest>,

--- a/src/generated/cloud/certificatemanager/v1/src/builder.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_certificates][super::super::client::CertificateManager::list_certificates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListCertificates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificates(RequestBuilder<crate::model::ListCertificatesRequest>);
 
@@ -167,6 +186,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_certificate][super::super::client::CertificateManager::get_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificate(RequestBuilder<crate::model::GetCertificateRequest>);
 
@@ -214,6 +248,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::create_certificate][super::super::client::CertificateManager::create_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::CreateCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCertificate(RequestBuilder<crate::model::CreateCertificateRequest>);
 
@@ -323,6 +373,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::update_certificate][super::super::client::CertificateManager::update_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::UpdateCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCertificate(RequestBuilder<crate::model::UpdateCertificateRequest>);
 
@@ -427,6 +493,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::delete_certificate][super::super::client::CertificateManager::delete_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::DeleteCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCertificate(RequestBuilder<crate::model::DeleteCertificateRequest>);
 
@@ -517,6 +599,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_certificate_maps][super::super::client::CertificateManager::list_certificate_maps] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListCertificateMaps;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificateMaps {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificateMaps(RequestBuilder<crate::model::ListCertificateMapsRequest>);
 
@@ -617,6 +718,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_certificate_map][super::super::client::CertificateManager::get_certificate_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetCertificateMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificateMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificateMap(RequestBuilder<crate::model::GetCertificateMapRequest>);
 
@@ -667,6 +783,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::create_certificate_map][super::super::client::CertificateManager::create_certificate_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::CreateCertificateMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCertificateMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCertificateMap(RequestBuilder<crate::model::CreateCertificateMapRequest>);
 
@@ -777,6 +909,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::update_certificate_map][super::super::client::CertificateManager::update_certificate_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::UpdateCertificateMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCertificateMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateMap(RequestBuilder<crate::model::UpdateCertificateMapRequest>);
 
@@ -882,6 +1030,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::delete_certificate_map][super::super::client::CertificateManager::delete_certificate_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::DeleteCertificateMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCertificateMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateMap(RequestBuilder<crate::model::DeleteCertificateMapRequest>);
 
@@ -972,6 +1136,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_certificate_map_entries][super::super::client::CertificateManager::list_certificate_map_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListCertificateMapEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificateMapEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificateMapEntries(
         RequestBuilder<crate::model::ListCertificateMapEntriesRequest>,
@@ -1076,6 +1259,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_certificate_map_entry][super::super::client::CertificateManager::get_certificate_map_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetCertificateMapEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificateMapEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificateMapEntry(RequestBuilder<crate::model::GetCertificateMapEntryRequest>);
 
@@ -1126,6 +1324,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::create_certificate_map_entry][super::super::client::CertificateManager::create_certificate_map_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::CreateCertificateMapEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCertificateMapEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCertificateMapEntry(
         RequestBuilder<crate::model::CreateCertificateMapEntryRequest>,
@@ -1240,6 +1454,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::update_certificate_map_entry][super::super::client::CertificateManager::update_certificate_map_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::UpdateCertificateMapEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCertificateMapEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateMapEntry(
         RequestBuilder<crate::model::UpdateCertificateMapEntryRequest>,
@@ -1349,6 +1579,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::delete_certificate_map_entry][super::super::client::CertificateManager::delete_certificate_map_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::DeleteCertificateMapEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCertificateMapEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateMapEntry(
         RequestBuilder<crate::model::DeleteCertificateMapEntryRequest>,
@@ -1441,6 +1687,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_dns_authorizations][super::super::client::CertificateManager::list_dns_authorizations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListDnsAuthorizations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDnsAuthorizations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDnsAuthorizations(RequestBuilder<crate::model::ListDnsAuthorizationsRequest>);
 
@@ -1541,6 +1806,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_dns_authorization][super::super::client::CertificateManager::get_dns_authorization] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetDnsAuthorization;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDnsAuthorization {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDnsAuthorization(RequestBuilder<crate::model::GetDnsAuthorizationRequest>);
 
@@ -1591,6 +1871,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::create_dns_authorization][super::super::client::CertificateManager::create_dns_authorization] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::CreateDnsAuthorization;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDnsAuthorization {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDnsAuthorization(RequestBuilder<crate::model::CreateDnsAuthorizationRequest>);
 
@@ -1703,6 +1999,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::update_dns_authorization][super::super::client::CertificateManager::update_dns_authorization] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::UpdateDnsAuthorization;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDnsAuthorization {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDnsAuthorization(RequestBuilder<crate::model::UpdateDnsAuthorizationRequest>);
 
@@ -1810,6 +2122,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::delete_dns_authorization][super::super::client::CertificateManager::delete_dns_authorization] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::DeleteDnsAuthorization;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDnsAuthorization {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDnsAuthorization(RequestBuilder<crate::model::DeleteDnsAuthorizationRequest>);
 
@@ -1900,6 +2228,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_certificate_issuance_configs][super::super::client::CertificateManager::list_certificate_issuance_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListCertificateIssuanceConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificateIssuanceConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificateIssuanceConfigs(
         RequestBuilder<crate::model::ListCertificateIssuanceConfigsRequest>,
@@ -2004,6 +2351,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_certificate_issuance_config][super::super::client::CertificateManager::get_certificate_issuance_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetCertificateIssuanceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificateIssuanceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificateIssuanceConfig(
         RequestBuilder<crate::model::GetCertificateIssuanceConfigRequest>,
@@ -2056,6 +2418,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::create_certificate_issuance_config][super::super::client::CertificateManager::create_certificate_issuance_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::CreateCertificateIssuanceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCertificateIssuanceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCertificateIssuanceConfig(
         RequestBuilder<crate::model::CreateCertificateIssuanceConfigRequest>,
@@ -2173,6 +2551,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::delete_certificate_issuance_config][super::super::client::CertificateManager::delete_certificate_issuance_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::DeleteCertificateIssuanceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCertificateIssuanceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateIssuanceConfig(
         RequestBuilder<crate::model::DeleteCertificateIssuanceConfigRequest>,
@@ -2265,6 +2659,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_trust_configs][super::super::client::CertificateManager::list_trust_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListTrustConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTrustConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTrustConfigs(RequestBuilder<crate::model::ListTrustConfigsRequest>);
 
@@ -2363,6 +2776,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_trust_config][super::super::client::CertificateManager::get_trust_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetTrustConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTrustConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTrustConfig(RequestBuilder<crate::model::GetTrustConfigRequest>);
 
@@ -2410,6 +2838,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::create_trust_config][super::super::client::CertificateManager::create_trust_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::CreateTrustConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTrustConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTrustConfig(RequestBuilder<crate::model::CreateTrustConfigRequest>);
 
@@ -2519,6 +2963,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::update_trust_config][super::super::client::CertificateManager::update_trust_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::UpdateTrustConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTrustConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTrustConfig(RequestBuilder<crate::model::UpdateTrustConfigRequest>);
 
@@ -2623,6 +3083,22 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::delete_trust_config][super::super::client::CertificateManager::delete_trust_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::DeleteTrustConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_certificatemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTrustConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTrustConfig(RequestBuilder<crate::model::DeleteTrustConfigRequest>);
 
@@ -2719,6 +3195,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_locations][super::super::client::CertificateManager::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2809,6 +3304,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_location][super::super::client::CertificateManager::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2854,6 +3364,25 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::list_operations][super::super::client::CertificateManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2946,6 +3475,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::get_operation][super::super::client::CertificateManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2994,6 +3538,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::delete_operation][super::super::client::CertificateManager::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3042,6 +3601,21 @@ pub mod certificate_manager {
     }
 
     /// The request builder for [CertificateManager::cancel_operation][super::super::client::CertificateManager::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_certificatemanager_v1::builder;
+    /// use builder::certificate_manager::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/chronicle/v1/src/builder.rs
+++ b/src/generated/cloud/chronicle/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::create_data_access_label][super::super::client::DataAccessControlService::create_data_access_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::CreateDataAccessLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataAccessLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataAccessLabel(RequestBuilder<crate::model::CreateDataAccessLabelRequest>);
 
@@ -140,6 +155,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::get_data_access_label][super::super::client::DataAccessControlService::get_data_access_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::GetDataAccessLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataAccessLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataAccessLabel(RequestBuilder<crate::model::GetDataAccessLabelRequest>);
 
@@ -190,6 +220,25 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::list_data_access_labels][super::super::client::DataAccessControlService::list_data_access_labels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::ListDataAccessLabels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataAccessLabels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataAccessLabels(RequestBuilder<crate::model::ListDataAccessLabelsRequest>);
 
@@ -284,6 +333,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::update_data_access_label][super::super::client::DataAccessControlService::update_data_access_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::UpdateDataAccessLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataAccessLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataAccessLabel(RequestBuilder<crate::model::UpdateDataAccessLabelRequest>);
 
@@ -348,6 +412,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::delete_data_access_label][super::super::client::DataAccessControlService::delete_data_access_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::DeleteDataAccessLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataAccessLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataAccessLabel(RequestBuilder<crate::model::DeleteDataAccessLabelRequest>);
 
@@ -398,6 +477,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::create_data_access_scope][super::super::client::DataAccessControlService::create_data_access_scope] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::CreateDataAccessScope;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataAccessScope {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataAccessScope(RequestBuilder<crate::model::CreateDataAccessScopeRequest>);
 
@@ -469,6 +563,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::get_data_access_scope][super::super::client::DataAccessControlService::get_data_access_scope] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::GetDataAccessScope;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataAccessScope {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataAccessScope(RequestBuilder<crate::model::GetDataAccessScopeRequest>);
 
@@ -519,6 +628,25 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::list_data_access_scopes][super::super::client::DataAccessControlService::list_data_access_scopes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::ListDataAccessScopes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataAccessScopes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataAccessScopes(RequestBuilder<crate::model::ListDataAccessScopesRequest>);
 
@@ -613,6 +741,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::update_data_access_scope][super::super::client::DataAccessControlService::update_data_access_scope] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::UpdateDataAccessScope;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataAccessScope {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataAccessScope(RequestBuilder<crate::model::UpdateDataAccessScopeRequest>);
 
@@ -677,6 +820,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::delete_data_access_scope][super::super::client::DataAccessControlService::delete_data_access_scope] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::DeleteDataAccessScope;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataAccessScope {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataAccessScope(RequestBuilder<crate::model::DeleteDataAccessScopeRequest>);
 
@@ -727,6 +885,25 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::list_operations][super::super::client::DataAccessControlService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -819,6 +996,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::get_operation][super::super::client::DataAccessControlService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -867,6 +1059,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::delete_operation][super::super::client::DataAccessControlService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -915,6 +1122,21 @@ pub mod data_access_control_service {
     }
 
     /// The request builder for [DataAccessControlService::cancel_operation][super::super::client::DataAccessControlService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::data_access_control_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1018,6 +1240,21 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::get_watchlist][super::super::client::EntityService::get_watchlist] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::GetWatchlist;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWatchlist {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWatchlist(RequestBuilder<crate::model::GetWatchlistRequest>);
 
@@ -1065,6 +1302,25 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::list_watchlists][super::super::client::EntityService::list_watchlists] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::ListWatchlists;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWatchlists {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWatchlists(RequestBuilder<crate::model::ListWatchlistsRequest>);
 
@@ -1154,6 +1410,21 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::create_watchlist][super::super::client::EntityService::create_watchlist] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::CreateWatchlist;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWatchlist {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWatchlist(RequestBuilder<crate::model::CreateWatchlistRequest>);
 
@@ -1218,6 +1489,21 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::update_watchlist][super::super::client::EntityService::update_watchlist] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::UpdateWatchlist;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWatchlist {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWatchlist(RequestBuilder<crate::model::UpdateWatchlistRequest>);
 
@@ -1277,6 +1563,21 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::delete_watchlist][super::super::client::EntityService::delete_watchlist] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::DeleteWatchlist;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWatchlist {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWatchlist(RequestBuilder<crate::model::DeleteWatchlistRequest>);
 
@@ -1330,6 +1631,25 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::list_operations][super::super::client::EntityService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1422,6 +1742,21 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::get_operation][super::super::client::EntityService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1470,6 +1805,21 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::delete_operation][super::super::client::EntityService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1518,6 +1868,21 @@ pub mod entity_service {
     }
 
     /// The request builder for [EntityService::cancel_operation][super::super::client::EntityService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::entity_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1621,6 +1986,21 @@ pub mod instance_service {
     }
 
     /// The request builder for [InstanceService::get_instance][super::super::client::InstanceService::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::instance_service::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -1668,6 +2048,25 @@ pub mod instance_service {
     }
 
     /// The request builder for [InstanceService::list_operations][super::super::client::InstanceService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::instance_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1760,6 +2159,21 @@ pub mod instance_service {
     }
 
     /// The request builder for [InstanceService::get_operation][super::super::client::InstanceService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::instance_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1808,6 +2222,21 @@ pub mod instance_service {
     }
 
     /// The request builder for [InstanceService::delete_operation][super::super::client::InstanceService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::instance_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1856,6 +2285,21 @@ pub mod instance_service {
     }
 
     /// The request builder for [InstanceService::cancel_operation][super::super::client::InstanceService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::instance_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1959,6 +2403,21 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::get_reference_list][super::super::client::ReferenceListService::get_reference_list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::GetReferenceList;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReferenceList {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReferenceList(RequestBuilder<crate::model::GetReferenceListRequest>);
 
@@ -2015,6 +2474,25 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::list_reference_lists][super::super::client::ReferenceListService::list_reference_lists] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::ListReferenceLists;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReferenceLists {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReferenceLists(RequestBuilder<crate::model::ListReferenceListsRequest>);
 
@@ -2109,6 +2587,21 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::create_reference_list][super::super::client::ReferenceListService::create_reference_list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::CreateReferenceList;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReferenceList {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReferenceList(RequestBuilder<crate::model::CreateReferenceListRequest>);
 
@@ -2178,6 +2671,21 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::update_reference_list][super::super::client::ReferenceListService::update_reference_list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::UpdateReferenceList;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateReferenceList {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateReferenceList(RequestBuilder<crate::model::UpdateReferenceListRequest>);
 
@@ -2240,6 +2748,25 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::list_operations][super::super::client::ReferenceListService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2332,6 +2859,21 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::get_operation][super::super::client::ReferenceListService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2380,6 +2922,21 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::delete_operation][super::super::client::ReferenceListService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2428,6 +2985,21 @@ pub mod reference_list_service {
     }
 
     /// The request builder for [ReferenceListService::cancel_operation][super::super::client::ReferenceListService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::reference_list_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2531,6 +3103,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::create_rule][super::super::client::RuleService::create_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::CreateRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRule(RequestBuilder<crate::model::CreateRuleRequest>);
 
@@ -2586,6 +3173,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::get_rule][super::super::client::RuleService::get_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::GetRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRule(RequestBuilder<crate::model::GetRuleRequest>);
 
@@ -2639,6 +3241,25 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::list_rules][super::super::client::RuleService::list_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::ListRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRules(RequestBuilder<crate::model::ListRulesRequest>);
 
@@ -2734,6 +3355,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::update_rule][super::super::client::RuleService::update_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::UpdateRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRule(RequestBuilder<crate::model::UpdateRuleRequest>);
 
@@ -2790,6 +3426,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::delete_rule][super::super::client::RuleService::delete_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::DeleteRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRule(RequestBuilder<crate::model::DeleteRuleRequest>);
 
@@ -2843,6 +3494,25 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::list_rule_revisions][super::super::client::RuleService::list_rule_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::ListRuleRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuleRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuleRevisions(RequestBuilder<crate::model::ListRuleRevisionsRequest>);
 
@@ -2935,6 +3605,22 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::create_retrohunt][super::super::client::RuleService::create_retrohunt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::CreateRetrohunt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_chronicle_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRetrohunt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRetrohunt(RequestBuilder<crate::model::CreateRetrohuntRequest>);
 
@@ -3031,6 +3717,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::get_retrohunt][super::super::client::RuleService::get_retrohunt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::GetRetrohunt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRetrohunt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRetrohunt(RequestBuilder<crate::model::GetRetrohuntRequest>);
 
@@ -3078,6 +3779,25 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::list_retrohunts][super::super::client::RuleService::list_retrohunts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::ListRetrohunts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRetrohunts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRetrohunts(RequestBuilder<crate::model::ListRetrohuntsRequest>);
 
@@ -3167,6 +3887,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::get_rule_deployment][super::super::client::RuleService::get_rule_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::GetRuleDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRuleDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRuleDeployment(RequestBuilder<crate::model::GetRuleDeploymentRequest>);
 
@@ -3217,6 +3952,25 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::list_rule_deployments][super::super::client::RuleService::list_rule_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::ListRuleDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuleDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuleDeployments(RequestBuilder<crate::model::ListRuleDeploymentsRequest>);
 
@@ -3311,6 +4065,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::update_rule_deployment][super::super::client::RuleService::update_rule_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::UpdateRuleDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRuleDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRuleDeployment(RequestBuilder<crate::model::UpdateRuleDeploymentRequest>);
 
@@ -3375,6 +4144,25 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::list_operations][super::super::client::RuleService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3467,6 +4255,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::get_operation][super::super::client::RuleService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3515,6 +4318,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::delete_operation][super::super::client::RuleService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3563,6 +4381,21 @@ pub mod rule_service {
     }
 
     /// The request builder for [RuleService::cancel_operation][super::super::client::RuleService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_chronicle_v1::builder;
+    /// use builder::rule_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::get_workload][super::super::client::CloudControlsPartnerCore::get_workload] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::GetWorkload;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkload {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkload(RequestBuilder<crate::model::GetWorkloadRequest>);
 
@@ -116,6 +131,25 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::list_workloads][super::super::client::CloudControlsPartnerCore::list_workloads] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::ListWorkloads;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkloads {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -211,6 +245,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::get_customer][super::super::client::CloudControlsPartnerCore::get_customer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::GetCustomer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCustomer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCustomer(RequestBuilder<crate::model::GetCustomerRequest>);
 
@@ -258,6 +307,25 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::list_customers][super::super::client::CloudControlsPartnerCore::list_customers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::ListCustomers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCustomers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCustomers(RequestBuilder<crate::model::ListCustomersRequest>);
 
@@ -353,6 +421,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::get_ekm_connections][super::super::client::CloudControlsPartnerCore::get_ekm_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::GetEkmConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEkmConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEkmConnections(RequestBuilder<crate::model::GetEkmConnectionsRequest>);
 
@@ -403,6 +486,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::get_partner_permissions][super::super::client::CloudControlsPartnerCore::get_partner_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::GetPartnerPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPartnerPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPartnerPermissions(RequestBuilder<crate::model::GetPartnerPermissionsRequest>);
 
@@ -453,6 +551,25 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::list_access_approval_requests][super::super::client::CloudControlsPartnerCore::list_access_approval_requests] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::ListAccessApprovalRequests;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAccessApprovalRequests {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAccessApprovalRequests(
         RequestBuilder<crate::model::ListAccessApprovalRequestsRequest>,
@@ -557,6 +674,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::get_partner][super::super::client::CloudControlsPartnerCore::get_partner] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::GetPartner;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPartner {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPartner(RequestBuilder<crate::model::GetPartnerRequest>);
 
@@ -604,6 +736,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::create_customer][super::super::client::CloudControlsPartnerCore::create_customer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::CreateCustomer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCustomer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCustomer(RequestBuilder<crate::model::CreateCustomerRequest>);
 
@@ -670,6 +817,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::update_customer][super::super::client::CloudControlsPartnerCore::update_customer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::UpdateCustomer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCustomer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCustomer(RequestBuilder<crate::model::UpdateCustomerRequest>);
 
@@ -729,6 +891,21 @@ pub mod cloud_controls_partner_core {
     }
 
     /// The request builder for [CloudControlsPartnerCore::delete_customer][super::super::client::CloudControlsPartnerCore::delete_customer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_core::DeleteCustomer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCustomer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCustomer(RequestBuilder<crate::model::DeleteCustomerRequest>);
 
@@ -831,6 +1008,25 @@ pub mod cloud_controls_partner_monitoring {
     }
 
     /// The request builder for [CloudControlsPartnerMonitoring::list_violations][super::super::client::CloudControlsPartnerMonitoring::list_violations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_monitoring::ListViolations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListViolations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListViolations(RequestBuilder<crate::model::ListViolationsRequest>);
 
@@ -935,6 +1131,21 @@ pub mod cloud_controls_partner_monitoring {
     }
 
     /// The request builder for [CloudControlsPartnerMonitoring::get_violation][super::super::client::CloudControlsPartnerMonitoring::get_violation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_cloudcontrolspartner_v1::builder;
+    /// use builder::cloud_controls_partner_monitoring::GetViolation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetViolation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetViolation(RequestBuilder<crate::model::GetViolationRequest>);
 

--- a/src/generated/cloud/clouddms/v1/src/builder.rs
+++ b/src/generated/cloud/clouddms/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::list_migration_jobs][super::super::client::DataMigrationService::list_migration_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ListMigrationJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMigrationJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMigrationJobs(RequestBuilder<crate::model::ListMigrationJobsRequest>);
 
@@ -167,6 +186,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_migration_job][super::super::client::DataMigrationService::get_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMigrationJob(RequestBuilder<crate::model::GetMigrationJobRequest>);
 
@@ -214,6 +248,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::create_migration_job][super::super::client::DataMigrationService::create_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::CreateMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMigrationJob(RequestBuilder<crate::model::CreateMigrationJobRequest>);
 
@@ -329,6 +379,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::update_migration_job][super::super::client::DataMigrationService::update_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::UpdateMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMigrationJob(RequestBuilder<crate::model::UpdateMigrationJobRequest>);
 
@@ -439,6 +505,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::delete_migration_job][super::super::client::DataMigrationService::delete_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DeleteMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMigrationJob(RequestBuilder<crate::model::DeleteMigrationJobRequest>);
 
@@ -541,6 +623,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::start_migration_job][super::super::client::DataMigrationService::start_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::StartMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartMigrationJob(RequestBuilder<crate::model::StartMigrationJobRequest>);
 
@@ -635,6 +733,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::stop_migration_job][super::super::client::DataMigrationService::stop_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::StopMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopMigrationJob(RequestBuilder<crate::model::StopMigrationJobRequest>);
 
@@ -723,6 +837,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::resume_migration_job][super::super::client::DataMigrationService::resume_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ResumeMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeMigrationJob(RequestBuilder<crate::model::ResumeMigrationJobRequest>);
 
@@ -811,6 +941,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::promote_migration_job][super::super::client::DataMigrationService::promote_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::PromoteMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PromoteMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PromoteMigrationJob(RequestBuilder<crate::model::PromoteMigrationJobRequest>);
 
@@ -899,6 +1045,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::verify_migration_job][super::super::client::DataMigrationService::verify_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::VerifyMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyMigrationJob(RequestBuilder<crate::model::VerifyMigrationJobRequest>);
 
@@ -1005,6 +1167,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::restart_migration_job][super::super::client::DataMigrationService::restart_migration_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::RestartMigrationJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestartMigrationJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestartMigrationJob(RequestBuilder<crate::model::RestartMigrationJobRequest>);
 
@@ -1099,6 +1277,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::generate_ssh_script][super::super::client::DataMigrationService::generate_ssh_script] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GenerateSshScript;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateSshScript {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateSshScript(RequestBuilder<crate::model::GenerateSshScriptRequest>);
 
@@ -1205,6 +1398,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::generate_tcp_proxy_script][super::super::client::DataMigrationService::generate_tcp_proxy_script] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GenerateTcpProxyScript;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateTcpProxyScript {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateTcpProxyScript(RequestBuilder<crate::model::GenerateTcpProxyScriptRequest>);
 
@@ -1283,6 +1491,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::list_connection_profiles][super::super::client::DataMigrationService::list_connection_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ListConnectionProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnectionProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnectionProfiles(RequestBuilder<crate::model::ListConnectionProfilesRequest>);
 
@@ -1385,6 +1612,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_connection_profile][super::super::client::DataMigrationService::get_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnectionProfile(RequestBuilder<crate::model::GetConnectionProfileRequest>);
 
@@ -1435,6 +1677,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::create_connection_profile][super::super::client::DataMigrationService::create_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::CreateConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnectionProfile(
         RequestBuilder<crate::model::CreateConnectionProfileRequest>,
@@ -1567,6 +1825,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::update_connection_profile][super::super::client::DataMigrationService::update_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::UpdateConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnectionProfile(
         RequestBuilder<crate::model::UpdateConnectionProfileRequest>,
@@ -1694,6 +1968,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::delete_connection_profile][super::super::client::DataMigrationService::delete_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DeleteConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnectionProfile(
         RequestBuilder<crate::model::DeleteConnectionProfileRequest>,
@@ -1798,6 +2088,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::create_private_connection][super::super::client::DataMigrationService::create_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::CreatePrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePrivateConnection(
         RequestBuilder<crate::model::CreatePrivateConnectionRequest>,
@@ -1924,6 +2230,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_private_connection][super::super::client::DataMigrationService::get_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetPrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPrivateConnection(RequestBuilder<crate::model::GetPrivateConnectionRequest>);
 
@@ -1974,6 +2295,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::list_private_connections][super::super::client::DataMigrationService::list_private_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ListPrivateConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPrivateConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnections(RequestBuilder<crate::model::ListPrivateConnectionsRequest>);
 
@@ -2076,6 +2416,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::delete_private_connection][super::super::client::DataMigrationService::delete_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DeletePrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePrivateConnection(
         RequestBuilder<crate::model::DeletePrivateConnectionRequest>,
@@ -2174,6 +2530,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_conversion_workspace][super::super::client::DataMigrationService::get_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversionWorkspace(RequestBuilder<crate::model::GetConversionWorkspaceRequest>);
 
@@ -2224,6 +2595,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::list_conversion_workspaces][super::super::client::DataMigrationService::list_conversion_workspaces] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ListConversionWorkspaces;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversionWorkspaces {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversionWorkspaces(
         RequestBuilder<crate::model::ListConversionWorkspacesRequest>,
@@ -2322,6 +2712,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::create_conversion_workspace][super::super::client::DataMigrationService::create_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::CreateConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversionWorkspace(
         RequestBuilder<crate::model::CreateConversionWorkspaceRequest>,
@@ -2442,6 +2848,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::update_conversion_workspace][super::super::client::DataMigrationService::update_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::UpdateConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConversionWorkspace(
         RequestBuilder<crate::model::UpdateConversionWorkspaceRequest>,
@@ -2557,6 +2979,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::delete_conversion_workspace][super::super::client::DataMigrationService::delete_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DeleteConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConversionWorkspace(
         RequestBuilder<crate::model::DeleteConversionWorkspaceRequest>,
@@ -2661,6 +3099,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::create_mapping_rule][super::super::client::DataMigrationService::create_mapping_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::CreateMappingRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMappingRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMappingRule(RequestBuilder<crate::model::CreateMappingRuleRequest>);
 
@@ -2736,6 +3189,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::delete_mapping_rule][super::super::client::DataMigrationService::delete_mapping_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DeleteMappingRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMappingRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMappingRule(RequestBuilder<crate::model::DeleteMappingRuleRequest>);
 
@@ -2792,6 +3260,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::list_mapping_rules][super::super::client::DataMigrationService::list_mapping_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ListMappingRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMappingRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMappingRules(RequestBuilder<crate::model::ListMappingRulesRequest>);
 
@@ -2878,6 +3365,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_mapping_rule][super::super::client::DataMigrationService::get_mapping_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetMappingRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMappingRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMappingRule(RequestBuilder<crate::model::GetMappingRuleRequest>);
 
@@ -2925,6 +3427,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::seed_conversion_workspace][super::super::client::DataMigrationService::seed_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::SeedConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SeedConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SeedConversionWorkspace(
         RequestBuilder<crate::model::SeedConversionWorkspaceRequest>,
@@ -3062,6 +3580,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::import_mapping_rules][super::super::client::DataMigrationService::import_mapping_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ImportMappingRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportMappingRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportMappingRules(RequestBuilder<crate::model::ImportMappingRulesRequest>);
 
@@ -3185,6 +3719,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::convert_conversion_workspace][super::super::client::DataMigrationService::convert_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ConvertConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ConvertConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ConvertConversionWorkspace(
         RequestBuilder<crate::model::ConvertConversionWorkspaceRequest>,
@@ -3294,6 +3844,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::commit_conversion_workspace][super::super::client::DataMigrationService::commit_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::CommitConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CommitConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CommitConversionWorkspace(
         RequestBuilder<crate::model::CommitConversionWorkspaceRequest>,
@@ -3393,6 +3959,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::rollback_conversion_workspace][super::super::client::DataMigrationService::rollback_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::RollbackConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RollbackConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RollbackConversionWorkspace(
         RequestBuilder<crate::model::RollbackConversionWorkspaceRequest>,
@@ -3486,6 +4068,22 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::apply_conversion_workspace][super::super::client::DataMigrationService::apply_conversion_workspace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ApplyConversionWorkspace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_clouddms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApplyConversionWorkspace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApplyConversionWorkspace(
         RequestBuilder<crate::model::ApplyConversionWorkspaceRequest>,
@@ -3624,6 +4222,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::describe_database_entities][super::super::client::DataMigrationService::describe_database_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DescribeDatabaseEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DescribeDatabaseEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DescribeDatabaseEntities(
         RequestBuilder<crate::model::DescribeDatabaseEntitiesRequest>,
@@ -3751,6 +4368,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::search_background_jobs][super::super::client::DataMigrationService::search_background_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::SearchBackgroundJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchBackgroundJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchBackgroundJobs(RequestBuilder<crate::model::SearchBackgroundJobsRequest>);
 
@@ -3822,6 +4454,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::describe_conversion_workspace_revisions][super::super::client::DataMigrationService::describe_conversion_workspace_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DescribeConversionWorkspaceRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DescribeConversionWorkspaceRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DescribeConversionWorkspaceRevisions(
         RequestBuilder<crate::model::DescribeConversionWorkspaceRevisionsRequest>,
@@ -3882,6 +4529,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::fetch_static_ips][super::super::client::DataMigrationService::fetch_static_ips] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::FetchStaticIps;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchStaticIps {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchStaticIps(RequestBuilder<crate::model::FetchStaticIpsRequest>);
 
@@ -3941,6 +4603,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::list_locations][super::super::client::DataMigrationService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4031,6 +4712,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_location][super::super::client::DataMigrationService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4076,6 +4772,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::set_iam_policy][super::super::client::DataMigrationService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4143,6 +4854,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_iam_policy][super::super::client::DataMigrationService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4199,6 +4925,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::test_iam_permissions][super::super::client::DataMigrationService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4262,6 +5003,25 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::list_operations][super::super::client::DataMigrationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4354,6 +5114,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::get_operation][super::super::client::DataMigrationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4402,6 +5177,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::delete_operation][super::super::client::DataMigrationService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4450,6 +5240,21 @@ pub mod data_migration_service {
     }
 
     /// The request builder for [DataMigrationService::cancel_operation][super::super::client::DataMigrationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_clouddms_v1::builder;
+    /// use builder::data_migration_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod license_management_service {
     }
 
     /// The request builder for [LicenseManagementService::get_license_pool][super::super::client::LicenseManagementService::get_license_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::license_management_service::GetLicensePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLicensePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLicensePool(RequestBuilder<crate::model::GetLicensePoolRequest>);
 
@@ -116,6 +131,21 @@ pub mod license_management_service {
     }
 
     /// The request builder for [LicenseManagementService::update_license_pool][super::super::client::LicenseManagementService::update_license_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::license_management_service::UpdateLicensePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLicensePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLicensePool(RequestBuilder<crate::model::UpdateLicensePoolRequest>);
 
@@ -180,6 +210,21 @@ pub mod license_management_service {
     }
 
     /// The request builder for [LicenseManagementService::assign][super::super::client::LicenseManagementService::assign] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::license_management_service::Assign;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Assign {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Assign(RequestBuilder<crate::model::AssignRequest>);
 
@@ -240,6 +285,21 @@ pub mod license_management_service {
     }
 
     /// The request builder for [LicenseManagementService::unassign][super::super::client::LicenseManagementService::unassign] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::license_management_service::Unassign;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Unassign {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Unassign(RequestBuilder<crate::model::UnassignRequest>);
 
@@ -300,6 +360,25 @@ pub mod license_management_service {
     }
 
     /// The request builder for [LicenseManagementService::enumerate_licensed_users][super::super::client::LicenseManagementService::enumerate_licensed_users] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::license_management_service::EnumerateLicensedUsers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnumerateLicensedUsers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnumerateLicensedUsers(RequestBuilder<crate::model::EnumerateLicensedUsersRequest>);
 
@@ -390,6 +469,21 @@ pub mod license_management_service {
     }
 
     /// The request builder for [LicenseManagementService::get_operation][super::super::client::LicenseManagementService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::license_management_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -493,6 +587,22 @@ pub mod consumer_procurement_service {
     }
 
     /// The request builder for [ConsumerProcurementService::place_order][super::super::client::ConsumerProcurementService::place_order] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::consumer_procurement_service::PlaceOrder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_commerce_consumer_procurement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PlaceOrder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PlaceOrder(RequestBuilder<crate::model::PlaceOrderRequest>);
 
@@ -603,6 +713,21 @@ pub mod consumer_procurement_service {
     }
 
     /// The request builder for [ConsumerProcurementService::get_order][super::super::client::ConsumerProcurementService::get_order] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::consumer_procurement_service::GetOrder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOrder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOrder(RequestBuilder<crate::model::GetOrderRequest>);
 
@@ -650,6 +775,25 @@ pub mod consumer_procurement_service {
     }
 
     /// The request builder for [ConsumerProcurementService::list_orders][super::super::client::ConsumerProcurementService::list_orders] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::consumer_procurement_service::ListOrders;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOrders {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOrders(RequestBuilder<crate::model::ListOrdersRequest>);
 
@@ -739,6 +883,22 @@ pub mod consumer_procurement_service {
     }
 
     /// The request builder for [ConsumerProcurementService::modify_order][super::super::client::ConsumerProcurementService::modify_order] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::consumer_procurement_service::ModifyOrder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_commerce_consumer_procurement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ModifyOrder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ModifyOrder(RequestBuilder<crate::model::ModifyOrderRequest>);
 
@@ -847,6 +1007,22 @@ pub mod consumer_procurement_service {
     }
 
     /// The request builder for [ConsumerProcurementService::cancel_order][super::super::client::ConsumerProcurementService::cancel_order] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::consumer_procurement_service::CancelOrder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_commerce_consumer_procurement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOrder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOrder(RequestBuilder<crate::model::CancelOrderRequest>);
 
@@ -949,6 +1125,21 @@ pub mod consumer_procurement_service {
     }
 
     /// The request builder for [ConsumerProcurementService::get_operation][super::super::client::ConsumerProcurementService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_commerce_consumer_procurement_v1::builder;
+    /// use builder::consumer_procurement_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod confidential_computing {
     }
 
     /// The request builder for [ConfidentialComputing::create_challenge][super::super::client::ConfidentialComputing::create_challenge] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_confidentialcomputing_v1::builder;
+    /// use builder::confidential_computing::CreateChallenge;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateChallenge {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateChallenge(RequestBuilder<crate::model::CreateChallengeRequest>);
 
@@ -127,6 +142,21 @@ pub mod confidential_computing {
     }
 
     /// The request builder for [ConfidentialComputing::verify_attestation][super::super::client::ConfidentialComputing::verify_attestation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_confidentialcomputing_v1::builder;
+    /// use builder::confidential_computing::VerifyAttestation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyAttestation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyAttestation(RequestBuilder<crate::model::VerifyAttestationRequest>);
 
@@ -267,6 +297,25 @@ pub mod confidential_computing {
     }
 
     /// The request builder for [ConfidentialComputing::list_locations][super::super::client::ConfidentialComputing::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_confidentialcomputing_v1::builder;
+    /// use builder::confidential_computing::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -357,6 +406,21 @@ pub mod confidential_computing {
     }
 
     /// The request builder for [ConfidentialComputing::get_location][super::super::client::ConfidentialComputing::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_confidentialcomputing_v1::builder;
+    /// use builder::confidential_computing::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/config/v1/src/builder.rs
+++ b/src/generated/cloud/config/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod config {
     }
 
     /// The request builder for [Config::list_deployments][super::super::client::Config::list_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ListDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -160,6 +179,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_deployment][super::super::client::Config::get_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -205,6 +239,22 @@ pub mod config {
     }
 
     /// The request builder for [Config::create_deployment][super::super::client::Config::create_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::CreateDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_config_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -316,6 +366,22 @@ pub mod config {
     }
 
     /// The request builder for [Config::update_deployment][super::super::client::Config::update_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::UpdateDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_config_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDeployment(RequestBuilder<crate::model::UpdateDeploymentRequest>);
 
@@ -420,6 +486,22 @@ pub mod config {
     }
 
     /// The request builder for [Config::delete_deployment][super::super::client::Config::delete_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::DeleteDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_config_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDeployment(RequestBuilder<crate::model::DeleteDeploymentRequest>);
 
@@ -527,6 +609,25 @@ pub mod config {
     }
 
     /// The request builder for [Config::list_revisions][super::super::client::Config::list_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ListRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRevisions(RequestBuilder<crate::model::ListRevisionsRequest>);
 
@@ -620,6 +721,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_revision][super::super::client::Config::get_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRevision(RequestBuilder<crate::model::GetRevisionRequest>);
 
@@ -665,6 +781,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_resource][super::super::client::Config::get_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetResource(RequestBuilder<crate::model::GetResourceRequest>);
 
@@ -710,6 +841,25 @@ pub mod config {
     }
 
     /// The request builder for [Config::list_resources][super::super::client::Config::list_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ListResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListResources(RequestBuilder<crate::model::ListResourcesRequest>);
 
@@ -803,6 +953,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::export_deployment_statefile][super::super::client::Config::export_deployment_statefile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ExportDeploymentStatefile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportDeploymentStatefile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportDeploymentStatefile(
         RequestBuilder<crate::model::ExportDeploymentStatefileRequest>,
@@ -859,6 +1024,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::export_revision_statefile][super::super::client::Config::export_revision_statefile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ExportRevisionStatefile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportRevisionStatefile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportRevisionStatefile(
         RequestBuilder<crate::model::ExportRevisionStatefileRequest>,
@@ -909,6 +1089,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::import_statefile][super::super::client::Config::import_statefile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ImportStatefile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportStatefile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportStatefile(RequestBuilder<crate::model::ImportStatefileRequest>);
 
@@ -968,6 +1163,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::delete_statefile][super::super::client::Config::delete_statefile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::DeleteStatefile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteStatefile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteStatefile(RequestBuilder<crate::model::DeleteStatefileRequest>);
 
@@ -1021,6 +1231,22 @@ pub mod config {
     }
 
     /// The request builder for [Config::lock_deployment][super::super::client::Config::lock_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::LockDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_config_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LockDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LockDeployment(RequestBuilder<crate::model::LockDeploymentRequest>);
 
@@ -1104,6 +1330,22 @@ pub mod config {
     }
 
     /// The request builder for [Config::unlock_deployment][super::super::client::Config::unlock_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::UnlockDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_config_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UnlockDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UnlockDeployment(RequestBuilder<crate::model::UnlockDeploymentRequest>);
 
@@ -1198,6 +1440,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::export_lock_info][super::super::client::Config::export_lock_info] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ExportLockInfo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportLockInfo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportLockInfo(RequestBuilder<crate::model::ExportLockInfoRequest>);
 
@@ -1243,6 +1500,22 @@ pub mod config {
     }
 
     /// The request builder for [Config::create_preview][super::super::client::Config::create_preview] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::CreatePreview;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_config_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePreview {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePreview(RequestBuilder<crate::model::CreatePreviewRequest>);
 
@@ -1349,6 +1622,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_preview][super::super::client::Config::get_preview] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetPreview;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPreview {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPreview(RequestBuilder<crate::model::GetPreviewRequest>);
 
@@ -1394,6 +1682,25 @@ pub mod config {
     }
 
     /// The request builder for [Config::list_previews][super::super::client::Config::list_previews] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ListPreviews;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPreviews {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPreviews(RequestBuilder<crate::model::ListPreviewsRequest>);
 
@@ -1487,6 +1794,22 @@ pub mod config {
     }
 
     /// The request builder for [Config::delete_preview][super::super::client::Config::delete_preview] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::DeletePreview;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_config_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePreview {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePreview(RequestBuilder<crate::model::DeletePreviewRequest>);
 
@@ -1576,6 +1899,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::export_preview_result][super::super::client::Config::export_preview_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ExportPreviewResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportPreviewResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportPreviewResult(RequestBuilder<crate::model::ExportPreviewResultRequest>);
 
@@ -1624,6 +1962,25 @@ pub mod config {
     }
 
     /// The request builder for [Config::list_terraform_versions][super::super::client::Config::list_terraform_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ListTerraformVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTerraformVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTerraformVersions(RequestBuilder<crate::model::ListTerraformVersionsRequest>);
 
@@ -1722,6 +2079,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_terraform_version][super::super::client::Config::get_terraform_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetTerraformVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTerraformVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTerraformVersion(RequestBuilder<crate::model::GetTerraformVersionRequest>);
 
@@ -1770,6 +2142,25 @@ pub mod config {
     }
 
     /// The request builder for [Config::list_locations][super::super::client::Config::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1858,6 +2249,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_location][super::super::client::Config::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1901,6 +2307,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::set_iam_policy][super::super::client::Config::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1966,6 +2387,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_iam_policy][super::super::client::Config::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2020,6 +2456,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::test_iam_permissions][super::super::client::Config::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2081,6 +2532,25 @@ pub mod config {
     }
 
     /// The request builder for [Config::list_operations][super::super::client::Config::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2171,6 +2641,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::get_operation][super::super::client::Config::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2217,6 +2702,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::delete_operation][super::super::client::Config::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2263,6 +2763,21 @@ pub mod config {
     }
 
     /// The request builder for [Config::cancel_operation][super::super::client::Config::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_config_v1::builder;
+    /// use builder::config::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/connectors/v1/src/builder.rs
+++ b/src/generated/cloud/connectors/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_connections][super::super::client::Connectors::list_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -170,6 +189,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_connection][super::super::client::Connectors::get_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -223,6 +257,22 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::create_connection][super::super::client::Connectors::create_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::CreateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_connectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -330,6 +380,22 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::update_connection][super::super::client::Connectors::update_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::UpdateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_connectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -432,6 +498,22 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::delete_connection][super::super::client::Connectors::delete_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::DeleteConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_connectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -522,6 +604,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_providers][super::super::client::Connectors::list_providers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListProviders;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProviders {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProviders(RequestBuilder<crate::model::ListProvidersRequest>);
 
@@ -605,6 +706,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_provider][super::super::client::Connectors::get_provider] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetProvider;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProvider {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProvider(RequestBuilder<crate::model::GetProviderRequest>);
 
@@ -652,6 +768,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_connectors][super::super::client::Connectors::list_connectors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListConnectors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnectors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnectors(RequestBuilder<crate::model::ListConnectorsRequest>);
 
@@ -735,6 +870,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_connector][super::super::client::Connectors::get_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnector(RequestBuilder<crate::model::GetConnectorRequest>);
 
@@ -782,6 +932,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_connector_versions][super::super::client::Connectors::list_connector_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListConnectorVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnectorVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnectorVersions(RequestBuilder<crate::model::ListConnectorVersionsRequest>);
 
@@ -876,6 +1045,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_connector_version][super::super::client::Connectors::get_connector_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetConnectorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnectorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnectorVersion(RequestBuilder<crate::model::GetConnectorVersionRequest>);
 
@@ -932,6 +1116,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_connection_schema_metadata][super::super::client::Connectors::get_connection_schema_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetConnectionSchemaMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnectionSchemaMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnectionSchemaMetadata(
         RequestBuilder<crate::model::GetConnectionSchemaMetadataRequest>,
@@ -984,6 +1183,22 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::refresh_connection_schema_metadata][super::super::client::Connectors::refresh_connection_schema_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::RefreshConnectionSchemaMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_connectors_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RefreshConnectionSchemaMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RefreshConnectionSchemaMetadata(
         RequestBuilder<crate::model::RefreshConnectionSchemaMetadataRequest>,
@@ -1077,6 +1292,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_runtime_entity_schemas][super::super::client::Connectors::list_runtime_entity_schemas] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListRuntimeEntitySchemas;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuntimeEntitySchemas {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuntimeEntitySchemas(
         RequestBuilder<crate::model::ListRuntimeEntitySchemasRequest>,
@@ -1177,6 +1411,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_runtime_action_schemas][super::super::client::Connectors::list_runtime_action_schemas] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListRuntimeActionSchemas;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuntimeActionSchemas {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuntimeActionSchemas(
         RequestBuilder<crate::model::ListRuntimeActionSchemasRequest>,
@@ -1277,6 +1530,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_runtime_config][super::super::client::Connectors::get_runtime_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetRuntimeConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRuntimeConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRuntimeConfig(RequestBuilder<crate::model::GetRuntimeConfigRequest>);
 
@@ -1327,6 +1595,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_global_settings][super::super::client::Connectors::get_global_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetGlobalSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGlobalSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGlobalSettings(RequestBuilder<crate::model::GetGlobalSettingsRequest>);
 
@@ -1377,6 +1660,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_locations][super::super::client::Connectors::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1467,6 +1769,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_location][super::super::client::Connectors::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1512,6 +1829,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::set_iam_policy][super::super::client::Connectors::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1579,6 +1911,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_iam_policy][super::super::client::Connectors::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1635,6 +1982,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::test_iam_permissions][super::super::client::Connectors::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1698,6 +2060,25 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::list_operations][super::super::client::Connectors::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1790,6 +2171,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::get_operation][super::super::client::Connectors::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1838,6 +2234,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::delete_operation][super::super::client::Connectors::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1886,6 +2297,21 @@ pub mod connectors {
     }
 
     /// The request builder for [Connectors::cancel_operation][super::super::client::Connectors::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_connectors_v1::builder;
+    /// use builder::connectors::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_conversation][super::super::client::ContactCenterInsights::create_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversation(RequestBuilder<crate::model::CreateConversationRequest>);
 
@@ -136,6 +151,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::upload_conversation][super::super::client::ContactCenterInsights::upload_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UploadConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UploadConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UploadConversation(RequestBuilder<crate::model::UploadConversationRequest>);
 
@@ -262,6 +293,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_conversation][super::super::client::ContactCenterInsights::update_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConversation(RequestBuilder<crate::model::UpdateConversationRequest>);
 
@@ -324,6 +370,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_conversation][super::super::client::ContactCenterInsights::get_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversation(RequestBuilder<crate::model::GetConversationRequest>);
 
@@ -377,6 +438,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_conversations][super::super::client::ContactCenterInsights::list_conversations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListConversations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversations(RequestBuilder<crate::model::ListConversationsRequest>);
 
@@ -481,6 +561,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_conversation][super::super::client::ContactCenterInsights::delete_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConversation(RequestBuilder<crate::model::DeleteConversationRequest>);
 
@@ -537,6 +632,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_analysis][super::super::client::ContactCenterInsights::create_analysis] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateAnalysis;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAnalysis {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAnalysis(RequestBuilder<crate::model::CreateAnalysisRequest>);
 
@@ -636,6 +747,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_analysis][super::super::client::ContactCenterInsights::get_analysis] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetAnalysis;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAnalysis {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAnalysis(RequestBuilder<crate::model::GetAnalysisRequest>);
 
@@ -683,6 +809,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_analyses][super::super::client::ContactCenterInsights::list_analyses] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListAnalyses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAnalyses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAnalyses(RequestBuilder<crate::model::ListAnalysesRequest>);
 
@@ -772,6 +917,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_analysis][super::super::client::ContactCenterInsights::delete_analysis] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteAnalysis;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAnalysis {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAnalysis(RequestBuilder<crate::model::DeleteAnalysisRequest>);
 
@@ -819,6 +979,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::bulk_analyze_conversations][super::super::client::ContactCenterInsights::bulk_analyze_conversations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::BulkAnalyzeConversations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BulkAnalyzeConversations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BulkAnalyzeConversations(
         RequestBuilder<crate::model::BulkAnalyzeConversationsRequest>,
@@ -941,6 +1117,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::bulk_delete_conversations][super::super::client::ContactCenterInsights::bulk_delete_conversations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::BulkDeleteConversations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BulkDeleteConversations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BulkDeleteConversations(
         RequestBuilder<crate::model::BulkDeleteConversationsRequest>,
@@ -1054,6 +1246,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::ingest_conversations][super::super::client::ContactCenterInsights::ingest_conversations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::IngestConversations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> IngestConversations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct IngestConversations(RequestBuilder<crate::model::IngestConversationsRequest>);
 
@@ -1246,6 +1454,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::export_insights_data][super::super::client::ContactCenterInsights::export_insights_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ExportInsightsData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportInsightsData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportInsightsData(RequestBuilder<crate::model::ExportInsightsDataRequest>);
 
@@ -1395,6 +1619,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_issue_model][super::super::client::ContactCenterInsights::create_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIssueModel(RequestBuilder<crate::model::CreateIssueModelRequest>);
 
@@ -1497,6 +1737,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_issue_model][super::super::client::ContactCenterInsights::update_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIssueModel(RequestBuilder<crate::model::UpdateIssueModelRequest>);
 
@@ -1559,6 +1814,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_issue_model][super::super::client::ContactCenterInsights::get_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIssueModel(RequestBuilder<crate::model::GetIssueModelRequest>);
 
@@ -1606,6 +1876,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_issue_models][super::super::client::ContactCenterInsights::list_issue_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListIssueModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIssueModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIssueModels(RequestBuilder<crate::model::ListIssueModelsRequest>);
 
@@ -1653,6 +1938,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_issue_model][super::super::client::ContactCenterInsights::delete_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIssueModel(RequestBuilder<crate::model::DeleteIssueModelRequest>);
 
@@ -1744,6 +2045,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::deploy_issue_model][super::super::client::ContactCenterInsights::deploy_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeployIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeployIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeployIssueModel(RequestBuilder<crate::model::DeployIssueModelRequest>);
 
@@ -1837,6 +2154,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::undeploy_issue_model][super::super::client::ContactCenterInsights::undeploy_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UndeployIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeployIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeployIssueModel(RequestBuilder<crate::model::UndeployIssueModelRequest>);
 
@@ -1930,6 +2263,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::export_issue_model][super::super::client::ContactCenterInsights::export_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ExportIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportIssueModel(RequestBuilder<crate::model::ExportIssueModelRequest>);
 
@@ -2054,6 +2403,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::import_issue_model][super::super::client::ContactCenterInsights::import_issue_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ImportIssueModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportIssueModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportIssueModel(RequestBuilder<crate::model::ImportIssueModelRequest>);
 
@@ -2182,6 +2547,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_issue][super::super::client::ContactCenterInsights::get_issue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetIssue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIssue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIssue(RequestBuilder<crate::model::GetIssueRequest>);
 
@@ -2229,6 +2609,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_issues][super::super::client::ContactCenterInsights::list_issues] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListIssues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIssues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIssues(RequestBuilder<crate::model::ListIssuesRequest>);
 
@@ -2276,6 +2671,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_issue][super::super::client::ContactCenterInsights::update_issue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateIssue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIssue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIssue(RequestBuilder<crate::model::UpdateIssueRequest>);
 
@@ -2335,6 +2745,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_issue][super::super::client::ContactCenterInsights::delete_issue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteIssue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIssue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIssue(RequestBuilder<crate::model::DeleteIssueRequest>);
 
@@ -2382,6 +2807,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::calculate_issue_model_stats][super::super::client::ContactCenterInsights::calculate_issue_model_stats] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CalculateIssueModelStats;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CalculateIssueModelStats {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CalculateIssueModelStats(
         RequestBuilder<crate::model::CalculateIssueModelStatsRequest>,
@@ -2434,6 +2874,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_phrase_matcher][super::super::client::ContactCenterInsights::create_phrase_matcher] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreatePhraseMatcher;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePhraseMatcher {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePhraseMatcher(RequestBuilder<crate::model::CreatePhraseMatcherRequest>);
 
@@ -2495,6 +2950,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_phrase_matcher][super::super::client::ContactCenterInsights::get_phrase_matcher] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetPhraseMatcher;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPhraseMatcher {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPhraseMatcher(RequestBuilder<crate::model::GetPhraseMatcherRequest>);
 
@@ -2545,6 +3015,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_phrase_matchers][super::super::client::ContactCenterInsights::list_phrase_matchers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListPhraseMatchers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPhraseMatchers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPhraseMatchers(RequestBuilder<crate::model::ListPhraseMatchersRequest>);
 
@@ -2639,6 +3128,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_phrase_matcher][super::super::client::ContactCenterInsights::delete_phrase_matcher] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeletePhraseMatcher;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePhraseMatcher {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePhraseMatcher(RequestBuilder<crate::model::DeletePhraseMatcherRequest>);
 
@@ -2689,6 +3193,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_phrase_matcher][super::super::client::ContactCenterInsights::update_phrase_matcher] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdatePhraseMatcher;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePhraseMatcher {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePhraseMatcher(RequestBuilder<crate::model::UpdatePhraseMatcherRequest>);
 
@@ -2751,6 +3270,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::calculate_stats][super::super::client::ContactCenterInsights::calculate_stats] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CalculateStats;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CalculateStats {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CalculateStats(RequestBuilder<crate::model::CalculateStatsRequest>);
 
@@ -2804,6 +3338,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_settings][super::super::client::ContactCenterInsights::get_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -2851,6 +3400,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_settings][super::super::client::ContactCenterInsights::update_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 
@@ -2912,6 +3476,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_analysis_rule][super::super::client::ContactCenterInsights::create_analysis_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateAnalysisRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAnalysisRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAnalysisRule(RequestBuilder<crate::model::CreateAnalysisRuleRequest>);
 
@@ -2973,6 +3552,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_analysis_rule][super::super::client::ContactCenterInsights::get_analysis_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetAnalysisRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAnalysisRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAnalysisRule(RequestBuilder<crate::model::GetAnalysisRuleRequest>);
 
@@ -3020,6 +3614,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_analysis_rules][super::super::client::ContactCenterInsights::list_analysis_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListAnalysisRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAnalysisRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAnalysisRules(RequestBuilder<crate::model::ListAnalysisRulesRequest>);
 
@@ -3106,6 +3719,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_analysis_rule][super::super::client::ContactCenterInsights::update_analysis_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateAnalysisRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAnalysisRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAnalysisRule(RequestBuilder<crate::model::UpdateAnalysisRuleRequest>);
 
@@ -3168,6 +3796,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_analysis_rule][super::super::client::ContactCenterInsights::delete_analysis_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteAnalysisRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAnalysisRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAnalysisRule(RequestBuilder<crate::model::DeleteAnalysisRuleRequest>);
 
@@ -3218,6 +3861,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_encryption_spec][super::super::client::ContactCenterInsights::get_encryption_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetEncryptionSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEncryptionSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEncryptionSpec(RequestBuilder<crate::model::GetEncryptionSpecRequest>);
 
@@ -3268,6 +3926,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::initialize_encryption_spec][super::super::client::ContactCenterInsights::initialize_encryption_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::InitializeEncryptionSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InitializeEncryptionSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InitializeEncryptionSpec(
         RequestBuilder<crate::model::InitializeEncryptionSpecRequest>,
@@ -3366,6 +4040,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_view][super::super::client::ContactCenterInsights::create_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateView(RequestBuilder<crate::model::CreateViewRequest>);
 
@@ -3421,6 +4110,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_view][super::super::client::ContactCenterInsights::get_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetView(RequestBuilder<crate::model::GetViewRequest>);
 
@@ -3468,6 +4172,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_views][super::super::client::ContactCenterInsights::list_views] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListViews;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListViews {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListViews(RequestBuilder<crate::model::ListViewsRequest>);
 
@@ -3551,6 +4274,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_view][super::super::client::ContactCenterInsights::update_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateView(RequestBuilder<crate::model::UpdateViewRequest>);
 
@@ -3607,6 +4345,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_view][super::super::client::ContactCenterInsights::delete_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteView(RequestBuilder<crate::model::DeleteViewRequest>);
 
@@ -3654,6 +4407,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::query_metrics][super::super::client::ContactCenterInsights::query_metrics] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::QueryMetrics;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryMetrics {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryMetrics(RequestBuilder<crate::model::QueryMetricsRequest>);
 
@@ -3781,6 +4550,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_qa_question][super::super::client::ContactCenterInsights::create_qa_question] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateQaQuestion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateQaQuestion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateQaQuestion(RequestBuilder<crate::model::CreateQaQuestionRequest>);
 
@@ -3848,6 +4632,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_qa_question][super::super::client::ContactCenterInsights::get_qa_question] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetQaQuestion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetQaQuestion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetQaQuestion(RequestBuilder<crate::model::GetQaQuestionRequest>);
 
@@ -3895,6 +4694,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_qa_question][super::super::client::ContactCenterInsights::update_qa_question] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateQaQuestion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateQaQuestion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateQaQuestion(RequestBuilder<crate::model::UpdateQaQuestionRequest>);
 
@@ -3959,6 +4773,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_qa_question][super::super::client::ContactCenterInsights::delete_qa_question] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteQaQuestion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteQaQuestion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteQaQuestion(RequestBuilder<crate::model::DeleteQaQuestionRequest>);
 
@@ -4009,6 +4838,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_qa_questions][super::super::client::ContactCenterInsights::list_qa_questions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListQaQuestions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListQaQuestions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListQaQuestions(RequestBuilder<crate::model::ListQaQuestionsRequest>);
 
@@ -4092,6 +4940,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_qa_scorecard][super::super::client::ContactCenterInsights::create_qa_scorecard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateQaScorecard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateQaScorecard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateQaScorecard(RequestBuilder<crate::model::CreateQaScorecardRequest>);
 
@@ -4159,6 +5022,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_qa_scorecard][super::super::client::ContactCenterInsights::get_qa_scorecard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetQaScorecard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetQaScorecard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetQaScorecard(RequestBuilder<crate::model::GetQaScorecardRequest>);
 
@@ -4206,6 +5084,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_qa_scorecard][super::super::client::ContactCenterInsights::update_qa_scorecard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateQaScorecard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateQaScorecard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateQaScorecard(RequestBuilder<crate::model::UpdateQaScorecardRequest>);
 
@@ -4270,6 +5163,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_qa_scorecard][super::super::client::ContactCenterInsights::delete_qa_scorecard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteQaScorecard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteQaScorecard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteQaScorecard(RequestBuilder<crate::model::DeleteQaScorecardRequest>);
 
@@ -4326,6 +5234,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_qa_scorecards][super::super::client::ContactCenterInsights::list_qa_scorecards] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListQaScorecards;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListQaScorecards {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListQaScorecards(RequestBuilder<crate::model::ListQaScorecardsRequest>);
 
@@ -4412,6 +5339,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_qa_scorecard_revision][super::super::client::ContactCenterInsights::create_qa_scorecard_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateQaScorecardRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateQaScorecardRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateQaScorecardRevision(
         RequestBuilder<crate::model::CreateQaScorecardRevisionRequest>,
@@ -4483,6 +5425,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_qa_scorecard_revision][super::super::client::ContactCenterInsights::get_qa_scorecard_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetQaScorecardRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetQaScorecardRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetQaScorecardRevision(RequestBuilder<crate::model::GetQaScorecardRevisionRequest>);
 
@@ -4533,6 +5490,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::tune_qa_scorecard_revision][super::super::client::ContactCenterInsights::tune_qa_scorecard_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::TuneQaScorecardRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TuneQaScorecardRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TuneQaScorecardRevision(
         RequestBuilder<crate::model::TuneQaScorecardRevisionRequest>,
@@ -4642,6 +5615,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::deploy_qa_scorecard_revision][super::super::client::ContactCenterInsights::deploy_qa_scorecard_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeployQaScorecardRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeployQaScorecardRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeployQaScorecardRevision(
         RequestBuilder<crate::model::DeployQaScorecardRevisionRequest>,
@@ -4694,6 +5682,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::undeploy_qa_scorecard_revision][super::super::client::ContactCenterInsights::undeploy_qa_scorecard_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UndeployQaScorecardRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeployQaScorecardRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeployQaScorecardRevision(
         RequestBuilder<crate::model::UndeployQaScorecardRevisionRequest>,
@@ -4746,6 +5749,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_qa_scorecard_revision][super::super::client::ContactCenterInsights::delete_qa_scorecard_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteQaScorecardRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteQaScorecardRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteQaScorecardRevision(
         RequestBuilder<crate::model::DeleteQaScorecardRevisionRequest>,
@@ -4804,6 +5822,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_qa_scorecard_revisions][super::super::client::ContactCenterInsights::list_qa_scorecard_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListQaScorecardRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListQaScorecardRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListQaScorecardRevisions(
         RequestBuilder<crate::model::ListQaScorecardRevisionsRequest>,
@@ -4902,6 +5939,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::create_feedback_label][super::super::client::ContactCenterInsights::create_feedback_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CreateFeedbackLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeedbackLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeedbackLabel(RequestBuilder<crate::model::CreateFeedbackLabelRequest>);
 
@@ -4969,6 +6021,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_feedback_labels][super::super::client::ContactCenterInsights::list_feedback_labels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListFeedbackLabels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeedbackLabels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeedbackLabels(RequestBuilder<crate::model::ListFeedbackLabelsRequest>);
 
@@ -5063,6 +6134,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_feedback_label][super::super::client::ContactCenterInsights::get_feedback_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetFeedbackLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeedbackLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeedbackLabel(RequestBuilder<crate::model::GetFeedbackLabelRequest>);
 
@@ -5113,6 +6199,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::update_feedback_label][super::super::client::ContactCenterInsights::update_feedback_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::UpdateFeedbackLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeedbackLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeedbackLabel(RequestBuilder<crate::model::UpdateFeedbackLabelRequest>);
 
@@ -5177,6 +6278,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::delete_feedback_label][super::super::client::ContactCenterInsights::delete_feedback_label] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::DeleteFeedbackLabel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeedbackLabel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeedbackLabel(RequestBuilder<crate::model::DeleteFeedbackLabelRequest>);
 
@@ -5227,6 +6343,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_all_feedback_labels][super::super::client::ContactCenterInsights::list_all_feedback_labels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListAllFeedbackLabels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAllFeedbackLabels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAllFeedbackLabels(RequestBuilder<crate::model::ListAllFeedbackLabelsRequest>);
 
@@ -5321,6 +6456,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::bulk_upload_feedback_labels][super::super::client::ContactCenterInsights::bulk_upload_feedback_labels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::BulkUploadFeedbackLabels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BulkUploadFeedbackLabels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BulkUploadFeedbackLabels(
         RequestBuilder<crate::model::BulkUploadFeedbackLabelsRequest>,
@@ -5453,6 +6604,22 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::bulk_download_feedback_labels][super::super::client::ContactCenterInsights::bulk_download_feedback_labels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::BulkDownloadFeedbackLabels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_contactcenterinsights_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BulkDownloadFeedbackLabels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BulkDownloadFeedbackLabels(
         RequestBuilder<crate::model::BulkDownloadFeedbackLabelsRequest>,
@@ -5621,6 +6788,25 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::list_operations][super::super::client::ContactCenterInsights::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5713,6 +6899,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::get_operation][super::super::client::ContactCenterInsights::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5761,6 +6962,21 @@ pub mod contact_center_insights {
     }
 
     /// The request builder for [ContactCenterInsights::cancel_operation][super::super::client::ContactCenterInsights::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_contactcenterinsights_v1::builder;
+    /// use builder::contact_center_insights::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
@@ -67,6 +67,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::process_open_lineage_run_event][super::super::client::Lineage::process_open_lineage_run_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::ProcessOpenLineageRunEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ProcessOpenLineageRunEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ProcessOpenLineageRunEvent(
         RequestBuilder<crate::model::ProcessOpenLineageRunEventRequest>,
@@ -131,6 +146,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::create_process][super::super::client::Lineage::create_process] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::CreateProcess;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProcess {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProcess(RequestBuilder<crate::model::CreateProcessRequest>);
 
@@ -193,6 +223,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::update_process][super::super::client::Lineage::update_process] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::UpdateProcess;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProcess {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProcess(RequestBuilder<crate::model::UpdateProcessRequest>);
 
@@ -256,6 +301,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::get_process][super::super::client::Lineage::get_process] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::GetProcess;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProcess {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProcess(RequestBuilder<crate::model::GetProcessRequest>);
 
@@ -301,6 +361,25 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::list_processes][super::super::client::Lineage::list_processes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::ListProcesses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProcesses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProcesses(RequestBuilder<crate::model::ListProcessesRequest>);
 
@@ -382,6 +461,22 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::delete_process][super::super::client::Lineage::delete_process] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::DeleteProcess;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datacatalog_lineage_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteProcess {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteProcess(RequestBuilder<crate::model::DeleteProcessRequest>);
 
@@ -473,6 +568,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::create_run][super::super::client::Lineage::create_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::CreateRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRun(RequestBuilder<crate::model::CreateRunRequest>);
 
@@ -532,6 +642,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::update_run][super::super::client::Lineage::update_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::UpdateRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRun(RequestBuilder<crate::model::UpdateRunRequest>);
 
@@ -592,6 +717,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::get_run][super::super::client::Lineage::get_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::GetRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRun(RequestBuilder<crate::model::GetRunRequest>);
 
@@ -637,6 +777,25 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::list_runs][super::super::client::Lineage::list_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::ListRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuns(RequestBuilder<crate::model::ListRunsRequest>);
 
@@ -718,6 +877,22 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::delete_run][super::super::client::Lineage::delete_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::DeleteRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datacatalog_lineage_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRun(RequestBuilder<crate::model::DeleteRunRequest>);
 
@@ -809,6 +984,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::create_lineage_event][super::super::client::Lineage::create_lineage_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::CreateLineageEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLineageEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLineageEvent(RequestBuilder<crate::model::CreateLineageEventRequest>);
 
@@ -874,6 +1064,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::get_lineage_event][super::super::client::Lineage::get_lineage_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::GetLineageEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLineageEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLineageEvent(RequestBuilder<crate::model::GetLineageEventRequest>);
 
@@ -919,6 +1124,25 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::list_lineage_events][super::super::client::Lineage::list_lineage_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::ListLineageEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLineageEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLineageEvents(RequestBuilder<crate::model::ListLineageEventsRequest>);
 
@@ -1003,6 +1227,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::delete_lineage_event][super::super::client::Lineage::delete_lineage_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::DeleteLineageEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLineageEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLineageEvent(RequestBuilder<crate::model::DeleteLineageEventRequest>);
 
@@ -1057,6 +1296,25 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::search_links][super::super::client::Lineage::search_links] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::SearchLinks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchLinks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchLinks(RequestBuilder<crate::model::SearchLinksRequest>);
 
@@ -1176,6 +1434,25 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::batch_search_link_processes][super::super::client::Lineage::batch_search_link_processes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::BatchSearchLinkProcesses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchSearchLinkProcesses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchSearchLinkProcesses(
         RequestBuilder<crate::model::BatchSearchLinkProcessesRequest>,
@@ -1279,6 +1556,25 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::list_operations][super::super::client::Lineage::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1369,6 +1665,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::get_operation][super::super::client::Lineage::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1415,6 +1726,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::delete_operation][super::super::client::Lineage::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1461,6 +1787,21 @@ pub mod lineage {
     }
 
     /// The request builder for [Lineage::cancel_operation][super::super::client::Lineage::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_lineage_v1::builder;
+    /// use builder::lineage::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datacatalog/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::search_catalog][super::super::client::DataCatalog::search_catalog] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::SearchCatalog;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchCatalog {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchCatalog(RequestBuilder<crate::model::SearchCatalogRequest>);
 
@@ -175,6 +194,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::create_entry_group][super::super::client::DataCatalog::create_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::CreateEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntryGroup(RequestBuilder<crate::model::CreateEntryGroupRequest>);
 
@@ -242,6 +276,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::get_entry_group][super::super::client::DataCatalog::get_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::GetEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntryGroup(RequestBuilder<crate::model::GetEntryGroupRequest>);
 
@@ -295,6 +344,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::update_entry_group][super::super::client::DataCatalog::update_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::UpdateEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntryGroup(RequestBuilder<crate::model::UpdateEntryGroupRequest>);
 
@@ -357,6 +421,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::delete_entry_group][super::super::client::DataCatalog::delete_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::DeleteEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntryGroup(RequestBuilder<crate::model::DeleteEntryGroupRequest>);
 
@@ -413,6 +492,25 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::list_entry_groups][super::super::client::DataCatalog::list_entry_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ListEntryGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntryGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntryGroups(RequestBuilder<crate::model::ListEntryGroupsRequest>);
 
@@ -496,6 +594,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::create_entry][super::super::client::DataCatalog::create_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::CreateEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntry(RequestBuilder<crate::model::CreateEntryRequest>);
 
@@ -562,6 +675,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::update_entry][super::super::client::DataCatalog::update_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::UpdateEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntry(RequestBuilder<crate::model::UpdateEntryRequest>);
 
@@ -621,6 +749,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::delete_entry][super::super::client::DataCatalog::delete_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::DeleteEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntry(RequestBuilder<crate::model::DeleteEntryRequest>);
 
@@ -668,6 +811,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::get_entry][super::super::client::DataCatalog::get_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::GetEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntry(RequestBuilder<crate::model::GetEntryRequest>);
 
@@ -715,6 +873,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::lookup_entry][super::super::client::DataCatalog::lookup_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::LookupEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupEntry(RequestBuilder<crate::model::LookupEntryRequest>);
 
@@ -817,6 +990,25 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::list_entries][super::super::client::DataCatalog::list_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ListEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntries(RequestBuilder<crate::model::ListEntriesRequest>);
 
@@ -906,6 +1098,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::modify_entry_overview][super::super::client::DataCatalog::modify_entry_overview] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ModifyEntryOverview;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ModifyEntryOverview {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ModifyEntryOverview(RequestBuilder<crate::model::ModifyEntryOverviewRequest>);
 
@@ -967,6 +1174,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::modify_entry_contacts][super::super::client::DataCatalog::modify_entry_contacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ModifyEntryContacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ModifyEntryContacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ModifyEntryContacts(RequestBuilder<crate::model::ModifyEntryContactsRequest>);
 
@@ -1028,6 +1250,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::create_tag_template][super::super::client::DataCatalog::create_tag_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::CreateTagTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTagTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTagTemplate(RequestBuilder<crate::model::CreateTagTemplateRequest>);
 
@@ -1097,6 +1334,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::get_tag_template][super::super::client::DataCatalog::get_tag_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::GetTagTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTagTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTagTemplate(RequestBuilder<crate::model::GetTagTemplateRequest>);
 
@@ -1144,6 +1396,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::update_tag_template][super::super::client::DataCatalog::update_tag_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::UpdateTagTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTagTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTagTemplate(RequestBuilder<crate::model::UpdateTagTemplateRequest>);
 
@@ -1206,6 +1473,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::delete_tag_template][super::super::client::DataCatalog::delete_tag_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::DeleteTagTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTagTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTagTemplate(RequestBuilder<crate::model::DeleteTagTemplateRequest>);
 
@@ -1264,6 +1546,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::create_tag_template_field][super::super::client::DataCatalog::create_tag_template_field] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::CreateTagTemplateField;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTagTemplateField {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTagTemplateField(RequestBuilder<crate::model::CreateTagTemplateFieldRequest>);
 
@@ -1335,6 +1632,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::update_tag_template_field][super::super::client::DataCatalog::update_tag_template_field] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::UpdateTagTemplateField;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTagTemplateField {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTagTemplateField(RequestBuilder<crate::model::UpdateTagTemplateFieldRequest>);
 
@@ -1407,6 +1719,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::rename_tag_template_field][super::super::client::DataCatalog::rename_tag_template_field] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::RenameTagTemplateField;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenameTagTemplateField {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenameTagTemplateField(RequestBuilder<crate::model::RenameTagTemplateFieldRequest>);
 
@@ -1465,6 +1792,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::rename_tag_template_field_enum_value][super::super::client::DataCatalog::rename_tag_template_field_enum_value] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::RenameTagTemplateFieldEnumValue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenameTagTemplateFieldEnumValue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenameTagTemplateFieldEnumValue(
         RequestBuilder<crate::model::RenameTagTemplateFieldEnumValueRequest>,
@@ -1528,6 +1870,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::delete_tag_template_field][super::super::client::DataCatalog::delete_tag_template_field] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::DeleteTagTemplateField;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTagTemplateField {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTagTemplateField(RequestBuilder<crate::model::DeleteTagTemplateFieldRequest>);
 
@@ -1586,6 +1943,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::create_tag][super::super::client::DataCatalog::create_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::CreateTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTag(RequestBuilder<crate::model::CreateTagRequest>);
 
@@ -1641,6 +2013,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::update_tag][super::super::client::DataCatalog::update_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::UpdateTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTag(RequestBuilder<crate::model::UpdateTagRequest>);
 
@@ -1697,6 +2084,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::delete_tag][super::super::client::DataCatalog::delete_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::DeleteTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTag(RequestBuilder<crate::model::DeleteTagRequest>);
 
@@ -1744,6 +2146,25 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::list_tags][super::super::client::DataCatalog::list_tags] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ListTags;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTags {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTags(RequestBuilder<crate::model::ListTagsRequest>);
 
@@ -1827,6 +2248,22 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::reconcile_tags][super::super::client::DataCatalog::reconcile_tags] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ReconcileTags;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datacatalog_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReconcileTags {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReconcileTags(RequestBuilder<crate::model::ReconcileTagsRequest>);
 
@@ -1940,6 +2377,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::star_entry][super::super::client::DataCatalog::star_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::StarEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StarEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StarEntry(RequestBuilder<crate::model::StarEntryRequest>);
 
@@ -1987,6 +2439,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::unstar_entry][super::super::client::DataCatalog::unstar_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::UnstarEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UnstarEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UnstarEntry(RequestBuilder<crate::model::UnstarEntryRequest>);
 
@@ -2034,6 +2501,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::set_iam_policy][super::super::client::DataCatalog::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2101,6 +2583,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::get_iam_policy][super::super::client::DataCatalog::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2157,6 +2654,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::test_iam_permissions][super::super::client::DataCatalog::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2220,6 +2732,22 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::import_entries][super::super::client::DataCatalog::import_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ImportEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datacatalog_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportEntries(RequestBuilder<crate::model::ImportEntriesRequest>);
 
@@ -2339,6 +2867,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::set_config][super::super::client::DataCatalog::set_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::SetConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetConfig(RequestBuilder<crate::model::SetConfigRequest>);
 
@@ -2430,6 +2973,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::retrieve_config][super::super::client::DataCatalog::retrieve_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::RetrieveConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetrieveConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetrieveConfig(RequestBuilder<crate::model::RetrieveConfigRequest>);
 
@@ -2477,6 +3035,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::retrieve_effective_config][super::super::client::DataCatalog::retrieve_effective_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::RetrieveEffectiveConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetrieveEffectiveConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetrieveEffectiveConfig(
         RequestBuilder<crate::model::RetrieveEffectiveConfigRequest>,
@@ -2529,6 +3102,25 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::list_operations][super::super::client::DataCatalog::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2621,6 +3213,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::get_operation][super::super::client::DataCatalog::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2669,6 +3276,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::delete_operation][super::super::client::DataCatalog::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2717,6 +3339,21 @@ pub mod data_catalog {
     }
 
     /// The request builder for [DataCatalog::cancel_operation][super::super::client::DataCatalog::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::data_catalog::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2820,6 +3457,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::create_taxonomy][super::super::client::PolicyTagManager::create_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::CreateTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTaxonomy(RequestBuilder<crate::model::CreateTaxonomyRequest>);
 
@@ -2876,6 +3528,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::delete_taxonomy][super::super::client::PolicyTagManager::delete_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::DeleteTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTaxonomy(RequestBuilder<crate::model::DeleteTaxonomyRequest>);
 
@@ -2923,6 +3590,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::update_taxonomy][super::super::client::PolicyTagManager::update_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::UpdateTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTaxonomy(RequestBuilder<crate::model::UpdateTaxonomyRequest>);
 
@@ -2980,6 +3662,25 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::list_taxonomies][super::super::client::PolicyTagManager::list_taxonomies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::ListTaxonomies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTaxonomies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTaxonomies(RequestBuilder<crate::model::ListTaxonomiesRequest>);
 
@@ -3069,6 +3770,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::get_taxonomy][super::super::client::PolicyTagManager::get_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::GetTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTaxonomy(RequestBuilder<crate::model::GetTaxonomyRequest>);
 
@@ -3116,6 +3832,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::create_policy_tag][super::super::client::PolicyTagManager::create_policy_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::CreatePolicyTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePolicyTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePolicyTag(RequestBuilder<crate::model::CreatePolicyTagRequest>);
 
@@ -3172,6 +3903,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::delete_policy_tag][super::super::client::PolicyTagManager::delete_policy_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::DeletePolicyTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePolicyTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePolicyTag(RequestBuilder<crate::model::DeletePolicyTagRequest>);
 
@@ -3219,6 +3965,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::update_policy_tag][super::super::client::PolicyTagManager::update_policy_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::UpdatePolicyTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePolicyTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePolicyTag(RequestBuilder<crate::model::UpdatePolicyTagRequest>);
 
@@ -3276,6 +4037,25 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::list_policy_tags][super::super::client::PolicyTagManager::list_policy_tags] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::ListPolicyTags;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPolicyTags {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPolicyTags(RequestBuilder<crate::model::ListPolicyTagsRequest>);
 
@@ -3359,6 +4139,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::get_policy_tag][super::super::client::PolicyTagManager::get_policy_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::GetPolicyTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPolicyTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPolicyTag(RequestBuilder<crate::model::GetPolicyTagRequest>);
 
@@ -3406,6 +4201,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::get_iam_policy][super::super::client::PolicyTagManager::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3462,6 +4272,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::set_iam_policy][super::super::client::PolicyTagManager::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3529,6 +4354,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::test_iam_permissions][super::super::client::PolicyTagManager::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3592,6 +4432,25 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::list_operations][super::super::client::PolicyTagManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3684,6 +4543,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::get_operation][super::super::client::PolicyTagManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3732,6 +4606,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::delete_operation][super::super::client::PolicyTagManager::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3780,6 +4669,21 @@ pub mod policy_tag_manager {
     }
 
     /// The request builder for [PolicyTagManager::cancel_operation][super::super::client::PolicyTagManager::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3883,6 +4787,21 @@ pub mod policy_tag_manager_serialization {
     }
 
     /// The request builder for [PolicyTagManagerSerialization::replace_taxonomy][super::super::client::PolicyTagManagerSerialization::replace_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager_serialization::ReplaceTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReplaceTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReplaceTaxonomy(RequestBuilder<crate::model::ReplaceTaxonomyRequest>);
 
@@ -3943,6 +4862,21 @@ pub mod policy_tag_manager_serialization {
     }
 
     /// The request builder for [PolicyTagManagerSerialization::import_taxonomies][super::super::client::PolicyTagManagerSerialization::import_taxonomies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager_serialization::ImportTaxonomies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportTaxonomies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportTaxonomies(RequestBuilder<crate::model::ImportTaxonomiesRequest>);
 
@@ -4035,6 +4969,21 @@ pub mod policy_tag_manager_serialization {
     }
 
     /// The request builder for [PolicyTagManagerSerialization::export_taxonomies][super::super::client::PolicyTagManagerSerialization::export_taxonomies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager_serialization::ExportTaxonomies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportTaxonomies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportTaxonomies(RequestBuilder<crate::model::ExportTaxonomiesRequest>);
 
@@ -4122,6 +5071,25 @@ pub mod policy_tag_manager_serialization {
     }
 
     /// The request builder for [PolicyTagManagerSerialization::list_operations][super::super::client::PolicyTagManagerSerialization::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager_serialization::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4214,6 +5182,21 @@ pub mod policy_tag_manager_serialization {
     }
 
     /// The request builder for [PolicyTagManagerSerialization::get_operation][super::super::client::PolicyTagManagerSerialization::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager_serialization::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4262,6 +5245,21 @@ pub mod policy_tag_manager_serialization {
     }
 
     /// The request builder for [PolicyTagManagerSerialization::delete_operation][super::super::client::PolicyTagManagerSerialization::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager_serialization::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4310,6 +5308,21 @@ pub mod policy_tag_manager_serialization {
     }
 
     /// The request builder for [PolicyTagManagerSerialization::cancel_operation][super::super::client::PolicyTagManagerSerialization::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datacatalog_v1::builder;
+    /// use builder::policy_tag_manager_serialization::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datafusion/v1/src/builder.rs
+++ b/src/generated/cloud/datafusion/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::list_available_versions][super::super::client::DataFusion::list_available_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::ListAvailableVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAvailableVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAvailableVersions(RequestBuilder<crate::model::ListAvailableVersionsRequest>);
 
@@ -163,6 +182,25 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::list_instances][super::super::client::DataFusion::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -258,6 +296,21 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::get_instance][super::super::client::DataFusion::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -305,6 +358,22 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::create_instance][super::super::client::DataFusion::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datafusion_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -407,6 +476,22 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::delete_instance][super::super::client::DataFusion::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datafusion_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -494,6 +579,22 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::update_instance][super::super::client::DataFusion::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datafusion_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -591,6 +692,22 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::restart_instance][super::super::client::DataFusion::restart_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::RestartInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datafusion_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestartInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestartInstance(RequestBuilder<crate::model::RestartInstanceRequest>);
 
@@ -676,6 +793,25 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::list_operations][super::super::client::DataFusion::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -768,6 +904,21 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::get_operation][super::super::client::DataFusion::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -816,6 +967,21 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::delete_operation][super::super::client::DataFusion::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -864,6 +1030,21 @@ pub mod data_fusion {
     }
 
     /// The request builder for [DataFusion::cancel_operation][super::super::client::DataFusion::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datafusion_v1::builder;
+    /// use builder::data_fusion::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/dataplex/v1/src/builder.rs
+++ b/src/generated/cloud/dataplex/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::create_entry_type][super::super::client::CatalogService::create_entry_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::CreateEntryType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntryType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntryType(RequestBuilder<crate::model::CreateEntryTypeRequest>);
 
@@ -179,6 +195,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::update_entry_type][super::super::client::CatalogService::update_entry_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::UpdateEntryType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntryType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntryType(RequestBuilder<crate::model::UpdateEntryTypeRequest>);
 
@@ -284,6 +316,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::delete_entry_type][super::super::client::CatalogService::delete_entry_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::DeleteEntryType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntryType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntryType(RequestBuilder<crate::model::DeleteEntryTypeRequest>);
 
@@ -377,6 +425,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_entry_types][super::super::client::CatalogService::list_entry_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::ListEntryTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntryTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntryTypes(RequestBuilder<crate::model::ListEntryTypesRequest>);
 
@@ -472,6 +539,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_entry_type][super::super::client::CatalogService::get_entry_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetEntryType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntryType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntryType(RequestBuilder<crate::model::GetEntryTypeRequest>);
 
@@ -519,6 +601,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::create_aspect_type][super::super::client::CatalogService::create_aspect_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::CreateAspectType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAspectType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAspectType(RequestBuilder<crate::model::CreateAspectTypeRequest>);
 
@@ -632,6 +730,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::update_aspect_type][super::super::client::CatalogService::update_aspect_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::UpdateAspectType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAspectType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAspectType(RequestBuilder<crate::model::UpdateAspectTypeRequest>);
 
@@ -740,6 +854,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::delete_aspect_type][super::super::client::CatalogService::delete_aspect_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::DeleteAspectType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAspectType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAspectType(RequestBuilder<crate::model::DeleteAspectTypeRequest>);
 
@@ -836,6 +966,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_aspect_types][super::super::client::CatalogService::list_aspect_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::ListAspectTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAspectTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAspectTypes(RequestBuilder<crate::model::ListAspectTypesRequest>);
 
@@ -931,6 +1080,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_aspect_type][super::super::client::CatalogService::get_aspect_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetAspectType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAspectType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAspectType(RequestBuilder<crate::model::GetAspectTypeRequest>);
 
@@ -978,6 +1142,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::create_entry_group][super::super::client::CatalogService::create_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::CreateEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntryGroup(RequestBuilder<crate::model::CreateEntryGroupRequest>);
 
@@ -1091,6 +1271,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::update_entry_group][super::super::client::CatalogService::update_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::UpdateEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntryGroup(RequestBuilder<crate::model::UpdateEntryGroupRequest>);
 
@@ -1199,6 +1395,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::delete_entry_group][super::super::client::CatalogService::delete_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::DeleteEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntryGroup(RequestBuilder<crate::model::DeleteEntryGroupRequest>);
 
@@ -1295,6 +1507,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_entry_groups][super::super::client::CatalogService::list_entry_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::ListEntryGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntryGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntryGroups(RequestBuilder<crate::model::ListEntryGroupsRequest>);
 
@@ -1390,6 +1621,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_entry_group][super::super::client::CatalogService::get_entry_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetEntryGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntryGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntryGroup(RequestBuilder<crate::model::GetEntryGroupRequest>);
 
@@ -1437,6 +1683,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::create_entry][super::super::client::CatalogService::create_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::CreateEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntry(RequestBuilder<crate::model::CreateEntryRequest>);
 
@@ -1503,6 +1764,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::update_entry][super::super::client::CatalogService::update_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::UpdateEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntry(RequestBuilder<crate::model::UpdateEntryRequest>);
 
@@ -1585,6 +1861,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::delete_entry][super::super::client::CatalogService::delete_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::DeleteEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntry(RequestBuilder<crate::model::DeleteEntryRequest>);
 
@@ -1632,6 +1923,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_entries][super::super::client::CatalogService::list_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::ListEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntries(RequestBuilder<crate::model::ListEntriesRequest>);
 
@@ -1721,6 +2031,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_entry][super::super::client::CatalogService::get_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntry(RequestBuilder<crate::model::GetEntryRequest>);
 
@@ -1796,6 +2121,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::lookup_entry][super::super::client::CatalogService::lookup_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::LookupEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupEntry(RequestBuilder<crate::model::LookupEntryRequest>);
 
@@ -1879,6 +2219,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::search_entries][super::super::client::CatalogService::search_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::SearchEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchEntries(RequestBuilder<crate::model::SearchEntriesRequest>);
 
@@ -1982,6 +2341,22 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::create_metadata_job][super::super::client::CatalogService::create_metadata_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::CreateMetadataJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMetadataJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMetadataJob(RequestBuilder<crate::model::CreateMetadataJobRequest>);
 
@@ -2095,6 +2470,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_metadata_job][super::super::client::CatalogService::get_metadata_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetMetadataJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMetadataJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMetadataJob(RequestBuilder<crate::model::GetMetadataJobRequest>);
 
@@ -2142,6 +2532,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_metadata_jobs][super::super::client::CatalogService::list_metadata_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::ListMetadataJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMetadataJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMetadataJobs(RequestBuilder<crate::model::ListMetadataJobsRequest>);
 
@@ -2240,6 +2649,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::cancel_metadata_job][super::super::client::CatalogService::cancel_metadata_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::CancelMetadataJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelMetadataJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelMetadataJob(RequestBuilder<crate::model::CancelMetadataJobRequest>);
 
@@ -2290,6 +2714,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_locations][super::super::client::CatalogService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2380,6 +2823,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_location][super::super::client::CatalogService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2425,6 +2883,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::set_iam_policy][super::super::client::CatalogService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2492,6 +2965,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_iam_policy][super::super::client::CatalogService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2548,6 +3036,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::test_iam_permissions][super::super::client::CatalogService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2611,6 +3114,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_operations][super::super::client::CatalogService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2703,6 +3225,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_operation][super::super::client::CatalogService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2751,6 +3288,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::delete_operation][super::super::client::CatalogService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2799,6 +3351,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::cancel_operation][super::super::client::CatalogService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::catalog_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2902,6 +3469,22 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::create_encryption_config][super::super::client::CmekService::create_encryption_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::CreateEncryptionConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEncryptionConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEncryptionConfig(RequestBuilder<crate::model::CreateEncryptionConfigRequest>);
 
@@ -3014,6 +3597,22 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::update_encryption_config][super::super::client::CmekService::update_encryption_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::UpdateEncryptionConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEncryptionConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEncryptionConfig(RequestBuilder<crate::model::UpdateEncryptionConfigRequest>);
 
@@ -3119,6 +3718,22 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::delete_encryption_config][super::super::client::CmekService::delete_encryption_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::DeleteEncryptionConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEncryptionConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEncryptionConfig(RequestBuilder<crate::model::DeleteEncryptionConfigRequest>);
 
@@ -3215,6 +3830,25 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::list_encryption_configs][super::super::client::CmekService::list_encryption_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::ListEncryptionConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEncryptionConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEncryptionConfigs(RequestBuilder<crate::model::ListEncryptionConfigsRequest>);
 
@@ -3315,6 +3949,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::get_encryption_config][super::super::client::CmekService::get_encryption_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::GetEncryptionConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEncryptionConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEncryptionConfig(RequestBuilder<crate::model::GetEncryptionConfigRequest>);
 
@@ -3365,6 +4014,25 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::list_locations][super::super::client::CmekService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3455,6 +4123,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::get_location][super::super::client::CmekService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3500,6 +4183,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::set_iam_policy][super::super::client::CmekService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3567,6 +4265,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::get_iam_policy][super::super::client::CmekService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3623,6 +4336,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::test_iam_permissions][super::super::client::CmekService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3686,6 +4414,25 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::list_operations][super::super::client::CmekService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3778,6 +4525,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::get_operation][super::super::client::CmekService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3826,6 +4588,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::delete_operation][super::super::client::CmekService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3874,6 +4651,21 @@ pub mod cmek_service {
     }
 
     /// The request builder for [CmekService::cancel_operation][super::super::client::CmekService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::cmek_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3977,6 +4769,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::create_content][super::super::client::ContentService::create_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::CreateContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateContent(RequestBuilder<crate::model::CreateContentRequest>);
 
@@ -4041,6 +4848,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::update_content][super::super::client::ContentService::update_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::UpdateContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateContent(RequestBuilder<crate::model::UpdateContentRequest>);
 
@@ -4108,6 +4930,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::delete_content][super::super::client::ContentService::delete_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::DeleteContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteContent(RequestBuilder<crate::model::DeleteContentRequest>);
 
@@ -4155,6 +4992,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::get_content][super::super::client::ContentService::get_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::GetContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetContent(RequestBuilder<crate::model::GetContentRequest>);
 
@@ -4211,6 +5063,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::get_iam_policy][super::super::client::ContentService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4267,6 +5134,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::set_iam_policy][super::super::client::ContentService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4334,6 +5216,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::test_iam_permissions][super::super::client::ContentService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4397,6 +5294,25 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::list_content][super::super::client::ContentService::list_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::ListContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListContent(RequestBuilder<crate::model::ListContentRequest>);
 
@@ -4486,6 +5402,25 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::list_locations][super::super::client::ContentService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4576,6 +5511,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::get_location][super::super::client::ContentService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4621,6 +5571,25 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::list_operations][super::super::client::ContentService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4713,6 +5682,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::get_operation][super::super::client::ContentService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4761,6 +5745,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::delete_operation][super::super::client::ContentService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4809,6 +5808,21 @@ pub mod content_service {
     }
 
     /// The request builder for [ContentService::cancel_operation][super::super::client::ContentService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::content_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4912,6 +5926,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::create_data_taxonomy][super::super::client::DataTaxonomyService::create_data_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::CreateDataTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataTaxonomy(RequestBuilder<crate::model::CreateDataTaxonomyRequest>);
 
@@ -5027,6 +6057,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::update_data_taxonomy][super::super::client::DataTaxonomyService::update_data_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::UpdateDataTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataTaxonomy(RequestBuilder<crate::model::UpdateDataTaxonomyRequest>);
 
@@ -5137,6 +6183,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::delete_data_taxonomy][super::super::client::DataTaxonomyService::delete_data_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::DeleteDataTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataTaxonomy(RequestBuilder<crate::model::DeleteDataTaxonomyRequest>);
 
@@ -5233,6 +6295,25 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::list_data_taxonomies][super::super::client::DataTaxonomyService::list_data_taxonomies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::ListDataTaxonomies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataTaxonomies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataTaxonomies(RequestBuilder<crate::model::ListDataTaxonomiesRequest>);
 
@@ -5333,6 +6414,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::get_data_taxonomy][super::super::client::DataTaxonomyService::get_data_taxonomy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::GetDataTaxonomy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataTaxonomy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataTaxonomy(RequestBuilder<crate::model::GetDataTaxonomyRequest>);
 
@@ -5380,6 +6476,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::create_data_attribute_binding][super::super::client::DataTaxonomyService::create_data_attribute_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::CreateDataAttributeBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataAttributeBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataAttributeBinding(
         RequestBuilder<crate::model::CreateDataAttributeBindingRequest>,
@@ -5500,6 +6612,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::update_data_attribute_binding][super::super::client::DataTaxonomyService::update_data_attribute_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::UpdateDataAttributeBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataAttributeBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataAttributeBinding(
         RequestBuilder<crate::model::UpdateDataAttributeBindingRequest>,
@@ -5615,6 +6743,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::delete_data_attribute_binding][super::super::client::DataTaxonomyService::delete_data_attribute_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::DeleteDataAttributeBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataAttributeBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataAttributeBinding(
         RequestBuilder<crate::model::DeleteDataAttributeBindingRequest>,
@@ -5715,6 +6859,25 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::list_data_attribute_bindings][super::super::client::DataTaxonomyService::list_data_attribute_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::ListDataAttributeBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataAttributeBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataAttributeBindings(
         RequestBuilder<crate::model::ListDataAttributeBindingsRequest>,
@@ -5819,6 +6982,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::get_data_attribute_binding][super::super::client::DataTaxonomyService::get_data_attribute_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::GetDataAttributeBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataAttributeBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataAttributeBinding(
         RequestBuilder<crate::model::GetDataAttributeBindingRequest>,
@@ -5871,6 +7049,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::create_data_attribute][super::super::client::DataTaxonomyService::create_data_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::CreateDataAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataAttribute(RequestBuilder<crate::model::CreateDataAttributeRequest>);
 
@@ -5987,6 +7181,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::update_data_attribute][super::super::client::DataTaxonomyService::update_data_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::UpdateDataAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataAttribute(RequestBuilder<crate::model::UpdateDataAttributeRequest>);
 
@@ -6098,6 +7308,22 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::delete_data_attribute][super::super::client::DataTaxonomyService::delete_data_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::DeleteDataAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataAttribute(RequestBuilder<crate::model::DeleteDataAttributeRequest>);
 
@@ -6194,6 +7420,25 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::list_data_attributes][super::super::client::DataTaxonomyService::list_data_attributes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::ListDataAttributes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataAttributes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataAttributes(RequestBuilder<crate::model::ListDataAttributesRequest>);
 
@@ -6294,6 +7539,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::get_data_attribute][super::super::client::DataTaxonomyService::get_data_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::GetDataAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataAttribute(RequestBuilder<crate::model::GetDataAttributeRequest>);
 
@@ -6344,6 +7604,25 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::list_locations][super::super::client::DataTaxonomyService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6434,6 +7713,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::get_location][super::super::client::DataTaxonomyService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6479,6 +7773,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::set_iam_policy][super::super::client::DataTaxonomyService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -6546,6 +7855,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::get_iam_policy][super::super::client::DataTaxonomyService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -6602,6 +7926,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::test_iam_permissions][super::super::client::DataTaxonomyService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -6665,6 +8004,25 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::list_operations][super::super::client::DataTaxonomyService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6757,6 +8115,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::get_operation][super::super::client::DataTaxonomyService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6805,6 +8178,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::delete_operation][super::super::client::DataTaxonomyService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -6853,6 +8241,21 @@ pub mod data_taxonomy_service {
     }
 
     /// The request builder for [DataTaxonomyService::cancel_operation][super::super::client::DataTaxonomyService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_taxonomy_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6956,6 +8359,22 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::create_data_scan][super::super::client::DataScanService::create_data_scan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::CreateDataScan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataScan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataScan(RequestBuilder<crate::model::CreateDataScanRequest>);
 
@@ -7066,6 +8485,22 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::update_data_scan][super::super::client::DataScanService::update_data_scan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::UpdateDataScan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataScan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataScan(RequestBuilder<crate::model::UpdateDataScanRequest>);
 
@@ -7169,6 +8604,22 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::delete_data_scan][super::super::client::DataScanService::delete_data_scan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::DeleteDataScan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataScan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataScan(RequestBuilder<crate::model::DeleteDataScanRequest>);
 
@@ -7262,6 +8713,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::get_data_scan][super::super::client::DataScanService::get_data_scan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::GetDataScan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataScan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataScan(RequestBuilder<crate::model::GetDataScanRequest>);
 
@@ -7318,6 +8784,25 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::list_data_scans][super::super::client::DataScanService::list_data_scans] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::ListDataScans;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataScans {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataScans(RequestBuilder<crate::model::ListDataScansRequest>);
 
@@ -7413,6 +8898,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::run_data_scan][super::super::client::DataScanService::run_data_scan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::RunDataScan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunDataScan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunDataScan(RequestBuilder<crate::model::RunDataScanRequest>);
 
@@ -7460,6 +8960,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::get_data_scan_job][super::super::client::DataScanService::get_data_scan_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::GetDataScanJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataScanJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataScanJob(RequestBuilder<crate::model::GetDataScanJobRequest>);
 
@@ -7516,6 +9031,25 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::list_data_scan_jobs][super::super::client::DataScanService::list_data_scan_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::ListDataScanJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataScanJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataScanJobs(RequestBuilder<crate::model::ListDataScanJobsRequest>);
 
@@ -7608,6 +9142,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::generate_data_quality_rules][super::super::client::DataScanService::generate_data_quality_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::GenerateDataQualityRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateDataQualityRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateDataQualityRules(
         RequestBuilder<crate::model::GenerateDataQualityRulesRequest>,
@@ -7660,6 +9209,25 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::list_locations][super::super::client::DataScanService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7750,6 +9318,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::get_location][super::super::client::DataScanService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -7795,6 +9378,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::set_iam_policy][super::super::client::DataScanService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -7862,6 +9460,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::get_iam_policy][super::super::client::DataScanService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -7918,6 +9531,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::test_iam_permissions][super::super::client::DataScanService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -7981,6 +9609,25 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::list_operations][super::super::client::DataScanService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8073,6 +9720,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::get_operation][super::super::client::DataScanService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8121,6 +9783,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::delete_operation][super::super::client::DataScanService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -8169,6 +9846,21 @@ pub mod data_scan_service {
     }
 
     /// The request builder for [DataScanService::cancel_operation][super::super::client::DataScanService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::data_scan_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8272,6 +9964,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::create_entity][super::super::client::MetadataService::create_entity] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::CreateEntity;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntity {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntity(RequestBuilder<crate::model::CreateEntityRequest>);
 
@@ -8336,6 +10043,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::update_entity][super::super::client::MetadataService::update_entity] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::UpdateEntity;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntity {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntity(RequestBuilder<crate::model::UpdateEntityRequest>);
 
@@ -8392,6 +10114,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_entity][super::super::client::MetadataService::delete_entity] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::DeleteEntity;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntity {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntity(RequestBuilder<crate::model::DeleteEntityRequest>);
 
@@ -8447,6 +10184,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_entity][super::super::client::MetadataService::get_entity] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::GetEntity;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntity {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntity(RequestBuilder<crate::model::GetEntityRequest>);
 
@@ -8503,6 +10255,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_entities][super::super::client::MetadataService::list_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::ListEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntities(RequestBuilder<crate::model::ListEntitiesRequest>);
 
@@ -8603,6 +10374,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::create_partition][super::super::client::MetadataService::create_partition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::CreatePartition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePartition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePartition(RequestBuilder<crate::model::CreatePartitionRequest>);
 
@@ -8667,6 +10453,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_partition][super::super::client::MetadataService::delete_partition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::DeletePartition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePartition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePartition(RequestBuilder<crate::model::DeletePartitionRequest>);
 
@@ -8721,6 +10522,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_partition][super::super::client::MetadataService::get_partition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::GetPartition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPartition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPartition(RequestBuilder<crate::model::GetPartitionRequest>);
 
@@ -8768,6 +10584,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_partitions][super::super::client::MetadataService::list_partitions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::ListPartitions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPartitions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPartitions(RequestBuilder<crate::model::ListPartitionsRequest>);
 
@@ -8857,6 +10692,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_locations][super::super::client::MetadataService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8947,6 +10801,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_location][super::super::client::MetadataService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8992,6 +10861,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::set_iam_policy][super::super::client::MetadataService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -9059,6 +10943,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_iam_policy][super::super::client::MetadataService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -9115,6 +11014,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::test_iam_permissions][super::super::client::MetadataService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -9178,6 +11092,25 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::list_operations][super::super::client::MetadataService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9270,6 +11203,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::get_operation][super::super::client::MetadataService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9318,6 +11266,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::delete_operation][super::super::client::MetadataService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -9366,6 +11329,21 @@ pub mod metadata_service {
     }
 
     /// The request builder for [MetadataService::cancel_operation][super::super::client::MetadataService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::metadata_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9469,6 +11447,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::create_lake][super::super::client::DataplexService::create_lake] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::CreateLake;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLake {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLake(RequestBuilder<crate::model::CreateLakeRequest>);
 
@@ -9576,6 +11570,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::update_lake][super::super::client::DataplexService::update_lake] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::UpdateLake;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLake {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLake(RequestBuilder<crate::model::UpdateLakeRequest>);
 
@@ -9678,6 +11688,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::delete_lake][super::super::client::DataplexService::delete_lake] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::DeleteLake;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLake {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLake(RequestBuilder<crate::model::DeleteLakeRequest>);
 
@@ -9765,6 +11791,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_lakes][super::super::client::DataplexService::list_lakes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListLakes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLakes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLakes(RequestBuilder<crate::model::ListLakesRequest>);
 
@@ -9860,6 +11905,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_lake][super::super::client::DataplexService::get_lake] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetLake;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLake {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLake(RequestBuilder<crate::model::GetLakeRequest>);
 
@@ -9907,6 +11967,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_lake_actions][super::super::client::DataplexService::list_lake_actions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListLakeActions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLakeActions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLakeActions(RequestBuilder<crate::model::ListLakeActionsRequest>);
 
@@ -9990,6 +12069,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::create_zone][super::super::client::DataplexService::create_zone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::CreateZone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateZone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateZone(RequestBuilder<crate::model::CreateZoneRequest>);
 
@@ -10097,6 +12192,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::update_zone][super::super::client::DataplexService::update_zone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::UpdateZone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateZone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateZone(RequestBuilder<crate::model::UpdateZoneRequest>);
 
@@ -10199,6 +12310,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::delete_zone][super::super::client::DataplexService::delete_zone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::DeleteZone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteZone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteZone(RequestBuilder<crate::model::DeleteZoneRequest>);
 
@@ -10286,6 +12413,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_zones][super::super::client::DataplexService::list_zones] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListZones;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListZones {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListZones(RequestBuilder<crate::model::ListZonesRequest>);
 
@@ -10381,6 +12527,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_zone][super::super::client::DataplexService::get_zone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetZone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetZone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetZone(RequestBuilder<crate::model::GetZoneRequest>);
 
@@ -10428,6 +12589,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_zone_actions][super::super::client::DataplexService::list_zone_actions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListZoneActions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListZoneActions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListZoneActions(RequestBuilder<crate::model::ListZoneActionsRequest>);
 
@@ -10511,6 +12691,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::create_asset][super::super::client::DataplexService::create_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::CreateAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAsset(RequestBuilder<crate::model::CreateAssetRequest>);
 
@@ -10621,6 +12817,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::update_asset][super::super::client::DataplexService::update_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::UpdateAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAsset(RequestBuilder<crate::model::UpdateAssetRequest>);
 
@@ -10726,6 +12938,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::delete_asset][super::super::client::DataplexService::delete_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::DeleteAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAsset(RequestBuilder<crate::model::DeleteAssetRequest>);
 
@@ -10813,6 +13041,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_assets][super::super::client::DataplexService::list_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAssets(RequestBuilder<crate::model::ListAssetsRequest>);
 
@@ -10908,6 +13155,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_asset][super::super::client::DataplexService::get_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAsset(RequestBuilder<crate::model::GetAssetRequest>);
 
@@ -10955,6 +13217,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_asset_actions][super::super::client::DataplexService::list_asset_actions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListAssetActions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAssetActions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAssetActions(RequestBuilder<crate::model::ListAssetActionsRequest>);
 
@@ -11041,6 +13322,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::create_task][super::super::client::DataplexService::create_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::CreateTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTask(RequestBuilder<crate::model::CreateTaskRequest>);
 
@@ -11148,6 +13445,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::update_task][super::super::client::DataplexService::update_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::UpdateTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTask(RequestBuilder<crate::model::UpdateTaskRequest>);
 
@@ -11250,6 +13563,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::delete_task][super::super::client::DataplexService::delete_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::DeleteTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTask(RequestBuilder<crate::model::DeleteTaskRequest>);
 
@@ -11337,6 +13666,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_tasks][super::super::client::DataplexService::list_tasks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListTasks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTasks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTasks(RequestBuilder<crate::model::ListTasksRequest>);
 
@@ -11432,6 +13780,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_task][super::super::client::DataplexService::get_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTask(RequestBuilder<crate::model::GetTaskRequest>);
 
@@ -11479,6 +13842,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_jobs][super::super::client::DataplexService::list_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -11562,6 +13944,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::run_task][super::super::client::DataplexService::run_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::RunTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunTask(RequestBuilder<crate::model::RunTaskRequest>);
 
@@ -11631,6 +14028,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_job][super::super::client::DataplexService::get_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -11678,6 +14090,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::cancel_job][super::super::client::DataplexService::cancel_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::CancelJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelJob(RequestBuilder<crate::model::CancelJobRequest>);
 
@@ -11725,6 +14152,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::create_environment][super::super::client::DataplexService::create_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::CreateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEnvironment(RequestBuilder<crate::model::CreateEnvironmentRequest>);
 
@@ -11840,6 +14283,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::update_environment][super::super::client::DataplexService::update_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::UpdateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEnvironment(RequestBuilder<crate::model::UpdateEnvironmentRequest>);
 
@@ -11950,6 +14409,22 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::delete_environment][super::super::client::DataplexService::delete_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::DeleteEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataplex_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEnvironment(RequestBuilder<crate::model::DeleteEnvironmentRequest>);
 
@@ -12040,6 +14515,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_environments][super::super::client::DataplexService::list_environments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListEnvironments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEnvironments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEnvironments(RequestBuilder<crate::model::ListEnvironmentsRequest>);
 
@@ -12138,6 +14632,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_environment][super::super::client::DataplexService::get_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -12185,6 +14694,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_sessions][super::super::client::DataplexService::list_sessions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListSessions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSessions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSessions(RequestBuilder<crate::model::ListSessionsRequest>);
 
@@ -12274,6 +14802,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_locations][super::super::client::DataplexService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12364,6 +14911,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_location][super::super::client::DataplexService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12409,6 +14971,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::set_iam_policy][super::super::client::DataplexService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -12476,6 +15053,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_iam_policy][super::super::client::DataplexService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -12532,6 +15124,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::test_iam_permissions][super::super::client::DataplexService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -12595,6 +15202,25 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::list_operations][super::super::client::DataplexService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -12687,6 +15313,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::get_operation][super::super::client::DataplexService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -12735,6 +15376,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::delete_operation][super::super::client::DataplexService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -12783,6 +15439,21 @@ pub mod dataplex_service {
     }
 
     /// The request builder for [DataplexService::cancel_operation][super::super::client::DataplexService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataplex_v1::builder;
+    /// use builder::dataplex_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/dataproc/v1/src/builder.rs
+++ b/src/generated/cloud/dataproc/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::create_autoscaling_policy][super::super::client::AutoscalingPolicyService::create_autoscaling_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::CreateAutoscalingPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAutoscalingPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAutoscalingPolicy(
         RequestBuilder<crate::model::CreateAutoscalingPolicyRequest>,
@@ -132,6 +147,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::update_autoscaling_policy][super::super::client::AutoscalingPolicyService::update_autoscaling_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::UpdateAutoscalingPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAutoscalingPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAutoscalingPolicy(
         RequestBuilder<crate::model::UpdateAutoscalingPolicyRequest>,
@@ -187,6 +217,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::get_autoscaling_policy][super::super::client::AutoscalingPolicyService::get_autoscaling_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::GetAutoscalingPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAutoscalingPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAutoscalingPolicy(RequestBuilder<crate::model::GetAutoscalingPolicyRequest>);
 
@@ -237,6 +282,25 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::list_autoscaling_policies][super::super::client::AutoscalingPolicyService::list_autoscaling_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::ListAutoscalingPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAutoscalingPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAutoscalingPolicies(
         RequestBuilder<crate::model::ListAutoscalingPoliciesRequest>,
@@ -329,6 +393,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::delete_autoscaling_policy][super::super::client::AutoscalingPolicyService::delete_autoscaling_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::DeleteAutoscalingPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAutoscalingPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAutoscalingPolicy(
         RequestBuilder<crate::model::DeleteAutoscalingPolicyRequest>,
@@ -381,6 +460,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::set_iam_policy][super::super::client::AutoscalingPolicyService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -448,6 +542,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::get_iam_policy][super::super::client::AutoscalingPolicyService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -504,6 +613,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::test_iam_permissions][super::super::client::AutoscalingPolicyService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -567,6 +691,25 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::list_operations][super::super::client::AutoscalingPolicyService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -659,6 +802,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::get_operation][super::super::client::AutoscalingPolicyService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -707,6 +865,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::delete_operation][super::super::client::AutoscalingPolicyService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -755,6 +928,21 @@ pub mod autoscaling_policy_service {
     }
 
     /// The request builder for [AutoscalingPolicyService::cancel_operation][super::super::client::AutoscalingPolicyService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::autoscaling_policy_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -858,6 +1046,22 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::create_batch][super::super::client::BatchController::create_batch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::CreateBatch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBatch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBatch(RequestBuilder<crate::model::CreateBatchRequest>);
 
@@ -966,6 +1170,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::get_batch][super::super::client::BatchController::get_batch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::GetBatch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBatch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBatch(RequestBuilder<crate::model::GetBatchRequest>);
 
@@ -1013,6 +1232,25 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::list_batches][super::super::client::BatchController::list_batches] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::ListBatches;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBatches {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBatches(RequestBuilder<crate::model::ListBatchesRequest>);
 
@@ -1108,6 +1346,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::delete_batch][super::super::client::BatchController::delete_batch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::DeleteBatch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBatch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBatch(RequestBuilder<crate::model::DeleteBatchRequest>);
 
@@ -1155,6 +1408,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::set_iam_policy][super::super::client::BatchController::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1222,6 +1490,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::get_iam_policy][super::super::client::BatchController::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1278,6 +1561,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::test_iam_permissions][super::super::client::BatchController::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1341,6 +1639,25 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::list_operations][super::super::client::BatchController::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1433,6 +1750,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::get_operation][super::super::client::BatchController::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1481,6 +1813,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::delete_operation][super::super::client::BatchController::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1529,6 +1876,21 @@ pub mod batch_controller {
     }
 
     /// The request builder for [BatchController::cancel_operation][super::super::client::BatchController::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::batch_controller::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1632,6 +1994,22 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::create_cluster][super::super::client::ClusterController::create_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::CreateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -1754,6 +2132,22 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::update_cluster][super::super::client::ClusterController::update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::UpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -1895,6 +2289,22 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::stop_cluster][super::super::client::ClusterController::stop_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::StopCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopCluster(RequestBuilder<crate::model::StopClusterRequest>);
 
@@ -2011,6 +2421,22 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::start_cluster][super::super::client::ClusterController::start_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::StartCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartCluster(RequestBuilder<crate::model::StartClusterRequest>);
 
@@ -2127,6 +2553,22 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::delete_cluster][super::super::client::ClusterController::delete_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::DeleteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -2243,6 +2685,21 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::get_cluster][super::super::client::ClusterController::get_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::GetCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -2306,6 +2763,25 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::list_clusters][super::super::client::ClusterController::list_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::ListClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -2403,6 +2879,22 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::diagnose_cluster][super::super::client::ClusterController::diagnose_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::DiagnoseCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiagnoseCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiagnoseCluster(RequestBuilder<crate::model::DiagnoseClusterRequest>);
 
@@ -2555,6 +3047,21 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::set_iam_policy][super::super::client::ClusterController::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2622,6 +3129,21 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::get_iam_policy][super::super::client::ClusterController::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2678,6 +3200,21 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::test_iam_permissions][super::super::client::ClusterController::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2741,6 +3278,25 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::list_operations][super::super::client::ClusterController::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2833,6 +3389,21 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::get_operation][super::super::client::ClusterController::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2881,6 +3452,21 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::delete_operation][super::super::client::ClusterController::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2929,6 +3515,21 @@ pub mod cluster_controller {
     }
 
     /// The request builder for [ClusterController::cancel_operation][super::super::client::ClusterController::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::cluster_controller::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3032,6 +3633,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::submit_job][super::super::client::JobController::submit_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::SubmitJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubmitJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubmitJob(RequestBuilder<crate::model::SubmitJobRequest>);
 
@@ -3101,6 +3717,22 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::submit_job_as_operation][super::super::client::JobController::submit_job_as_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::SubmitJobAsOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubmitJobAsOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubmitJobAsOperation(RequestBuilder<crate::model::SubmitJobRequest>);
 
@@ -3205,6 +3837,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::get_job][super::super::client::JobController::get_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::GetJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -3268,6 +3915,25 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::list_jobs][super::super::client::JobController::list_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::ListJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -3380,6 +4046,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::update_job][super::super::client::JobController::update_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::UpdateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -3462,6 +4143,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::cancel_job][super::super::client::JobController::cancel_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::CancelJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelJob(RequestBuilder<crate::model::CancelJobRequest>);
 
@@ -3525,6 +4221,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::delete_job][super::super::client::JobController::delete_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::DeleteJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -3588,6 +4299,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::set_iam_policy][super::super::client::JobController::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3655,6 +4381,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::get_iam_policy][super::super::client::JobController::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3711,6 +4452,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::test_iam_permissions][super::super::client::JobController::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3774,6 +4530,25 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::list_operations][super::super::client::JobController::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3866,6 +4641,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::get_operation][super::super::client::JobController::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3914,6 +4704,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::delete_operation][super::super::client::JobController::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3962,6 +4767,21 @@ pub mod job_controller {
     }
 
     /// The request builder for [JobController::cancel_operation][super::super::client::JobController::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::job_controller::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4065,6 +4885,22 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::create_node_group][super::super::client::NodeGroupController::create_node_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::CreateNodeGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNodeGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNodeGroup(RequestBuilder<crate::model::CreateNodeGroupRequest>);
 
@@ -4176,6 +5012,22 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::resize_node_group][super::super::client::NodeGroupController::resize_node_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::ResizeNodeGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResizeNodeGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResizeNodeGroup(RequestBuilder<crate::model::ResizeNodeGroupRequest>);
 
@@ -4287,6 +5139,21 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::get_node_group][super::super::client::NodeGroupController::get_node_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::GetNodeGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNodeGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNodeGroup(RequestBuilder<crate::model::GetNodeGroupRequest>);
 
@@ -4334,6 +5201,21 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::set_iam_policy][super::super::client::NodeGroupController::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4401,6 +5283,21 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::get_iam_policy][super::super::client::NodeGroupController::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4457,6 +5354,21 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::test_iam_permissions][super::super::client::NodeGroupController::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4520,6 +5432,25 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::list_operations][super::super::client::NodeGroupController::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4612,6 +5543,21 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::get_operation][super::super::client::NodeGroupController::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4660,6 +5606,21 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::delete_operation][super::super::client::NodeGroupController::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4708,6 +5669,21 @@ pub mod node_group_controller {
     }
 
     /// The request builder for [NodeGroupController::cancel_operation][super::super::client::NodeGroupController::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::node_group_controller::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4811,6 +5787,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::create_session_template][super::super::client::SessionTemplateController::create_session_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::CreateSessionTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSessionTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSessionTemplate(RequestBuilder<crate::model::CreateSessionTemplateRequest>);
 
@@ -4872,6 +5863,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::update_session_template][super::super::client::SessionTemplateController::update_session_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::UpdateSessionTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSessionTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSessionTemplate(RequestBuilder<crate::model::UpdateSessionTemplateRequest>);
 
@@ -4925,6 +5931,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::get_session_template][super::super::client::SessionTemplateController::get_session_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::GetSessionTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSessionTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSessionTemplate(RequestBuilder<crate::model::GetSessionTemplateRequest>);
 
@@ -4975,6 +5996,25 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::list_session_templates][super::super::client::SessionTemplateController::list_session_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::ListSessionTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSessionTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSessionTemplates(RequestBuilder<crate::model::ListSessionTemplatesRequest>);
 
@@ -5069,6 +6109,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::delete_session_template][super::super::client::SessionTemplateController::delete_session_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::DeleteSessionTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSessionTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSessionTemplate(RequestBuilder<crate::model::DeleteSessionTemplateRequest>);
 
@@ -5119,6 +6174,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::set_iam_policy][super::super::client::SessionTemplateController::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5186,6 +6256,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::get_iam_policy][super::super::client::SessionTemplateController::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5242,6 +6327,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::test_iam_permissions][super::super::client::SessionTemplateController::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5305,6 +6405,25 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::list_operations][super::super::client::SessionTemplateController::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5397,6 +6516,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::get_operation][super::super::client::SessionTemplateController::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5445,6 +6579,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::delete_operation][super::super::client::SessionTemplateController::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5493,6 +6642,21 @@ pub mod session_template_controller {
     }
 
     /// The request builder for [SessionTemplateController::cancel_operation][super::super::client::SessionTemplateController::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_template_controller::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5596,6 +6760,22 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::create_session][super::super::client::SessionController::create_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::CreateSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSession(RequestBuilder<crate::model::CreateSessionRequest>);
 
@@ -5709,6 +6889,21 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::get_session][super::super::client::SessionController::get_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::GetSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSession(RequestBuilder<crate::model::GetSessionRequest>);
 
@@ -5756,6 +6951,25 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::list_sessions][super::super::client::SessionController::list_sessions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::ListSessions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSessions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSessions(RequestBuilder<crate::model::ListSessionsRequest>);
 
@@ -5845,6 +7059,22 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::terminate_session][super::super::client::SessionController::terminate_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::TerminateSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TerminateSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TerminateSession(RequestBuilder<crate::model::TerminateSessionRequest>);
 
@@ -5942,6 +7172,22 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::delete_session][super::super::client::SessionController::delete_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::DeleteSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSession(RequestBuilder<crate::model::DeleteSessionRequest>);
 
@@ -6036,6 +7282,21 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::set_iam_policy][super::super::client::SessionController::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -6103,6 +7364,21 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::get_iam_policy][super::super::client::SessionController::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -6159,6 +7435,21 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::test_iam_permissions][super::super::client::SessionController::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -6222,6 +7513,25 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::list_operations][super::super::client::SessionController::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6314,6 +7624,21 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::get_operation][super::super::client::SessionController::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6362,6 +7687,21 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::delete_operation][super::super::client::SessionController::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -6410,6 +7750,21 @@ pub mod session_controller {
     }
 
     /// The request builder for [SessionController::cancel_operation][super::super::client::SessionController::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::session_controller::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6513,6 +7868,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::create_workflow_template][super::super::client::WorkflowTemplateService::create_workflow_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::CreateWorkflowTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkflowTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkflowTemplate(RequestBuilder<crate::model::CreateWorkflowTemplateRequest>);
 
@@ -6574,6 +7944,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::get_workflow_template][super::super::client::WorkflowTemplateService::get_workflow_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::GetWorkflowTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkflowTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkflowTemplate(RequestBuilder<crate::model::GetWorkflowTemplateRequest>);
 
@@ -6630,6 +8015,22 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::instantiate_workflow_template][super::super::client::WorkflowTemplateService::instantiate_workflow_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::InstantiateWorkflowTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InstantiateWorkflowTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InstantiateWorkflowTemplate(
         RequestBuilder<crate::model::InstantiateWorkflowTemplateRequest>,
@@ -6745,6 +8146,22 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::instantiate_inline_workflow_template][super::super::client::WorkflowTemplateService::instantiate_inline_workflow_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::InstantiateInlineWorkflowTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dataproc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InstantiateInlineWorkflowTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InstantiateInlineWorkflowTemplate(
         RequestBuilder<crate::model::InstantiateInlineWorkflowTemplateRequest>,
@@ -6854,6 +8271,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::update_workflow_template][super::super::client::WorkflowTemplateService::update_workflow_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::UpdateWorkflowTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkflowTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkflowTemplate(RequestBuilder<crate::model::UpdateWorkflowTemplateRequest>);
 
@@ -6907,6 +8339,25 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::list_workflow_templates][super::super::client::WorkflowTemplateService::list_workflow_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::ListWorkflowTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkflowTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkflowTemplates(RequestBuilder<crate::model::ListWorkflowTemplatesRequest>);
 
@@ -6995,6 +8446,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::delete_workflow_template][super::super::client::WorkflowTemplateService::delete_workflow_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::DeleteWorkflowTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkflowTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkflowTemplate(RequestBuilder<crate::model::DeleteWorkflowTemplateRequest>);
 
@@ -7051,6 +8517,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::set_iam_policy][super::super::client::WorkflowTemplateService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -7118,6 +8599,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::get_iam_policy][super::super::client::WorkflowTemplateService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -7174,6 +8670,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::test_iam_permissions][super::super::client::WorkflowTemplateService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -7237,6 +8748,25 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::list_operations][super::super::client::WorkflowTemplateService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7329,6 +8859,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::get_operation][super::super::client::WorkflowTemplateService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7377,6 +8922,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::delete_operation][super::super::client::WorkflowTemplateService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -7425,6 +8985,21 @@ pub mod workflow_template_service {
     }
 
     /// The request builder for [WorkflowTemplateService::cancel_operation][super::super::client::WorkflowTemplateService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dataproc_v1::builder;
+    /// use builder::workflow_template_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/datastream/v1/src/builder.rs
+++ b/src/generated/cloud/datastream/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::list_connection_profiles][super::super::client::Datastream::list_connection_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::ListConnectionProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnectionProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnectionProfiles(RequestBuilder<crate::model::ListConnectionProfilesRequest>);
 
@@ -171,6 +190,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::get_connection_profile][super::super::client::Datastream::get_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::GetConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnectionProfile(RequestBuilder<crate::model::GetConnectionProfileRequest>);
 
@@ -221,6 +255,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::create_connection_profile][super::super::client::Datastream::create_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::CreateConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnectionProfile(
         RequestBuilder<crate::model::CreateConnectionProfileRequest>,
@@ -353,6 +403,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::update_connection_profile][super::super::client::Datastream::update_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::UpdateConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnectionProfile(
         RequestBuilder<crate::model::UpdateConnectionProfileRequest>,
@@ -478,6 +544,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::delete_connection_profile][super::super::client::Datastream::delete_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::DeleteConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnectionProfile(
         RequestBuilder<crate::model::DeleteConnectionProfileRequest>,
@@ -576,6 +658,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::discover_connection_profile][super::super::client::Datastream::discover_connection_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::DiscoverConnectionProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiscoverConnectionProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiscoverConnectionProfile(
         RequestBuilder<crate::model::DiscoverConnectionProfileRequest>,
@@ -776,6 +873,25 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::list_streams][super::super::client::Datastream::list_streams] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::ListStreams;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListStreams {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListStreams(RequestBuilder<crate::model::ListStreamsRequest>);
 
@@ -871,6 +987,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::get_stream][super::super::client::Datastream::get_stream] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::GetStream;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStream {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStream(RequestBuilder<crate::model::GetStreamRequest>);
 
@@ -918,6 +1049,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::create_stream][super::super::client::Datastream::create_stream] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::CreateStream;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateStream {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateStream(RequestBuilder<crate::model::CreateStreamRequest>);
 
@@ -1040,6 +1187,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::update_stream][super::super::client::Datastream::update_stream] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::UpdateStream;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateStream {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateStream(RequestBuilder<crate::model::UpdateStreamRequest>);
 
@@ -1155,6 +1318,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::delete_stream][super::super::client::Datastream::delete_stream] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::DeleteStream;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteStream {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteStream(RequestBuilder<crate::model::DeleteStreamRequest>);
 
@@ -1248,6 +1427,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::run_stream][super::super::client::Datastream::run_stream] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::RunStream;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunStream {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunStream(RequestBuilder<crate::model::RunStreamRequest>);
 
@@ -1348,6 +1543,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::get_stream_object][super::super::client::Datastream::get_stream_object] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::GetStreamObject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStreamObject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStreamObject(RequestBuilder<crate::model::GetStreamObjectRequest>);
 
@@ -1395,6 +1605,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::lookup_stream_object][super::super::client::Datastream::lookup_stream_object] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::LookupStreamObject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupStreamObject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupStreamObject(RequestBuilder<crate::model::LookupStreamObjectRequest>);
 
@@ -1458,6 +1683,25 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::list_stream_objects][super::super::client::Datastream::list_stream_objects] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::ListStreamObjects;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListStreamObjects {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListStreamObjects(RequestBuilder<crate::model::ListStreamObjectsRequest>);
 
@@ -1544,6 +1788,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::start_backfill_job][super::super::client::Datastream::start_backfill_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::StartBackfillJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartBackfillJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartBackfillJob(RequestBuilder<crate::model::StartBackfillJobRequest>);
 
@@ -1594,6 +1853,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::stop_backfill_job][super::super::client::Datastream::stop_backfill_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::StopBackfillJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopBackfillJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopBackfillJob(RequestBuilder<crate::model::StopBackfillJobRequest>);
 
@@ -1641,6 +1915,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::fetch_static_ips][super::super::client::Datastream::fetch_static_ips] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::FetchStaticIps;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchStaticIps {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchStaticIps(RequestBuilder<crate::model::FetchStaticIpsRequest>);
 
@@ -1700,6 +1989,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::create_private_connection][super::super::client::Datastream::create_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::CreatePrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePrivateConnection(
         RequestBuilder<crate::model::CreatePrivateConnectionRequest>,
@@ -1826,6 +2131,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::get_private_connection][super::super::client::Datastream::get_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::GetPrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPrivateConnection(RequestBuilder<crate::model::GetPrivateConnectionRequest>);
 
@@ -1876,6 +2196,25 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::list_private_connections][super::super::client::Datastream::list_private_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::ListPrivateConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPrivateConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnections(RequestBuilder<crate::model::ListPrivateConnectionsRequest>);
 
@@ -1978,6 +2317,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::delete_private_connection][super::super::client::Datastream::delete_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::DeletePrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePrivateConnection(
         RequestBuilder<crate::model::DeletePrivateConnectionRequest>,
@@ -2082,6 +2437,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::create_route][super::super::client::Datastream::create_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::CreateRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRoute(RequestBuilder<crate::model::CreateRouteRequest>);
 
@@ -2192,6 +2563,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::get_route][super::super::client::Datastream::get_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::GetRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRoute(RequestBuilder<crate::model::GetRouteRequest>);
 
@@ -2239,6 +2625,25 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::list_routes][super::super::client::Datastream::list_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::ListRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRoutes(RequestBuilder<crate::model::ListRoutesRequest>);
 
@@ -2334,6 +2739,22 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::delete_route][super::super::client::Datastream::delete_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::DeleteRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRoute(RequestBuilder<crate::model::DeleteRouteRequest>);
 
@@ -2427,6 +2848,25 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::list_locations][super::super::client::Datastream::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2517,6 +2957,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::get_location][super::super::client::Datastream::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2562,6 +3017,25 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::list_operations][super::super::client::Datastream::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2654,6 +3128,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::get_operation][super::super::client::Datastream::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2702,6 +3191,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::delete_operation][super::super::client::Datastream::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2750,6 +3254,21 @@ pub mod datastream {
     }
 
     /// The request builder for [Datastream::cancel_operation][super::super::client::Datastream::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastream_v1::builder;
+    /// use builder::datastream::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/deploy/v1/src/builder.rs
+++ b/src/generated/cloud/deploy/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_delivery_pipelines][super::super::client::CloudDeploy::list_delivery_pipelines] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListDeliveryPipelines;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeliveryPipelines {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeliveryPipelines(RequestBuilder<crate::model::ListDeliveryPipelinesRequest>);
 
@@ -169,6 +188,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_delivery_pipeline][super::super::client::CloudDeploy::get_delivery_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetDeliveryPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeliveryPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeliveryPipeline(RequestBuilder<crate::model::GetDeliveryPipelineRequest>);
 
@@ -219,6 +253,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::create_delivery_pipeline][super::super::client::CloudDeploy::create_delivery_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CreateDeliveryPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeliveryPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeliveryPipeline(RequestBuilder<crate::model::CreateDeliveryPipelineRequest>);
 
@@ -343,6 +393,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::update_delivery_pipeline][super::super::client::CloudDeploy::update_delivery_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::UpdateDeliveryPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDeliveryPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDeliveryPipeline(RequestBuilder<crate::model::UpdateDeliveryPipelineRequest>);
 
@@ -468,6 +534,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::delete_delivery_pipeline][super::super::client::CloudDeploy::delete_delivery_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::DeleteDeliveryPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDeliveryPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDeliveryPipeline(RequestBuilder<crate::model::DeleteDeliveryPipelineRequest>);
 
@@ -588,6 +670,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_targets][super::super::client::CloudDeploy::list_targets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListTargets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTargets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTargets(RequestBuilder<crate::model::ListTargetsRequest>);
 
@@ -683,6 +784,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::rollback_target][super::super::client::CloudDeploy::rollback_target] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::RollbackTarget;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RollbackTarget {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RollbackTarget(RequestBuilder<crate::model::RollbackTargetRequest>);
 
@@ -786,6 +902,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_target][super::super::client::CloudDeploy::get_target] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetTarget;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTarget {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTarget(RequestBuilder<crate::model::GetTargetRequest>);
 
@@ -833,6 +964,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::create_target][super::super::client::CloudDeploy::create_target] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CreateTarget;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTarget {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTarget(RequestBuilder<crate::model::CreateTargetRequest>);
 
@@ -949,6 +1096,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::update_target][super::super::client::CloudDeploy::update_target] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::UpdateTarget;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTarget {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTarget(RequestBuilder<crate::model::UpdateTargetRequest>);
 
@@ -1066,6 +1229,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::delete_target][super::super::client::CloudDeploy::delete_target] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::DeleteTarget;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTarget {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTarget(RequestBuilder<crate::model::DeleteTargetRequest>);
 
@@ -1177,6 +1356,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_custom_target_types][super::super::client::CloudDeploy::list_custom_target_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListCustomTargetTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCustomTargetTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCustomTargetTypes(RequestBuilder<crate::model::ListCustomTargetTypesRequest>);
 
@@ -1277,6 +1475,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_custom_target_type][super::super::client::CloudDeploy::get_custom_target_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetCustomTargetType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCustomTargetType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCustomTargetType(RequestBuilder<crate::model::GetCustomTargetTypeRequest>);
 
@@ -1327,6 +1540,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::create_custom_target_type][super::super::client::CloudDeploy::create_custom_target_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CreateCustomTargetType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCustomTargetType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCustomTargetType(RequestBuilder<crate::model::CreateCustomTargetTypeRequest>);
 
@@ -1451,6 +1680,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::update_custom_target_type][super::super::client::CloudDeploy::update_custom_target_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::UpdateCustomTargetType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCustomTargetType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCustomTargetType(RequestBuilder<crate::model::UpdateCustomTargetTypeRequest>);
 
@@ -1576,6 +1821,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::delete_custom_target_type][super::super::client::CloudDeploy::delete_custom_target_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::DeleteCustomTargetType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCustomTargetType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCustomTargetType(RequestBuilder<crate::model::DeleteCustomTargetTypeRequest>);
 
@@ -1690,6 +1951,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_releases][super::super::client::CloudDeploy::list_releases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListReleases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReleases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReleases(RequestBuilder<crate::model::ListReleasesRequest>);
 
@@ -1785,6 +2065,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_release][super::super::client::CloudDeploy::get_release] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetRelease;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRelease {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRelease(RequestBuilder<crate::model::GetReleaseRequest>);
 
@@ -1832,6 +2127,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::create_release][super::super::client::CloudDeploy::create_release] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CreateRelease;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRelease {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRelease(RequestBuilder<crate::model::CreateReleaseRequest>);
 
@@ -1959,6 +2270,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::abandon_release][super::super::client::CloudDeploy::abandon_release] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::AbandonRelease;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AbandonRelease {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AbandonRelease(RequestBuilder<crate::model::AbandonReleaseRequest>);
 
@@ -2006,6 +2332,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::create_deploy_policy][super::super::client::CloudDeploy::create_deploy_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CreateDeployPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeployPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeployPolicy(RequestBuilder<crate::model::CreateDeployPolicyRequest>);
 
@@ -2127,6 +2469,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::update_deploy_policy][super::super::client::CloudDeploy::update_deploy_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::UpdateDeployPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDeployPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDeployPolicy(RequestBuilder<crate::model::UpdateDeployPolicyRequest>);
 
@@ -2249,6 +2607,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::delete_deploy_policy][super::super::client::CloudDeploy::delete_deploy_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::DeleteDeployPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDeployPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDeployPolicy(RequestBuilder<crate::model::DeleteDeployPolicyRequest>);
 
@@ -2363,6 +2737,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_deploy_policies][super::super::client::CloudDeploy::list_deploy_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListDeployPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeployPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeployPolicies(RequestBuilder<crate::model::ListDeployPoliciesRequest>);
 
@@ -2463,6 +2856,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_deploy_policy][super::super::client::CloudDeploy::get_deploy_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetDeployPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeployPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeployPolicy(RequestBuilder<crate::model::GetDeployPolicyRequest>);
 
@@ -2510,6 +2918,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::approve_rollout][super::super::client::CloudDeploy::approve_rollout] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ApproveRollout;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApproveRollout {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApproveRollout(RequestBuilder<crate::model::ApproveRolloutRequest>);
 
@@ -2576,6 +2999,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::advance_rollout][super::super::client::CloudDeploy::advance_rollout] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::AdvanceRollout;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AdvanceRollout {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AdvanceRollout(RequestBuilder<crate::model::AdvanceRolloutRequest>);
 
@@ -2642,6 +3080,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::cancel_rollout][super::super::client::CloudDeploy::cancel_rollout] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CancelRollout;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelRollout {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelRollout(RequestBuilder<crate::model::CancelRolloutRequest>);
 
@@ -2700,6 +3153,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_rollouts][super::super::client::CloudDeploy::list_rollouts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListRollouts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRollouts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRollouts(RequestBuilder<crate::model::ListRolloutsRequest>);
 
@@ -2795,6 +3267,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_rollout][super::super::client::CloudDeploy::get_rollout] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetRollout;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRollout {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRollout(RequestBuilder<crate::model::GetRolloutRequest>);
 
@@ -2842,6 +3329,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::create_rollout][super::super::client::CloudDeploy::create_rollout] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CreateRollout;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRollout {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRollout(RequestBuilder<crate::model::CreateRolloutRequest>);
 
@@ -2975,6 +3478,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::ignore_job][super::super::client::CloudDeploy::ignore_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::IgnoreJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> IgnoreJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct IgnoreJob(RequestBuilder<crate::model::IgnoreJobRequest>);
 
@@ -3049,6 +3567,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::retry_job][super::super::client::CloudDeploy::retry_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::RetryJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetryJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetryJob(RequestBuilder<crate::model::RetryJobRequest>);
 
@@ -3123,6 +3656,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_job_runs][super::super::client::CloudDeploy::list_job_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListJobRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobRuns(RequestBuilder<crate::model::ListJobRunsRequest>);
 
@@ -3218,6 +3770,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_job_run][super::super::client::CloudDeploy::get_job_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetJobRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJobRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJobRun(RequestBuilder<crate::model::GetJobRunRequest>);
 
@@ -3265,6 +3832,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::terminate_job_run][super::super::client::CloudDeploy::terminate_job_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::TerminateJobRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TerminateJobRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TerminateJobRun(RequestBuilder<crate::model::TerminateJobRunRequest>);
 
@@ -3323,6 +3905,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_config][super::super::client::CloudDeploy::get_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConfig(RequestBuilder<crate::model::GetConfigRequest>);
 
@@ -3370,6 +3967,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::create_automation][super::super::client::CloudDeploy::create_automation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CreateAutomation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAutomation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAutomation(RequestBuilder<crate::model::CreateAutomationRequest>);
 
@@ -3489,6 +4102,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::update_automation][super::super::client::CloudDeploy::update_automation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::UpdateAutomation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAutomation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAutomation(RequestBuilder<crate::model::UpdateAutomationRequest>);
 
@@ -3609,6 +4238,22 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::delete_automation][super::super::client::CloudDeploy::delete_automation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::DeleteAutomation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_deploy_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAutomation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAutomation(RequestBuilder<crate::model::DeleteAutomationRequest>);
 
@@ -3723,6 +4368,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_automation][super::super::client::CloudDeploy::get_automation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetAutomation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAutomation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAutomation(RequestBuilder<crate::model::GetAutomationRequest>);
 
@@ -3770,6 +4430,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_automations][super::super::client::CloudDeploy::list_automations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListAutomations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAutomations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAutomations(RequestBuilder<crate::model::ListAutomationsRequest>);
 
@@ -3865,6 +4544,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_automation_run][super::super::client::CloudDeploy::get_automation_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetAutomationRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAutomationRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAutomationRun(RequestBuilder<crate::model::GetAutomationRunRequest>);
 
@@ -3915,6 +4609,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_automation_runs][super::super::client::CloudDeploy::list_automation_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListAutomationRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAutomationRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAutomationRuns(RequestBuilder<crate::model::ListAutomationRunsRequest>);
 
@@ -4015,6 +4728,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::cancel_automation_run][super::super::client::CloudDeploy::cancel_automation_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CancelAutomationRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelAutomationRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelAutomationRun(RequestBuilder<crate::model::CancelAutomationRunRequest>);
 
@@ -4065,6 +4793,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_locations][super::super::client::CloudDeploy::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4155,6 +4902,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_location][super::super::client::CloudDeploy::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4200,6 +4962,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::set_iam_policy][super::super::client::CloudDeploy::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4267,6 +5044,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_iam_policy][super::super::client::CloudDeploy::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4323,6 +5115,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::test_iam_permissions][super::super::client::CloudDeploy::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4386,6 +5193,25 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::list_operations][super::super::client::CloudDeploy::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4478,6 +5304,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::get_operation][super::super::client::CloudDeploy::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4526,6 +5367,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::delete_operation][super::super::client::CloudDeploy::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4574,6 +5430,21 @@ pub mod cloud_deploy {
     }
 
     /// The request builder for [CloudDeploy::cancel_operation][super::super::client::CloudDeploy::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_deploy_v1::builder;
+    /// use builder::cloud_deploy::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/developerconnect/v1/src/builder.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::list_connections][super::super::client::DeveloperConnect::list_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::ListConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -164,6 +183,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::get_connection][super::super::client::DeveloperConnect::get_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::GetConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -211,6 +245,22 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::create_connection][super::super::client::DeveloperConnect::create_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::CreateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_developerconnect_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -330,6 +380,22 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::update_connection][super::super::client::DeveloperConnect::update_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::UpdateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_developerconnect_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -450,6 +516,22 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::delete_connection][super::super::client::DeveloperConnect::delete_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::DeleteConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_developerconnect_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -558,6 +640,22 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::create_git_repository_link][super::super::client::DeveloperConnect::create_git_repository_link] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::CreateGitRepositoryLink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_developerconnect_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGitRepositoryLink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGitRepositoryLink(
         RequestBuilder<crate::model::CreateGitRepositoryLinkRequest>,
@@ -684,6 +782,22 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::delete_git_repository_link][super::super::client::DeveloperConnect::delete_git_repository_link] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::DeleteGitRepositoryLink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_developerconnect_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGitRepositoryLink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGitRepositoryLink(
         RequestBuilder<crate::model::DeleteGitRepositoryLinkRequest>,
@@ -794,6 +908,25 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::list_git_repository_links][super::super::client::DeveloperConnect::list_git_repository_links] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::ListGitRepositoryLinks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGitRepositoryLinks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGitRepositoryLinks(RequestBuilder<crate::model::ListGitRepositoryLinksRequest>);
 
@@ -896,6 +1029,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::get_git_repository_link][super::super::client::DeveloperConnect::get_git_repository_link] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::GetGitRepositoryLink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGitRepositoryLink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGitRepositoryLink(RequestBuilder<crate::model::GetGitRepositoryLinkRequest>);
 
@@ -946,6 +1094,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::fetch_read_write_token][super::super::client::DeveloperConnect::fetch_read_write_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::FetchReadWriteToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchReadWriteToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchReadWriteToken(RequestBuilder<crate::model::FetchReadWriteTokenRequest>);
 
@@ -996,6 +1159,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::fetch_read_token][super::super::client::DeveloperConnect::fetch_read_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::FetchReadToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchReadToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchReadToken(RequestBuilder<crate::model::FetchReadTokenRequest>);
 
@@ -1043,6 +1221,25 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::fetch_linkable_git_repositories][super::super::client::DeveloperConnect::fetch_linkable_git_repositories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::FetchLinkableGitRepositories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchLinkableGitRepositories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchLinkableGitRepositories(
         RequestBuilder<crate::model::FetchLinkableGitRepositoriesRequest>,
@@ -1135,6 +1332,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::fetch_git_hub_installations][super::super::client::DeveloperConnect::fetch_git_hub_installations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::FetchGitHubInstallations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchGitHubInstallations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchGitHubInstallations(
         RequestBuilder<crate::model::FetchGitHubInstallationsRequest>,
@@ -1187,6 +1399,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::fetch_git_refs][super::super::client::DeveloperConnect::fetch_git_refs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::FetchGitRefs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchGitRefs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchGitRefs(RequestBuilder<crate::model::FetchGitRefsRequest>);
 
@@ -1257,6 +1484,25 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::list_locations][super::super::client::DeveloperConnect::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1347,6 +1593,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::get_location][super::super::client::DeveloperConnect::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1392,6 +1653,25 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::list_operations][super::super::client::DeveloperConnect::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1484,6 +1764,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::get_operation][super::super::client::DeveloperConnect::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1532,6 +1827,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::delete_operation][super::super::client::DeveloperConnect::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1580,6 +1890,21 @@ pub mod developer_connect {
     }
 
     /// The request builder for [DeveloperConnect::cancel_operation][super::super::client::DeveloperConnect::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_developerconnect_v1::builder;
+    /// use builder::developer_connect::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
@@ -67,6 +67,25 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::list_agents][super::super::client::Agents::list_agents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::ListAgents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAgents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAgents(RequestBuilder<crate::model::ListAgentsRequest>);
 
@@ -148,6 +167,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_agent][super::super::client::Agents::get_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::GetAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAgent(RequestBuilder<crate::model::GetAgentRequest>);
 
@@ -193,6 +227,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::create_agent][super::super::client::Agents::create_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::CreateAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAgent(RequestBuilder<crate::model::CreateAgentRequest>);
 
@@ -249,6 +298,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::update_agent][super::super::client::Agents::update_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::UpdateAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAgent(RequestBuilder<crate::model::UpdateAgentRequest>);
 
@@ -306,6 +370,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::delete_agent][super::super::client::Agents::delete_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::DeleteAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAgent(RequestBuilder<crate::model::DeleteAgentRequest>);
 
@@ -351,6 +430,22 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::export_agent][super::super::client::Agents::export_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::ExportAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportAgent(RequestBuilder<crate::model::ExportAgentRequest>);
 
@@ -470,6 +565,22 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::restore_agent][super::super::client::Agents::restore_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::RestoreAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreAgent(RequestBuilder<crate::model::RestoreAgentRequest>);
 
@@ -611,6 +722,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::validate_agent][super::super::client::Agents::validate_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::ValidateAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ValidateAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ValidateAgent(RequestBuilder<crate::model::ValidateAgentRequest>);
 
@@ -662,6 +788,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_agent_validation_result][super::super::client::Agents::get_agent_validation_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::GetAgentValidationResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAgentValidationResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAgentValidationResult(
         RequestBuilder<crate::model::GetAgentValidationResultRequest>,
@@ -718,6 +859,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_generative_settings][super::super::client::Agents::get_generative_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::GetGenerativeSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGenerativeSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGenerativeSettings(RequestBuilder<crate::model::GetGenerativeSettingsRequest>);
 
@@ -774,6 +930,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::update_generative_settings][super::super::client::Agents::update_generative_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::UpdateGenerativeSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGenerativeSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGenerativeSettings(
         RequestBuilder<crate::model::UpdateGenerativeSettingsRequest>,
@@ -838,6 +1009,25 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::list_locations][super::super::client::Agents::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -926,6 +1116,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_location][super::super::client::Agents::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -969,6 +1174,25 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::list_operations][super::super::client::Agents::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1059,6 +1283,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_operation][super::super::client::Agents::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1105,6 +1344,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::cancel_operation][super::super::client::Agents::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::agents::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1206,6 +1460,25 @@ pub mod changelogs {
     }
 
     /// The request builder for [Changelogs::list_changelogs][super::super::client::Changelogs::list_changelogs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::changelogs::ListChangelogs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListChangelogs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListChangelogs(RequestBuilder<crate::model::ListChangelogsRequest>);
 
@@ -1295,6 +1568,21 @@ pub mod changelogs {
     }
 
     /// The request builder for [Changelogs::get_changelog][super::super::client::Changelogs::get_changelog] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::changelogs::GetChangelog;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetChangelog {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetChangelog(RequestBuilder<crate::model::GetChangelogRequest>);
 
@@ -1342,6 +1630,25 @@ pub mod changelogs {
     }
 
     /// The request builder for [Changelogs::list_locations][super::super::client::Changelogs::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::changelogs::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1432,6 +1739,21 @@ pub mod changelogs {
     }
 
     /// The request builder for [Changelogs::get_location][super::super::client::Changelogs::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::changelogs::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1477,6 +1799,25 @@ pub mod changelogs {
     }
 
     /// The request builder for [Changelogs::list_operations][super::super::client::Changelogs::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::changelogs::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1569,6 +1910,21 @@ pub mod changelogs {
     }
 
     /// The request builder for [Changelogs::get_operation][super::super::client::Changelogs::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::changelogs::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1617,6 +1973,21 @@ pub mod changelogs {
     }
 
     /// The request builder for [Changelogs::cancel_operation][super::super::client::Changelogs::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::changelogs::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1720,6 +2091,25 @@ pub mod deployments {
     }
 
     /// The request builder for [Deployments::list_deployments][super::super::client::Deployments::list_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::deployments::ListDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -1803,6 +2193,21 @@ pub mod deployments {
     }
 
     /// The request builder for [Deployments::get_deployment][super::super::client::Deployments::get_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::deployments::GetDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -1850,6 +2255,25 @@ pub mod deployments {
     }
 
     /// The request builder for [Deployments::list_locations][super::super::client::Deployments::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::deployments::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1940,6 +2364,21 @@ pub mod deployments {
     }
 
     /// The request builder for [Deployments::get_location][super::super::client::Deployments::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::deployments::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1985,6 +2424,25 @@ pub mod deployments {
     }
 
     /// The request builder for [Deployments::list_operations][super::super::client::Deployments::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::deployments::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2077,6 +2535,21 @@ pub mod deployments {
     }
 
     /// The request builder for [Deployments::get_operation][super::super::client::Deployments::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::deployments::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2125,6 +2598,21 @@ pub mod deployments {
     }
 
     /// The request builder for [Deployments::cancel_operation][super::super::client::Deployments::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::deployments::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2228,6 +2716,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::get_entity_type][super::super::client::EntityTypes::get_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::GetEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntityType(RequestBuilder<crate::model::GetEntityTypeRequest>);
 
@@ -2281,6 +2784,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::create_entity_type][super::super::client::EntityTypes::create_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::CreateEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntityType(RequestBuilder<crate::model::CreateEntityTypeRequest>);
 
@@ -2348,6 +2866,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::update_entity_type][super::super::client::EntityTypes::update_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::UpdateEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntityType(RequestBuilder<crate::model::UpdateEntityTypeRequest>);
 
@@ -2416,6 +2949,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::delete_entity_type][super::super::client::EntityTypes::delete_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::DeleteEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntityType(RequestBuilder<crate::model::DeleteEntityTypeRequest>);
 
@@ -2472,6 +3020,25 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::list_entity_types][super::super::client::EntityTypes::list_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::ListEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntityTypes(RequestBuilder<crate::model::ListEntityTypesRequest>);
 
@@ -2561,6 +3128,22 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::export_entity_types][super::super::client::EntityTypes::export_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::ExportEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportEntityTypes(RequestBuilder<crate::model::ExportEntityTypesRequest>);
 
@@ -2722,6 +3305,22 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::import_entity_types][super::super::client::EntityTypes::import_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::ImportEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportEntityTypes(RequestBuilder<crate::model::ImportEntityTypesRequest>);
 
@@ -2874,6 +3473,25 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::list_locations][super::super::client::EntityTypes::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2964,6 +3582,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::get_location][super::super::client::EntityTypes::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3009,6 +3642,25 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::list_operations][super::super::client::EntityTypes::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3101,6 +3753,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::get_operation][super::super::client::EntityTypes::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3149,6 +3816,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::cancel_operation][super::super::client::EntityTypes::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::entity_types::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3252,6 +3934,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::ListEnvironments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEnvironments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEnvironments(RequestBuilder<crate::model::ListEnvironmentsRequest>);
 
@@ -3338,6 +4039,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::GetEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -3385,6 +4101,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::CreateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEnvironment(RequestBuilder<crate::model::CreateEnvironmentRequest>);
 
@@ -3481,6 +4213,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::UpdateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEnvironment(RequestBuilder<crate::model::UpdateEnvironmentRequest>);
 
@@ -3580,6 +4328,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::DeleteEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEnvironment(RequestBuilder<crate::model::DeleteEnvironmentRequest>);
 
@@ -3630,6 +4393,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::lookup_environment_history][super::super::client::Environments::lookup_environment_history] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::LookupEnvironmentHistory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LookupEnvironmentHistory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LookupEnvironmentHistory(
         RequestBuilder<crate::model::LookupEnvironmentHistoryRequest>,
@@ -3722,6 +4504,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::run_continuous_test][super::super::client::Environments::run_continuous_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::RunContinuousTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunContinuousTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunContinuousTest(RequestBuilder<crate::model::RunContinuousTestRequest>);
 
@@ -3815,6 +4613,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_continuous_test_results][super::super::client::Environments::list_continuous_test_results] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::ListContinuousTestResults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListContinuousTestResults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListContinuousTestResults(
         RequestBuilder<crate::model::ListContinuousTestResultsRequest>,
@@ -3907,6 +4724,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::deploy_flow][super::super::client::Environments::deploy_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::DeployFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeployFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeployFlow(RequestBuilder<crate::model::DeployFlowRequest>);
 
@@ -4003,6 +4836,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_locations][super::super::client::Environments::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4093,6 +4945,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_location][super::super::client::Environments::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4138,6 +5005,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4230,6 +5116,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4278,6 +5179,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::cancel_operation][super::super::client::Environments::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::environments::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4381,6 +5297,25 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::list_experiments][super::super::client::Experiments::list_experiments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::ListExperiments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExperiments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExperiments(RequestBuilder<crate::model::ListExperimentsRequest>);
 
@@ -4464,6 +5399,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::get_experiment][super::super::client::Experiments::get_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::GetExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExperiment(RequestBuilder<crate::model::GetExperimentRequest>);
 
@@ -4511,6 +5461,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::create_experiment][super::super::client::Experiments::create_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::CreateExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExperiment(RequestBuilder<crate::model::CreateExperimentRequest>);
 
@@ -4572,6 +5537,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::update_experiment][super::super::client::Experiments::update_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::UpdateExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExperiment(RequestBuilder<crate::model::UpdateExperimentRequest>);
 
@@ -4636,6 +5616,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::delete_experiment][super::super::client::Experiments::delete_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::DeleteExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteExperiment(RequestBuilder<crate::model::DeleteExperimentRequest>);
 
@@ -4686,6 +5681,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::start_experiment][super::super::client::Experiments::start_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::StartExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartExperiment(RequestBuilder<crate::model::StartExperimentRequest>);
 
@@ -4733,6 +5743,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::stop_experiment][super::super::client::Experiments::stop_experiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::StopExperiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopExperiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopExperiment(RequestBuilder<crate::model::StopExperimentRequest>);
 
@@ -4780,6 +5805,25 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::list_locations][super::super::client::Experiments::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4870,6 +5914,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::get_location][super::super::client::Experiments::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4915,6 +5974,25 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::list_operations][super::super::client::Experiments::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5007,6 +6085,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::get_operation][super::super::client::Experiments::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5055,6 +6148,21 @@ pub mod experiments {
     }
 
     /// The request builder for [Experiments::cancel_operation][super::super::client::Experiments::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::experiments::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5156,6 +6264,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::create_flow][super::super::client::Flows::create_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::CreateFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFlow(RequestBuilder<crate::model::CreateFlowRequest>);
 
@@ -5215,6 +6338,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::delete_flow][super::super::client::Flows::delete_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::DeleteFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFlow(RequestBuilder<crate::model::DeleteFlowRequest>);
 
@@ -5266,6 +6404,25 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::list_flows][super::super::client::Flows::list_flows] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::ListFlows;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFlows {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFlows(RequestBuilder<crate::model::ListFlowsRequest>);
 
@@ -5353,6 +6510,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::get_flow][super::super::client::Flows::get_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::GetFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFlow(RequestBuilder<crate::model::GetFlowRequest>);
 
@@ -5404,6 +6576,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::update_flow][super::super::client::Flows::update_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::UpdateFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFlow(RequestBuilder<crate::model::UpdateFlowRequest>);
 
@@ -5464,6 +6651,22 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::train_flow][super::super::client::Flows::train_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::TrainFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TrainFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TrainFlow(RequestBuilder<crate::model::TrainFlowRequest>);
 
@@ -5549,6 +6752,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::validate_flow][super::super::client::Flows::validate_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::ValidateFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ValidateFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ValidateFlow(RequestBuilder<crate::model::ValidateFlowRequest>);
 
@@ -5600,6 +6818,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::get_flow_validation_result][super::super::client::Flows::get_flow_validation_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::GetFlowValidationResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFlowValidationResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFlowValidationResult(
         RequestBuilder<crate::model::GetFlowValidationResultRequest>,
@@ -5656,6 +6889,22 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::import_flow][super::super::client::Flows::import_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::ImportFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportFlow(RequestBuilder<crate::model::ImportFlowRequest>);
 
@@ -5789,6 +7038,22 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::export_flow][super::super::client::Flows::export_flow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::ExportFlow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportFlow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportFlow(RequestBuilder<crate::model::ExportFlowRequest>);
 
@@ -5882,6 +7147,25 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::list_locations][super::super::client::Flows::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5970,6 +7254,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::get_location][super::super::client::Flows::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6013,6 +7312,25 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::list_operations][super::super::client::Flows::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6103,6 +7421,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::get_operation][super::super::client::Flows::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6149,6 +7482,21 @@ pub mod flows {
     }
 
     /// The request builder for [Flows::cancel_operation][super::super::client::Flows::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::flows::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6250,6 +7598,25 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::list_generators][super::super::client::Generators::list_generators] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::ListGenerators;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGenerators {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGenerators(RequestBuilder<crate::model::ListGeneratorsRequest>);
 
@@ -6339,6 +7706,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::get_generator][super::super::client::Generators::get_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::GetGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGenerator(RequestBuilder<crate::model::GetGeneratorRequest>);
 
@@ -6392,6 +7774,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::create_generator][super::super::client::Generators::create_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::CreateGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGenerator(RequestBuilder<crate::model::CreateGeneratorRequest>);
 
@@ -6456,6 +7853,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::update_generator][super::super::client::Generators::update_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::UpdateGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGenerator(RequestBuilder<crate::model::UpdateGeneratorRequest>);
 
@@ -6521,6 +7933,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::delete_generator][super::super::client::Generators::delete_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::DeleteGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGenerator(RequestBuilder<crate::model::DeleteGeneratorRequest>);
 
@@ -6574,6 +8001,25 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::list_locations][super::super::client::Generators::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6664,6 +8110,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::get_location][super::super::client::Generators::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6709,6 +8170,25 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::list_operations][super::super::client::Generators::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6801,6 +8281,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::get_operation][super::super::client::Generators::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6849,6 +8344,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::cancel_operation][super::super::client::Generators::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::generators::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6950,6 +8460,25 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::list_intents][super::super::client::Intents::list_intents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::ListIntents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIntents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIntents(RequestBuilder<crate::model::ListIntentsRequest>);
 
@@ -7043,6 +8572,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::get_intent][super::super::client::Intents::get_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::GetIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIntent(RequestBuilder<crate::model::GetIntentRequest>);
 
@@ -7094,6 +8638,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::create_intent][super::super::client::Intents::create_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::CreateIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIntent(RequestBuilder<crate::model::CreateIntentRequest>);
 
@@ -7156,6 +8715,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::update_intent][super::super::client::Intents::update_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::UpdateIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIntent(RequestBuilder<crate::model::UpdateIntentRequest>);
 
@@ -7219,6 +8793,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::delete_intent][super::super::client::Intents::delete_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::DeleteIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIntent(RequestBuilder<crate::model::DeleteIntentRequest>);
 
@@ -7264,6 +8853,22 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::import_intents][super::super::client::Intents::import_intents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::ImportIntents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportIntents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportIntents(RequestBuilder<crate::model::ImportIntentsRequest>);
 
@@ -7396,6 +9001,22 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::export_intents][super::super::client::Intents::export_intents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::ExportIntents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportIntents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportIntents(RequestBuilder<crate::model::ExportIntentsRequest>);
 
@@ -7538,6 +9159,25 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::list_locations][super::super::client::Intents::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7626,6 +9266,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::get_location][super::super::client::Intents::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -7669,6 +9324,25 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::list_operations][super::super::client::Intents::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7759,6 +9433,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::get_operation][super::super::client::Intents::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7805,6 +9494,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::cancel_operation][super::super::client::Intents::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::intents::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7904,6 +9608,25 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::list_pages][super::super::client::Pages::list_pages] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::ListPages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPages(RequestBuilder<crate::model::ListPagesRequest>);
 
@@ -7991,6 +9714,21 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::get_page][super::super::client::Pages::get_page] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::GetPage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPage(RequestBuilder<crate::model::GetPageRequest>);
 
@@ -8042,6 +9780,21 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::create_page][super::super::client::Pages::create_page] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::CreatePage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePage(RequestBuilder<crate::model::CreatePageRequest>);
 
@@ -8101,6 +9854,21 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::update_page][super::super::client::Pages::update_page] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::UpdatePage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePage(RequestBuilder<crate::model::UpdatePageRequest>);
 
@@ -8161,6 +9929,21 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::delete_page][super::super::client::Pages::delete_page] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::DeletePage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePage(RequestBuilder<crate::model::DeletePageRequest>);
 
@@ -8212,6 +9995,25 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::list_locations][super::super::client::Pages::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8300,6 +10102,21 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::get_location][super::super::client::Pages::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8343,6 +10160,25 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::list_operations][super::super::client::Pages::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8433,6 +10269,21 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::get_operation][super::super::client::Pages::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8479,6 +10330,21 @@ pub mod pages {
     }
 
     /// The request builder for [Pages::cancel_operation][super::super::client::Pages::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::pages::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8580,6 +10446,21 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::create_security_settings][super::super::client::SecuritySettingsService::create_security_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::CreateSecuritySettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSecuritySettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSecuritySettings(RequestBuilder<crate::model::CreateSecuritySettingsRequest>);
 
@@ -8643,6 +10524,21 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::get_security_settings][super::super::client::SecuritySettingsService::get_security_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::GetSecuritySettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSecuritySettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSecuritySettings(RequestBuilder<crate::model::GetSecuritySettingsRequest>);
 
@@ -8693,6 +10589,21 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::update_security_settings][super::super::client::SecuritySettingsService::update_security_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::UpdateSecuritySettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSecuritySettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSecuritySettings(RequestBuilder<crate::model::UpdateSecuritySettingsRequest>);
 
@@ -8759,6 +10670,25 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::list_security_settings][super::super::client::SecuritySettingsService::list_security_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::ListSecuritySettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSecuritySettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSecuritySettings(RequestBuilder<crate::model::ListSecuritySettingsRequest>);
 
@@ -8847,6 +10777,21 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::delete_security_settings][super::super::client::SecuritySettingsService::delete_security_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::DeleteSecuritySettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSecuritySettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSecuritySettings(RequestBuilder<crate::model::DeleteSecuritySettingsRequest>);
 
@@ -8897,6 +10842,25 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::list_locations][super::super::client::SecuritySettingsService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -8987,6 +10951,21 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::get_location][super::super::client::SecuritySettingsService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -9032,6 +11011,25 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::list_operations][super::super::client::SecuritySettingsService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9124,6 +11122,21 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::get_operation][super::super::client::SecuritySettingsService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9172,6 +11185,21 @@ pub mod security_settings_service {
     }
 
     /// The request builder for [SecuritySettingsService::cancel_operation][super::super::client::SecuritySettingsService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::security_settings_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9273,6 +11301,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::detect_intent][super::super::client::Sessions::detect_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::DetectIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DetectIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DetectIntent(RequestBuilder<crate::model::DetectIntentRequest>);
 
@@ -9349,6 +11392,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::match_intent][super::super::client::Sessions::match_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::MatchIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MatchIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MatchIntent(RequestBuilder<crate::model::MatchIntentRequest>);
 
@@ -9420,6 +11478,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::fulfill_intent][super::super::client::Sessions::fulfill_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::FulfillIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FulfillIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FulfillIntent(RequestBuilder<crate::model::FulfillIntentRequest>);
 
@@ -9488,6 +11561,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::submit_answer_feedback][super::super::client::Sessions::submit_answer_feedback] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::SubmitAnswerFeedback;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubmitAnswerFeedback {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubmitAnswerFeedback(RequestBuilder<crate::model::SubmitAnswerFeedbackRequest>);
 
@@ -9564,6 +11652,25 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::list_locations][super::super::client::Sessions::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -9652,6 +11759,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::get_location][super::super::client::Sessions::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -9695,6 +11817,25 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::list_operations][super::super::client::Sessions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9785,6 +11926,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::get_operation][super::super::client::Sessions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9831,6 +11987,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::cancel_operation][super::super::client::Sessions::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::sessions::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9932,6 +12103,25 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::list_session_entity_types][super::super::client::SessionEntityTypes::list_session_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::ListSessionEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSessionEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSessionEntityTypes(RequestBuilder<crate::model::ListSessionEntityTypesRequest>);
 
@@ -10022,6 +12212,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::get_session_entity_type][super::super::client::SessionEntityTypes::get_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::GetSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSessionEntityType(RequestBuilder<crate::model::GetSessionEntityTypeRequest>);
 
@@ -10072,6 +12277,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::create_session_entity_type][super::super::client::SessionEntityTypes::create_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::CreateSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSessionEntityType(
         RequestBuilder<crate::model::CreateSessionEntityTypeRequest>,
@@ -10137,6 +12357,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::update_session_entity_type][super::super::client::SessionEntityTypes::update_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::UpdateSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSessionEntityType(
         RequestBuilder<crate::model::UpdateSessionEntityTypeRequest>,
@@ -10203,6 +12438,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::delete_session_entity_type][super::super::client::SessionEntityTypes::delete_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::DeleteSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSessionEntityType(
         RequestBuilder<crate::model::DeleteSessionEntityTypeRequest>,
@@ -10255,6 +12505,25 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::list_locations][super::super::client::SessionEntityTypes::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10345,6 +12614,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::get_location][super::super::client::SessionEntityTypes::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10390,6 +12674,25 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::list_operations][super::super::client::SessionEntityTypes::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10482,6 +12785,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::get_operation][super::super::client::SessionEntityTypes::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10530,6 +12848,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::cancel_operation][super::super::client::SessionEntityTypes::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::session_entity_types::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -10633,6 +12966,25 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::list_test_cases][super::super::client::TestCases::list_test_cases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::ListTestCases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTestCases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTestCases(RequestBuilder<crate::model::ListTestCasesRequest>);
 
@@ -10725,6 +13077,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::batch_delete_test_cases][super::super::client::TestCases::batch_delete_test_cases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::BatchDeleteTestCases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteTestCases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteTestCases(RequestBuilder<crate::model::BatchDeleteTestCasesRequest>);
 
@@ -10788,6 +13155,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::get_test_case][super::super::client::TestCases::get_test_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::GetTestCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTestCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTestCase(RequestBuilder<crate::model::GetTestCaseRequest>);
 
@@ -10835,6 +13217,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::create_test_case][super::super::client::TestCases::create_test_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::CreateTestCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTestCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTestCase(RequestBuilder<crate::model::CreateTestCaseRequest>);
 
@@ -10893,6 +13290,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::update_test_case][super::super::client::TestCases::update_test_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::UpdateTestCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTestCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTestCase(RequestBuilder<crate::model::UpdateTestCaseRequest>);
 
@@ -10954,6 +13366,22 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::run_test_case][super::super::client::TestCases::run_test_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::RunTestCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunTestCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunTestCase(RequestBuilder<crate::model::RunTestCaseRequest>);
 
@@ -11048,6 +13476,22 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::batch_run_test_cases][super::super::client::TestCases::batch_run_test_cases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::BatchRunTestCases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchRunTestCases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchRunTestCases(RequestBuilder<crate::model::BatchRunTestCasesRequest>);
 
@@ -11160,6 +13604,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::calculate_coverage][super::super::client::TestCases::calculate_coverage] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::CalculateCoverage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CalculateCoverage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CalculateCoverage(RequestBuilder<crate::model::CalculateCoverageRequest>);
 
@@ -11221,6 +13680,22 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::import_test_cases][super::super::client::TestCases::import_test_cases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::ImportTestCases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportTestCases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportTestCases(RequestBuilder<crate::model::ImportTestCasesRequest>);
 
@@ -11341,6 +13816,22 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::export_test_cases][super::super::client::TestCases::export_test_cases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::ExportTestCases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportTestCases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportTestCases(RequestBuilder<crate::model::ExportTestCasesRequest>);
 
@@ -11468,6 +13959,25 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::list_test_case_results][super::super::client::TestCases::list_test_case_results] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::ListTestCaseResults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTestCaseResults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTestCaseResults(RequestBuilder<crate::model::ListTestCaseResultsRequest>);
 
@@ -11562,6 +14072,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::get_test_case_result][super::super::client::TestCases::get_test_case_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::GetTestCaseResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTestCaseResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTestCaseResult(RequestBuilder<crate::model::GetTestCaseResultRequest>);
 
@@ -11612,6 +14137,25 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::list_locations][super::super::client::TestCases::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -11702,6 +14246,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::get_location][super::super::client::TestCases::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -11747,6 +14306,25 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::list_operations][super::super::client::TestCases::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -11839,6 +14417,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::get_operation][super::super::client::TestCases::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -11887,6 +14480,21 @@ pub mod test_cases {
     }
 
     /// The request builder for [TestCases::cancel_operation][super::super::client::TestCases::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::test_cases::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -11990,6 +14598,25 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::list_transition_route_groups][super::super::client::TransitionRouteGroups::list_transition_route_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::ListTransitionRouteGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTransitionRouteGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTransitionRouteGroups(
         RequestBuilder<crate::model::ListTransitionRouteGroupsRequest>,
@@ -12088,6 +14715,21 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::get_transition_route_group][super::super::client::TransitionRouteGroups::get_transition_route_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::GetTransitionRouteGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTransitionRouteGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTransitionRouteGroup(
         RequestBuilder<crate::model::GetTransitionRouteGroupRequest>,
@@ -12146,6 +14788,21 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::create_transition_route_group][super::super::client::TransitionRouteGroups::create_transition_route_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::CreateTransitionRouteGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTransitionRouteGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTransitionRouteGroup(
         RequestBuilder<crate::model::CreateTransitionRouteGroupRequest>,
@@ -12217,6 +14874,21 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::update_transition_route_group][super::super::client::TransitionRouteGroups::update_transition_route_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::UpdateTransitionRouteGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTransitionRouteGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTransitionRouteGroup(
         RequestBuilder<crate::model::UpdateTransitionRouteGroupRequest>,
@@ -12289,6 +14961,21 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::delete_transition_route_group][super::super::client::TransitionRouteGroups::delete_transition_route_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::DeleteTransitionRouteGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTransitionRouteGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTransitionRouteGroup(
         RequestBuilder<crate::model::DeleteTransitionRouteGroupRequest>,
@@ -12347,6 +15034,25 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::list_locations][super::super::client::TransitionRouteGroups::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12437,6 +15143,21 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::get_location][super::super::client::TransitionRouteGroups::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12482,6 +15203,25 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::list_operations][super::super::client::TransitionRouteGroups::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -12574,6 +15314,21 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::get_operation][super::super::client::TransitionRouteGroups::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -12622,6 +15377,21 @@ pub mod transition_route_groups {
     }
 
     /// The request builder for [TransitionRouteGroups::cancel_operation][super::super::client::TransitionRouteGroups::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::transition_route_groups::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -12723,6 +15493,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::ListVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -12804,6 +15593,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::GetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -12849,6 +15653,22 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::CreateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -12946,6 +15766,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::UpdateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -13005,6 +15840,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::DeleteVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -13050,6 +15900,22 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::load_version][super::super::client::Versions::load_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::LoadVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_cx_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LoadVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LoadVersion(RequestBuilder<crate::model::LoadVersionRequest>);
 
@@ -13141,6 +16007,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::compare_versions][super::super::client::Versions::compare_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::CompareVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompareVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompareVersions(RequestBuilder<crate::model::CompareVersionsRequest>);
 
@@ -13200,6 +16081,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_locations][super::super::client::Versions::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -13288,6 +16188,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_location][super::super::client::Versions::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -13331,6 +16246,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -13421,6 +16355,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -13467,6 +16416,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::cancel_operation][super::super::client::Versions::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::versions::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -13566,6 +16530,25 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::list_webhooks][super::super::client::Webhooks::list_webhooks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::ListWebhooks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWebhooks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWebhooks(RequestBuilder<crate::model::ListWebhooksRequest>);
 
@@ -13647,6 +16630,21 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::get_webhook][super::super::client::Webhooks::get_webhook] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::GetWebhook;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWebhook {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWebhook(RequestBuilder<crate::model::GetWebhookRequest>);
 
@@ -13692,6 +16690,21 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::create_webhook][super::super::client::Webhooks::create_webhook] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::CreateWebhook;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWebhook {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWebhook(RequestBuilder<crate::model::CreateWebhookRequest>);
 
@@ -13748,6 +16761,21 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::update_webhook][super::super::client::Webhooks::update_webhook] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::UpdateWebhook;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWebhook {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWebhook(RequestBuilder<crate::model::UpdateWebhookRequest>);
 
@@ -13805,6 +16833,21 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::delete_webhook][super::super::client::Webhooks::delete_webhook] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::DeleteWebhook;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWebhook {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWebhook(RequestBuilder<crate::model::DeleteWebhookRequest>);
 
@@ -13856,6 +16899,25 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::list_locations][super::super::client::Webhooks::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -13944,6 +17006,21 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::get_location][super::super::client::Webhooks::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -13987,6 +17064,25 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::list_operations][super::super::client::Webhooks::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -14077,6 +17173,21 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::get_operation][super::super::client::Webhooks::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -14123,6 +17234,21 @@ pub mod webhooks {
     }
 
     /// The request builder for [Webhooks::cancel_operation][super::super::client::Webhooks::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_cx_v3::builder;
+    /// use builder::webhooks::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/dialogflow/v2/src/builder.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builder.rs
@@ -67,6 +67,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_agent][super::super::client::Agents::get_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::GetAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAgent(RequestBuilder<crate::model::GetAgentRequest>);
 
@@ -112,6 +127,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::set_agent][super::super::client::Agents::set_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::SetAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetAgent(RequestBuilder<crate::model::SetAgentRequest>);
 
@@ -169,6 +199,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::delete_agent][super::super::client::Agents::delete_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::DeleteAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAgent(RequestBuilder<crate::model::DeleteAgentRequest>);
 
@@ -214,6 +259,25 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::search_agents][super::super::client::Agents::search_agents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::SearchAgents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchAgents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchAgents(RequestBuilder<crate::model::SearchAgentsRequest>);
 
@@ -295,6 +359,22 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::train_agent][super::super::client::Agents::train_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::TrainAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TrainAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TrainAgent(RequestBuilder<crate::model::TrainAgentRequest>);
 
@@ -380,6 +460,22 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::export_agent][super::super::client::Agents::export_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::ExportAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportAgent(RequestBuilder<crate::model::ExportAgentRequest>);
 
@@ -469,6 +565,22 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::import_agent][super::super::client::Agents::import_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::ImportAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportAgent(RequestBuilder<crate::model::ImportAgentRequest>);
 
@@ -586,6 +698,22 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::restore_agent][super::super::client::Agents::restore_agent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::RestoreAgent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreAgent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreAgent(RequestBuilder<crate::model::RestoreAgentRequest>);
 
@@ -703,6 +831,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_validation_result][super::super::client::Agents::get_validation_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::GetValidationResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetValidationResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetValidationResult(RequestBuilder<crate::model::GetValidationResultRequest>);
 
@@ -757,6 +900,25 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::list_locations][super::super::client::Agents::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -845,6 +1007,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_location][super::super::client::Agents::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -888,6 +1065,25 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::list_operations][super::super::client::Agents::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -978,6 +1174,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::get_operation][super::super::client::Agents::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1024,6 +1235,21 @@ pub mod agents {
     }
 
     /// The request builder for [Agents::cancel_operation][super::super::client::Agents::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::agents::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1125,6 +1351,25 @@ pub mod answer_records {
     }
 
     /// The request builder for [AnswerRecords::list_answer_records][super::super::client::AnswerRecords::list_answer_records] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::answer_records::ListAnswerRecords;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAnswerRecords {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAnswerRecords(RequestBuilder<crate::model::ListAnswerRecordsRequest>);
 
@@ -1217,6 +1462,21 @@ pub mod answer_records {
     }
 
     /// The request builder for [AnswerRecords::update_answer_record][super::super::client::AnswerRecords::update_answer_record] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::answer_records::UpdateAnswerRecord;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAnswerRecord {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAnswerRecord(RequestBuilder<crate::model::UpdateAnswerRecordRequest>);
 
@@ -1281,6 +1541,25 @@ pub mod answer_records {
     }
 
     /// The request builder for [AnswerRecords::list_locations][super::super::client::AnswerRecords::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::answer_records::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1371,6 +1650,21 @@ pub mod answer_records {
     }
 
     /// The request builder for [AnswerRecords::get_location][super::super::client::AnswerRecords::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::answer_records::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1416,6 +1710,25 @@ pub mod answer_records {
     }
 
     /// The request builder for [AnswerRecords::list_operations][super::super::client::AnswerRecords::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::answer_records::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1508,6 +1821,21 @@ pub mod answer_records {
     }
 
     /// The request builder for [AnswerRecords::get_operation][super::super::client::AnswerRecords::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::answer_records::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1556,6 +1884,21 @@ pub mod answer_records {
     }
 
     /// The request builder for [AnswerRecords::cancel_operation][super::super::client::AnswerRecords::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::answer_records::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1657,6 +2000,25 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::list_contexts][super::super::client::Contexts::list_contexts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::ListContexts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListContexts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListContexts(RequestBuilder<crate::model::ListContextsRequest>);
 
@@ -1738,6 +2100,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::get_context][super::super::client::Contexts::get_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::GetContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetContext(RequestBuilder<crate::model::GetContextRequest>);
 
@@ -1783,6 +2160,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::create_context][super::super::client::Contexts::create_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::CreateContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateContext(RequestBuilder<crate::model::CreateContextRequest>);
 
@@ -1839,6 +2231,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::update_context][super::super::client::Contexts::update_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::UpdateContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateContext(RequestBuilder<crate::model::UpdateContextRequest>);
 
@@ -1896,6 +2303,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::delete_context][super::super::client::Contexts::delete_context] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::DeleteContext;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteContext {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteContext(RequestBuilder<crate::model::DeleteContextRequest>);
 
@@ -1941,6 +2363,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::delete_all_contexts][super::super::client::Contexts::delete_all_contexts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::DeleteAllContexts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAllContexts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAllContexts(RequestBuilder<crate::model::DeleteAllContextsRequest>);
 
@@ -1989,6 +2426,25 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::list_locations][super::super::client::Contexts::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2077,6 +2533,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::get_location][super::super::client::Contexts::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2120,6 +2591,25 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::list_operations][super::super::client::Contexts::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2210,6 +2700,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::get_operation][super::super::client::Contexts::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2256,6 +2761,21 @@ pub mod contexts {
     }
 
     /// The request builder for [Contexts::cancel_operation][super::super::client::Contexts::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::contexts::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2357,6 +2877,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::create_conversation][super::super::client::Conversations::create_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::CreateConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversation(RequestBuilder<crate::model::CreateConversationRequest>);
 
@@ -2424,6 +2959,25 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::list_conversations][super::super::client::Conversations::list_conversations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::ListConversations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversations(RequestBuilder<crate::model::ListConversationsRequest>);
 
@@ -2516,6 +3070,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::get_conversation][super::super::client::Conversations::get_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::GetConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversation(RequestBuilder<crate::model::GetConversationRequest>);
 
@@ -2563,6 +3132,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::complete_conversation][super::super::client::Conversations::complete_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::CompleteConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompleteConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompleteConversation(RequestBuilder<crate::model::CompleteConversationRequest>);
 
@@ -2613,6 +3197,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::ingest_context_references][super::super::client::Conversations::ingest_context_references] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::IngestContextReferences;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> IngestContextReferences {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct IngestContextReferences(
         RequestBuilder<crate::model::IngestContextReferencesRequest>,
@@ -2679,6 +3278,25 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::list_messages][super::super::client::Conversations::list_messages] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::ListMessages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMessages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMessages(RequestBuilder<crate::model::ListMessagesRequest>);
 
@@ -2768,6 +3386,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::suggest_conversation_summary][super::super::client::Conversations::suggest_conversation_summary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::SuggestConversationSummary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SuggestConversationSummary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SuggestConversationSummary(
         RequestBuilder<crate::model::SuggestConversationSummaryRequest>,
@@ -2843,6 +3476,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::generate_stateless_summary][super::super::client::Conversations::generate_stateless_summary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::GenerateStatelessSummary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateStatelessSummary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateStatelessSummary(
         RequestBuilder<crate::model::GenerateStatelessSummaryRequest>,
@@ -2929,6 +3577,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::generate_stateless_suggestion][super::super::client::Conversations::generate_stateless_suggestion] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::GenerateStatelessSuggestion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateStatelessSuggestion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateStatelessSuggestion(
         RequestBuilder<crate::model::GenerateStatelessSuggestionRequest>,
@@ -3055,6 +3718,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::search_knowledge][super::super::client::Conversations::search_knowledge] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::SearchKnowledge;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchKnowledge {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchKnowledge(RequestBuilder<crate::model::SearchKnowledgeRequest>);
 
@@ -3176,6 +3854,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::generate_suggestions][super::super::client::Conversations::generate_suggestions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::GenerateSuggestions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateSuggestions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateSuggestions(RequestBuilder<crate::model::GenerateSuggestionsRequest>);
 
@@ -3243,6 +3936,25 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::list_locations][super::super::client::Conversations::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3333,6 +4045,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::get_location][super::super::client::Conversations::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3378,6 +4105,25 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::list_operations][super::super::client::Conversations::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3470,6 +4216,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::get_operation][super::super::client::Conversations::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3518,6 +4279,21 @@ pub mod conversations {
     }
 
     /// The request builder for [Conversations::cancel_operation][super::super::client::Conversations::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversations::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3621,6 +4397,22 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::create_conversation_dataset][super::super::client::ConversationDatasets::create_conversation_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::CreateConversationDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversationDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversationDataset(
         RequestBuilder<crate::model::CreateConversationDatasetRequest>,
@@ -3729,6 +4521,21 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::get_conversation_dataset][super::super::client::ConversationDatasets::get_conversation_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::GetConversationDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversationDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversationDataset(RequestBuilder<crate::model::GetConversationDatasetRequest>);
 
@@ -3779,6 +4586,25 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::list_conversation_datasets][super::super::client::ConversationDatasets::list_conversation_datasets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::ListConversationDatasets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversationDatasets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversationDatasets(
         RequestBuilder<crate::model::ListConversationDatasetsRequest>,
@@ -3871,6 +4697,22 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::delete_conversation_dataset][super::super::client::ConversationDatasets::delete_conversation_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::DeleteConversationDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConversationDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConversationDataset(
         RequestBuilder<crate::model::DeleteConversationDatasetRequest>,
@@ -3969,6 +4811,22 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::import_conversation_data][super::super::client::ConversationDatasets::import_conversation_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::ImportConversationData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportConversationData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportConversationData(RequestBuilder<crate::model::ImportConversationDataRequest>);
 
@@ -4073,6 +4931,25 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::list_locations][super::super::client::ConversationDatasets::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4163,6 +5040,21 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::get_location][super::super::client::ConversationDatasets::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4208,6 +5100,25 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::list_operations][super::super::client::ConversationDatasets::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4300,6 +5211,21 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::get_operation][super::super::client::ConversationDatasets::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4348,6 +5274,21 @@ pub mod conversation_datasets {
     }
 
     /// The request builder for [ConversationDatasets::cancel_operation][super::super::client::ConversationDatasets::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_datasets::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4451,6 +5392,22 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::create_conversation_model][super::super::client::ConversationModels::create_conversation_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::CreateConversationModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversationModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversationModel(
         RequestBuilder<crate::model::CreateConversationModelRequest>,
@@ -4557,6 +5514,21 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::get_conversation_model][super::super::client::ConversationModels::get_conversation_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::GetConversationModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversationModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversationModel(RequestBuilder<crate::model::GetConversationModelRequest>);
 
@@ -4607,6 +5579,25 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::list_conversation_models][super::super::client::ConversationModels::list_conversation_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::ListConversationModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversationModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversationModels(RequestBuilder<crate::model::ListConversationModelsRequest>);
 
@@ -4697,6 +5688,22 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::delete_conversation_model][super::super::client::ConversationModels::delete_conversation_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::DeleteConversationModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConversationModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConversationModel(
         RequestBuilder<crate::model::DeleteConversationModelRequest>,
@@ -4794,6 +5801,22 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::deploy_conversation_model][super::super::client::ConversationModels::deploy_conversation_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::DeployConversationModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeployConversationModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeployConversationModel(
         RequestBuilder<crate::model::DeployConversationModelRequest>,
@@ -4891,6 +5914,22 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::undeploy_conversation_model][super::super::client::ConversationModels::undeploy_conversation_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::UndeployConversationModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeployConversationModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeployConversationModel(
         RequestBuilder<crate::model::UndeployConversationModelRequest>,
@@ -4989,6 +6028,21 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::get_conversation_model_evaluation][super::super::client::ConversationModels::get_conversation_model_evaluation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::GetConversationModelEvaluation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversationModelEvaluation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversationModelEvaluation(
         RequestBuilder<crate::model::GetConversationModelEvaluationRequest>,
@@ -5041,6 +6095,25 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::list_conversation_model_evaluations][super::super::client::ConversationModels::list_conversation_model_evaluations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::ListConversationModelEvaluations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversationModelEvaluations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversationModelEvaluations(
         RequestBuilder<crate::model::ListConversationModelEvaluationsRequest>,
@@ -5133,6 +6206,22 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::create_conversation_model_evaluation][super::super::client::ConversationModels::create_conversation_model_evaluation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::CreateConversationModelEvaluation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversationModelEvaluation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversationModelEvaluation(
         RequestBuilder<crate::model::CreateConversationModelEvaluationRequest>,
@@ -5241,6 +6330,25 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::list_locations][super::super::client::ConversationModels::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5331,6 +6439,21 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::get_location][super::super::client::ConversationModels::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5376,6 +6499,25 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::list_operations][super::super::client::ConversationModels::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5468,6 +6610,21 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::get_operation][super::super::client::ConversationModels::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5516,6 +6673,21 @@ pub mod conversation_models {
     }
 
     /// The request builder for [ConversationModels::cancel_operation][super::super::client::ConversationModels::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_models::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5619,6 +6791,25 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::list_conversation_profiles][super::super::client::ConversationProfiles::list_conversation_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::ListConversationProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversationProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversationProfiles(
         RequestBuilder<crate::model::ListConversationProfilesRequest>,
@@ -5711,6 +6902,21 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::get_conversation_profile][super::super::client::ConversationProfiles::get_conversation_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::GetConversationProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversationProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversationProfile(RequestBuilder<crate::model::GetConversationProfileRequest>);
 
@@ -5761,6 +6967,21 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::create_conversation_profile][super::super::client::ConversationProfiles::create_conversation_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::CreateConversationProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversationProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversationProfile(
         RequestBuilder<crate::model::CreateConversationProfileRequest>,
@@ -5826,6 +7047,21 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::update_conversation_profile][super::super::client::ConversationProfiles::update_conversation_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::UpdateConversationProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConversationProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConversationProfile(
         RequestBuilder<crate::model::UpdateConversationProfileRequest>,
@@ -5894,6 +7130,21 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::delete_conversation_profile][super::super::client::ConversationProfiles::delete_conversation_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::DeleteConversationProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConversationProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConversationProfile(
         RequestBuilder<crate::model::DeleteConversationProfileRequest>,
@@ -5946,6 +7197,22 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::set_suggestion_feature_config][super::super::client::ConversationProfiles::set_suggestion_feature_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::SetSuggestionFeatureConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetSuggestionFeatureConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetSuggestionFeatureConfig(
         RequestBuilder<crate::model::SetSuggestionFeatureConfigRequest>,
@@ -6069,6 +7336,22 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::clear_suggestion_feature_config][super::super::client::ConversationProfiles::clear_suggestion_feature_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::ClearSuggestionFeatureConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ClearSuggestionFeatureConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ClearSuggestionFeatureConfig(
         RequestBuilder<crate::model::ClearSuggestionFeatureConfigRequest>,
@@ -6186,6 +7469,25 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::list_locations][super::super::client::ConversationProfiles::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6276,6 +7578,21 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::get_location][super::super::client::ConversationProfiles::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6321,6 +7638,25 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::list_operations][super::super::client::ConversationProfiles::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6413,6 +7749,21 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::get_operation][super::super::client::ConversationProfiles::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6461,6 +7812,21 @@ pub mod conversation_profiles {
     }
 
     /// The request builder for [ConversationProfiles::cancel_operation][super::super::client::ConversationProfiles::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::conversation_profiles::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6564,6 +7930,25 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::list_documents][super::super::client::Documents::list_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::ListDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDocuments(RequestBuilder<crate::model::ListDocumentsRequest>);
 
@@ -6653,6 +8038,21 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::get_document][super::super::client::Documents::get_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::GetDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDocument(RequestBuilder<crate::model::GetDocumentRequest>);
 
@@ -6700,6 +8100,22 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::create_document][super::super::client::Documents::create_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::CreateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDocument(RequestBuilder<crate::model::CreateDocumentRequest>);
 
@@ -6799,6 +8215,22 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::import_documents][super::super::client::Documents::import_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::ImportDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportDocuments(RequestBuilder<crate::model::ImportDocumentsRequest>);
 
@@ -6933,6 +8365,22 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::delete_document][super::super::client::Documents::delete_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::DeleteDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDocument(RequestBuilder<crate::model::DeleteDocumentRequest>);
 
@@ -7021,6 +8469,22 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::update_document][super::super::client::Documents::update_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::UpdateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDocument(RequestBuilder<crate::model::UpdateDocumentRequest>);
 
@@ -7121,6 +8585,22 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::reload_document][super::super::client::Documents::reload_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::ReloadDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReloadDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReloadDocument(RequestBuilder<crate::model::ReloadDocumentRequest>);
 
@@ -7243,6 +8723,22 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::export_document][super::super::client::Documents::export_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::ExportDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportDocument(RequestBuilder<crate::model::ExportDocumentRequest>);
 
@@ -7372,6 +8868,25 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::list_locations][super::super::client::Documents::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7462,6 +8977,21 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::get_location][super::super::client::Documents::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -7507,6 +9037,25 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::list_operations][super::super::client::Documents::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7599,6 +9148,21 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::get_operation][super::super::client::Documents::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7647,6 +9211,21 @@ pub mod documents {
     }
 
     /// The request builder for [Documents::cancel_operation][super::super::client::Documents::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::documents::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7750,6 +9329,21 @@ pub mod encryption_spec_service {
     }
 
     /// The request builder for [EncryptionSpecService::get_encryption_spec][super::super::client::EncryptionSpecService::get_encryption_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::encryption_spec_service::GetEncryptionSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEncryptionSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEncryptionSpec(RequestBuilder<crate::model::GetEncryptionSpecRequest>);
 
@@ -7800,6 +9394,22 @@ pub mod encryption_spec_service {
     }
 
     /// The request builder for [EncryptionSpecService::initialize_encryption_spec][super::super::client::EncryptionSpecService::initialize_encryption_spec] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::encryption_spec_service::InitializeEncryptionSpec;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InitializeEncryptionSpec {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InitializeEncryptionSpec(
         RequestBuilder<crate::model::InitializeEncryptionSpecRequest>,
@@ -7898,6 +9508,25 @@ pub mod encryption_spec_service {
     }
 
     /// The request builder for [EncryptionSpecService::list_locations][super::super::client::EncryptionSpecService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::encryption_spec_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -7988,6 +9617,21 @@ pub mod encryption_spec_service {
     }
 
     /// The request builder for [EncryptionSpecService::get_location][super::super::client::EncryptionSpecService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::encryption_spec_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -8033,6 +9677,25 @@ pub mod encryption_spec_service {
     }
 
     /// The request builder for [EncryptionSpecService::list_operations][super::super::client::EncryptionSpecService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::encryption_spec_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8125,6 +9788,21 @@ pub mod encryption_spec_service {
     }
 
     /// The request builder for [EncryptionSpecService::get_operation][super::super::client::EncryptionSpecService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::encryption_spec_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8173,6 +9851,21 @@ pub mod encryption_spec_service {
     }
 
     /// The request builder for [EncryptionSpecService::cancel_operation][super::super::client::EncryptionSpecService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::encryption_spec_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8276,6 +9969,25 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::list_entity_types][super::super::client::EntityTypes::list_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::ListEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntityTypes(RequestBuilder<crate::model::ListEntityTypesRequest>);
 
@@ -8365,6 +10077,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::get_entity_type][super::super::client::EntityTypes::get_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::GetEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntityType(RequestBuilder<crate::model::GetEntityTypeRequest>);
 
@@ -8418,6 +10145,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::create_entity_type][super::super::client::EntityTypes::create_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::CreateEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntityType(RequestBuilder<crate::model::CreateEntityTypeRequest>);
 
@@ -8485,6 +10227,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::update_entity_type][super::super::client::EntityTypes::update_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::UpdateEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntityType(RequestBuilder<crate::model::UpdateEntityTypeRequest>);
 
@@ -8553,6 +10310,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::delete_entity_type][super::super::client::EntityTypes::delete_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::DeleteEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntityType(RequestBuilder<crate::model::DeleteEntityTypeRequest>);
 
@@ -8603,6 +10375,22 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::batch_update_entity_types][super::super::client::EntityTypes::batch_update_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::BatchUpdateEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchUpdateEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchUpdateEntityTypes(RequestBuilder<crate::model::BatchUpdateEntityTypesRequest>);
 
@@ -8748,6 +10536,22 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::batch_delete_entity_types][super::super::client::EntityTypes::batch_delete_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::BatchDeleteEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteEntityTypes(RequestBuilder<crate::model::BatchDeleteEntityTypesRequest>);
 
@@ -8851,6 +10655,22 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::batch_create_entities][super::super::client::EntityTypes::batch_create_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::BatchCreateEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateEntities(RequestBuilder<crate::model::BatchCreateEntitiesRequest>);
 
@@ -8960,6 +10780,22 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::batch_update_entities][super::super::client::EntityTypes::batch_update_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::BatchUpdateEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchUpdateEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchUpdateEntities(RequestBuilder<crate::model::BatchUpdateEntitiesRequest>);
 
@@ -9078,6 +10914,22 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::batch_delete_entities][super::super::client::EntityTypes::batch_delete_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::BatchDeleteEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteEntities(RequestBuilder<crate::model::BatchDeleteEntitiesRequest>);
 
@@ -9187,6 +11039,25 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::list_locations][super::super::client::EntityTypes::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -9277,6 +11148,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::get_location][super::super::client::EntityTypes::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -9322,6 +11208,25 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::list_operations][super::super::client::EntityTypes::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -9414,6 +11319,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::get_operation][super::super::client::EntityTypes::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -9462,6 +11382,21 @@ pub mod entity_types {
     }
 
     /// The request builder for [EntityTypes::cancel_operation][super::super::client::EntityTypes::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::entity_types::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -9565,6 +11500,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::ListEnvironments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEnvironments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEnvironments(RequestBuilder<crate::model::ListEnvironmentsRequest>);
 
@@ -9651,6 +11605,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::GetEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -9698,6 +11667,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::CreateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEnvironment(RequestBuilder<crate::model::CreateEnvironmentRequest>);
 
@@ -9767,6 +11751,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::UpdateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEnvironment(RequestBuilder<crate::model::UpdateEnvironmentRequest>);
 
@@ -9837,6 +11836,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::DeleteEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEnvironment(RequestBuilder<crate::model::DeleteEnvironmentRequest>);
 
@@ -9887,6 +11901,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_environment_history][super::super::client::Environments::get_environment_history] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::GetEnvironmentHistory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnvironmentHistory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnvironmentHistory(RequestBuilder<crate::model::GetEnvironmentHistoryRequest>);
 
@@ -9973,6 +12006,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_locations][super::super::client::Environments::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10063,6 +12115,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_location][super::super::client::Environments::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10108,6 +12175,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10200,6 +12286,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10248,6 +12349,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::cancel_operation][super::super::client::Environments::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::environments::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -10351,6 +12467,21 @@ pub mod fulfillments {
     }
 
     /// The request builder for [Fulfillments::get_fulfillment][super::super::client::Fulfillments::get_fulfillment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::fulfillments::GetFulfillment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFulfillment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFulfillment(RequestBuilder<crate::model::GetFulfillmentRequest>);
 
@@ -10398,6 +12529,21 @@ pub mod fulfillments {
     }
 
     /// The request builder for [Fulfillments::update_fulfillment][super::super::client::Fulfillments::update_fulfillment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::fulfillments::UpdateFulfillment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFulfillment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFulfillment(RequestBuilder<crate::model::UpdateFulfillmentRequest>);
 
@@ -10462,6 +12608,25 @@ pub mod fulfillments {
     }
 
     /// The request builder for [Fulfillments::list_locations][super::super::client::Fulfillments::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::fulfillments::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -10552,6 +12717,21 @@ pub mod fulfillments {
     }
 
     /// The request builder for [Fulfillments::get_location][super::super::client::Fulfillments::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::fulfillments::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -10597,6 +12777,25 @@ pub mod fulfillments {
     }
 
     /// The request builder for [Fulfillments::list_operations][super::super::client::Fulfillments::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::fulfillments::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10689,6 +12888,21 @@ pub mod fulfillments {
     }
 
     /// The request builder for [Fulfillments::get_operation][super::super::client::Fulfillments::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::fulfillments::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10737,6 +12951,21 @@ pub mod fulfillments {
     }
 
     /// The request builder for [Fulfillments::cancel_operation][super::super::client::Fulfillments::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::fulfillments::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -10840,6 +13069,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::create_generator][super::super::client::Generators::create_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::CreateGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGenerator(RequestBuilder<crate::model::CreateGeneratorRequest>);
 
@@ -10904,6 +13148,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::get_generator][super::super::client::Generators::get_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::GetGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGenerator(RequestBuilder<crate::model::GetGeneratorRequest>);
 
@@ -10951,6 +13210,25 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::list_generators][super::super::client::Generators::list_generators] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::ListGenerators;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGenerators {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGenerators(RequestBuilder<crate::model::ListGeneratorsRequest>);
 
@@ -11034,6 +13312,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::delete_generator][super::super::client::Generators::delete_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::DeleteGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGenerator(RequestBuilder<crate::model::DeleteGeneratorRequest>);
 
@@ -11081,6 +13374,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::update_generator][super::super::client::Generators::update_generator] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::UpdateGenerator;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGenerator {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGenerator(RequestBuilder<crate::model::UpdateGeneratorRequest>);
 
@@ -11140,6 +13448,25 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::list_locations][super::super::client::Generators::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -11230,6 +13557,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::get_location][super::super::client::Generators::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -11275,6 +13617,25 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::list_operations][super::super::client::Generators::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -11367,6 +13728,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::get_operation][super::super::client::Generators::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -11415,6 +13791,21 @@ pub mod generators {
     }
 
     /// The request builder for [Generators::cancel_operation][super::super::client::Generators::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::generators::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -11516,6 +13907,25 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::list_intents][super::super::client::Intents::list_intents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::ListIntents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIntents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIntents(RequestBuilder<crate::model::ListIntentsRequest>);
 
@@ -11609,6 +14019,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::get_intent][super::super::client::Intents::get_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::GetIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIntent(RequestBuilder<crate::model::GetIntentRequest>);
 
@@ -11666,6 +14091,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::create_intent][super::super::client::Intents::create_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::CreateIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIntent(RequestBuilder<crate::model::CreateIntentRequest>);
 
@@ -11734,6 +14174,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::update_intent][super::super::client::Intents::update_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::UpdateIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIntent(RequestBuilder<crate::model::UpdateIntentRequest>);
 
@@ -11803,6 +14258,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::delete_intent][super::super::client::Intents::delete_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::DeleteIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIntent(RequestBuilder<crate::model::DeleteIntentRequest>);
 
@@ -11848,6 +14318,22 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::batch_update_intents][super::super::client::Intents::batch_update_intents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::BatchUpdateIntents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchUpdateIntents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchUpdateIntents(RequestBuilder<crate::model::BatchUpdateIntentsRequest>);
 
@@ -11997,6 +14483,22 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::batch_delete_intents][super::super::client::Intents::batch_delete_intents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::BatchDeleteIntents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_dialogflow_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteIntents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteIntents(RequestBuilder<crate::model::BatchDeleteIntentsRequest>);
 
@@ -12098,6 +14600,25 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::list_locations][super::super::client::Intents::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12186,6 +14707,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::get_location][super::super::client::Intents::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12229,6 +14765,25 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::list_operations][super::super::client::Intents::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -12319,6 +14874,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::get_operation][super::super::client::Intents::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -12365,6 +14935,21 @@ pub mod intents {
     }
 
     /// The request builder for [Intents::cancel_operation][super::super::client::Intents::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::intents::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -12466,6 +15051,25 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::list_knowledge_bases][super::super::client::KnowledgeBases::list_knowledge_bases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::ListKnowledgeBases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListKnowledgeBases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListKnowledgeBases(RequestBuilder<crate::model::ListKnowledgeBasesRequest>);
 
@@ -12560,6 +15164,21 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::get_knowledge_base][super::super::client::KnowledgeBases::get_knowledge_base] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::GetKnowledgeBase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetKnowledgeBase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetKnowledgeBase(RequestBuilder<crate::model::GetKnowledgeBaseRequest>);
 
@@ -12610,6 +15229,21 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::create_knowledge_base][super::super::client::KnowledgeBases::create_knowledge_base] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::CreateKnowledgeBase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateKnowledgeBase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateKnowledgeBase(RequestBuilder<crate::model::CreateKnowledgeBaseRequest>);
 
@@ -12671,6 +15305,21 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::delete_knowledge_base][super::super::client::KnowledgeBases::delete_knowledge_base] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::DeleteKnowledgeBase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteKnowledgeBase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteKnowledgeBase(RequestBuilder<crate::model::DeleteKnowledgeBaseRequest>);
 
@@ -12727,6 +15376,21 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::update_knowledge_base][super::super::client::KnowledgeBases::update_knowledge_base] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::UpdateKnowledgeBase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateKnowledgeBase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateKnowledgeBase(RequestBuilder<crate::model::UpdateKnowledgeBaseRequest>);
 
@@ -12789,6 +15453,25 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::list_locations][super::super::client::KnowledgeBases::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -12879,6 +15562,21 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::get_location][super::super::client::KnowledgeBases::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -12924,6 +15622,25 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::list_operations][super::super::client::KnowledgeBases::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -13016,6 +15733,21 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::get_operation][super::super::client::KnowledgeBases::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -13064,6 +15796,21 @@ pub mod knowledge_bases {
     }
 
     /// The request builder for [KnowledgeBases::cancel_operation][super::super::client::KnowledgeBases::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::knowledge_bases::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -13167,6 +15914,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::create_participant][super::super::client::Participants::create_participant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::CreateParticipant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateParticipant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateParticipant(RequestBuilder<crate::model::CreateParticipantRequest>);
 
@@ -13228,6 +15990,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::get_participant][super::super::client::Participants::get_participant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::GetParticipant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetParticipant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetParticipant(RequestBuilder<crate::model::GetParticipantRequest>);
 
@@ -13275,6 +16052,25 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::list_participants][super::super::client::Participants::list_participants] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::ListParticipants;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListParticipants {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListParticipants(RequestBuilder<crate::model::ListParticipantsRequest>);
 
@@ -13361,6 +16157,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::update_participant][super::super::client::Participants::update_participant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::UpdateParticipant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateParticipant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateParticipant(RequestBuilder<crate::model::UpdateParticipantRequest>);
 
@@ -13425,6 +16236,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::analyze_content][super::super::client::Participants::analyze_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::AnalyzeContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeContent(RequestBuilder<crate::model::AnalyzeContentRequest>);
 
@@ -13584,6 +16410,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::suggest_articles][super::super::client::Participants::suggest_articles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::SuggestArticles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SuggestArticles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SuggestArticles(RequestBuilder<crate::model::SuggestArticlesRequest>);
 
@@ -13654,6 +16495,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::suggest_faq_answers][super::super::client::Participants::suggest_faq_answers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::SuggestFaqAnswers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SuggestFaqAnswers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SuggestFaqAnswers(RequestBuilder<crate::model::SuggestFaqAnswersRequest>);
 
@@ -13727,6 +16583,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::suggest_smart_replies][super::super::client::Participants::suggest_smart_replies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::SuggestSmartReplies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SuggestSmartReplies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SuggestSmartReplies(RequestBuilder<crate::model::SuggestSmartRepliesRequest>);
 
@@ -13798,6 +16669,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::suggest_knowledge_assist][super::super::client::Participants::suggest_knowledge_assist] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::SuggestKnowledgeAssist;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SuggestKnowledgeAssist {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SuggestKnowledgeAssist(RequestBuilder<crate::model::SuggestKnowledgeAssistRequest>);
 
@@ -13866,6 +16752,25 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::list_locations][super::super::client::Participants::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -13956,6 +16861,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::get_location][super::super::client::Participants::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -14001,6 +16921,25 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::list_operations][super::super::client::Participants::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -14093,6 +17032,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::get_operation][super::super::client::Participants::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -14141,6 +17095,21 @@ pub mod participants {
     }
 
     /// The request builder for [Participants::cancel_operation][super::super::client::Participants::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::participants::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -14242,6 +17211,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::detect_intent][super::super::client::Sessions::detect_intent] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::sessions::DetectIntent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DetectIntent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DetectIntent(RequestBuilder<crate::model::DetectIntentRequest>);
 
@@ -14333,6 +17317,25 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::list_locations][super::super::client::Sessions::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::sessions::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -14421,6 +17424,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::get_location][super::super::client::Sessions::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::sessions::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -14464,6 +17482,25 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::list_operations][super::super::client::Sessions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::sessions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -14554,6 +17591,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::get_operation][super::super::client::Sessions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::sessions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -14600,6 +17652,21 @@ pub mod sessions {
     }
 
     /// The request builder for [Sessions::cancel_operation][super::super::client::Sessions::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::sessions::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -14701,6 +17768,25 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::list_session_entity_types][super::super::client::SessionEntityTypes::list_session_entity_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::ListSessionEntityTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSessionEntityTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSessionEntityTypes(RequestBuilder<crate::model::ListSessionEntityTypesRequest>);
 
@@ -14791,6 +17877,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::get_session_entity_type][super::super::client::SessionEntityTypes::get_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::GetSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSessionEntityType(RequestBuilder<crate::model::GetSessionEntityTypeRequest>);
 
@@ -14841,6 +17942,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::create_session_entity_type][super::super::client::SessionEntityTypes::create_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::CreateSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSessionEntityType(
         RequestBuilder<crate::model::CreateSessionEntityTypeRequest>,
@@ -14906,6 +18022,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::update_session_entity_type][super::super::client::SessionEntityTypes::update_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::UpdateSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSessionEntityType(
         RequestBuilder<crate::model::UpdateSessionEntityTypeRequest>,
@@ -14972,6 +18103,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::delete_session_entity_type][super::super::client::SessionEntityTypes::delete_session_entity_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::DeleteSessionEntityType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSessionEntityType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSessionEntityType(
         RequestBuilder<crate::model::DeleteSessionEntityTypeRequest>,
@@ -15024,6 +18170,25 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::list_locations][super::super::client::SessionEntityTypes::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -15114,6 +18279,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::get_location][super::super::client::SessionEntityTypes::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -15159,6 +18339,25 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::list_operations][super::super::client::SessionEntityTypes::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -15251,6 +18450,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::get_operation][super::super::client::SessionEntityTypes::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -15299,6 +18513,21 @@ pub mod session_entity_types {
     }
 
     /// The request builder for [SessionEntityTypes::cancel_operation][super::super::client::SessionEntityTypes::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::session_entity_types::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -15400,6 +18629,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::ListVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -15481,6 +18729,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::GetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -15526,6 +18789,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::CreateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVersion(RequestBuilder<crate::model::CreateVersionRequest>);
 
@@ -15582,6 +18860,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::UpdateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -15641,6 +18934,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::DeleteVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -15686,6 +18994,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_locations][super::super::client::Versions::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -15774,6 +19101,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_location][super::super::client::Versions::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -15817,6 +19159,25 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -15907,6 +19268,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -15953,6 +19329,21 @@ pub mod versions {
     }
 
     /// The request builder for [Versions::cancel_operation][super::super::client::Versions::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_dialogflow_v2::builder;
+    /// use builder::versions::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::complete_query][super::super::client::CompletionService::complete_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::CompleteQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompleteQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompleteQuery(RequestBuilder<crate::model::CompleteQueryRequest>);
 
@@ -142,6 +157,22 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::import_suggestion_deny_list_entries][super::super::client::CompletionService::import_suggestion_deny_list_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::ImportSuggestionDenyListEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportSuggestionDenyListEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportSuggestionDenyListEntries(
         RequestBuilder<crate::model::ImportSuggestionDenyListEntriesRequest>,
@@ -283,6 +314,22 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::purge_suggestion_deny_list_entries][super::super::client::CompletionService::purge_suggestion_deny_list_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::PurgeSuggestionDenyListEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeSuggestionDenyListEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeSuggestionDenyListEntries(
         RequestBuilder<crate::model::PurgeSuggestionDenyListEntriesRequest>,
@@ -378,6 +425,22 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::import_completion_suggestions][super::super::client::CompletionService::import_completion_suggestions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::ImportCompletionSuggestions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportCompletionSuggestions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportCompletionSuggestions(
         RequestBuilder<crate::model::ImportCompletionSuggestionsRequest>,
@@ -543,6 +606,22 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::purge_completion_suggestions][super::super::client::CompletionService::purge_completion_suggestions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::PurgeCompletionSuggestions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeCompletionSuggestions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeCompletionSuggestions(
         RequestBuilder<crate::model::PurgeCompletionSuggestionsRequest>,
@@ -638,6 +717,25 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::list_operations][super::super::client::CompletionService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -730,6 +828,21 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::get_operation][super::super::client::CompletionService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -778,6 +891,21 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::cancel_operation][super::super::client::CompletionService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::completion_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -881,6 +1009,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::create_control][super::super::client::ControlService::create_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::CreateControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateControl(RequestBuilder<crate::model::CreateControlRequest>);
 
@@ -947,6 +1090,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::delete_control][super::super::client::ControlService::delete_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::DeleteControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteControl(RequestBuilder<crate::model::DeleteControlRequest>);
 
@@ -994,6 +1152,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::update_control][super::super::client::ControlService::update_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::UpdateControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateControl(RequestBuilder<crate::model::UpdateControlRequest>);
 
@@ -1053,6 +1226,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::get_control][super::super::client::ControlService::get_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::GetControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetControl(RequestBuilder<crate::model::GetControlRequest>);
 
@@ -1100,6 +1288,25 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::list_controls][super::super::client::ControlService::list_controls] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::ListControls;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListControls {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListControls(RequestBuilder<crate::model::ListControlsRequest>);
 
@@ -1189,6 +1396,25 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::list_operations][super::super::client::ControlService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1281,6 +1507,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::get_operation][super::super::client::ControlService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1329,6 +1570,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::cancel_operation][super::super::client::ControlService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::control_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1432,6 +1688,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::converse_conversation][super::super::client::ConversationalSearchService::converse_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::ConverseConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ConverseConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ConverseConversation(RequestBuilder<crate::model::ConverseConversationRequest>);
 
@@ -1555,6 +1826,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::create_conversation][super::super::client::ConversationalSearchService::create_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::CreateConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConversation(RequestBuilder<crate::model::CreateConversationRequest>);
 
@@ -1616,6 +1902,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::delete_conversation][super::super::client::ConversationalSearchService::delete_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::DeleteConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConversation(RequestBuilder<crate::model::DeleteConversationRequest>);
 
@@ -1666,6 +1967,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::update_conversation][super::super::client::ConversationalSearchService::update_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::UpdateConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConversation(RequestBuilder<crate::model::UpdateConversationRequest>);
 
@@ -1728,6 +2044,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::get_conversation][super::super::client::ConversationalSearchService::get_conversation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::GetConversation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConversation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConversation(RequestBuilder<crate::model::GetConversationRequest>);
 
@@ -1775,6 +2106,25 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::list_conversations][super::super::client::ConversationalSearchService::list_conversations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::ListConversations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConversations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConversations(RequestBuilder<crate::model::ListConversationsRequest>);
 
@@ -1873,6 +2223,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::answer_query][super::super::client::ConversationalSearchService::answer_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::AnswerQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnswerQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnswerQuery(RequestBuilder<crate::model::AnswerQueryRequest>);
 
@@ -2038,6 +2403,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::get_answer][super::super::client::ConversationalSearchService::get_answer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::GetAnswer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAnswer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAnswer(RequestBuilder<crate::model::GetAnswerRequest>);
 
@@ -2085,6 +2465,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::create_session][super::super::client::ConversationalSearchService::create_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::CreateSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSession(RequestBuilder<crate::model::CreateSessionRequest>);
 
@@ -2143,6 +2538,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::delete_session][super::super::client::ConversationalSearchService::delete_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::DeleteSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSession(RequestBuilder<crate::model::DeleteSessionRequest>);
 
@@ -2190,6 +2600,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::update_session][super::super::client::ConversationalSearchService::update_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::UpdateSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSession(RequestBuilder<crate::model::UpdateSessionRequest>);
 
@@ -2249,6 +2674,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::get_session][super::super::client::ConversationalSearchService::get_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::GetSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSession(RequestBuilder<crate::model::GetSessionRequest>);
 
@@ -2302,6 +2742,25 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::list_sessions][super::super::client::ConversationalSearchService::list_sessions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::ListSessions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSessions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSessions(RequestBuilder<crate::model::ListSessionsRequest>);
 
@@ -2397,6 +2856,25 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::list_operations][super::super::client::ConversationalSearchService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2489,6 +2967,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::get_operation][super::super::client::ConversationalSearchService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2537,6 +3030,21 @@ pub mod conversational_search_service {
     }
 
     /// The request builder for [ConversationalSearchService::cancel_operation][super::super::client::ConversationalSearchService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::conversational_search_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2640,6 +3148,22 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::create_data_store][super::super::client::DataStoreService::create_data_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::CreateDataStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataStore(RequestBuilder<crate::model::CreateDataStoreRequest>);
 
@@ -2759,6 +3283,21 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::get_data_store][super::super::client::DataStoreService::get_data_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::GetDataStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataStore(RequestBuilder<crate::model::GetDataStoreRequest>);
 
@@ -2806,6 +3345,25 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::list_data_stores][super::super::client::DataStoreService::list_data_stores] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::ListDataStores;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataStores {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataStores(RequestBuilder<crate::model::ListDataStoresRequest>);
 
@@ -2895,6 +3453,22 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::delete_data_store][super::super::client::DataStoreService::delete_data_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::DeleteDataStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataStore(RequestBuilder<crate::model::DeleteDataStoreRequest>);
 
@@ -2983,6 +3557,21 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::update_data_store][super::super::client::DataStoreService::update_data_store] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::UpdateDataStore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataStore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataStore(RequestBuilder<crate::model::UpdateDataStoreRequest>);
 
@@ -3042,6 +3631,25 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::list_operations][super::super::client::DataStoreService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3134,6 +3742,21 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::get_operation][super::super::client::DataStoreService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3182,6 +3805,21 @@ pub mod data_store_service {
     }
 
     /// The request builder for [DataStoreService::cancel_operation][super::super::client::DataStoreService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::data_store_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3285,6 +3923,21 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::get_document][super::super::client::DocumentService::get_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::GetDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDocument(RequestBuilder<crate::model::GetDocumentRequest>);
 
@@ -3332,6 +3985,25 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::list_documents][super::super::client::DocumentService::list_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::ListDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDocuments(RequestBuilder<crate::model::ListDocumentsRequest>);
 
@@ -3415,6 +4087,21 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::create_document][super::super::client::DocumentService::create_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::CreateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDocument(RequestBuilder<crate::model::CreateDocumentRequest>);
 
@@ -3481,6 +4168,21 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::update_document][super::super::client::DocumentService::update_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::UpdateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDocument(RequestBuilder<crate::model::UpdateDocumentRequest>);
 
@@ -3546,6 +4248,21 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::delete_document][super::super::client::DocumentService::delete_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::DeleteDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDocument(RequestBuilder<crate::model::DeleteDocumentRequest>);
 
@@ -3593,6 +4310,22 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::import_documents][super::super::client::DocumentService::import_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::ImportDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportDocuments(RequestBuilder<crate::model::ImportDocumentsRequest>);
 
@@ -3875,6 +4608,22 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::purge_documents][super::super::client::DocumentService::purge_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::PurgeDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeDocuments(RequestBuilder<crate::model::PurgeDocumentsRequest>);
 
@@ -4028,6 +4777,21 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::batch_get_documents_metadata][super::super::client::DocumentService::batch_get_documents_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::BatchGetDocumentsMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchGetDocumentsMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchGetDocumentsMetadata(
         RequestBuilder<crate::model::BatchGetDocumentsMetadataRequest>,
@@ -4093,6 +4857,25 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::list_operations][super::super::client::DocumentService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4185,6 +4968,21 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::get_operation][super::super::client::DocumentService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4233,6 +5031,21 @@ pub mod document_service {
     }
 
     /// The request builder for [DocumentService::cancel_operation][super::super::client::DocumentService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::document_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4336,6 +5149,22 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::create_engine][super::super::client::EngineService::create_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::CreateEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEngine(RequestBuilder<crate::model::CreateEngineRequest>);
 
@@ -4440,6 +5269,22 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::delete_engine][super::super::client::EngineService::delete_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::DeleteEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEngine(RequestBuilder<crate::model::DeleteEngineRequest>);
 
@@ -4528,6 +5373,21 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::update_engine][super::super::client::EngineService::update_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::UpdateEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEngine(RequestBuilder<crate::model::UpdateEngineRequest>);
 
@@ -4587,6 +5447,21 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::get_engine][super::super::client::EngineService::get_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::GetEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEngine(RequestBuilder<crate::model::GetEngineRequest>);
 
@@ -4634,6 +5509,25 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::list_engines][super::super::client::EngineService::list_engines] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::ListEngines;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEngines {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEngines(RequestBuilder<crate::model::ListEnginesRequest>);
 
@@ -4723,6 +5617,25 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::list_operations][super::super::client::EngineService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4815,6 +5728,21 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::get_operation][super::super::client::EngineService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4863,6 +5791,21 @@ pub mod engine_service {
     }
 
     /// The request builder for [EngineService::cancel_operation][super::super::client::EngineService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::engine_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -4966,6 +5909,21 @@ pub mod grounded_generation_service {
     }
 
     /// The request builder for [GroundedGenerationService::generate_grounded_content][super::super::client::GroundedGenerationService::generate_grounded_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::grounded_generation_service::GenerateGroundedContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateGroundedContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateGroundedContent(
         RequestBuilder<crate::model::GenerateGroundedContentRequest>,
@@ -5079,6 +6037,21 @@ pub mod grounded_generation_service {
     }
 
     /// The request builder for [GroundedGenerationService::check_grounding][super::super::client::GroundedGenerationService::check_grounding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::grounded_generation_service::CheckGrounding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckGrounding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckGrounding(RequestBuilder<crate::model::CheckGroundingRequest>);
 
@@ -5165,6 +6138,25 @@ pub mod grounded_generation_service {
     }
 
     /// The request builder for [GroundedGenerationService::list_operations][super::super::client::GroundedGenerationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::grounded_generation_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5257,6 +6249,21 @@ pub mod grounded_generation_service {
     }
 
     /// The request builder for [GroundedGenerationService::get_operation][super::super::client::GroundedGenerationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::grounded_generation_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5305,6 +6312,21 @@ pub mod grounded_generation_service {
     }
 
     /// The request builder for [GroundedGenerationService::cancel_operation][super::super::client::GroundedGenerationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::grounded_generation_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5408,6 +6430,22 @@ pub mod project_service {
     }
 
     /// The request builder for [ProjectService::provision_project][super::super::client::ProjectService::provision_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::project_service::ProvisionProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ProvisionProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ProvisionProject(RequestBuilder<crate::model::ProvisionProjectRequest>);
 
@@ -5515,6 +6553,25 @@ pub mod project_service {
     }
 
     /// The request builder for [ProjectService::list_operations][super::super::client::ProjectService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::project_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5607,6 +6664,21 @@ pub mod project_service {
     }
 
     /// The request builder for [ProjectService::get_operation][super::super::client::ProjectService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::project_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5655,6 +6727,21 @@ pub mod project_service {
     }
 
     /// The request builder for [ProjectService::cancel_operation][super::super::client::ProjectService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::project_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5758,6 +6845,21 @@ pub mod rank_service {
     }
 
     /// The request builder for [RankService::rank][super::super::client::RankService::rank] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::rank_service::Rank;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Rank {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Rank(RequestBuilder<crate::model::RankRequest>);
 
@@ -5853,6 +6955,25 @@ pub mod rank_service {
     }
 
     /// The request builder for [RankService::list_operations][super::super::client::RankService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::rank_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5945,6 +7066,21 @@ pub mod rank_service {
     }
 
     /// The request builder for [RankService::get_operation][super::super::client::RankService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::rank_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5993,6 +7129,21 @@ pub mod rank_service {
     }
 
     /// The request builder for [RankService::cancel_operation][super::super::client::RankService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::rank_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6096,6 +7247,21 @@ pub mod recommendation_service {
     }
 
     /// The request builder for [RecommendationService::recommend][super::super::client::RecommendationService::recommend] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::recommendation_service::Recommend;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Recommend {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Recommend(RequestBuilder<crate::model::RecommendRequest>);
 
@@ -6194,6 +7360,25 @@ pub mod recommendation_service {
     }
 
     /// The request builder for [RecommendationService::list_operations][super::super::client::RecommendationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::recommendation_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6286,6 +7471,21 @@ pub mod recommendation_service {
     }
 
     /// The request builder for [RecommendationService::get_operation][super::super::client::RecommendationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::recommendation_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6334,6 +7534,21 @@ pub mod recommendation_service {
     }
 
     /// The request builder for [RecommendationService::cancel_operation][super::super::client::RecommendationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::recommendation_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -6437,6 +7652,21 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::get_schema][super::super::client::SchemaService::get_schema] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::GetSchema;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSchema {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSchema(RequestBuilder<crate::model::GetSchemaRequest>);
 
@@ -6484,6 +7714,25 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::list_schemas][super::super::client::SchemaService::list_schemas] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::ListSchemas;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSchemas {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSchemas(RequestBuilder<crate::model::ListSchemasRequest>);
 
@@ -6567,6 +7816,22 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::create_schema][super::super::client::SchemaService::create_schema] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::CreateSchema;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSchema {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSchema(RequestBuilder<crate::model::CreateSchemaRequest>);
 
@@ -6671,6 +7936,22 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::update_schema][super::super::client::SchemaService::update_schema] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::UpdateSchema;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSchema {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSchema(RequestBuilder<crate::model::UpdateSchemaRequest>);
 
@@ -6765,6 +8046,22 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::delete_schema][super::super::client::SchemaService::delete_schema] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::DeleteSchema;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSchema {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSchema(RequestBuilder<crate::model::DeleteSchemaRequest>);
 
@@ -6853,6 +8150,25 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::list_operations][super::super::client::SchemaService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6945,6 +8261,21 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::get_operation][super::super::client::SchemaService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6993,6 +8324,21 @@ pub mod schema_service {
     }
 
     /// The request builder for [SchemaService::cancel_operation][super::super::client::SchemaService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::schema_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7096,6 +8442,25 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::search][super::super::client::SearchService::search] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_service::Search;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Search {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Search(RequestBuilder<crate::model::SearchRequest>);
 
@@ -7408,6 +8773,25 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::search_lite][super::super::client::SearchService::search_lite] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_service::SearchLite;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchLite {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchLite(RequestBuilder<crate::model::SearchRequest>);
 
@@ -7720,6 +9104,25 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::list_operations][super::super::client::SearchService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7812,6 +9215,21 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::get_operation][super::super::client::SearchService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7860,6 +9278,21 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::cancel_operation][super::super::client::SearchService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -7963,6 +9396,22 @@ pub mod search_tuning_service {
     }
 
     /// The request builder for [SearchTuningService::train_custom_model][super::super::client::SearchTuningService::train_custom_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_tuning_service::TrainCustomModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TrainCustomModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TrainCustomModel(RequestBuilder<crate::model::TrainCustomModelRequest>);
 
@@ -8108,6 +9557,21 @@ pub mod search_tuning_service {
     }
 
     /// The request builder for [SearchTuningService::list_custom_models][super::super::client::SearchTuningService::list_custom_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_tuning_service::ListCustomModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCustomModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCustomModels(RequestBuilder<crate::model::ListCustomModelsRequest>);
 
@@ -8158,6 +9622,25 @@ pub mod search_tuning_service {
     }
 
     /// The request builder for [SearchTuningService::list_operations][super::super::client::SearchTuningService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_tuning_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8250,6 +9733,21 @@ pub mod search_tuning_service {
     }
 
     /// The request builder for [SearchTuningService::get_operation][super::super::client::SearchTuningService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_tuning_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8298,6 +9796,21 @@ pub mod search_tuning_service {
     }
 
     /// The request builder for [SearchTuningService::cancel_operation][super::super::client::SearchTuningService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::search_tuning_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8401,6 +9914,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::update_serving_config][super::super::client::ServingConfigService::update_serving_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::serving_config_service::UpdateServingConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServingConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServingConfig(RequestBuilder<crate::model::UpdateServingConfigRequest>);
 
@@ -8463,6 +9991,25 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::list_operations][super::super::client::ServingConfigService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::serving_config_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -8555,6 +10102,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::get_operation][super::super::client::ServingConfigService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::serving_config_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -8603,6 +10165,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::cancel_operation][super::super::client::ServingConfigService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::serving_config_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -8706,6 +10283,21 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::get_site_search_engine][super::super::client::SiteSearchEngineService::get_site_search_engine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::GetSiteSearchEngine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSiteSearchEngine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSiteSearchEngine(RequestBuilder<crate::model::GetSiteSearchEngineRequest>);
 
@@ -8756,6 +10348,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::create_target_site][super::super::client::SiteSearchEngineService::create_target_site] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::CreateTargetSite;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTargetSite {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTargetSite(RequestBuilder<crate::model::CreateTargetSiteRequest>);
 
@@ -8858,6 +10466,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::batch_create_target_sites][super::super::client::SiteSearchEngineService::batch_create_target_sites] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::BatchCreateTargetSites;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateTargetSites {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateTargetSites(RequestBuilder<crate::model::BatchCreateTargetSitesRequest>);
 
@@ -8964,6 +10588,21 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::get_target_site][super::super::client::SiteSearchEngineService::get_target_site] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::GetTargetSite;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTargetSite {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTargetSite(RequestBuilder<crate::model::GetTargetSiteRequest>);
 
@@ -9011,6 +10650,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::update_target_site][super::super::client::SiteSearchEngineService::update_target_site] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::UpdateTargetSite;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTargetSite {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTargetSite(RequestBuilder<crate::model::UpdateTargetSiteRequest>);
 
@@ -9105,6 +10760,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::delete_target_site][super::super::client::SiteSearchEngineService::delete_target_site] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::DeleteTargetSite;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTargetSite {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTargetSite(RequestBuilder<crate::model::DeleteTargetSiteRequest>);
 
@@ -9196,6 +10867,25 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::list_target_sites][super::super::client::SiteSearchEngineService::list_target_sites] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::ListTargetSites;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTargetSites {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTargetSites(RequestBuilder<crate::model::ListTargetSitesRequest>);
 
@@ -9279,6 +10969,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::create_sitemap][super::super::client::SiteSearchEngineService::create_sitemap] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::CreateSitemap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSitemap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSitemap(RequestBuilder<crate::model::CreateSitemapRequest>);
 
@@ -9377,6 +11083,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::delete_sitemap][super::super::client::SiteSearchEngineService::delete_sitemap] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::DeleteSitemap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSitemap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSitemap(RequestBuilder<crate::model::DeleteSitemapRequest>);
 
@@ -9465,6 +11187,21 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::fetch_sitemaps][super::super::client::SiteSearchEngineService::fetch_sitemaps] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::FetchSitemaps;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchSitemaps {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchSitemaps(RequestBuilder<crate::model::FetchSitemapsRequest>);
 
@@ -9523,6 +11260,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::enable_advanced_site_search][super::super::client::SiteSearchEngineService::enable_advanced_site_search] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::EnableAdvancedSiteSearch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableAdvancedSiteSearch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableAdvancedSiteSearch(
         RequestBuilder<crate::model::EnableAdvancedSiteSearchRequest>,
@@ -9618,6 +11371,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::disable_advanced_site_search][super::super::client::SiteSearchEngineService::disable_advanced_site_search] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::DisableAdvancedSiteSearch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableAdvancedSiteSearch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableAdvancedSiteSearch(
         RequestBuilder<crate::model::DisableAdvancedSiteSearchRequest>,
@@ -9713,6 +11482,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::recrawl_uris][super::super::client::SiteSearchEngineService::recrawl_uris] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::RecrawlUris;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RecrawlUris {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RecrawlUris(RequestBuilder<crate::model::RecrawlUrisRequest>);
 
@@ -9820,6 +11605,22 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::batch_verify_target_sites][super::super::client::SiteSearchEngineService::batch_verify_target_sites] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::BatchVerifyTargetSites;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchVerifyTargetSites {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchVerifyTargetSites(RequestBuilder<crate::model::BatchVerifyTargetSitesRequest>);
 
@@ -9913,6 +11714,25 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::fetch_domain_verification_status][super::super::client::SiteSearchEngineService::fetch_domain_verification_status] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::FetchDomainVerificationStatus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchDomainVerificationStatus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchDomainVerificationStatus(
         RequestBuilder<crate::model::FetchDomainVerificationStatusRequest>,
@@ -10005,6 +11825,25 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::list_operations][super::super::client::SiteSearchEngineService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10097,6 +11936,21 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::get_operation][super::super::client::SiteSearchEngineService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10145,6 +11999,21 @@ pub mod site_search_engine_service {
     }
 
     /// The request builder for [SiteSearchEngineService::cancel_operation][super::super::client::SiteSearchEngineService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::site_search_engine_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -10248,6 +12117,21 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::write_user_event][super::super::client::UserEventService::write_user_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::user_event_service::WriteUserEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WriteUserEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WriteUserEvent(RequestBuilder<crate::model::WriteUserEventRequest>);
 
@@ -10312,6 +12196,21 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::collect_user_event][super::super::client::UserEventService::collect_user_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::user_event_service::CollectUserEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CollectUserEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CollectUserEvent(RequestBuilder<crate::model::CollectUserEventRequest>);
 
@@ -10382,6 +12281,22 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::purge_user_events][super::super::client::UserEventService::purge_user_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::user_event_service::PurgeUserEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeUserEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeUserEvents(RequestBuilder<crate::model::PurgeUserEventsRequest>);
 
@@ -10484,6 +12399,22 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::import_user_events][super::super::client::UserEventService::import_user_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::user_event_service::ImportUserEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_discoveryengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportUserEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportUserEvents(RequestBuilder<crate::model::ImportUserEventsRequest>);
 
@@ -10643,6 +12574,25 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::list_operations][super::super::client::UserEventService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::user_event_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -10735,6 +12685,21 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::get_operation][super::super::client::UserEventService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::user_event_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -10783,6 +12748,21 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::cancel_operation][super::super::client::UserEventService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_discoveryengine_v1::builder;
+    /// use builder::user_event_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/documentai/v1/src/builder.rs
+++ b/src/generated/cloud/documentai/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::process_document][super::super::client::DocumentProcessorService::process_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ProcessDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ProcessDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ProcessDocument(RequestBuilder<crate::model::ProcessRequest>);
 
@@ -214,6 +229,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::batch_process_documents][super::super::client::DocumentProcessorService::batch_process_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::BatchProcessDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchProcessDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchProcessDocuments(RequestBuilder<crate::model::BatchProcessRequest>);
 
@@ -350,6 +381,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::fetch_processor_types][super::super::client::DocumentProcessorService::fetch_processor_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::FetchProcessorTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchProcessorTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchProcessorTypes(RequestBuilder<crate::model::FetchProcessorTypesRequest>);
 
@@ -400,6 +446,25 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::list_processor_types][super::super::client::DocumentProcessorService::list_processor_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ListProcessorTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProcessorTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProcessorTypes(RequestBuilder<crate::model::ListProcessorTypesRequest>);
 
@@ -488,6 +553,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::get_processor_type][super::super::client::DocumentProcessorService::get_processor_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::GetProcessorType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProcessorType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProcessorType(RequestBuilder<crate::model::GetProcessorTypeRequest>);
 
@@ -538,6 +618,25 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::list_processors][super::super::client::DocumentProcessorService::list_processors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ListProcessors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProcessors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProcessors(RequestBuilder<crate::model::ListProcessorsRequest>);
 
@@ -621,6 +720,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::get_processor][super::super::client::DocumentProcessorService::get_processor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::GetProcessor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProcessor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProcessor(RequestBuilder<crate::model::GetProcessorRequest>);
 
@@ -668,6 +782,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::train_processor_version][super::super::client::DocumentProcessorService::train_processor_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::TrainProcessorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TrainProcessorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TrainProcessorVersion(RequestBuilder<crate::model::TrainProcessorVersionRequest>);
 
@@ -843,6 +973,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::get_processor_version][super::super::client::DocumentProcessorService::get_processor_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::GetProcessorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProcessorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProcessorVersion(RequestBuilder<crate::model::GetProcessorVersionRequest>);
 
@@ -893,6 +1038,25 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::list_processor_versions][super::super::client::DocumentProcessorService::list_processor_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ListProcessorVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProcessorVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProcessorVersions(RequestBuilder<crate::model::ListProcessorVersionsRequest>);
 
@@ -981,6 +1145,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::delete_processor_version][super::super::client::DocumentProcessorService::delete_processor_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::DeleteProcessorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteProcessorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteProcessorVersion(RequestBuilder<crate::model::DeleteProcessorVersionRequest>);
 
@@ -1072,6 +1252,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::deploy_processor_version][super::super::client::DocumentProcessorService::deploy_processor_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::DeployProcessorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeployProcessorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeployProcessorVersion(RequestBuilder<crate::model::DeployProcessorVersionRequest>);
 
@@ -1165,6 +1361,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::undeploy_processor_version][super::super::client::DocumentProcessorService::undeploy_processor_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::UndeployProcessorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeployProcessorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeployProcessorVersion(
         RequestBuilder<crate::model::UndeployProcessorVersionRequest>,
@@ -1260,6 +1472,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::create_processor][super::super::client::DocumentProcessorService::create_processor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::CreateProcessor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProcessor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProcessor(RequestBuilder<crate::model::CreateProcessorRequest>);
 
@@ -1318,6 +1545,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::delete_processor][super::super::client::DocumentProcessorService::delete_processor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::DeleteProcessor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteProcessor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteProcessor(RequestBuilder<crate::model::DeleteProcessorRequest>);
 
@@ -1406,6 +1649,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::enable_processor][super::super::client::DocumentProcessorService::enable_processor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::EnableProcessor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableProcessor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableProcessor(RequestBuilder<crate::model::EnableProcessorRequest>);
 
@@ -1494,6 +1753,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::disable_processor][super::super::client::DocumentProcessorService::disable_processor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::DisableProcessor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableProcessor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableProcessor(RequestBuilder<crate::model::DisableProcessorRequest>);
 
@@ -1587,6 +1862,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::set_default_processor_version][super::super::client::DocumentProcessorService::set_default_processor_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::SetDefaultProcessorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetDefaultProcessorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetDefaultProcessorVersion(
         RequestBuilder<crate::model::SetDefaultProcessorVersionRequest>,
@@ -1690,6 +1981,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::review_document][super::super::client::DocumentProcessorService::review_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ReviewDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReviewDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReviewDocument(RequestBuilder<crate::model::ReviewDocumentRequest>);
 
@@ -1831,6 +2138,22 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::evaluate_processor_version][super::super::client::DocumentProcessorService::evaluate_processor_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::EvaluateProcessorVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_documentai_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EvaluateProcessorVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EvaluateProcessorVersion(
         RequestBuilder<crate::model::EvaluateProcessorVersionRequest>,
@@ -1937,6 +2260,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::get_evaluation][super::super::client::DocumentProcessorService::get_evaluation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::GetEvaluation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEvaluation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEvaluation(RequestBuilder<crate::model::GetEvaluationRequest>);
 
@@ -1984,6 +2322,25 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::list_evaluations][super::super::client::DocumentProcessorService::list_evaluations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ListEvaluations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEvaluations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEvaluations(RequestBuilder<crate::model::ListEvaluationsRequest>);
 
@@ -2067,6 +2424,25 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::list_locations][super::super::client::DocumentProcessorService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2157,6 +2533,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::get_location][super::super::client::DocumentProcessorService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2202,6 +2593,25 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::list_operations][super::super::client::DocumentProcessorService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2294,6 +2704,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::get_operation][super::super::client::DocumentProcessorService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2342,6 +2767,21 @@ pub mod document_processor_service {
     }
 
     /// The request builder for [DocumentProcessorService::cancel_operation][super::super::client::DocumentProcessorService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_documentai_v1::builder;
+    /// use builder::document_processor_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/domains/v1/src/builder.rs
+++ b/src/generated/cloud/domains/v1/src/builder.rs
@@ -67,6 +67,21 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::search_domains][super::super::client::Domains::search_domains] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::SearchDomains;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchDomains {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchDomains(RequestBuilder<crate::model::SearchDomainsRequest>);
 
@@ -120,6 +135,21 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::retrieve_register_parameters][super::super::client::Domains::retrieve_register_parameters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::RetrieveRegisterParameters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetrieveRegisterParameters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetrieveRegisterParameters(
         RequestBuilder<crate::model::RetrieveRegisterParametersRequest>,
@@ -178,6 +208,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::register_domain][super::super::client::Domains::register_domain] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::RegisterDomain;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RegisterDomain {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RegisterDomain(RequestBuilder<crate::model::RegisterDomainRequest>);
 
@@ -313,6 +359,21 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::retrieve_transfer_parameters][super::super::client::Domains::retrieve_transfer_parameters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::RetrieveTransferParameters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetrieveTransferParameters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetrieveTransferParameters(
         RequestBuilder<crate::model::RetrieveTransferParametersRequest>,
@@ -371,6 +432,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::transfer_domain][super::super::client::Domains::transfer_domain] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::TransferDomain;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TransferDomain {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TransferDomain(RequestBuilder<crate::model::TransferDomainRequest>);
 
@@ -506,6 +583,25 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::list_registrations][super::super::client::Domains::list_registrations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::ListRegistrations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRegistrations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRegistrations(RequestBuilder<crate::model::ListRegistrationsRequest>);
 
@@ -596,6 +692,21 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::get_registration][super::super::client::Domains::get_registration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::GetRegistration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRegistration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRegistration(RequestBuilder<crate::model::GetRegistrationRequest>);
 
@@ -641,6 +752,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::update_registration][super::super::client::Domains::update_registration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::UpdateRegistration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRegistration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRegistration(RequestBuilder<crate::model::UpdateRegistrationRequest>);
 
@@ -741,6 +868,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::configure_management_settings][super::super::client::Domains::configure_management_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::ConfigureManagementSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ConfigureManagementSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ConfigureManagementSettings(
         RequestBuilder<crate::model::ConfigureManagementSettingsRequest>,
@@ -853,6 +996,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::configure_dns_settings][super::super::client::Domains::configure_dns_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::ConfigureDnsSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ConfigureDnsSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ConfigureDnsSettings(RequestBuilder<crate::model::ConfigureDnsSettingsRequest>);
 
@@ -967,6 +1126,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::configure_contact_settings][super::super::client::Domains::configure_contact_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::ConfigureContactSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ConfigureContactSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ConfigureContactSettings(
         RequestBuilder<crate::model::ConfigureContactSettingsRequest>,
@@ -1094,6 +1269,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::export_registration][super::super::client::Domains::export_registration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::ExportRegistration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportRegistration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportRegistration(RequestBuilder<crate::model::ExportRegistrationRequest>);
 
@@ -1182,6 +1373,22 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::delete_registration][super::super::client::Domains::delete_registration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::DeleteRegistration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_domains_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRegistration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRegistration(RequestBuilder<crate::model::DeleteRegistrationRequest>);
 
@@ -1270,6 +1477,21 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::retrieve_authorization_code][super::super::client::Domains::retrieve_authorization_code] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::RetrieveAuthorizationCode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetrieveAuthorizationCode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetrieveAuthorizationCode(
         RequestBuilder<crate::model::RetrieveAuthorizationCodeRequest>,
@@ -1320,6 +1542,21 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::reset_authorization_code][super::super::client::Domains::reset_authorization_code] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::ResetAuthorizationCode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetAuthorizationCode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetAuthorizationCode(RequestBuilder<crate::model::ResetAuthorizationCodeRequest>);
 
@@ -1368,6 +1605,25 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::list_operations][super::super::client::Domains::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1458,6 +1714,21 @@ pub mod domains {
     }
 
     /// The request builder for [Domains::get_operation][super::super::client::Domains::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_domains_v1::builder;
+    /// use builder::domains::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/edgecontainer/v1/src/builder.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::list_clusters][super::super::client::EdgeContainer::list_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::ListClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -164,6 +183,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::get_cluster][super::super::client::EdgeContainer::get_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GetCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -211,6 +245,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::create_cluster][super::super::client::EdgeContainer::create_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::CreateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -321,6 +371,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::update_cluster][super::super::client::EdgeContainer::update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::UpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -422,6 +488,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::upgrade_cluster][super::super::client::EdgeContainer::upgrade_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::UpgradeCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpgradeCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpgradeCluster(RequestBuilder<crate::model::UpgradeClusterRequest>);
 
@@ -530,6 +612,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::delete_cluster][super::super::client::EdgeContainer::delete_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::DeleteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -623,6 +721,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::generate_access_token][super::super::client::EdgeContainer::generate_access_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GenerateAccessToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAccessToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAccessToken(RequestBuilder<crate::model::GenerateAccessTokenRequest>);
 
@@ -673,6 +786,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::generate_offline_credential][super::super::client::EdgeContainer::generate_offline_credential] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GenerateOfflineCredential;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateOfflineCredential {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateOfflineCredential(
         RequestBuilder<crate::model::GenerateOfflineCredentialRequest>,
@@ -725,6 +853,25 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::list_node_pools][super::super::client::EdgeContainer::list_node_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::ListNodePools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNodePools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNodePools(RequestBuilder<crate::model::ListNodePoolsRequest>);
 
@@ -820,6 +967,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::get_node_pool][super::super::client::EdgeContainer::get_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GetNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNodePool(RequestBuilder<crate::model::GetNodePoolRequest>);
 
@@ -867,6 +1029,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::create_node_pool][super::super::client::EdgeContainer::create_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::CreateNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNodePool(RequestBuilder<crate::model::CreateNodePoolRequest>);
 
@@ -977,6 +1155,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::update_node_pool][super::super::client::EdgeContainer::update_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::UpdateNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNodePool(RequestBuilder<crate::model::UpdateNodePoolRequest>);
 
@@ -1078,6 +1272,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::delete_node_pool][super::super::client::EdgeContainer::delete_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::DeleteNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNodePool(RequestBuilder<crate::model::DeleteNodePoolRequest>);
 
@@ -1171,6 +1381,25 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::list_machines][super::super::client::EdgeContainer::list_machines] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::ListMachines;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMachines {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMachines(RequestBuilder<crate::model::ListMachinesRequest>);
 
@@ -1266,6 +1495,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::get_machine][super::super::client::EdgeContainer::get_machine] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GetMachine;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMachine {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMachine(RequestBuilder<crate::model::GetMachineRequest>);
 
@@ -1313,6 +1557,25 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::list_vpn_connections][super::super::client::EdgeContainer::list_vpn_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::ListVpnConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVpnConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVpnConnections(RequestBuilder<crate::model::ListVpnConnectionsRequest>);
 
@@ -1413,6 +1676,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::get_vpn_connection][super::super::client::EdgeContainer::get_vpn_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GetVpnConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVpnConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVpnConnection(RequestBuilder<crate::model::GetVpnConnectionRequest>);
 
@@ -1463,6 +1741,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::create_vpn_connection][super::super::client::EdgeContainer::create_vpn_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::CreateVpnConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVpnConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVpnConnection(RequestBuilder<crate::model::CreateVpnConnectionRequest>);
 
@@ -1579,6 +1873,22 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::delete_vpn_connection][super::super::client::EdgeContainer::delete_vpn_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::DeleteVpnConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgecontainer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVpnConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVpnConnection(RequestBuilder<crate::model::DeleteVpnConnectionRequest>);
 
@@ -1675,6 +1985,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::get_server_config][super::super::client::EdgeContainer::get_server_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GetServerConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServerConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServerConfig(RequestBuilder<crate::model::GetServerConfigRequest>);
 
@@ -1722,6 +2047,25 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::list_locations][super::super::client::EdgeContainer::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1812,6 +2156,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::get_location][super::super::client::EdgeContainer::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1857,6 +2216,25 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::list_operations][super::super::client::EdgeContainer::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1949,6 +2327,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::get_operation][super::super::client::EdgeContainer::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1997,6 +2390,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::delete_operation][super::super::client::EdgeContainer::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2045,6 +2453,21 @@ pub mod edge_container {
     }
 
     /// The request builder for [EdgeContainer::cancel_operation][super::super::client::EdgeContainer::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgecontainer_v1::builder;
+    /// use builder::edge_container::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/edgenetwork/v1/src/builder.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::initialize_zone][super::super::client::EdgeNetwork::initialize_zone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::InitializeZone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InitializeZone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InitializeZone(RequestBuilder<crate::model::InitializeZoneRequest>);
 
@@ -116,6 +131,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_zones][super::super::client::EdgeNetwork::list_zones] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListZones;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListZones {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListZones(RequestBuilder<crate::model::ListZonesRequest>);
 
@@ -211,6 +245,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_zone][super::super::client::EdgeNetwork::get_zone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetZone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetZone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetZone(RequestBuilder<crate::model::GetZoneRequest>);
 
@@ -258,6 +307,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_networks][super::super::client::EdgeNetwork::list_networks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListNetworks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNetworks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNetworks(RequestBuilder<crate::model::ListNetworksRequest>);
 
@@ -353,6 +421,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_network][super::super::client::EdgeNetwork::get_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNetwork(RequestBuilder<crate::model::GetNetworkRequest>);
 
@@ -400,6 +483,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::diagnose_network][super::super::client::EdgeNetwork::diagnose_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DiagnoseNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiagnoseNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiagnoseNetwork(RequestBuilder<crate::model::DiagnoseNetworkRequest>);
 
@@ -447,6 +545,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::create_network][super::super::client::EdgeNetwork::create_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::CreateNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNetwork(RequestBuilder<crate::model::CreateNetworkRequest>);
 
@@ -557,6 +671,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::delete_network][super::super::client::EdgeNetwork::delete_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DeleteNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNetwork(RequestBuilder<crate::model::DeleteNetworkRequest>);
 
@@ -650,6 +780,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_subnets][super::super::client::EdgeNetwork::list_subnets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListSubnets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSubnets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSubnets(RequestBuilder<crate::model::ListSubnetsRequest>);
 
@@ -745,6 +894,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_subnet][super::super::client::EdgeNetwork::get_subnet] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetSubnet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSubnet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSubnet(RequestBuilder<crate::model::GetSubnetRequest>);
 
@@ -792,6 +956,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::create_subnet][super::super::client::EdgeNetwork::create_subnet] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::CreateSubnet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSubnet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSubnet(RequestBuilder<crate::model::CreateSubnetRequest>);
 
@@ -902,6 +1082,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::update_subnet][super::super::client::EdgeNetwork::update_subnet] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::UpdateSubnet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSubnet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSubnet(RequestBuilder<crate::model::UpdateSubnetRequest>);
 
@@ -1007,6 +1203,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::delete_subnet][super::super::client::EdgeNetwork::delete_subnet] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DeleteSubnet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSubnet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSubnet(RequestBuilder<crate::model::DeleteSubnetRequest>);
 
@@ -1100,6 +1312,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_interconnects][super::super::client::EdgeNetwork::list_interconnects] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListInterconnects;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInterconnects {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInterconnects(RequestBuilder<crate::model::ListInterconnectsRequest>);
 
@@ -1198,6 +1429,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_interconnect][super::super::client::EdgeNetwork::get_interconnect] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetInterconnect;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInterconnect {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInterconnect(RequestBuilder<crate::model::GetInterconnectRequest>);
 
@@ -1245,6 +1491,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::diagnose_interconnect][super::super::client::EdgeNetwork::diagnose_interconnect] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DiagnoseInterconnect;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiagnoseInterconnect {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiagnoseInterconnect(RequestBuilder<crate::model::DiagnoseInterconnectRequest>);
 
@@ -1295,6 +1556,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_interconnect_attachments][super::super::client::EdgeNetwork::list_interconnect_attachments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListInterconnectAttachments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInterconnectAttachments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInterconnectAttachments(
         RequestBuilder<crate::model::ListInterconnectAttachmentsRequest>,
@@ -1399,6 +1679,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_interconnect_attachment][super::super::client::EdgeNetwork::get_interconnect_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetInterconnectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInterconnectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInterconnectAttachment(
         RequestBuilder<crate::model::GetInterconnectAttachmentRequest>,
@@ -1451,6 +1746,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::create_interconnect_attachment][super::super::client::EdgeNetwork::create_interconnect_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::CreateInterconnectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInterconnectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInterconnectAttachment(
         RequestBuilder<crate::model::CreateInterconnectAttachmentRequest>,
@@ -1574,6 +1885,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::delete_interconnect_attachment][super::super::client::EdgeNetwork::delete_interconnect_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DeleteInterconnectAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInterconnectAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInterconnectAttachment(
         RequestBuilder<crate::model::DeleteInterconnectAttachmentRequest>,
@@ -1672,6 +1999,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_routers][super::super::client::EdgeNetwork::list_routers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListRouters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRouters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRouters(RequestBuilder<crate::model::ListRoutersRequest>);
 
@@ -1767,6 +2113,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_router][super::super::client::EdgeNetwork::get_router] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetRouter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRouter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRouter(RequestBuilder<crate::model::GetRouterRequest>);
 
@@ -1814,6 +2175,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::diagnose_router][super::super::client::EdgeNetwork::diagnose_router] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DiagnoseRouter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiagnoseRouter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiagnoseRouter(RequestBuilder<crate::model::DiagnoseRouterRequest>);
 
@@ -1861,6 +2237,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::create_router][super::super::client::EdgeNetwork::create_router] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::CreateRouter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRouter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRouter(RequestBuilder<crate::model::CreateRouterRequest>);
 
@@ -1971,6 +2363,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::update_router][super::super::client::EdgeNetwork::update_router] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::UpdateRouter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRouter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRouter(RequestBuilder<crate::model::UpdateRouterRequest>);
 
@@ -2076,6 +2484,22 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::delete_router][super::super::client::EdgeNetwork::delete_router] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DeleteRouter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_edgenetwork_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRouter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRouter(RequestBuilder<crate::model::DeleteRouterRequest>);
 
@@ -2169,6 +2593,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_locations][super::super::client::EdgeNetwork::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2259,6 +2702,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_location][super::super::client::EdgeNetwork::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2304,6 +2762,25 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::list_operations][super::super::client::EdgeNetwork::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2396,6 +2873,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::get_operation][super::super::client::EdgeNetwork::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2444,6 +2936,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::delete_operation][super::super::client::EdgeNetwork::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2492,6 +2999,21 @@ pub mod edge_network {
     }
 
     /// The request builder for [EdgeNetwork::cancel_operation][super::super::client::EdgeNetwork::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_edgenetwork_v1::builder;
+    /// use builder::edge_network::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/essentialcontacts/v1/src/builder.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod essential_contacts_service {
     }
 
     /// The request builder for [EssentialContactsService::create_contact][super::super::client::EssentialContactsService::create_contact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_essentialcontacts_v1::builder;
+    /// use builder::essential_contacts_service::CreateContact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateContact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateContact(RequestBuilder<crate::model::CreateContactRequest>);
 
@@ -127,6 +142,21 @@ pub mod essential_contacts_service {
     }
 
     /// The request builder for [EssentialContactsService::update_contact][super::super::client::EssentialContactsService::update_contact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_essentialcontacts_v1::builder;
+    /// use builder::essential_contacts_service::UpdateContact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateContact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateContact(RequestBuilder<crate::model::UpdateContactRequest>);
 
@@ -186,6 +216,25 @@ pub mod essential_contacts_service {
     }
 
     /// The request builder for [EssentialContactsService::list_contacts][super::super::client::EssentialContactsService::list_contacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_essentialcontacts_v1::builder;
+    /// use builder::essential_contacts_service::ListContacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListContacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListContacts(RequestBuilder<crate::model::ListContactsRequest>);
 
@@ -269,6 +318,21 @@ pub mod essential_contacts_service {
     }
 
     /// The request builder for [EssentialContactsService::get_contact][super::super::client::EssentialContactsService::get_contact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_essentialcontacts_v1::builder;
+    /// use builder::essential_contacts_service::GetContact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetContact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetContact(RequestBuilder<crate::model::GetContactRequest>);
 
@@ -316,6 +380,21 @@ pub mod essential_contacts_service {
     }
 
     /// The request builder for [EssentialContactsService::delete_contact][super::super::client::EssentialContactsService::delete_contact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_essentialcontacts_v1::builder;
+    /// use builder::essential_contacts_service::DeleteContact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteContact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteContact(RequestBuilder<crate::model::DeleteContactRequest>);
 
@@ -363,6 +442,25 @@ pub mod essential_contacts_service {
     }
 
     /// The request builder for [EssentialContactsService::compute_contacts][super::super::client::EssentialContactsService::compute_contacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_essentialcontacts_v1::builder;
+    /// use builder::essential_contacts_service::ComputeContacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ComputeContacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ComputeContacts(RequestBuilder<crate::model::ComputeContactsRequest>);
 
@@ -457,6 +555,21 @@ pub mod essential_contacts_service {
     }
 
     /// The request builder for [EssentialContactsService::send_test_message][super::super::client::EssentialContactsService::send_test_message] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_essentialcontacts_v1::builder;
+    /// use builder::essential_contacts_service::SendTestMessage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SendTestMessage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SendTestMessage(RequestBuilder<crate::model::SendTestMessageRequest>);
 

--- a/src/generated/cloud/eventarc/v1/src/builder.rs
+++ b/src/generated/cloud/eventarc/v1/src/builder.rs
@@ -67,6 +67,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_trigger][super::super::client::Eventarc::get_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTrigger(RequestBuilder<crate::model::GetTriggerRequest>);
 
@@ -112,6 +127,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_triggers][super::super::client::Eventarc::list_triggers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListTriggers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTriggers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTriggers(RequestBuilder<crate::model::ListTriggersRequest>);
 
@@ -205,6 +239,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::create_trigger][super::super::client::Eventarc::create_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CreateTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTrigger(RequestBuilder<crate::model::CreateTriggerRequest>);
 
@@ -313,6 +363,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::update_trigger][super::super::client::Eventarc::update_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::UpdateTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTrigger(RequestBuilder<crate::model::UpdateTriggerRequest>);
 
@@ -418,6 +484,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_trigger][super::super::client::Eventarc::delete_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeleteTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTrigger(RequestBuilder<crate::model::DeleteTriggerRequest>);
 
@@ -519,6 +601,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_channel][super::super::client::Eventarc::get_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetChannel(RequestBuilder<crate::model::GetChannelRequest>);
 
@@ -564,6 +661,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_channels][super::super::client::Eventarc::list_channels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListChannels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListChannels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListChannels(RequestBuilder<crate::model::ListChannelsRequest>);
 
@@ -651,6 +767,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::create_channel][super::super::client::Eventarc::create_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CreateChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateChannel(RequestBuilder<crate::model::CreateChannelRequest>);
 
@@ -759,6 +891,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::update_channel][super::super::client::Eventarc::update_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::UpdateChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateChannel(RequestBuilder<crate::model::UpdateChannelRequest>);
 
@@ -858,6 +1006,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_channel][super::super::client::Eventarc::delete_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeleteChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteChannel(RequestBuilder<crate::model::DeleteChannelRequest>);
 
@@ -947,6 +1111,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_provider][super::super::client::Eventarc::get_provider] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetProvider;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProvider {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProvider(RequestBuilder<crate::model::GetProviderRequest>);
 
@@ -992,6 +1171,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_providers][super::super::client::Eventarc::list_providers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListProviders;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProviders {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProviders(RequestBuilder<crate::model::ListProvidersRequest>);
 
@@ -1085,6 +1283,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_channel_connection][super::super::client::Eventarc::get_channel_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetChannelConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetChannelConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetChannelConnection(RequestBuilder<crate::model::GetChannelConnectionRequest>);
 
@@ -1133,6 +1346,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_channel_connections][super::super::client::Eventarc::list_channel_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListChannelConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListChannelConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListChannelConnections(RequestBuilder<crate::model::ListChannelConnectionsRequest>);
 
@@ -1221,6 +1453,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::create_channel_connection][super::super::client::Eventarc::create_channel_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CreateChannelConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateChannelConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateChannelConnection(
         RequestBuilder<crate::model::CreateChannelConnectionRequest>,
@@ -1333,6 +1581,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_channel_connection][super::super::client::Eventarc::delete_channel_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeleteChannelConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteChannelConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteChannelConnection(
         RequestBuilder<crate::model::DeleteChannelConnectionRequest>,
@@ -1424,6 +1688,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_google_channel_config][super::super::client::Eventarc::get_google_channel_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetGoogleChannelConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGoogleChannelConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGoogleChannelConfig(RequestBuilder<crate::model::GetGoogleChannelConfigRequest>);
 
@@ -1472,6 +1751,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::update_google_channel_config][super::super::client::Eventarc::update_google_channel_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::UpdateGoogleChannelConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGoogleChannelConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGoogleChannelConfig(
         RequestBuilder<crate::model::UpdateGoogleChannelConfigRequest>,
@@ -1536,6 +1830,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_message_bus][super::super::client::Eventarc::get_message_bus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetMessageBus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMessageBus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMessageBus(RequestBuilder<crate::model::GetMessageBusRequest>);
 
@@ -1581,6 +1890,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_message_buses][super::super::client::Eventarc::list_message_buses] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListMessageBuses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMessageBuses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMessageBuses(RequestBuilder<crate::model::ListMessageBusesRequest>);
 
@@ -1677,6 +2005,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_message_bus_enrollments][super::super::client::Eventarc::list_message_bus_enrollments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListMessageBusEnrollments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMessageBusEnrollments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMessageBusEnrollments(
         RequestBuilder<crate::model::ListMessageBusEnrollmentsRequest>,
@@ -1739,6 +2082,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::create_message_bus][super::super::client::Eventarc::create_message_bus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CreateMessageBus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMessageBus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMessageBus(RequestBuilder<crate::model::CreateMessageBusRequest>);
 
@@ -1850,6 +2209,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::update_message_bus][super::super::client::Eventarc::update_message_bus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::UpdateMessageBus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMessageBus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMessageBus(RequestBuilder<crate::model::UpdateMessageBusRequest>);
 
@@ -1960,6 +2335,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_message_bus][super::super::client::Eventarc::delete_message_bus] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeleteMessageBus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMessageBus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMessageBus(RequestBuilder<crate::model::DeleteMessageBusRequest>);
 
@@ -2064,6 +2455,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_enrollment][super::super::client::Eventarc::get_enrollment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetEnrollment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnrollment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnrollment(RequestBuilder<crate::model::GetEnrollmentRequest>);
 
@@ -2109,6 +2515,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_enrollments][super::super::client::Eventarc::list_enrollments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListEnrollments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEnrollments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEnrollments(RequestBuilder<crate::model::ListEnrollmentsRequest>);
 
@@ -2202,6 +2627,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::create_enrollment][super::super::client::Eventarc::create_enrollment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CreateEnrollment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEnrollment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEnrollment(RequestBuilder<crate::model::CreateEnrollmentRequest>);
 
@@ -2313,6 +2754,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::update_enrollment][super::super::client::Eventarc::update_enrollment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::UpdateEnrollment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEnrollment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEnrollment(RequestBuilder<crate::model::UpdateEnrollmentRequest>);
 
@@ -2423,6 +2880,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_enrollment][super::super::client::Eventarc::delete_enrollment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeleteEnrollment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEnrollment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEnrollment(RequestBuilder<crate::model::DeleteEnrollmentRequest>);
 
@@ -2527,6 +3000,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_pipeline][super::super::client::Eventarc::get_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetPipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPipeline(RequestBuilder<crate::model::GetPipelineRequest>);
 
@@ -2572,6 +3060,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_pipelines][super::super::client::Eventarc::list_pipelines] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListPipelines;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPipelines {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPipelines(RequestBuilder<crate::model::ListPipelinesRequest>);
 
@@ -2665,6 +3172,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::create_pipeline][super::super::client::Eventarc::create_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CreatePipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePipeline(RequestBuilder<crate::model::CreatePipelineRequest>);
 
@@ -2773,6 +3296,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::update_pipeline][super::super::client::Eventarc::update_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::UpdatePipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePipeline(RequestBuilder<crate::model::UpdatePipelineRequest>);
 
@@ -2880,6 +3419,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_pipeline][super::super::client::Eventarc::delete_pipeline] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeletePipeline;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePipeline {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePipeline(RequestBuilder<crate::model::DeletePipelineRequest>);
 
@@ -2981,6 +3536,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_google_api_source][super::super::client::Eventarc::get_google_api_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetGoogleApiSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGoogleApiSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGoogleApiSource(RequestBuilder<crate::model::GetGoogleApiSourceRequest>);
 
@@ -3029,6 +3599,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_google_api_sources][super::super::client::Eventarc::list_google_api_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListGoogleApiSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGoogleApiSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGoogleApiSources(RequestBuilder<crate::model::ListGoogleApiSourcesRequest>);
 
@@ -3127,6 +3716,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::create_google_api_source][super::super::client::Eventarc::create_google_api_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CreateGoogleApiSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGoogleApiSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGoogleApiSource(RequestBuilder<crate::model::CreateGoogleApiSourceRequest>);
 
@@ -3243,6 +3848,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::update_google_api_source][super::super::client::Eventarc::update_google_api_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::UpdateGoogleApiSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGoogleApiSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGoogleApiSource(RequestBuilder<crate::model::UpdateGoogleApiSourceRequest>);
 
@@ -3358,6 +3979,22 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_google_api_source][super::super::client::Eventarc::delete_google_api_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeleteGoogleApiSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_eventarc_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGoogleApiSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGoogleApiSource(RequestBuilder<crate::model::DeleteGoogleApiSourceRequest>);
 
@@ -3465,6 +4102,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_locations][super::super::client::Eventarc::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3553,6 +4209,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_location][super::super::client::Eventarc::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3596,6 +4267,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::set_iam_policy][super::super::client::Eventarc::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3661,6 +4347,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_iam_policy][super::super::client::Eventarc::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3715,6 +4416,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::test_iam_permissions][super::super::client::Eventarc::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3776,6 +4492,25 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::list_operations][super::super::client::Eventarc::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3866,6 +4601,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::get_operation][super::super::client::Eventarc::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3912,6 +4662,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::delete_operation][super::super::client::Eventarc::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3958,6 +4723,21 @@ pub mod eventarc {
     }
 
     /// The request builder for [Eventarc::cancel_operation][super::super::client::Eventarc::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_eventarc_v1::builder;
+    /// use builder::eventarc::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/filestore/v1/src/builder.rs
+++ b/src/generated/cloud/filestore/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::list_instances][super::super::client::CloudFilestoreManager::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -164,6 +183,21 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::get_instance][super::super::client::CloudFilestoreManager::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -211,6 +245,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::create_instance][super::super::client::CloudFilestoreManager::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -318,6 +368,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::update_instance][super::super::client::CloudFilestoreManager::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -416,6 +482,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::restore_instance][super::super::client::CloudFilestoreManager::restore_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::RestoreInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreInstance(RequestBuilder<crate::model::RestoreInstanceRequest>);
 
@@ -537,6 +619,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::revert_instance][super::super::client::CloudFilestoreManager::revert_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::RevertInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RevertInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RevertInstance(RequestBuilder<crate::model::RevertInstanceRequest>);
 
@@ -633,6 +731,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::delete_instance][super::super::client::CloudFilestoreManager::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -727,6 +841,25 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::list_snapshots][super::super::client::CloudFilestoreManager::list_snapshots] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::ListSnapshots;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSnapshots {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSnapshots(RequestBuilder<crate::model::ListSnapshotsRequest>);
 
@@ -828,6 +961,21 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::get_snapshot][super::super::client::CloudFilestoreManager::get_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::GetSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSnapshot(RequestBuilder<crate::model::GetSnapshotRequest>);
 
@@ -875,6 +1023,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::create_snapshot][super::super::client::CloudFilestoreManager::create_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::CreateSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSnapshot(RequestBuilder<crate::model::CreateSnapshotRequest>);
 
@@ -982,6 +1146,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::delete_snapshot][super::super::client::CloudFilestoreManager::delete_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::DeleteSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSnapshot(RequestBuilder<crate::model::DeleteSnapshotRequest>);
 
@@ -1070,6 +1250,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::update_snapshot][super::super::client::CloudFilestoreManager::update_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::UpdateSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSnapshot(RequestBuilder<crate::model::UpdateSnapshotRequest>);
 
@@ -1172,6 +1368,25 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::list_backups][super::super::client::CloudFilestoreManager::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1267,6 +1482,21 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::get_backup][super::super::client::CloudFilestoreManager::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1314,6 +1544,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::create_backup][super::super::client::CloudFilestoreManager::create_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::CreateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -1421,6 +1667,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::delete_backup][super::super::client::CloudFilestoreManager::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1509,6 +1771,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::update_backup][super::super::client::CloudFilestoreManager::update_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::UpdateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -1611,6 +1889,22 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::promote_replica][super::super::client::CloudFilestoreManager::promote_replica] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::PromoteReplica;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_filestore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PromoteReplica {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PromoteReplica(RequestBuilder<crate::model::PromoteReplicaRequest>);
 
@@ -1705,6 +1999,25 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::list_locations][super::super::client::CloudFilestoreManager::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1795,6 +2108,21 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::get_location][super::super::client::CloudFilestoreManager::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1840,6 +2168,25 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::list_operations][super::super::client::CloudFilestoreManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1932,6 +2279,21 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::get_operation][super::super::client::CloudFilestoreManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1980,6 +2342,21 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::delete_operation][super::super::client::CloudFilestoreManager::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2028,6 +2405,21 @@ pub mod cloud_filestore_manager {
     }
 
     /// The request builder for [CloudFilestoreManager::cancel_operation][super::super::client::CloudFilestoreManager::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_filestore_v1::builder;
+    /// use builder::cloud_filestore_manager::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/financialservices/v1/src/builder.rs
+++ b/src/generated/cloud/financialservices/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_instances][super::super::client::Aml::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -160,6 +179,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_instance][super::super::client::Aml::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -205,6 +239,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::create_instance][super::super::client::Aml::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -313,6 +363,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::update_instance][super::super::client::Aml::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -414,6 +480,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::delete_instance][super::super::client::Aml::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -505,6 +587,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::import_registered_parties][super::super::client::Aml::import_registered_parties] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ImportRegisteredParties;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportRegisteredParties {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportRegisteredParties(
         RequestBuilder<crate::model::ImportRegisteredPartiesRequest>,
@@ -634,6 +732,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::export_registered_parties][super::super::client::Aml::export_registered_parties] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ExportRegisteredParties;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportRegisteredParties {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportRegisteredParties(
         RequestBuilder<crate::model::ExportRegisteredPartiesRequest>,
@@ -746,6 +860,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_datasets][super::super::client::Aml::list_datasets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListDatasets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatasets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -839,6 +972,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_dataset][super::super::client::Aml::get_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -884,6 +1032,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::create_dataset][super::super::client::Aml::create_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::CreateDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataset(RequestBuilder<crate::model::CreateDatasetRequest>);
 
@@ -992,6 +1156,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::update_dataset][super::super::client::Aml::update_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::UpdateDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDataset(RequestBuilder<crate::model::UpdateDatasetRequest>);
 
@@ -1093,6 +1273,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::delete_dataset][super::super::client::Aml::delete_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::DeleteDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -1184,6 +1380,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_models][super::super::client::Aml::list_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -1277,6 +1492,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_model][super::super::client::Aml::get_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -1322,6 +1552,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::create_model][super::super::client::Aml::create_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::CreateModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateModel(RequestBuilder<crate::model::CreateModelRequest>);
 
@@ -1430,6 +1676,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::update_model][super::super::client::Aml::update_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::UpdateModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateModel(RequestBuilder<crate::model::UpdateModelRequest>);
 
@@ -1531,6 +1793,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::export_model_metadata][super::super::client::Aml::export_model_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ExportModelMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportModelMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportModelMetadata(RequestBuilder<crate::model::ExportModelMetadataRequest>);
 
@@ -1633,6 +1911,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::delete_model][super::super::client::Aml::delete_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::DeleteModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -1724,6 +2018,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_engine_configs][super::super::client::Aml::list_engine_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListEngineConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEngineConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEngineConfigs(RequestBuilder<crate::model::ListEngineConfigsRequest>);
 
@@ -1820,6 +2133,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_engine_config][super::super::client::Aml::get_engine_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetEngineConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEngineConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEngineConfig(RequestBuilder<crate::model::GetEngineConfigRequest>);
 
@@ -1865,6 +2193,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::create_engine_config][super::super::client::Aml::create_engine_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::CreateEngineConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEngineConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEngineConfig(RequestBuilder<crate::model::CreateEngineConfigRequest>);
 
@@ -1978,6 +2322,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::update_engine_config][super::super::client::Aml::update_engine_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::UpdateEngineConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEngineConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEngineConfig(RequestBuilder<crate::model::UpdateEngineConfigRequest>);
 
@@ -2084,6 +2444,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::export_engine_config_metadata][super::super::client::Aml::export_engine_config_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ExportEngineConfigMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportEngineConfigMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportEngineConfigMetadata(
         RequestBuilder<crate::model::ExportEngineConfigMetadataRequest>,
@@ -2190,6 +2566,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::delete_engine_config][super::super::client::Aml::delete_engine_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::DeleteEngineConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEngineConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEngineConfig(RequestBuilder<crate::model::DeleteEngineConfigRequest>);
 
@@ -2284,6 +2676,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_engine_version][super::super::client::Aml::get_engine_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetEngineVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEngineVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEngineVersion(RequestBuilder<crate::model::GetEngineVersionRequest>);
 
@@ -2332,6 +2739,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_engine_versions][super::super::client::Aml::list_engine_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListEngineVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEngineVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEngineVersions(RequestBuilder<crate::model::ListEngineVersionsRequest>);
 
@@ -2430,6 +2856,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_prediction_results][super::super::client::Aml::list_prediction_results] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListPredictionResults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPredictionResults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPredictionResults(RequestBuilder<crate::model::ListPredictionResultsRequest>);
 
@@ -2528,6 +2973,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_prediction_result][super::super::client::Aml::get_prediction_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetPredictionResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPredictionResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPredictionResult(RequestBuilder<crate::model::GetPredictionResultRequest>);
 
@@ -2576,6 +3036,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::create_prediction_result][super::super::client::Aml::create_prediction_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::CreatePredictionResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePredictionResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePredictionResult(RequestBuilder<crate::model::CreatePredictionResultRequest>);
 
@@ -2692,6 +3168,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::update_prediction_result][super::super::client::Aml::update_prediction_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::UpdatePredictionResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePredictionResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePredictionResult(RequestBuilder<crate::model::UpdatePredictionResultRequest>);
 
@@ -2801,6 +3293,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::export_prediction_result_metadata][super::super::client::Aml::export_prediction_result_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ExportPredictionResultMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportPredictionResultMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportPredictionResultMetadata(
         RequestBuilder<crate::model::ExportPredictionResultMetadataRequest>,
@@ -2907,6 +3415,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::delete_prediction_result][super::super::client::Aml::delete_prediction_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::DeletePredictionResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePredictionResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePredictionResult(RequestBuilder<crate::model::DeletePredictionResultRequest>);
 
@@ -3001,6 +3525,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_backtest_results][super::super::client::Aml::list_backtest_results] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListBacktestResults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBacktestResults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBacktestResults(RequestBuilder<crate::model::ListBacktestResultsRequest>);
 
@@ -3099,6 +3642,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_backtest_result][super::super::client::Aml::get_backtest_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetBacktestResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBacktestResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBacktestResult(RequestBuilder<crate::model::GetBacktestResultRequest>);
 
@@ -3147,6 +3705,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::create_backtest_result][super::super::client::Aml::create_backtest_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::CreateBacktestResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBacktestResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBacktestResult(RequestBuilder<crate::model::CreateBacktestResultRequest>);
 
@@ -3261,6 +3835,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::update_backtest_result][super::super::client::Aml::update_backtest_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::UpdateBacktestResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBacktestResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBacktestResult(RequestBuilder<crate::model::UpdateBacktestResultRequest>);
 
@@ -3368,6 +3958,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::export_backtest_result_metadata][super::super::client::Aml::export_backtest_result_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ExportBacktestResultMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportBacktestResultMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportBacktestResultMetadata(
         RequestBuilder<crate::model::ExportBacktestResultMetadataRequest>,
@@ -3474,6 +4080,22 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::delete_backtest_result][super::super::client::Aml::delete_backtest_result] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::DeleteBacktestResult;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_financialservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBacktestResult {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBacktestResult(RequestBuilder<crate::model::DeleteBacktestResultRequest>);
 
@@ -3568,6 +4190,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_locations][super::super::client::Aml::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3656,6 +4297,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_location][super::super::client::Aml::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3699,6 +4355,25 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::list_operations][super::super::client::Aml::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3789,6 +4464,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::get_operation][super::super::client::Aml::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3835,6 +4525,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::delete_operation][super::super::client::Aml::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3881,6 +4586,21 @@ pub mod aml {
     }
 
     /// The request builder for [Aml::cancel_operation][super::super::client::Aml::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_financialservices_v1::builder;
+    /// use builder::aml::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/functions/v2/src/builder.rs
+++ b/src/generated/cloud/functions/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::get_function][super::super::client::FunctionService::get_function] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::GetFunction;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFunction {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFunction(RequestBuilder<crate::model::GetFunctionRequest>);
 
@@ -122,6 +137,25 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::list_functions][super::super::client::FunctionService::list_functions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::ListFunctions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFunctions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFunctions(RequestBuilder<crate::model::ListFunctionsRequest>);
 
@@ -217,6 +251,22 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::create_function][super::super::client::FunctionService::create_function] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::CreateFunction;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_functions_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFunction {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFunction(RequestBuilder<crate::model::CreateFunctionRequest>);
 
@@ -319,6 +369,22 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::update_function][super::super::client::FunctionService::update_function] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::UpdateFunction;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_functions_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFunction {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFunction(RequestBuilder<crate::model::UpdateFunctionRequest>);
 
@@ -416,6 +482,22 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::delete_function][super::super::client::FunctionService::delete_function] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::DeleteFunction;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_functions_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFunction {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFunction(RequestBuilder<crate::model::DeleteFunctionRequest>);
 
@@ -503,6 +585,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::generate_upload_url][super::super::client::FunctionService::generate_upload_url] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::GenerateUploadUrl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateUploadUrl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateUploadUrl(RequestBuilder<crate::model::GenerateUploadUrlRequest>);
 
@@ -565,6 +662,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::generate_download_url][super::super::client::FunctionService::generate_download_url] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::GenerateDownloadUrl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateDownloadUrl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateDownloadUrl(RequestBuilder<crate::model::GenerateDownloadUrlRequest>);
 
@@ -615,6 +727,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::list_runtimes][super::super::client::FunctionService::list_runtimes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::ListRuntimes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuntimes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuntimes(RequestBuilder<crate::model::ListRuntimesRequest>);
 
@@ -668,6 +795,25 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::list_locations][super::super::client::FunctionService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -758,6 +904,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::set_iam_policy][super::super::client::FunctionService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -825,6 +986,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::get_iam_policy][super::super::client::FunctionService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -881,6 +1057,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::test_iam_permissions][super::super::client::FunctionService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -944,6 +1135,25 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::list_operations][super::super::client::FunctionService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1036,6 +1246,21 @@ pub mod function_service {
     }
 
     /// The request builder for [FunctionService::get_operation][super::super::client::FunctionService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_functions_v2::builder;
+    /// use builder::function_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/gkebackup/v1/src/builder.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::create_backup_plan][super::super::client::BackupForGKE::create_backup_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::CreateBackupPlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupPlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupPlan(RequestBuilder<crate::model::CreateBackupPlanRequest>);
 
@@ -176,6 +192,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_backup_plans][super::super::client::BackupForGKE::list_backup_plans] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListBackupPlans;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupPlans {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupPlans(RequestBuilder<crate::model::ListBackupPlansRequest>);
 
@@ -271,6 +306,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_backup_plan][super::super::client::BackupForGKE::get_backup_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetBackupPlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupPlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupPlan(RequestBuilder<crate::model::GetBackupPlanRequest>);
 
@@ -318,6 +368,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::update_backup_plan][super::super::client::BackupForGKE::update_backup_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::UpdateBackupPlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackupPlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackupPlan(RequestBuilder<crate::model::UpdateBackupPlanRequest>);
 
@@ -418,6 +484,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::delete_backup_plan][super::super::client::BackupForGKE::delete_backup_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::DeleteBackupPlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupPlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPlan(RequestBuilder<crate::model::DeleteBackupPlanRequest>);
 
@@ -514,6 +596,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::create_backup_channel][super::super::client::BackupForGKE::create_backup_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::CreateBackupChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupChannel(RequestBuilder<crate::model::CreateBackupChannelRequest>);
 
@@ -622,6 +720,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_backup_channels][super::super::client::BackupForGKE::list_backup_channels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListBackupChannels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupChannels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupChannels(RequestBuilder<crate::model::ListBackupChannelsRequest>);
 
@@ -722,6 +839,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_backup_channel][super::super::client::BackupForGKE::get_backup_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetBackupChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupChannel(RequestBuilder<crate::model::GetBackupChannelRequest>);
 
@@ -772,6 +904,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::update_backup_channel][super::super::client::BackupForGKE::update_backup_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::UpdateBackupChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackupChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackupChannel(RequestBuilder<crate::model::UpdateBackupChannelRequest>);
 
@@ -875,6 +1023,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::delete_backup_channel][super::super::client::BackupForGKE::delete_backup_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::DeleteBackupChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupChannel(RequestBuilder<crate::model::DeleteBackupChannelRequest>);
 
@@ -977,6 +1141,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_backup_plan_bindings][super::super::client::BackupForGKE::list_backup_plan_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListBackupPlanBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupPlanBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupPlanBindings(RequestBuilder<crate::model::ListBackupPlanBindingsRequest>);
 
@@ -1079,6 +1262,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_backup_plan_binding][super::super::client::BackupForGKE::get_backup_plan_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetBackupPlanBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupPlanBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupPlanBinding(RequestBuilder<crate::model::GetBackupPlanBindingRequest>);
 
@@ -1129,6 +1327,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::create_backup][super::super::client::BackupForGKE::create_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::CreateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -1229,6 +1443,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_backups][super::super::client::BackupForGKE::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1330,6 +1563,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_backup][super::super::client::BackupForGKE::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1377,6 +1625,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::update_backup][super::super::client::BackupForGKE::update_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::UpdateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -1474,6 +1738,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::delete_backup][super::super::client::BackupForGKE::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1573,6 +1853,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_volume_backups][super::super::client::BackupForGKE::list_volume_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListVolumeBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVolumeBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVolumeBackups(RequestBuilder<crate::model::ListVolumeBackupsRequest>);
 
@@ -1671,6 +1970,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_volume_backup][super::super::client::BackupForGKE::get_volume_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetVolumeBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVolumeBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVolumeBackup(RequestBuilder<crate::model::GetVolumeBackupRequest>);
 
@@ -1718,6 +2032,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::create_restore_plan][super::super::client::BackupForGKE::create_restore_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::CreateRestorePlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRestorePlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRestorePlan(RequestBuilder<crate::model::CreateRestorePlanRequest>);
 
@@ -1827,6 +2157,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_restore_plans][super::super::client::BackupForGKE::list_restore_plans] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListRestorePlans;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRestorePlans {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRestorePlans(RequestBuilder<crate::model::ListRestorePlansRequest>);
 
@@ -1925,6 +2274,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_restore_plan][super::super::client::BackupForGKE::get_restore_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetRestorePlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRestorePlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRestorePlan(RequestBuilder<crate::model::GetRestorePlanRequest>);
 
@@ -1972,6 +2336,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::update_restore_plan][super::super::client::BackupForGKE::update_restore_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::UpdateRestorePlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRestorePlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRestorePlan(RequestBuilder<crate::model::UpdateRestorePlanRequest>);
 
@@ -2074,6 +2454,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::delete_restore_plan][super::super::client::BackupForGKE::delete_restore_plan] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::DeleteRestorePlan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRestorePlan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRestorePlan(RequestBuilder<crate::model::DeleteRestorePlanRequest>);
 
@@ -2176,6 +2572,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::create_restore_channel][super::super::client::BackupForGKE::create_restore_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::CreateRestoreChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRestoreChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRestoreChannel(RequestBuilder<crate::model::CreateRestoreChannelRequest>);
 
@@ -2284,6 +2696,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_restore_channels][super::super::client::BackupForGKE::list_restore_channels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListRestoreChannels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRestoreChannels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRestoreChannels(RequestBuilder<crate::model::ListRestoreChannelsRequest>);
 
@@ -2384,6 +2815,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_restore_channel][super::super::client::BackupForGKE::get_restore_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetRestoreChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRestoreChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRestoreChannel(RequestBuilder<crate::model::GetRestoreChannelRequest>);
 
@@ -2434,6 +2880,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::update_restore_channel][super::super::client::BackupForGKE::update_restore_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::UpdateRestoreChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRestoreChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRestoreChannel(RequestBuilder<crate::model::UpdateRestoreChannelRequest>);
 
@@ -2537,6 +2999,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::delete_restore_channel][super::super::client::BackupForGKE::delete_restore_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::DeleteRestoreChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRestoreChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRestoreChannel(RequestBuilder<crate::model::DeleteRestoreChannelRequest>);
 
@@ -2633,6 +3111,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_restore_plan_bindings][super::super::client::BackupForGKE::list_restore_plan_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListRestorePlanBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRestorePlanBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRestorePlanBindings(
         RequestBuilder<crate::model::ListRestorePlanBindingsRequest>,
@@ -2737,6 +3234,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_restore_plan_binding][super::super::client::BackupForGKE::get_restore_plan_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetRestorePlanBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRestorePlanBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRestorePlanBinding(RequestBuilder<crate::model::GetRestorePlanBindingRequest>);
 
@@ -2787,6 +3299,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::create_restore][super::super::client::BackupForGKE::create_restore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::CreateRestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRestore(RequestBuilder<crate::model::CreateRestoreRequest>);
 
@@ -2891,6 +3419,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_restores][super::super::client::BackupForGKE::list_restores] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListRestores;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRestores {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRestores(RequestBuilder<crate::model::ListRestoresRequest>);
 
@@ -2986,6 +3533,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_restore][super::super::client::BackupForGKE::get_restore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetRestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRestore(RequestBuilder<crate::model::GetRestoreRequest>);
 
@@ -3033,6 +3595,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::update_restore][super::super::client::BackupForGKE::update_restore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::UpdateRestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRestore(RequestBuilder<crate::model::UpdateRestoreRequest>);
 
@@ -3130,6 +3708,22 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::delete_restore][super::super::client::BackupForGKE::delete_restore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::DeleteRestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkebackup_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRestore(RequestBuilder<crate::model::DeleteRestoreRequest>);
 
@@ -3229,6 +3823,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_volume_restores][super::super::client::BackupForGKE::list_volume_restores] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListVolumeRestores;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVolumeRestores {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVolumeRestores(RequestBuilder<crate::model::ListVolumeRestoresRequest>);
 
@@ -3329,6 +3942,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_volume_restore][super::super::client::BackupForGKE::get_volume_restore] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetVolumeRestore;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVolumeRestore {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVolumeRestore(RequestBuilder<crate::model::GetVolumeRestoreRequest>);
 
@@ -3379,6 +4007,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_backup_index_download_url][super::super::client::BackupForGKE::get_backup_index_download_url] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetBackupIndexDownloadUrl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupIndexDownloadUrl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupIndexDownloadUrl(
         RequestBuilder<crate::model::GetBackupIndexDownloadUrlRequest>,
@@ -3431,6 +4074,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_locations][super::super::client::BackupForGKE::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3521,6 +4183,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_location][super::super::client::BackupForGKE::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3566,6 +4243,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::set_iam_policy][super::super::client::BackupForGKE::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3633,6 +4325,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_iam_policy][super::super::client::BackupForGKE::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3689,6 +4396,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::test_iam_permissions][super::super::client::BackupForGKE::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3752,6 +4474,25 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::list_operations][super::super::client::BackupForGKE::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3844,6 +4585,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::get_operation][super::super::client::BackupForGKE::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3892,6 +4648,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::delete_operation][super::super::client::BackupForGKE::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3940,6 +4711,21 @@ pub mod backup_for_gke {
     }
 
     /// The request builder for [BackupForGKE::cancel_operation][super::super::client::BackupForGKE::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkebackup_v1::builder;
+    /// use builder::backup_for_gke::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod gateway_control {
     }
 
     /// The request builder for [GatewayControl::generate_credentials][super::super::client::GatewayControl::generate_credentials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkeconnect_gateway_v1::builder;
+    /// use builder::gateway_control::GenerateCredentials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateCredentials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateCredentials(RequestBuilder<crate::model::GenerateCredentialsRequest>);
 

--- a/src/generated/cloud/gkehub/v1/src/builder.rs
+++ b/src/generated/cloud/gkehub/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::list_memberships][super::super::client::GkeHub::list_memberships] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::ListMemberships;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMemberships {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMemberships(RequestBuilder<crate::model::ListMembershipsRequest>);
 
@@ -160,6 +179,25 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::list_features][super::super::client::GkeHub::list_features] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::ListFeatures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFeatures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFeatures(RequestBuilder<crate::model::ListFeaturesRequest>);
 
@@ -251,6 +289,21 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::get_membership][super::super::client::GkeHub::get_membership] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::GetMembership;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMembership {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMembership(RequestBuilder<crate::model::GetMembershipRequest>);
 
@@ -296,6 +349,21 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::get_feature][super::super::client::GkeHub::get_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::GetFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFeature(RequestBuilder<crate::model::GetFeatureRequest>);
 
@@ -339,6 +407,22 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::create_membership][super::super::client::GkeHub::create_membership] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::CreateMembership;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkehub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMembership {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMembership(RequestBuilder<crate::model::CreateMembershipRequest>);
 
@@ -450,6 +534,22 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::create_feature][super::super::client::GkeHub::create_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::CreateFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkehub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFeature(RequestBuilder<crate::model::CreateFeatureRequest>);
 
@@ -552,6 +652,22 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::delete_membership][super::super::client::GkeHub::delete_membership] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::DeleteMembership;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkehub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMembership {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMembership(RequestBuilder<crate::model::DeleteMembershipRequest>);
 
@@ -652,6 +768,22 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::delete_feature][super::super::client::GkeHub::delete_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::DeleteFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkehub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFeature(RequestBuilder<crate::model::DeleteFeatureRequest>);
 
@@ -747,6 +879,22 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::update_membership][super::super::client::GkeHub::update_membership] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::UpdateMembership;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkehub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMembership {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMembership(RequestBuilder<crate::model::UpdateMembershipRequest>);
 
@@ -861,6 +1009,22 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::update_feature][super::super::client::GkeHub::update_feature] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::UpdateFeature;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkehub_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFeature {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFeature(RequestBuilder<crate::model::UpdateFeatureRequest>);
 
@@ -966,6 +1130,21 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::generate_connect_manifest][super::super::client::GkeHub::generate_connect_manifest] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::GenerateConnectManifest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateConnectManifest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateConnectManifest(
         RequestBuilder<crate::model::GenerateConnectManifestRequest>,
@@ -1052,6 +1231,25 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::list_operations][super::super::client::GkeHub::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1142,6 +1340,21 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::get_operation][super::super::client::GkeHub::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1188,6 +1401,21 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::delete_operation][super::super::client::GkeHub::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1234,6 +1462,21 @@ pub mod gke_hub {
     }
 
     /// The request builder for [GkeHub::cancel_operation][super::super::client::GkeHub::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkehub_v1::builder;
+    /// use builder::gke_hub::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/gkemulticloud/v1/src/builder.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::create_attached_cluster][super::super::client::AttachedClusters::create_attached_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::CreateAttachedCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAttachedCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAttachedCluster(RequestBuilder<crate::model::CreateAttachedClusterRequest>);
 
@@ -185,6 +201,22 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::update_attached_cluster][super::super::client::AttachedClusters::update_attached_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::UpdateAttachedCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAttachedCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAttachedCluster(RequestBuilder<crate::model::UpdateAttachedClusterRequest>);
 
@@ -296,6 +328,22 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::import_attached_cluster][super::super::client::AttachedClusters::import_attached_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::ImportAttachedCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportAttachedCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportAttachedCluster(RequestBuilder<crate::model::ImportAttachedClusterRequest>);
 
@@ -426,6 +474,21 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::get_attached_cluster][super::super::client::AttachedClusters::get_attached_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::GetAttachedCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAttachedCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAttachedCluster(RequestBuilder<crate::model::GetAttachedClusterRequest>);
 
@@ -476,6 +539,25 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::list_attached_clusters][super::super::client::AttachedClusters::list_attached_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::ListAttachedClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAttachedClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAttachedClusters(RequestBuilder<crate::model::ListAttachedClustersRequest>);
 
@@ -564,6 +646,22 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::delete_attached_cluster][super::super::client::AttachedClusters::delete_attached_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::DeleteAttachedCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAttachedCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAttachedCluster(RequestBuilder<crate::model::DeleteAttachedClusterRequest>);
 
@@ -678,6 +776,21 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::get_attached_server_config][super::super::client::AttachedClusters::get_attached_server_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::GetAttachedServerConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAttachedServerConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAttachedServerConfig(
         RequestBuilder<crate::model::GetAttachedServerConfigRequest>,
@@ -730,6 +843,21 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::generate_attached_cluster_install_manifest][super::super::client::AttachedClusters::generate_attached_cluster_install_manifest] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::GenerateAttachedClusterInstallManifest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAttachedClusterInstallManifest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAttachedClusterInstallManifest(
         RequestBuilder<crate::model::GenerateAttachedClusterInstallManifestRequest>,
@@ -811,6 +939,21 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::generate_attached_cluster_agent_token][super::super::client::AttachedClusters::generate_attached_cluster_agent_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::GenerateAttachedClusterAgentToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAttachedClusterAgentToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAttachedClusterAgentToken(
         RequestBuilder<crate::model::GenerateAttachedClusterAgentTokenRequest>,
@@ -917,6 +1060,25 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::list_operations][super::super::client::AttachedClusters::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1009,6 +1171,21 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::get_operation][super::super::client::AttachedClusters::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1057,6 +1234,21 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::delete_operation][super::super::client::AttachedClusters::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1105,6 +1297,21 @@ pub mod attached_clusters {
     }
 
     /// The request builder for [AttachedClusters::cancel_operation][super::super::client::AttachedClusters::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::attached_clusters::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1208,6 +1415,22 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::create_aws_cluster][super::super::client::AwsClusters::create_aws_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::CreateAwsCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAwsCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAwsCluster(RequestBuilder<crate::model::CreateAwsClusterRequest>);
 
@@ -1321,6 +1544,22 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::update_aws_cluster][super::super::client::AwsClusters::update_aws_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::UpdateAwsCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAwsCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAwsCluster(RequestBuilder<crate::model::UpdateAwsClusterRequest>);
 
@@ -1429,6 +1668,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::get_aws_cluster][super::super::client::AwsClusters::get_aws_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GetAwsCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAwsCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAwsCluster(RequestBuilder<crate::model::GetAwsClusterRequest>);
 
@@ -1476,6 +1730,25 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::list_aws_clusters][super::super::client::AwsClusters::list_aws_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::ListAwsClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAwsClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAwsClusters(RequestBuilder<crate::model::ListAwsClustersRequest>);
 
@@ -1559,6 +1832,22 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::delete_aws_cluster][super::super::client::AwsClusters::delete_aws_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::DeleteAwsCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAwsCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAwsCluster(RequestBuilder<crate::model::DeleteAwsClusterRequest>);
 
@@ -1673,6 +1962,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::generate_aws_cluster_agent_token][super::super::client::AwsClusters::generate_aws_cluster_agent_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GenerateAwsClusterAgentToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAwsClusterAgentToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAwsClusterAgentToken(
         RequestBuilder<crate::model::GenerateAwsClusterAgentTokenRequest>,
@@ -1785,6 +2089,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::generate_aws_access_token][super::super::client::AwsClusters::generate_aws_access_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GenerateAwsAccessToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAwsAccessToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAwsAccessToken(RequestBuilder<crate::model::GenerateAwsAccessTokenRequest>);
 
@@ -1835,6 +2154,22 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::create_aws_node_pool][super::super::client::AwsClusters::create_aws_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::CreateAwsNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAwsNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAwsNodePool(RequestBuilder<crate::model::CreateAwsNodePoolRequest>);
 
@@ -1950,6 +2285,22 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::update_aws_node_pool][super::super::client::AwsClusters::update_aws_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::UpdateAwsNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAwsNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAwsNodePool(RequestBuilder<crate::model::UpdateAwsNodePoolRequest>);
 
@@ -2060,6 +2411,22 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::rollback_aws_node_pool_update][super::super::client::AwsClusters::rollback_aws_node_pool_update] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::RollbackAwsNodePoolUpdate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RollbackAwsNodePoolUpdate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RollbackAwsNodePoolUpdate(
         RequestBuilder<crate::model::RollbackAwsNodePoolUpdateRequest>,
@@ -2158,6 +2525,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::get_aws_node_pool][super::super::client::AwsClusters::get_aws_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GetAwsNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAwsNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAwsNodePool(RequestBuilder<crate::model::GetAwsNodePoolRequest>);
 
@@ -2205,6 +2587,25 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::list_aws_node_pools][super::super::client::AwsClusters::list_aws_node_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::ListAwsNodePools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAwsNodePools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAwsNodePools(RequestBuilder<crate::model::ListAwsNodePoolsRequest>);
 
@@ -2291,6 +2692,22 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::delete_aws_node_pool][super::super::client::AwsClusters::delete_aws_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::DeleteAwsNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAwsNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAwsNodePool(RequestBuilder<crate::model::DeleteAwsNodePoolRequest>);
 
@@ -2405,6 +2822,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::get_aws_open_id_config][super::super::client::AwsClusters::get_aws_open_id_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GetAwsOpenIdConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAwsOpenIdConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAwsOpenIdConfig(RequestBuilder<crate::model::GetAwsOpenIdConfigRequest>);
 
@@ -2455,6 +2887,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::get_aws_json_web_keys][super::super::client::AwsClusters::get_aws_json_web_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GetAwsJsonWebKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAwsJsonWebKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAwsJsonWebKeys(RequestBuilder<crate::model::GetAwsJsonWebKeysRequest>);
 
@@ -2505,6 +2952,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::get_aws_server_config][super::super::client::AwsClusters::get_aws_server_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GetAwsServerConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAwsServerConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAwsServerConfig(RequestBuilder<crate::model::GetAwsServerConfigRequest>);
 
@@ -2555,6 +3017,25 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::list_operations][super::super::client::AwsClusters::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2647,6 +3128,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::get_operation][super::super::client::AwsClusters::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2695,6 +3191,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::delete_operation][super::super::client::AwsClusters::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2743,6 +3254,21 @@ pub mod aws_clusters {
     }
 
     /// The request builder for [AwsClusters::cancel_operation][super::super::client::AwsClusters::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::aws_clusters::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2846,6 +3372,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::create_azure_client][super::super::client::AzureClusters::create_azure_client] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::CreateAzureClient;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAzureClient {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAzureClient(RequestBuilder<crate::model::CreateAzureClientRequest>);
 
@@ -2961,6 +3503,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::get_azure_client][super::super::client::AzureClusters::get_azure_client] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GetAzureClient;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAzureClient {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAzureClient(RequestBuilder<crate::model::GetAzureClientRequest>);
 
@@ -3008,6 +3565,25 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::list_azure_clients][super::super::client::AzureClusters::list_azure_clients] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::ListAzureClients;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAzureClients {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAzureClients(RequestBuilder<crate::model::ListAzureClientsRequest>);
 
@@ -3094,6 +3670,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::delete_azure_client][super::super::client::AzureClusters::delete_azure_client] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::DeleteAzureClient;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAzureClient {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAzureClient(RequestBuilder<crate::model::DeleteAzureClientRequest>);
 
@@ -3196,6 +3788,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::create_azure_cluster][super::super::client::AzureClusters::create_azure_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::CreateAzureCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAzureCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAzureCluster(RequestBuilder<crate::model::CreateAzureClusterRequest>);
 
@@ -3311,6 +3919,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::update_azure_cluster][super::super::client::AzureClusters::update_azure_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::UpdateAzureCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAzureCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAzureCluster(RequestBuilder<crate::model::UpdateAzureClusterRequest>);
 
@@ -3421,6 +4045,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::get_azure_cluster][super::super::client::AzureClusters::get_azure_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GetAzureCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAzureCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAzureCluster(RequestBuilder<crate::model::GetAzureClusterRequest>);
 
@@ -3468,6 +4107,25 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::list_azure_clusters][super::super::client::AzureClusters::list_azure_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::ListAzureClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAzureClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAzureClusters(RequestBuilder<crate::model::ListAzureClustersRequest>);
 
@@ -3554,6 +4212,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::delete_azure_cluster][super::super::client::AzureClusters::delete_azure_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::DeleteAzureCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAzureCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAzureCluster(RequestBuilder<crate::model::DeleteAzureClusterRequest>);
 
@@ -3668,6 +4342,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::generate_azure_cluster_agent_token][super::super::client::AzureClusters::generate_azure_cluster_agent_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GenerateAzureClusterAgentToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAzureClusterAgentToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAzureClusterAgentToken(
         RequestBuilder<crate::model::GenerateAzureClusterAgentTokenRequest>,
@@ -3780,6 +4469,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::generate_azure_access_token][super::super::client::AzureClusters::generate_azure_access_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GenerateAzureAccessToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAzureAccessToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAzureAccessToken(
         RequestBuilder<crate::model::GenerateAzureAccessTokenRequest>,
@@ -3832,6 +4536,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::create_azure_node_pool][super::super::client::AzureClusters::create_azure_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::CreateAzureNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAzureNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAzureNodePool(RequestBuilder<crate::model::CreateAzureNodePoolRequest>);
 
@@ -3948,6 +4668,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::update_azure_node_pool][super::super::client::AzureClusters::update_azure_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::UpdateAzureNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAzureNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAzureNodePool(RequestBuilder<crate::model::UpdateAzureNodePoolRequest>);
 
@@ -4059,6 +4795,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::get_azure_node_pool][super::super::client::AzureClusters::get_azure_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GetAzureNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAzureNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAzureNodePool(RequestBuilder<crate::model::GetAzureNodePoolRequest>);
 
@@ -4109,6 +4860,25 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::list_azure_node_pools][super::super::client::AzureClusters::list_azure_node_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::ListAzureNodePools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAzureNodePools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAzureNodePools(RequestBuilder<crate::model::ListAzureNodePoolsRequest>);
 
@@ -4197,6 +4967,22 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::delete_azure_node_pool][super::super::client::AzureClusters::delete_azure_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::DeleteAzureNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_gkemulticloud_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAzureNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAzureNodePool(RequestBuilder<crate::model::DeleteAzureNodePoolRequest>);
 
@@ -4311,6 +5097,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::get_azure_open_id_config][super::super::client::AzureClusters::get_azure_open_id_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GetAzureOpenIdConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAzureOpenIdConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAzureOpenIdConfig(RequestBuilder<crate::model::GetAzureOpenIdConfigRequest>);
 
@@ -4361,6 +5162,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::get_azure_json_web_keys][super::super::client::AzureClusters::get_azure_json_web_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GetAzureJsonWebKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAzureJsonWebKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAzureJsonWebKeys(RequestBuilder<crate::model::GetAzureJsonWebKeysRequest>);
 
@@ -4411,6 +5227,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::get_azure_server_config][super::super::client::AzureClusters::get_azure_server_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GetAzureServerConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAzureServerConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAzureServerConfig(RequestBuilder<crate::model::GetAzureServerConfigRequest>);
 
@@ -4461,6 +5292,25 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::list_operations][super::super::client::AzureClusters::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4553,6 +5403,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::get_operation][super::super::client::AzureClusters::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4601,6 +5466,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::delete_operation][super::super::client::AzureClusters::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4649,6 +5529,21 @@ pub mod azure_clusters {
     }
 
     /// The request builder for [AzureClusters::cancel_operation][super::super::client::AzureClusters::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gkemulticloud_v1::builder;
+    /// use builder::azure_clusters::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::get_authorization][super::super::client::GSuiteAddOns::get_authorization] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::GetAuthorization;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAuthorization {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAuthorization(RequestBuilder<crate::model::GetAuthorizationRequest>);
 
@@ -119,6 +134,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::create_deployment][super::super::client::GSuiteAddOns::create_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::CreateDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -188,6 +218,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::replace_deployment][super::super::client::GSuiteAddOns::replace_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::ReplaceDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReplaceDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReplaceDeployment(RequestBuilder<crate::model::ReplaceDeploymentRequest>);
 
@@ -241,6 +286,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::get_deployment][super::super::client::GSuiteAddOns::get_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::GetDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -288,6 +348,25 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::list_deployments][super::super::client::GSuiteAddOns::list_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::ListDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -371,6 +450,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::delete_deployment][super::super::client::GSuiteAddOns::delete_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::DeleteDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDeployment(RequestBuilder<crate::model::DeleteDeploymentRequest>);
 
@@ -427,6 +521,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::install_deployment][super::super::client::GSuiteAddOns::install_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::InstallDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InstallDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InstallDeployment(RequestBuilder<crate::model::InstallDeploymentRequest>);
 
@@ -477,6 +586,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::uninstall_deployment][super::super::client::GSuiteAddOns::uninstall_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::UninstallDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UninstallDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UninstallDeployment(RequestBuilder<crate::model::UninstallDeploymentRequest>);
 
@@ -527,6 +651,21 @@ pub mod g_suite_add_ons {
     }
 
     /// The request builder for [GSuiteAddOns::get_install_status][super::super::client::GSuiteAddOns::get_install_status] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_gsuiteaddons_v1::builder;
+    /// use builder::g_suite_add_ons::GetInstallStatus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstallStatus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstallStatus(RequestBuilder<crate::model::GetInstallStatusRequest>);
 

--- a/src/generated/cloud/iap/v1/src/builder.rs
+++ b/src/generated/cloud/iap/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::set_iam_policy][super::super::client::IdentityAwareProxyAdminService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -136,6 +151,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::get_iam_policy][super::super::client::IdentityAwareProxyAdminService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -192,6 +222,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::test_iam_permissions][super::super::client::IdentityAwareProxyAdminService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -255,6 +300,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::get_iap_settings][super::super::client::IdentityAwareProxyAdminService::get_iap_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::GetIapSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIapSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIapSettings(RequestBuilder<crate::model::GetIapSettingsRequest>);
 
@@ -302,6 +362,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::update_iap_settings][super::super::client::IdentityAwareProxyAdminService::update_iap_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::UpdateIapSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateIapSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateIapSettings(RequestBuilder<crate::model::UpdateIapSettingsRequest>);
 
@@ -364,6 +439,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::validate_iap_attribute_expression][super::super::client::IdentityAwareProxyAdminService::validate_iap_attribute_expression] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::ValidateIapAttributeExpression;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ValidateIapAttributeExpression {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ValidateIapAttributeExpression(
         RequestBuilder<crate::model::ValidateIapAttributeExpressionRequest>,
@@ -424,6 +514,25 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::list_tunnel_dest_groups][super::super::client::IdentityAwareProxyAdminService::list_tunnel_dest_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::ListTunnelDestGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTunnelDestGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTunnelDestGroups(RequestBuilder<crate::model::ListTunnelDestGroupsRequest>);
 
@@ -512,6 +621,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::create_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::create_tunnel_dest_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::CreateTunnelDestGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTunnelDestGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTunnelDestGroup(RequestBuilder<crate::model::CreateTunnelDestGroupRequest>);
 
@@ -583,6 +707,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::get_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::get_tunnel_dest_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::GetTunnelDestGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTunnelDestGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTunnelDestGroup(RequestBuilder<crate::model::GetTunnelDestGroupRequest>);
 
@@ -633,6 +772,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::delete_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::delete_tunnel_dest_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::DeleteTunnelDestGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTunnelDestGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTunnelDestGroup(RequestBuilder<crate::model::DeleteTunnelDestGroupRequest>);
 
@@ -683,6 +837,21 @@ pub mod identity_aware_proxy_admin_service {
     }
 
     /// The request builder for [IdentityAwareProxyAdminService::update_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::update_tunnel_dest_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_admin_service::UpdateTunnelDestGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTunnelDestGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTunnelDestGroup(RequestBuilder<crate::model::UpdateTunnelDestGroupRequest>);
 
@@ -802,6 +971,21 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::list_brands][super::super::client::IdentityAwareProxyOAuthService::list_brands] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::ListBrands;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBrands {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBrands(RequestBuilder<crate::model::ListBrandsRequest>);
 
@@ -849,6 +1033,21 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::create_brand][super::super::client::IdentityAwareProxyOAuthService::create_brand] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::CreateBrand;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBrand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBrand(RequestBuilder<crate::model::CreateBrandRequest>);
 
@@ -907,6 +1106,21 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::get_brand][super::super::client::IdentityAwareProxyOAuthService::get_brand] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::GetBrand;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBrand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBrand(RequestBuilder<crate::model::GetBrandRequest>);
 
@@ -954,6 +1168,21 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::create_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::create_identity_aware_proxy_client] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::CreateIdentityAwareProxyClient;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIdentityAwareProxyClient {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIdentityAwareProxyClient(
         RequestBuilder<crate::model::CreateIdentityAwareProxyClientRequest>,
@@ -1019,6 +1248,25 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients][super::super::client::IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::ListIdentityAwareProxyClients;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIdentityAwareProxyClients {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIdentityAwareProxyClients(
         RequestBuilder<crate::model::ListIdentityAwareProxyClientsRequest>,
@@ -1111,6 +1359,21 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::get_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::get_identity_aware_proxy_client] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::GetIdentityAwareProxyClient;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIdentityAwareProxyClient {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIdentityAwareProxyClient(
         RequestBuilder<crate::model::GetIdentityAwareProxyClientRequest>,
@@ -1163,6 +1426,21 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret][super::super::client::IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::ResetIdentityAwareProxyClientSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetIdentityAwareProxyClientSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetIdentityAwareProxyClientSecret(
         RequestBuilder<crate::model::ResetIdentityAwareProxyClientSecretRequest>,
@@ -1215,6 +1493,21 @@ pub mod identity_aware_proxy_o_auth_service {
     }
 
     /// The request builder for [IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iap_v1::builder;
+    /// use builder::identity_aware_proxy_o_auth_service::DeleteIdentityAwareProxyClient;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIdentityAwareProxyClient {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIdentityAwareProxyClient(
         RequestBuilder<crate::model::DeleteIdentityAwareProxyClientRequest>,

--- a/src/generated/cloud/ids/v1/src/builder.rs
+++ b/src/generated/cloud/ids/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::list_endpoints][super::super::client::Ids::list_endpoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::ListEndpoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEndpoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEndpoints(RequestBuilder<crate::model::ListEndpointsRequest>);
 
@@ -160,6 +179,21 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::get_endpoint][super::super::client::Ids::get_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::GetEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEndpoint(RequestBuilder<crate::model::GetEndpointRequest>);
 
@@ -205,6 +239,22 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::create_endpoint][super::super::client::Ids::create_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::CreateEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_ids_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEndpoint(RequestBuilder<crate::model::CreateEndpointRequest>);
 
@@ -313,6 +363,22 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::delete_endpoint][super::super::client::Ids::delete_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::DeleteEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_ids_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEndpoint(RequestBuilder<crate::model::DeleteEndpointRequest>);
 
@@ -404,6 +470,25 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::list_operations][super::super::client::Ids::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -494,6 +579,21 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::get_operation][super::super::client::Ids::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -540,6 +640,21 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::delete_operation][super::super::client::Ids::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -586,6 +701,21 @@ pub mod ids {
     }
 
     /// The request builder for [Ids::cancel_operation][super::super::client::Ids::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_ids_v1::builder;
+    /// use builder::ids::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/kms/inventory/v1/src/builder.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod key_dashboard_service {
     }
 
     /// The request builder for [KeyDashboardService::list_crypto_keys][super::super::client::KeyDashboardService::list_crypto_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_inventory_v1::builder;
+    /// use builder::key_dashboard_service::ListCryptoKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCryptoKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCryptoKeys(RequestBuilder<crate::model::ListCryptoKeysRequest>);
 
@@ -207,6 +226,21 @@ pub mod key_tracking_service {
     }
 
     /// The request builder for [KeyTrackingService::get_protected_resources_summary][super::super::client::KeyTrackingService::get_protected_resources_summary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_inventory_v1::builder;
+    /// use builder::key_tracking_service::GetProtectedResourcesSummary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProtectedResourcesSummary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProtectedResourcesSummary(
         RequestBuilder<crate::model::GetProtectedResourcesSummaryRequest>,
@@ -259,6 +293,25 @@ pub mod key_tracking_service {
     }
 
     /// The request builder for [KeyTrackingService::search_protected_resources][super::super::client::KeyTrackingService::search_protected_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_inventory_v1::builder;
+    /// use builder::key_tracking_service::SearchProtectedResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchProtectedResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchProtectedResources(
         RequestBuilder<crate::model::SearchProtectedResourcesRequest>,

--- a/src/generated/cloud/kms/v1/src/builder.rs
+++ b/src/generated/cloud/kms/v1/src/builder.rs
@@ -67,6 +67,22 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::create_key_handle][super::super::client::Autokey::create_key_handle] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::CreateKeyHandle;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_kms_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateKeyHandle {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateKeyHandle(RequestBuilder<crate::model::CreateKeyHandleRequest>);
 
@@ -170,6 +186,21 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::get_key_handle][super::super::client::Autokey::get_key_handle] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::GetKeyHandle;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetKeyHandle {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetKeyHandle(RequestBuilder<crate::model::GetKeyHandleRequest>);
 
@@ -215,6 +246,25 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::list_key_handles][super::super::client::Autokey::list_key_handles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::ListKeyHandles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListKeyHandles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListKeyHandles(RequestBuilder<crate::model::ListKeyHandlesRequest>);
 
@@ -302,6 +352,25 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::list_locations][super::super::client::Autokey::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -390,6 +459,21 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::get_location][super::super::client::Autokey::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -433,6 +517,21 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::set_iam_policy][super::super::client::Autokey::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -498,6 +597,21 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::get_iam_policy][super::super::client::Autokey::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -552,6 +666,21 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::test_iam_permissions][super::super::client::Autokey::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -613,6 +742,21 @@ pub mod autokey {
     }
 
     /// The request builder for [Autokey::get_operation][super::super::client::Autokey::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -714,6 +858,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::update_autokey_config][super::super::client::AutokeyAdmin::update_autokey_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::UpdateAutokeyConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAutokeyConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAutokeyConfig(RequestBuilder<crate::model::UpdateAutokeyConfigRequest>);
 
@@ -778,6 +937,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::get_autokey_config][super::super::client::AutokeyAdmin::get_autokey_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::GetAutokeyConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAutokeyConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAutokeyConfig(RequestBuilder<crate::model::GetAutokeyConfigRequest>);
 
@@ -828,6 +1002,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::show_effective_autokey_config][super::super::client::AutokeyAdmin::show_effective_autokey_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::ShowEffectiveAutokeyConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ShowEffectiveAutokeyConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ShowEffectiveAutokeyConfig(
         RequestBuilder<crate::model::ShowEffectiveAutokeyConfigRequest>,
@@ -880,6 +1069,25 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::list_locations][super::super::client::AutokeyAdmin::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -970,6 +1178,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::get_location][super::super::client::AutokeyAdmin::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1015,6 +1238,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::set_iam_policy][super::super::client::AutokeyAdmin::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1082,6 +1320,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::get_iam_policy][super::super::client::AutokeyAdmin::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1138,6 +1391,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::test_iam_permissions][super::super::client::AutokeyAdmin::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1201,6 +1469,21 @@ pub mod autokey_admin {
     }
 
     /// The request builder for [AutokeyAdmin::get_operation][super::super::client::AutokeyAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::autokey_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1304,6 +1587,25 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::list_ekm_connections][super::super::client::EkmService::list_ekm_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::ListEkmConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEkmConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEkmConnections(RequestBuilder<crate::model::ListEkmConnectionsRequest>);
 
@@ -1404,6 +1706,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::get_ekm_connection][super::super::client::EkmService::get_ekm_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::GetEkmConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEkmConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEkmConnection(RequestBuilder<crate::model::GetEkmConnectionRequest>);
 
@@ -1454,6 +1771,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::create_ekm_connection][super::super::client::EkmService::create_ekm_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::CreateEkmConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEkmConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEkmConnection(RequestBuilder<crate::model::CreateEkmConnectionRequest>);
 
@@ -1523,6 +1855,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::update_ekm_connection][super::super::client::EkmService::update_ekm_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::UpdateEkmConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEkmConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEkmConnection(RequestBuilder<crate::model::UpdateEkmConnectionRequest>);
 
@@ -1587,6 +1934,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::get_ekm_config][super::super::client::EkmService::get_ekm_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::GetEkmConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEkmConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEkmConfig(RequestBuilder<crate::model::GetEkmConfigRequest>);
 
@@ -1634,6 +1996,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::update_ekm_config][super::super::client::EkmService::update_ekm_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::UpdateEkmConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEkmConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEkmConfig(RequestBuilder<crate::model::UpdateEkmConfigRequest>);
 
@@ -1695,6 +2072,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::verify_connectivity][super::super::client::EkmService::verify_connectivity] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::VerifyConnectivity;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyConnectivity {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyConnectivity(RequestBuilder<crate::model::VerifyConnectivityRequest>);
 
@@ -1745,6 +2137,25 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::list_locations][super::super::client::EkmService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1835,6 +2246,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::get_location][super::super::client::EkmService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1880,6 +2306,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::set_iam_policy][super::super::client::EkmService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1947,6 +2388,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::get_iam_policy][super::super::client::EkmService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2003,6 +2459,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::test_iam_permissions][super::super::client::EkmService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2066,6 +2537,21 @@ pub mod ekm_service {
     }
 
     /// The request builder for [EkmService::get_operation][super::super::client::EkmService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::ekm_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2169,6 +2655,25 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::list_key_rings][super::super::client::KeyManagementService::list_key_rings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::ListKeyRings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListKeyRings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListKeyRings(RequestBuilder<crate::model::ListKeyRingsRequest>);
 
@@ -2264,6 +2769,25 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::list_crypto_keys][super::super::client::KeyManagementService::list_crypto_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::ListCryptoKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCryptoKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCryptoKeys(RequestBuilder<crate::model::ListCryptoKeysRequest>);
 
@@ -2368,6 +2892,25 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::list_crypto_key_versions][super::super::client::KeyManagementService::list_crypto_key_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::ListCryptoKeyVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCryptoKeyVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCryptoKeyVersions(RequestBuilder<crate::model::ListCryptoKeyVersionsRequest>);
 
@@ -2477,6 +3020,25 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::list_import_jobs][super::super::client::KeyManagementService::list_import_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::ListImportJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListImportJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListImportJobs(RequestBuilder<crate::model::ListImportJobsRequest>);
 
@@ -2572,6 +3134,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_key_ring][super::super::client::KeyManagementService::get_key_ring] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetKeyRing;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetKeyRing {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetKeyRing(RequestBuilder<crate::model::GetKeyRingRequest>);
 
@@ -2619,6 +3196,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_crypto_key][super::super::client::KeyManagementService::get_crypto_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetCryptoKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCryptoKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCryptoKey(RequestBuilder<crate::model::GetCryptoKeyRequest>);
 
@@ -2666,6 +3258,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_crypto_key_version][super::super::client::KeyManagementService::get_crypto_key_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetCryptoKeyVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCryptoKeyVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCryptoKeyVersion(RequestBuilder<crate::model::GetCryptoKeyVersionRequest>);
 
@@ -2716,6 +3323,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_public_key][super::super::client::KeyManagementService::get_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetPublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPublicKey(RequestBuilder<crate::model::GetPublicKeyRequest>);
 
@@ -2772,6 +3394,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_import_job][super::super::client::KeyManagementService::get_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetImportJob(RequestBuilder<crate::model::GetImportJobRequest>);
 
@@ -2819,6 +3456,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::create_key_ring][super::super::client::KeyManagementService::create_key_ring] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::CreateKeyRing;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateKeyRing {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateKeyRing(RequestBuilder<crate::model::CreateKeyRingRequest>);
 
@@ -2885,6 +3537,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::create_crypto_key][super::super::client::KeyManagementService::create_crypto_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::CreateCryptoKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCryptoKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCryptoKey(RequestBuilder<crate::model::CreateCryptoKeyRequest>);
 
@@ -2957,6 +3624,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::create_crypto_key_version][super::super::client::KeyManagementService::create_crypto_key_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::CreateCryptoKeyVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCryptoKeyVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCryptoKeyVersion(RequestBuilder<crate::model::CreateCryptoKeyVersionRequest>);
 
@@ -3020,6 +3702,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::import_crypto_key_version][super::super::client::KeyManagementService::import_crypto_key_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::ImportCryptoKeyVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportCryptoKeyVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportCryptoKeyVersion(RequestBuilder<crate::model::ImportCryptoKeyVersionRequest>);
 
@@ -3130,6 +3827,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::create_import_job][super::super::client::KeyManagementService::create_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::CreateImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateImportJob(RequestBuilder<crate::model::CreateImportJobRequest>);
 
@@ -3196,6 +3908,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::update_crypto_key][super::super::client::KeyManagementService::update_crypto_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::UpdateCryptoKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCryptoKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCryptoKey(RequestBuilder<crate::model::UpdateCryptoKeyRequest>);
 
@@ -3257,6 +3984,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::update_crypto_key_version][super::super::client::KeyManagementService::update_crypto_key_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::UpdateCryptoKeyVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCryptoKeyVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCryptoKeyVersion(RequestBuilder<crate::model::UpdateCryptoKeyVersionRequest>);
 
@@ -3323,6 +4065,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::update_crypto_key_primary_version][super::super::client::KeyManagementService::update_crypto_key_primary_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::UpdateCryptoKeyPrimaryVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCryptoKeyPrimaryVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCryptoKeyPrimaryVersion(
         RequestBuilder<crate::model::UpdateCryptoKeyPrimaryVersionRequest>,
@@ -3383,6 +4140,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::destroy_crypto_key_version][super::super::client::KeyManagementService::destroy_crypto_key_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::DestroyCryptoKeyVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DestroyCryptoKeyVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DestroyCryptoKeyVersion(
         RequestBuilder<crate::model::DestroyCryptoKeyVersionRequest>,
@@ -3435,6 +4207,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::restore_crypto_key_version][super::super::client::KeyManagementService::restore_crypto_key_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::RestoreCryptoKeyVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreCryptoKeyVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreCryptoKeyVersion(
         RequestBuilder<crate::model::RestoreCryptoKeyVersionRequest>,
@@ -3487,6 +4274,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::encrypt][super::super::client::KeyManagementService::encrypt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::Encrypt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Encrypt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Encrypt(RequestBuilder<crate::model::EncryptRequest>);
 
@@ -3568,6 +4370,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::decrypt][super::super::client::KeyManagementService::decrypt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::Decrypt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Decrypt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Decrypt(RequestBuilder<crate::model::DecryptRequest>);
 
@@ -3649,6 +4466,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::raw_encrypt][super::super::client::KeyManagementService::raw_encrypt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::RawEncrypt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RawEncrypt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RawEncrypt(RequestBuilder<crate::model::RawEncryptRequest>);
 
@@ -3745,6 +4577,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::raw_decrypt][super::super::client::KeyManagementService::raw_decrypt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::RawDecrypt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RawDecrypt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RawDecrypt(RequestBuilder<crate::model::RawDecryptRequest>);
 
@@ -3849,6 +4696,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::asymmetric_sign][super::super::client::KeyManagementService::asymmetric_sign] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::AsymmetricSign;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AsymmetricSign {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AsymmetricSign(RequestBuilder<crate::model::AsymmetricSignRequest>);
 
@@ -3929,6 +4791,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::asymmetric_decrypt][super::super::client::KeyManagementService::asymmetric_decrypt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::AsymmetricDecrypt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AsymmetricDecrypt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AsymmetricDecrypt(RequestBuilder<crate::model::AsymmetricDecryptRequest>);
 
@@ -3996,6 +4873,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::mac_sign][super::super::client::KeyManagementService::mac_sign] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::MacSign;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MacSign {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MacSign(RequestBuilder<crate::model::MacSignRequest>);
 
@@ -4060,6 +4952,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::mac_verify][super::super::client::KeyManagementService::mac_verify] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::MacVerify;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MacVerify {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MacVerify(RequestBuilder<crate::model::MacVerifyRequest>);
 
@@ -4141,6 +5048,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::generate_random_bytes][super::super::client::KeyManagementService::generate_random_bytes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GenerateRandomBytes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateRandomBytes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateRandomBytes(RequestBuilder<crate::model::GenerateRandomBytesRequest>);
 
@@ -4204,6 +5126,25 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::list_locations][super::super::client::KeyManagementService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4294,6 +5235,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_location][super::super::client::KeyManagementService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4339,6 +5295,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::set_iam_policy][super::super::client::KeyManagementService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4406,6 +5377,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_iam_policy][super::super::client::KeyManagementService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4462,6 +5448,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::test_iam_permissions][super::super::client::KeyManagementService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4525,6 +5526,21 @@ pub mod key_management_service {
     }
 
     /// The request builder for [KeyManagementService::get_operation][super::super::client::KeyManagementService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_kms_v1::builder;
+    /// use builder::key_management_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/language/v2/src/builder.rs
+++ b/src/generated/cloud/language/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod language_service {
     }
 
     /// The request builder for [LanguageService::analyze_sentiment][super::super::client::LanguageService::analyze_sentiment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_language_v2::builder;
+    /// use builder::language_service::AnalyzeSentiment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeSentiment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeSentiment(RequestBuilder<crate::model::AnalyzeSentimentRequest>);
 
@@ -128,6 +143,21 @@ pub mod language_service {
     }
 
     /// The request builder for [LanguageService::analyze_entities][super::super::client::LanguageService::analyze_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_language_v2::builder;
+    /// use builder::language_service::AnalyzeEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnalyzeEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnalyzeEntities(RequestBuilder<crate::model::AnalyzeEntitiesRequest>);
 
@@ -184,6 +214,21 @@ pub mod language_service {
     }
 
     /// The request builder for [LanguageService::classify_text][super::super::client::LanguageService::classify_text] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_language_v2::builder;
+    /// use builder::language_service::ClassifyText;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ClassifyText {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ClassifyText(RequestBuilder<crate::model::ClassifyTextRequest>);
 
@@ -234,6 +279,21 @@ pub mod language_service {
     }
 
     /// The request builder for [LanguageService::moderate_text][super::super::client::LanguageService::moderate_text] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_language_v2::builder;
+    /// use builder::language_service::ModerateText;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ModerateText {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ModerateText(RequestBuilder<crate::model::ModerateTextRequest>);
 
@@ -293,6 +353,21 @@ pub mod language_service {
     }
 
     /// The request builder for [LanguageService::annotate_text][super::super::client::LanguageService::annotate_text] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_language_v2::builder;
+    /// use builder::language_service::AnnotateText;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnnotateText {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnnotateText(RequestBuilder<crate::model::AnnotateTextRequest>);
 

--- a/src/generated/cloud/licensemanager/v1/src/builder.rs
+++ b/src/generated/cloud/licensemanager/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::list_configurations][super::super::client::LicenseManager::list_configurations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::ListConfigurations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConfigurations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConfigurations(RequestBuilder<crate::model::ListConfigurationsRequest>);
 
@@ -169,6 +188,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::get_configuration][super::super::client::LicenseManager::get_configuration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::GetConfiguration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConfiguration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConfiguration(RequestBuilder<crate::model::GetConfigurationRequest>);
 
@@ -219,6 +253,22 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::create_configuration][super::super::client::LicenseManager::create_configuration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::CreateConfiguration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_licensemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConfiguration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConfiguration(RequestBuilder<crate::model::CreateConfigurationRequest>);
 
@@ -335,6 +385,22 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::update_configuration][super::super::client::LicenseManager::update_configuration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::UpdateConfiguration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_licensemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConfiguration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConfiguration(RequestBuilder<crate::model::UpdateConfigurationRequest>);
 
@@ -444,6 +510,22 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::delete_configuration][super::super::client::LicenseManager::delete_configuration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::DeleteConfiguration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_licensemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConfiguration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConfiguration(RequestBuilder<crate::model::DeleteConfigurationRequest>);
 
@@ -540,6 +622,25 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::list_instances][super::super::client::LicenseManager::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -635,6 +736,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::get_instance][super::super::client::LicenseManager::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -682,6 +798,22 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::deactivate_configuration][super::super::client::LicenseManager::deactivate_configuration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::DeactivateConfiguration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_licensemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeactivateConfiguration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeactivateConfiguration(
         RequestBuilder<crate::model::DeactivateConfigurationRequest>,
@@ -781,6 +913,22 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::reactivate_configuration][super::super::client::LicenseManager::reactivate_configuration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::ReactivateConfiguration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_licensemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReactivateConfiguration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReactivateConfiguration(
         RequestBuilder<crate::model::ReactivateConfigurationRequest>,
@@ -880,6 +1028,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::query_configuration_license_usage][super::super::client::LicenseManager::query_configuration_license_usage] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::QueryConfigurationLicenseUsage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryConfigurationLicenseUsage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryConfigurationLicenseUsage(
         RequestBuilder<crate::model::QueryConfigurationLicenseUsageRequest>,
@@ -951,6 +1114,25 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::aggregate_usage][super::super::client::LicenseManager::aggregate_usage] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::AggregateUsage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AggregateUsage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AggregateUsage(RequestBuilder<crate::model::AggregateUsageRequest>);
 
@@ -1065,6 +1247,25 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::list_products][super::super::client::LicenseManager::list_products] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::ListProducts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProducts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProducts(RequestBuilder<crate::model::ListProductsRequest>);
 
@@ -1160,6 +1361,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::get_product][super::super::client::LicenseManager::get_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::GetProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProduct(RequestBuilder<crate::model::GetProductRequest>);
 
@@ -1207,6 +1423,25 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::list_locations][super::super::client::LicenseManager::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1297,6 +1532,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::get_location][super::super::client::LicenseManager::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1342,6 +1592,25 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::list_operations][super::super::client::LicenseManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1434,6 +1703,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::get_operation][super::super::client::LicenseManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1482,6 +1766,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::delete_operation][super::super::client::LicenseManager::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1530,6 +1829,21 @@ pub mod license_manager {
     }
 
     /// The request builder for [LicenseManager::cancel_operation][super::super::client::LicenseManager::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_licensemanager_v1::builder;
+    /// use builder::license_manager::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/location/src/builder.rs
+++ b/src/generated/cloud/location/src/builder.rs
@@ -69,6 +69,25 @@ pub mod locations {
     }
 
     /// The request builder for [Locations::list_locations][super::super::client::Locations::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_location::builder;
+    /// use builder::locations::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -156,6 +175,21 @@ pub mod locations {
     }
 
     /// The request builder for [Locations::get_location][super::super::client::Locations::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_location::builder;
+    /// use builder::locations::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 

--- a/src/generated/cloud/lustre/v1/src/builder.rs
+++ b/src/generated/cloud/lustre/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::list_instances][super::super::client::Lustre::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -160,6 +179,21 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::get_instance][super::super::client::Lustre::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -205,6 +239,22 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::create_instance][super::super::client::Lustre::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_lustre_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -313,6 +363,22 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::update_instance][super::super::client::Lustre::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_lustre_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -414,6 +480,22 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::delete_instance][super::super::client::Lustre::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_lustre_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -505,6 +587,22 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::import_data][super::super::client::Lustre::import_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::ImportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_lustre_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportData(RequestBuilder<crate::model::ImportDataRequest>);
 
@@ -653,6 +751,22 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::export_data][super::super::client::Lustre::export_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::ExportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_lustre_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportData(RequestBuilder<crate::model::ExportDataRequest>);
 
@@ -801,6 +915,25 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::list_locations][super::super::client::Lustre::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -889,6 +1022,21 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::get_location][super::super::client::Lustre::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -932,6 +1080,25 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::list_operations][super::super::client::Lustre::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1022,6 +1189,21 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::get_operation][super::super::client::Lustre::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1068,6 +1250,21 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::delete_operation][super::super::client::Lustre::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1114,6 +1311,21 @@ pub mod lustre {
     }
 
     /// The request builder for [Lustre::cancel_operation][super::super::client::Lustre::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_lustre_v1::builder;
+    /// use builder::lustre::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/managedidentities/v1/src/builder.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::create_microsoft_ad_domain][super::super::client::ManagedIdentitiesService::create_microsoft_ad_domain] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::CreateMicrosoftAdDomain;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_managedidentities_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMicrosoftAdDomain {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMicrosoftAdDomain(
         RequestBuilder<crate::model::CreateMicrosoftAdDomainRequest>,
@@ -176,6 +192,21 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::reset_admin_password][super::super::client::ManagedIdentitiesService::reset_admin_password] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::ResetAdminPassword;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetAdminPassword {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetAdminPassword(RequestBuilder<crate::model::ResetAdminPasswordRequest>);
 
@@ -226,6 +257,25 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::list_domains][super::super::client::ManagedIdentitiesService::list_domains] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::ListDomains;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDomains {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDomains(RequestBuilder<crate::model::ListDomainsRequest>);
 
@@ -321,6 +371,21 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::get_domain][super::super::client::ManagedIdentitiesService::get_domain] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::GetDomain;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDomain {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDomain(RequestBuilder<crate::model::GetDomainRequest>);
 
@@ -368,6 +433,22 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::update_domain][super::super::client::ManagedIdentitiesService::update_domain] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::UpdateDomain;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_managedidentities_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDomain {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDomain(RequestBuilder<crate::model::UpdateDomainRequest>);
 
@@ -465,6 +546,22 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::delete_domain][super::super::client::ManagedIdentitiesService::delete_domain] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::DeleteDomain;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_managedidentities_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDomain {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDomain(RequestBuilder<crate::model::DeleteDomainRequest>);
 
@@ -552,6 +649,22 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::attach_trust][super::super::client::ManagedIdentitiesService::attach_trust] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::AttachTrust;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_managedidentities_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AttachTrust {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AttachTrust(RequestBuilder<crate::model::AttachTrustRequest>);
 
@@ -646,6 +759,22 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::reconfigure_trust][super::super::client::ManagedIdentitiesService::reconfigure_trust] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::ReconfigureTrust;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_managedidentities_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReconfigureTrust {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReconfigureTrust(RequestBuilder<crate::model::ReconfigureTrustRequest>);
 
@@ -753,6 +882,22 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::detach_trust][super::super::client::ManagedIdentitiesService::detach_trust] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::DetachTrust;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_managedidentities_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DetachTrust {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DetachTrust(RequestBuilder<crate::model::DetachTrustRequest>);
 
@@ -847,6 +992,22 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::validate_trust][super::super::client::ManagedIdentitiesService::validate_trust] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::ValidateTrust;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_managedidentities_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ValidateTrust {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ValidateTrust(RequestBuilder<crate::model::ValidateTrustRequest>);
 
@@ -941,6 +1102,25 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::list_operations][super::super::client::ManagedIdentitiesService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1033,6 +1213,21 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::get_operation][super::super::client::ManagedIdentitiesService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1081,6 +1276,21 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::delete_operation][super::super::client::ManagedIdentitiesService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1129,6 +1339,21 @@ pub mod managed_identities_service {
     }
 
     /// The request builder for [ManagedIdentitiesService::cancel_operation][super::super::client::ManagedIdentitiesService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_managedidentities_v1::builder;
+    /// use builder::managed_identities_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/memcache/v1/src/builder.rs
+++ b/src/generated/cloud/memcache/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::list_instances][super::super::client::CloudMemcache::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -164,6 +183,21 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::get_instance][super::super::client::CloudMemcache::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -211,6 +245,22 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::create_instance][super::super::client::CloudMemcache::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memcache_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -315,6 +365,22 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::update_instance][super::super::client::CloudMemcache::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memcache_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -414,6 +480,22 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::update_parameters][super::super::client::CloudMemcache::update_parameters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::UpdateParameters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memcache_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateParameters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateParameters(RequestBuilder<crate::model::UpdateParametersRequest>);
 
@@ -522,6 +604,22 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::delete_instance][super::super::client::CloudMemcache::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memcache_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -609,6 +707,22 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::apply_parameters][super::super::client::CloudMemcache::apply_parameters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::ApplyParameters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memcache_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApplyParameters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApplyParameters(RequestBuilder<crate::model::ApplyParametersRequest>);
 
@@ -711,6 +825,22 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::reschedule_maintenance][super::super::client::CloudMemcache::reschedule_maintenance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::RescheduleMaintenance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memcache_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RescheduleMaintenance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RescheduleMaintenance(RequestBuilder<crate::model::RescheduleMaintenanceRequest>);
 
@@ -821,6 +951,25 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::list_locations][super::super::client::CloudMemcache::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -911,6 +1060,21 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::get_location][super::super::client::CloudMemcache::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -956,6 +1120,25 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::list_operations][super::super::client::CloudMemcache::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1048,6 +1231,21 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::get_operation][super::super::client::CloudMemcache::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1096,6 +1294,21 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::delete_operation][super::super::client::CloudMemcache::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1144,6 +1357,21 @@ pub mod cloud_memcache {
     }
 
     /// The request builder for [CloudMemcache::cancel_operation][super::super::client::CloudMemcache::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memcache_v1::builder;
+    /// use builder::cloud_memcache::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/memorystore/v1/src/builder.rs
+++ b/src/generated/cloud/memorystore/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::list_instances][super::super::client::Memorystore::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -164,6 +183,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::get_instance][super::super::client::Memorystore::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -211,6 +245,22 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::create_instance][super::super::client::Memorystore::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memorystore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -321,6 +371,22 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::update_instance][super::super::client::Memorystore::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memorystore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -424,6 +490,22 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::delete_instance][super::super::client::Memorystore::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memorystore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -517,6 +599,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::get_certificate_authority][super::super::client::Memorystore::get_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::GetCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificateAuthority(
         RequestBuilder<crate::model::GetCertificateAuthorityRequest>,
@@ -569,6 +666,22 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::reschedule_maintenance][super::super::client::Memorystore::reschedule_maintenance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::RescheduleMaintenance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memorystore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RescheduleMaintenance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RescheduleMaintenance(RequestBuilder<crate::model::RescheduleMaintenanceRequest>);
 
@@ -679,6 +792,25 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::list_backup_collections][super::super::client::Memorystore::list_backup_collections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::ListBackupCollections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupCollections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupCollections(RequestBuilder<crate::model::ListBackupCollectionsRequest>);
 
@@ -767,6 +899,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::get_backup_collection][super::super::client::Memorystore::get_backup_collection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::GetBackupCollection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupCollection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupCollection(RequestBuilder<crate::model::GetBackupCollectionRequest>);
 
@@ -817,6 +964,25 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::list_backups][super::super::client::Memorystore::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -900,6 +1066,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::get_backup][super::super::client::Memorystore::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -947,6 +1128,22 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::delete_backup][super::super::client::Memorystore::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memorystore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1040,6 +1237,22 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::export_backup][super::super::client::Memorystore::export_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::ExportBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memorystore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportBackup(RequestBuilder<crate::model::ExportBackupRequest>);
 
@@ -1149,6 +1362,22 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::backup_instance][super::super::client::Memorystore::backup_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::BackupInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_memorystore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BackupInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BackupInstance(RequestBuilder<crate::model::BackupInstanceRequest>);
 
@@ -1249,6 +1478,25 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::list_locations][super::super::client::Memorystore::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1339,6 +1587,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::get_location][super::super::client::Memorystore::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1384,6 +1647,25 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::list_operations][super::super::client::Memorystore::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1476,6 +1758,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::get_operation][super::super::client::Memorystore::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1524,6 +1821,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::delete_operation][super::super::client::Memorystore::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1572,6 +1884,21 @@ pub mod memorystore {
     }
 
     /// The request builder for [Memorystore::cancel_operation][super::super::client::Memorystore::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_memorystore_v1::builder;
+    /// use builder::memorystore::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/metastore/v1/src/builder.rs
+++ b/src/generated/cloud/metastore/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::list_services][super::super::client::DataprocMetastore::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -164,6 +183,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::get_service][super::super::client::DataprocMetastore::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -211,6 +245,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::create_service][super::super::client::DataprocMetastore::create_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::CreateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -321,6 +371,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::update_service][super::super::client::DataprocMetastore::update_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::UpdateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -426,6 +492,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::delete_service][super::super::client::DataprocMetastore::delete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::DeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -519,6 +601,25 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::list_metadata_imports][super::super::client::DataprocMetastore::list_metadata_imports] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::ListMetadataImports;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMetadataImports {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMetadataImports(RequestBuilder<crate::model::ListMetadataImportsRequest>);
 
@@ -619,6 +720,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::get_metadata_import][super::super::client::DataprocMetastore::get_metadata_import] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::GetMetadataImport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMetadataImport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMetadataImport(RequestBuilder<crate::model::GetMetadataImportRequest>);
 
@@ -669,6 +785,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::create_metadata_import][super::super::client::DataprocMetastore::create_metadata_import] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::CreateMetadataImport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMetadataImport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMetadataImport(RequestBuilder<crate::model::CreateMetadataImportRequest>);
 
@@ -785,6 +917,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::update_metadata_import][super::super::client::DataprocMetastore::update_metadata_import] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::UpdateMetadataImport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMetadataImport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMetadataImport(RequestBuilder<crate::model::UpdateMetadataImportRequest>);
 
@@ -896,6 +1044,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::export_metadata][super::super::client::DataprocMetastore::export_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::ExportMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportMetadata(RequestBuilder<crate::model::ExportMetadataRequest>);
 
@@ -1026,6 +1190,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::restore_service][super::super::client::DataprocMetastore::restore_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::RestoreService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreService(RequestBuilder<crate::model::RestoreServiceRequest>);
 
@@ -1134,6 +1314,25 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::list_backups][super::super::client::DataprocMetastore::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1229,6 +1428,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::get_backup][super::super::client::DataprocMetastore::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1276,6 +1490,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::create_backup][super::super::client::DataprocMetastore::create_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::CreateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -1386,6 +1616,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::delete_backup][super::super::client::DataprocMetastore::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1479,6 +1725,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::query_metadata][super::super::client::DataprocMetastore::query_metadata] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::QueryMetadata;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryMetadata {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryMetadata(RequestBuilder<crate::model::QueryMetadataRequest>);
 
@@ -1575,6 +1837,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::move_table_to_database][super::super::client::DataprocMetastore::move_table_to_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::MoveTableToDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MoveTableToDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MoveTableToDatabase(RequestBuilder<crate::model::MoveTableToDatabaseRequest>);
 
@@ -1690,6 +1968,22 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::alter_metadata_resource_location][super::super::client::DataprocMetastore::alter_metadata_resource_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::AlterMetadataResourceLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AlterMetadataResourceLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AlterMetadataResourceLocation(
         RequestBuilder<crate::model::AlterMetadataResourceLocationRequest>,
@@ -1801,6 +2095,25 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::list_locations][super::super::client::DataprocMetastore::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1891,6 +2204,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::get_location][super::super::client::DataprocMetastore::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1936,6 +2264,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::set_iam_policy][super::super::client::DataprocMetastore::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2003,6 +2346,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::get_iam_policy][super::super::client::DataprocMetastore::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2059,6 +2417,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::test_iam_permissions][super::super::client::DataprocMetastore::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2122,6 +2495,25 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::list_operations][super::super::client::DataprocMetastore::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2214,6 +2606,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::get_operation][super::super::client::DataprocMetastore::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2262,6 +2669,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::delete_operation][super::super::client::DataprocMetastore::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2310,6 +2732,21 @@ pub mod dataproc_metastore {
     }
 
     /// The request builder for [DataprocMetastore::cancel_operation][super::super::client::DataprocMetastore::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2413,6 +2850,25 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::list_federations][super::super::client::DataprocMetastoreFederation::list_federations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::ListFederations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFederations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFederations(RequestBuilder<crate::model::ListFederationsRequest>);
 
@@ -2508,6 +2964,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::get_federation][super::super::client::DataprocMetastoreFederation::get_federation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::GetFederation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFederation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFederation(RequestBuilder<crate::model::GetFederationRequest>);
 
@@ -2555,6 +3026,22 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::create_federation][super::super::client::DataprocMetastoreFederation::create_federation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::CreateFederation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFederation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFederation(RequestBuilder<crate::model::CreateFederationRequest>);
 
@@ -2668,6 +3155,22 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::update_federation][super::super::client::DataprocMetastoreFederation::update_federation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::UpdateFederation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFederation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFederation(RequestBuilder<crate::model::UpdateFederationRequest>);
 
@@ -2776,6 +3279,22 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::delete_federation][super::super::client::DataprocMetastoreFederation::delete_federation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::DeleteFederation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_metastore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFederation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFederation(RequestBuilder<crate::model::DeleteFederationRequest>);
 
@@ -2872,6 +3391,25 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::list_locations][super::super::client::DataprocMetastoreFederation::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2962,6 +3500,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::get_location][super::super::client::DataprocMetastoreFederation::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3007,6 +3560,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::set_iam_policy][super::super::client::DataprocMetastoreFederation::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3074,6 +3642,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::get_iam_policy][super::super::client::DataprocMetastoreFederation::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3130,6 +3713,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::test_iam_permissions][super::super::client::DataprocMetastoreFederation::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3193,6 +3791,25 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::list_operations][super::super::client::DataprocMetastoreFederation::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3285,6 +3902,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::get_operation][super::super::client::DataprocMetastoreFederation::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3333,6 +3965,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::delete_operation][super::super::client::DataprocMetastoreFederation::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3381,6 +4028,21 @@ pub mod dataproc_metastore_federation {
     }
 
     /// The request builder for [DataprocMetastoreFederation::cancel_operation][super::super::client::DataprocMetastoreFederation::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_metastore_v1::builder;
+    /// use builder::dataproc_metastore_federation::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/migrationcenter/v1/src/builder.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_assets][super::super::client::MigrationCenter::list_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAssets(RequestBuilder<crate::model::ListAssetsRequest>);
 
@@ -170,6 +189,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_asset][super::super::client::MigrationCenter::get_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAsset(RequestBuilder<crate::model::GetAssetRequest>);
 
@@ -223,6 +257,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::update_asset][super::super::client::MigrationCenter::update_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::UpdateAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAsset(RequestBuilder<crate::model::UpdateAssetRequest>);
 
@@ -290,6 +339,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::batch_update_assets][super::super::client::MigrationCenter::batch_update_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::BatchUpdateAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchUpdateAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchUpdateAssets(RequestBuilder<crate::model::BatchUpdateAssetsRequest>);
 
@@ -353,6 +417,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_asset][super::super::client::MigrationCenter::delete_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAsset(RequestBuilder<crate::model::DeleteAssetRequest>);
 
@@ -406,6 +485,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::batch_delete_assets][super::super::client::MigrationCenter::batch_delete_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::BatchDeleteAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteAssets(RequestBuilder<crate::model::BatchDeleteAssetsRequest>);
 
@@ -475,6 +569,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::report_asset_frames][super::super::client::MigrationCenter::report_asset_frames] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ReportAssetFrames;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReportAssetFrames {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReportAssetFrames(RequestBuilder<crate::model::ReportAssetFramesRequest>);
 
@@ -542,6 +651,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::aggregate_assets_values][super::super::client::MigrationCenter::aggregate_assets_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::AggregateAssetsValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AggregateAssetsValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AggregateAssetsValues(RequestBuilder<crate::model::AggregateAssetsValuesRequest>);
 
@@ -609,6 +733,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::create_import_job][super::super::client::MigrationCenter::create_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CreateImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateImportJob(RequestBuilder<crate::model::CreateImportJobRequest>);
 
@@ -719,6 +859,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_import_jobs][super::super::client::MigrationCenter::list_import_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListImportJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListImportJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListImportJobs(RequestBuilder<crate::model::ListImportJobsRequest>);
 
@@ -820,6 +979,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_import_job][super::super::client::MigrationCenter::get_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetImportJob(RequestBuilder<crate::model::GetImportJobRequest>);
 
@@ -873,6 +1047,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_import_job][super::super::client::MigrationCenter::delete_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteImportJob(RequestBuilder<crate::model::DeleteImportJobRequest>);
 
@@ -972,6 +1162,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::update_import_job][super::super::client::MigrationCenter::update_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::UpdateImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateImportJob(RequestBuilder<crate::model::UpdateImportJobRequest>);
 
@@ -1077,6 +1283,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::validate_import_job][super::super::client::MigrationCenter::validate_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ValidateImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ValidateImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ValidateImportJob(RequestBuilder<crate::model::ValidateImportJobRequest>);
 
@@ -1173,6 +1395,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::run_import_job][super::super::client::MigrationCenter::run_import_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::RunImportJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunImportJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunImportJob(RequestBuilder<crate::model::RunImportJobRequest>);
 
@@ -1266,6 +1504,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_import_data_file][super::super::client::MigrationCenter::get_import_data_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetImportDataFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetImportDataFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetImportDataFile(RequestBuilder<crate::model::GetImportDataFileRequest>);
 
@@ -1316,6 +1569,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_import_data_files][super::super::client::MigrationCenter::list_import_data_files] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListImportDataFiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListImportDataFiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListImportDataFiles(RequestBuilder<crate::model::ListImportDataFilesRequest>);
 
@@ -1416,6 +1688,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::create_import_data_file][super::super::client::MigrationCenter::create_import_data_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CreateImportDataFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateImportDataFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateImportDataFile(RequestBuilder<crate::model::CreateImportDataFileRequest>);
 
@@ -1532,6 +1820,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_import_data_file][super::super::client::MigrationCenter::delete_import_data_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteImportDataFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteImportDataFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteImportDataFile(RequestBuilder<crate::model::DeleteImportDataFileRequest>);
 
@@ -1628,6 +1932,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_groups][super::super::client::MigrationCenter::list_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -1723,6 +2046,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_group][super::super::client::MigrationCenter::get_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -1770,6 +2108,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::create_group][super::super::client::MigrationCenter::create_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CreateGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGroup(RequestBuilder<crate::model::CreateGroupRequest>);
 
@@ -1880,6 +2234,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::update_group][super::super::client::MigrationCenter::update_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::UpdateGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -1985,6 +2355,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_group][super::super::client::MigrationCenter::delete_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGroup(RequestBuilder<crate::model::DeleteGroupRequest>);
 
@@ -2078,6 +2464,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::add_assets_to_group][super::super::client::MigrationCenter::add_assets_to_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::AddAssetsToGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddAssetsToGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddAssetsToGroup(RequestBuilder<crate::model::AddAssetsToGroupRequest>);
 
@@ -2189,6 +2591,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::remove_assets_from_group][super::super::client::MigrationCenter::remove_assets_from_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::RemoveAssetsFromGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveAssetsFromGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveAssetsFromGroup(RequestBuilder<crate::model::RemoveAssetsFromGroupRequest>);
 
@@ -2300,6 +2718,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_error_frames][super::super::client::MigrationCenter::list_error_frames] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListErrorFrames;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListErrorFrames {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListErrorFrames(RequestBuilder<crate::model::ListErrorFramesRequest>);
 
@@ -2389,6 +2826,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_error_frame][super::super::client::MigrationCenter::get_error_frame] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetErrorFrame;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetErrorFrame {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetErrorFrame(RequestBuilder<crate::model::GetErrorFrameRequest>);
 
@@ -2442,6 +2894,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_sources][super::super::client::MigrationCenter::list_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSources(RequestBuilder<crate::model::ListSourcesRequest>);
 
@@ -2537,6 +3008,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_source][super::super::client::MigrationCenter::get_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSource(RequestBuilder<crate::model::GetSourceRequest>);
 
@@ -2584,6 +3070,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::create_source][super::super::client::MigrationCenter::create_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CreateSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSource(RequestBuilder<crate::model::CreateSourceRequest>);
 
@@ -2694,6 +3196,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::update_source][super::super::client::MigrationCenter::update_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::UpdateSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSource(RequestBuilder<crate::model::UpdateSourceRequest>);
 
@@ -2799,6 +3317,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_source][super::super::client::MigrationCenter::delete_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSource(RequestBuilder<crate::model::DeleteSourceRequest>);
 
@@ -2892,6 +3426,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_preference_sets][super::super::client::MigrationCenter::list_preference_sets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListPreferenceSets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPreferenceSets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPreferenceSets(RequestBuilder<crate::model::ListPreferenceSetsRequest>);
 
@@ -2986,6 +3539,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_preference_set][super::super::client::MigrationCenter::get_preference_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetPreferenceSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPreferenceSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPreferenceSet(RequestBuilder<crate::model::GetPreferenceSetRequest>);
 
@@ -3036,6 +3604,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::create_preference_set][super::super::client::MigrationCenter::create_preference_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CreatePreferenceSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePreferenceSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePreferenceSet(RequestBuilder<crate::model::CreatePreferenceSetRequest>);
 
@@ -3152,6 +3736,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::update_preference_set][super::super::client::MigrationCenter::update_preference_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::UpdatePreferenceSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePreferenceSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePreferenceSet(RequestBuilder<crate::model::UpdatePreferenceSetRequest>);
 
@@ -3263,6 +3863,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_preference_set][super::super::client::MigrationCenter::delete_preference_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeletePreferenceSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePreferenceSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePreferenceSet(RequestBuilder<crate::model::DeletePreferenceSetRequest>);
 
@@ -3359,6 +3975,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_settings][super::super::client::MigrationCenter::get_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -3406,6 +4037,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::update_settings][super::super::client::MigrationCenter::update_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::UpdateSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 
@@ -3511,6 +4158,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::create_report_config][super::super::client::MigrationCenter::create_report_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CreateReportConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReportConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReportConfig(RequestBuilder<crate::model::CreateReportConfigRequest>);
 
@@ -3626,6 +4289,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_report_config][super::super::client::MigrationCenter::get_report_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetReportConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReportConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReportConfig(RequestBuilder<crate::model::GetReportConfigRequest>);
 
@@ -3673,6 +4351,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_report_configs][super::super::client::MigrationCenter::list_report_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListReportConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReportConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReportConfigs(RequestBuilder<crate::model::ListReportConfigsRequest>);
 
@@ -3771,6 +4468,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_report_config][super::super::client::MigrationCenter::delete_report_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteReportConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteReportConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteReportConfig(RequestBuilder<crate::model::DeleteReportConfigRequest>);
 
@@ -3873,6 +4586,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::create_report][super::super::client::MigrationCenter::create_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CreateReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReport(RequestBuilder<crate::model::CreateReportRequest>);
 
@@ -3983,6 +4712,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_report][super::super::client::MigrationCenter::get_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReport(RequestBuilder<crate::model::GetReportRequest>);
 
@@ -4036,6 +4780,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_reports][super::super::client::MigrationCenter::list_reports] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListReports;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReports {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReports(RequestBuilder<crate::model::ListReportsRequest>);
 
@@ -4137,6 +4900,22 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_report][super::super::client::MigrationCenter::delete_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_migrationcenter_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteReport(RequestBuilder<crate::model::DeleteReportRequest>);
 
@@ -4230,6 +5009,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_locations][super::super::client::MigrationCenter::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4320,6 +5118,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_location][super::super::client::MigrationCenter::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4365,6 +5178,25 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::list_operations][super::super::client::MigrationCenter::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4457,6 +5289,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::get_operation][super::super::client::MigrationCenter::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4505,6 +5352,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::delete_operation][super::super::client::MigrationCenter::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4553,6 +5415,21 @@ pub mod migration_center {
     }
 
     /// The request builder for [MigrationCenter::cancel_operation][super::super::client::MigrationCenter::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_migrationcenter_v1::builder;
+    /// use builder::migration_center::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/modelarmor/v1/src/builder.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::list_templates][super::super::client::ModelArmor::list_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::ListTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTemplates(RequestBuilder<crate::model::ListTemplatesRequest>);
 
@@ -164,6 +183,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::get_template][super::super::client::ModelArmor::get_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::GetTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTemplate(RequestBuilder<crate::model::GetTemplateRequest>);
 
@@ -211,6 +245,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::create_template][super::super::client::ModelArmor::create_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::CreateTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTemplate(RequestBuilder<crate::model::CreateTemplateRequest>);
 
@@ -283,6 +332,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::update_template][super::super::client::ModelArmor::update_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::UpdateTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTemplate(RequestBuilder<crate::model::UpdateTemplateRequest>);
 
@@ -350,6 +414,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::delete_template][super::super::client::ModelArmor::delete_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::DeleteTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTemplate(RequestBuilder<crate::model::DeleteTemplateRequest>);
 
@@ -403,6 +482,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::get_floor_setting][super::super::client::ModelArmor::get_floor_setting] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::GetFloorSetting;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFloorSetting {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFloorSetting(RequestBuilder<crate::model::GetFloorSettingRequest>);
 
@@ -450,6 +544,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::update_floor_setting][super::super::client::ModelArmor::update_floor_setting] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::UpdateFloorSetting;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFloorSetting {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFloorSetting(RequestBuilder<crate::model::UpdateFloorSettingRequest>);
 
@@ -512,6 +621,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::sanitize_user_prompt][super::super::client::ModelArmor::sanitize_user_prompt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::SanitizeUserPrompt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SanitizeUserPrompt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SanitizeUserPrompt(RequestBuilder<crate::model::SanitizeUserPromptRequest>);
 
@@ -573,6 +697,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::sanitize_model_response][super::super::client::ModelArmor::sanitize_model_response] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::SanitizeModelResponse;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SanitizeModelResponse {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SanitizeModelResponse(RequestBuilder<crate::model::SanitizeModelResponseRequest>);
 
@@ -640,6 +779,25 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::list_locations][super::super::client::ModelArmor::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -730,6 +888,21 @@ pub mod model_armor {
     }
 
     /// The request builder for [ModelArmor::get_location][super::super::client::ModelArmor::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_modelarmor_v1::builder;
+    /// use builder::model_armor::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/netapp/v1/src/builder.rs
+++ b/src/generated/cloud/netapp/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_storage_pools][super::super::client::NetApp::list_storage_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListStoragePools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListStoragePools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListStoragePools(RequestBuilder<crate::model::ListStoragePoolsRequest>);
 
@@ -163,6 +182,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_storage_pool][super::super::client::NetApp::create_storage_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateStoragePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateStoragePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateStoragePool(RequestBuilder<crate::model::CreateStoragePoolRequest>);
 
@@ -270,6 +305,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_storage_pool][super::super::client::NetApp::get_storage_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetStoragePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStoragePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStoragePool(RequestBuilder<crate::model::GetStoragePoolRequest>);
 
@@ -315,6 +365,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_storage_pool][super::super::client::NetApp::update_storage_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateStoragePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateStoragePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateStoragePool(RequestBuilder<crate::model::UpdateStoragePoolRequest>);
 
@@ -417,6 +483,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_storage_pool][super::super::client::NetApp::delete_storage_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteStoragePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteStoragePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteStoragePool(RequestBuilder<crate::model::DeleteStoragePoolRequest>);
 
@@ -505,6 +587,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::validate_directory_service][super::super::client::NetApp::validate_directory_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ValidateDirectoryService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ValidateDirectoryService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ValidateDirectoryService(
         RequestBuilder<crate::model::ValidateDirectoryServiceRequest>,
@@ -604,6 +702,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::switch_active_replica_zone][super::super::client::NetApp::switch_active_replica_zone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::SwitchActiveReplicaZone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SwitchActiveReplicaZone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SwitchActiveReplicaZone(
         RequestBuilder<crate::model::SwitchActiveReplicaZoneRequest>,
@@ -694,6 +808,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_volumes][super::super::client::NetApp::list_volumes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListVolumes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVolumes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVolumes(RequestBuilder<crate::model::ListVolumesRequest>);
 
@@ -787,6 +920,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_volume][super::super::client::NetApp::get_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVolume(RequestBuilder<crate::model::GetVolumeRequest>);
 
@@ -832,6 +980,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_volume][super::super::client::NetApp::create_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVolume(RequestBuilder<crate::model::CreateVolumeRequest>);
 
@@ -934,6 +1098,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_volume][super::super::client::NetApp::update_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVolume(RequestBuilder<crate::model::UpdateVolumeRequest>);
 
@@ -1031,6 +1211,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_volume][super::super::client::NetApp::delete_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVolume(RequestBuilder<crate::model::DeleteVolumeRequest>);
 
@@ -1122,6 +1318,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::revert_volume][super::super::client::NetApp::revert_volume] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::RevertVolume;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RevertVolume {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RevertVolume(RequestBuilder<crate::model::RevertVolumeRequest>);
 
@@ -1213,6 +1425,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_snapshots][super::super::client::NetApp::list_snapshots] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListSnapshots;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSnapshots {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSnapshots(RequestBuilder<crate::model::ListSnapshotsRequest>);
 
@@ -1306,6 +1537,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_snapshot][super::super::client::NetApp::get_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSnapshot(RequestBuilder<crate::model::GetSnapshotRequest>);
 
@@ -1351,6 +1597,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_snapshot][super::super::client::NetApp::create_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSnapshot(RequestBuilder<crate::model::CreateSnapshotRequest>);
 
@@ -1453,6 +1715,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_snapshot][super::super::client::NetApp::delete_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSnapshot(RequestBuilder<crate::model::DeleteSnapshotRequest>);
 
@@ -1538,6 +1816,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_snapshot][super::super::client::NetApp::update_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSnapshot(RequestBuilder<crate::model::UpdateSnapshotRequest>);
 
@@ -1635,6 +1929,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_active_directories][super::super::client::NetApp::list_active_directories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListActiveDirectories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListActiveDirectories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListActiveDirectories(RequestBuilder<crate::model::ListActiveDirectoriesRequest>);
 
@@ -1733,6 +2046,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_active_directory][super::super::client::NetApp::get_active_directory] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetActiveDirectory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetActiveDirectory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetActiveDirectory(RequestBuilder<crate::model::GetActiveDirectoryRequest>);
 
@@ -1781,6 +2109,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_active_directory][super::super::client::NetApp::create_active_directory] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateActiveDirectory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateActiveDirectory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateActiveDirectory(RequestBuilder<crate::model::CreateActiveDirectoryRequest>);
 
@@ -1889,6 +2233,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_active_directory][super::super::client::NetApp::update_active_directory] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateActiveDirectory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateActiveDirectory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateActiveDirectory(RequestBuilder<crate::model::UpdateActiveDirectoryRequest>);
 
@@ -1992,6 +2352,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_active_directory][super::super::client::NetApp::delete_active_directory] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteActiveDirectory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteActiveDirectory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteActiveDirectory(RequestBuilder<crate::model::DeleteActiveDirectoryRequest>);
 
@@ -2080,6 +2456,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_kms_configs][super::super::client::NetApp::list_kms_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListKmsConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListKmsConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListKmsConfigs(RequestBuilder<crate::model::ListKmsConfigsRequest>);
 
@@ -2173,6 +2568,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_kms_config][super::super::client::NetApp::create_kms_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateKmsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateKmsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateKmsConfig(RequestBuilder<crate::model::CreateKmsConfigRequest>);
 
@@ -2275,6 +2686,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_kms_config][super::super::client::NetApp::get_kms_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetKmsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetKmsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetKmsConfig(RequestBuilder<crate::model::GetKmsConfigRequest>);
 
@@ -2320,6 +2746,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_kms_config][super::super::client::NetApp::update_kms_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateKmsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateKmsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateKmsConfig(RequestBuilder<crate::model::UpdateKmsConfigRequest>);
 
@@ -2417,6 +2859,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::encrypt_volumes][super::super::client::NetApp::encrypt_volumes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::EncryptVolumes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EncryptVolumes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EncryptVolumes(RequestBuilder<crate::model::EncryptVolumesRequest>);
 
@@ -2500,6 +2958,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::verify_kms_config][super::super::client::NetApp::verify_kms_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::VerifyKmsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyKmsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyKmsConfig(RequestBuilder<crate::model::VerifyKmsConfigRequest>);
 
@@ -2545,6 +3018,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_kms_config][super::super::client::NetApp::delete_kms_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteKmsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteKmsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteKmsConfig(RequestBuilder<crate::model::DeleteKmsConfigRequest>);
 
@@ -2630,6 +3119,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_replications][super::super::client::NetApp::list_replications] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListReplications;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReplications {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReplications(RequestBuilder<crate::model::ListReplicationsRequest>);
 
@@ -2726,6 +3234,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_replication][super::super::client::NetApp::get_replication] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetReplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReplication(RequestBuilder<crate::model::GetReplicationRequest>);
 
@@ -2771,6 +3294,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_replication][super::super::client::NetApp::create_replication] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateReplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReplication(RequestBuilder<crate::model::CreateReplicationRequest>);
 
@@ -2878,6 +3417,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_replication][super::super::client::NetApp::delete_replication] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteReplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteReplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteReplication(RequestBuilder<crate::model::DeleteReplicationRequest>);
 
@@ -2966,6 +3521,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_replication][super::super::client::NetApp::update_replication] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateReplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateReplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateReplication(RequestBuilder<crate::model::UpdateReplicationRequest>);
 
@@ -3068,6 +3639,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::stop_replication][super::super::client::NetApp::stop_replication] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::StopReplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopReplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopReplication(RequestBuilder<crate::model::StopReplicationRequest>);
 
@@ -3159,6 +3746,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::resume_replication][super::super::client::NetApp::resume_replication] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ResumeReplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeReplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeReplication(RequestBuilder<crate::model::ResumeReplicationRequest>);
 
@@ -3247,6 +3850,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::reverse_replication_direction][super::super::client::NetApp::reverse_replication_direction] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ReverseReplicationDirection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReverseReplicationDirection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReverseReplicationDirection(
         RequestBuilder<crate::model::ReverseReplicationDirectionRequest>,
@@ -3337,6 +3956,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::establish_peering][super::super::client::NetApp::establish_peering] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::EstablishPeering;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EstablishPeering {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EstablishPeering(RequestBuilder<crate::model::EstablishPeeringRequest>);
 
@@ -3460,6 +4095,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::sync_replication][super::super::client::NetApp::sync_replication] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::SyncReplication;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SyncReplication {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SyncReplication(RequestBuilder<crate::model::SyncReplicationRequest>);
 
@@ -3545,6 +4196,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_backup_vault][super::super::client::NetApp::create_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupVault(RequestBuilder<crate::model::CreateBackupVaultRequest>);
 
@@ -3652,6 +4319,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_backup_vault][super::super::client::NetApp::get_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupVault(RequestBuilder<crate::model::GetBackupVaultRequest>);
 
@@ -3697,6 +4379,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_backup_vaults][super::super::client::NetApp::list_backup_vaults] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListBackupVaults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupVaults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupVaults(RequestBuilder<crate::model::ListBackupVaultsRequest>);
 
@@ -3793,6 +4494,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_backup_vault][super::super::client::NetApp::update_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackupVault(RequestBuilder<crate::model::UpdateBackupVaultRequest>);
 
@@ -3895,6 +4612,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_backup_vault][super::super::client::NetApp::delete_backup_vault] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteBackupVault;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupVault {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupVault(RequestBuilder<crate::model::DeleteBackupVaultRequest>);
 
@@ -3983,6 +4716,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_backup][super::super::client::NetApp::create_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -4085,6 +4834,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_backup][super::super::client::NetApp::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -4130,6 +4894,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_backups][super::super::client::NetApp::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -4223,6 +5006,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_backup][super::super::client::NetApp::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -4308,6 +5107,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_backup][super::super::client::NetApp::update_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -4405,6 +5220,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_backup_policy][super::super::client::NetApp::create_backup_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateBackupPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupPolicy(RequestBuilder<crate::model::CreateBackupPolicyRequest>);
 
@@ -4512,6 +5343,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_backup_policy][super::super::client::NetApp::get_backup_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetBackupPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupPolicy(RequestBuilder<crate::model::GetBackupPolicyRequest>);
 
@@ -4557,6 +5403,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_backup_policies][super::super::client::NetApp::list_backup_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListBackupPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupPolicies(RequestBuilder<crate::model::ListBackupPoliciesRequest>);
 
@@ -4655,6 +5520,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_backup_policy][super::super::client::NetApp::update_backup_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateBackupPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackupPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackupPolicy(RequestBuilder<crate::model::UpdateBackupPolicyRequest>);
 
@@ -4757,6 +5638,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_backup_policy][super::super::client::NetApp::delete_backup_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteBackupPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupPolicy(RequestBuilder<crate::model::DeleteBackupPolicyRequest>);
 
@@ -4845,6 +5742,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_quota_rules][super::super::client::NetApp::list_quota_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListQuotaRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListQuotaRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListQuotaRules(RequestBuilder<crate::model::ListQuotaRulesRequest>);
 
@@ -4938,6 +5854,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_quota_rule][super::super::client::NetApp::get_quota_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetQuotaRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetQuotaRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetQuotaRule(RequestBuilder<crate::model::GetQuotaRuleRequest>);
 
@@ -4983,6 +5914,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::create_quota_rule][super::super::client::NetApp::create_quota_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CreateQuotaRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateQuotaRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateQuotaRule(RequestBuilder<crate::model::CreateQuotaRuleRequest>);
 
@@ -5085,6 +6032,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::update_quota_rule][super::super::client::NetApp::update_quota_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::UpdateQuotaRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateQuotaRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateQuotaRule(RequestBuilder<crate::model::UpdateQuotaRuleRequest>);
 
@@ -5180,6 +6143,22 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_quota_rule][super::super::client::NetApp::delete_quota_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteQuotaRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_netapp_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteQuotaRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteQuotaRule(RequestBuilder<crate::model::DeleteQuotaRuleRequest>);
 
@@ -5265,6 +6244,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_locations][super::super::client::NetApp::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5353,6 +6351,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_location][super::super::client::NetApp::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5396,6 +6409,25 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::list_operations][super::super::client::NetApp::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5486,6 +6518,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::get_operation][super::super::client::NetApp::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5532,6 +6579,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::delete_operation][super::super::client::NetApp::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5578,6 +6640,21 @@ pub mod net_app {
     }
 
     /// The request builder for [NetApp::cancel_operation][super::super::client::NetApp::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_netapp_v1::builder;
+    /// use builder::net_app::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networkconnectivity/v1/src/builder.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::list_service_connection_maps][super::super::client::CrossNetworkAutomationService::list_service_connection_maps] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::ListServiceConnectionMaps;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceConnectionMaps {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceConnectionMaps(
         RequestBuilder<crate::model::ListServiceConnectionMapsRequest>,
@@ -173,6 +192,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::get_service_connection_map][super::super::client::CrossNetworkAutomationService::get_service_connection_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::GetServiceConnectionMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceConnectionMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceConnectionMap(
         RequestBuilder<crate::model::GetServiceConnectionMapRequest>,
@@ -225,6 +259,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::create_service_connection_map][super::super::client::CrossNetworkAutomationService::create_service_connection_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::CreateServiceConnectionMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceConnectionMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceConnectionMap(
         RequestBuilder<crate::model::CreateServiceConnectionMapRequest>,
@@ -343,6 +393,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::update_service_connection_map][super::super::client::CrossNetworkAutomationService::update_service_connection_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::UpdateServiceConnectionMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServiceConnectionMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServiceConnectionMap(
         RequestBuilder<crate::model::UpdateServiceConnectionMapRequest>,
@@ -456,6 +522,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::delete_service_connection_map][super::super::client::CrossNetworkAutomationService::delete_service_connection_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::DeleteServiceConnectionMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceConnectionMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceConnectionMap(
         RequestBuilder<crate::model::DeleteServiceConnectionMapRequest>,
@@ -560,6 +642,25 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::list_service_connection_policies][super::super::client::CrossNetworkAutomationService::list_service_connection_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::ListServiceConnectionPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceConnectionPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceConnectionPolicies(
         RequestBuilder<crate::model::ListServiceConnectionPoliciesRequest>,
@@ -664,6 +765,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::get_service_connection_policy][super::super::client::CrossNetworkAutomationService::get_service_connection_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::GetServiceConnectionPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceConnectionPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceConnectionPolicy(
         RequestBuilder<crate::model::GetServiceConnectionPolicyRequest>,
@@ -716,6 +832,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::create_service_connection_policy][super::super::client::CrossNetworkAutomationService::create_service_connection_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::CreateServiceConnectionPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceConnectionPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceConnectionPolicy(
         RequestBuilder<crate::model::CreateServiceConnectionPolicyRequest>,
@@ -837,6 +969,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::update_service_connection_policy][super::super::client::CrossNetworkAutomationService::update_service_connection_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::UpdateServiceConnectionPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServiceConnectionPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServiceConnectionPolicy(
         RequestBuilder<crate::model::UpdateServiceConnectionPolicyRequest>,
@@ -950,6 +1098,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::delete_service_connection_policy][super::super::client::CrossNetworkAutomationService::delete_service_connection_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::DeleteServiceConnectionPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceConnectionPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceConnectionPolicy(
         RequestBuilder<crate::model::DeleteServiceConnectionPolicyRequest>,
@@ -1054,6 +1218,25 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::list_service_classes][super::super::client::CrossNetworkAutomationService::list_service_classes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::ListServiceClasses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceClasses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceClasses(RequestBuilder<crate::model::ListServiceClassesRequest>);
 
@@ -1154,6 +1337,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::get_service_class][super::super::client::CrossNetworkAutomationService::get_service_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::GetServiceClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceClass(RequestBuilder<crate::model::GetServiceClassRequest>);
 
@@ -1201,6 +1399,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::update_service_class][super::super::client::CrossNetworkAutomationService::update_service_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::UpdateServiceClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServiceClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServiceClass(RequestBuilder<crate::model::UpdateServiceClassRequest>);
 
@@ -1309,6 +1523,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::delete_service_class][super::super::client::CrossNetworkAutomationService::delete_service_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::DeleteServiceClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceClass(RequestBuilder<crate::model::DeleteServiceClassRequest>);
 
@@ -1411,6 +1641,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::get_service_connection_token][super::super::client::CrossNetworkAutomationService::get_service_connection_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::GetServiceConnectionToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceConnectionToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceConnectionToken(
         RequestBuilder<crate::model::GetServiceConnectionTokenRequest>,
@@ -1463,6 +1708,25 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::list_service_connection_tokens][super::super::client::CrossNetworkAutomationService::list_service_connection_tokens] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::ListServiceConnectionTokens;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceConnectionTokens {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceConnectionTokens(
         RequestBuilder<crate::model::ListServiceConnectionTokensRequest>,
@@ -1567,6 +1831,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::create_service_connection_token][super::super::client::CrossNetworkAutomationService::create_service_connection_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::CreateServiceConnectionToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceConnectionToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceConnectionToken(
         RequestBuilder<crate::model::CreateServiceConnectionTokenRequest>,
@@ -1688,6 +1968,22 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::delete_service_connection_token][super::super::client::CrossNetworkAutomationService::delete_service_connection_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::DeleteServiceConnectionToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceConnectionToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceConnectionToken(
         RequestBuilder<crate::model::DeleteServiceConnectionTokenRequest>,
@@ -1792,6 +2088,25 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::list_locations][super::super::client::CrossNetworkAutomationService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1882,6 +2197,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::get_location][super::super::client::CrossNetworkAutomationService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1927,6 +2257,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::set_iam_policy][super::super::client::CrossNetworkAutomationService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1994,6 +2339,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::get_iam_policy][super::super::client::CrossNetworkAutomationService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2050,6 +2410,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::test_iam_permissions][super::super::client::CrossNetworkAutomationService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2113,6 +2488,25 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::list_operations][super::super::client::CrossNetworkAutomationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2205,6 +2599,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::get_operation][super::super::client::CrossNetworkAutomationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2253,6 +2662,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::delete_operation][super::super::client::CrossNetworkAutomationService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2301,6 +2725,21 @@ pub mod cross_network_automation_service {
     }
 
     /// The request builder for [CrossNetworkAutomationService::cancel_operation][super::super::client::CrossNetworkAutomationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::cross_network_automation_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2404,6 +2843,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_hubs][super::super::client::HubService::list_hubs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListHubs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHubs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHubs(RequestBuilder<crate::model::ListHubsRequest>);
 
@@ -2499,6 +2957,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_hub][super::super::client::HubService::get_hub] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetHub;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetHub {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetHub(RequestBuilder<crate::model::GetHubRequest>);
 
@@ -2546,6 +3019,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::create_hub][super::super::client::HubService::create_hub] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::CreateHub;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateHub {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateHub(RequestBuilder<crate::model::CreateHubRequest>);
 
@@ -2653,6 +3142,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::update_hub][super::super::client::HubService::update_hub] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::UpdateHub;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateHub {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateHub(RequestBuilder<crate::model::UpdateHubRequest>);
 
@@ -2753,6 +3258,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::delete_hub][super::super::client::HubService::delete_hub] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::DeleteHub;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteHub {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteHub(RequestBuilder<crate::model::DeleteHubRequest>);
 
@@ -2846,6 +3367,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_hub_spokes][super::super::client::HubService::list_hub_spokes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListHubSpokes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHubSpokes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHubSpokes(RequestBuilder<crate::model::ListHubSpokesRequest>);
 
@@ -2961,6 +3501,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::query_hub_status][super::super::client::HubService::query_hub_status] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::QueryHubStatus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryHubStatus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryHubStatus(RequestBuilder<crate::model::QueryHubStatusRequest>);
 
@@ -3062,6 +3621,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_spokes][super::super::client::HubService::list_spokes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListSpokes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSpokes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSpokes(RequestBuilder<crate::model::ListSpokesRequest>);
 
@@ -3157,6 +3735,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_spoke][super::super::client::HubService::get_spoke] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetSpoke;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSpoke {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSpoke(RequestBuilder<crate::model::GetSpokeRequest>);
 
@@ -3204,6 +3797,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::create_spoke][super::super::client::HubService::create_spoke] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::CreateSpoke;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSpoke {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSpoke(RequestBuilder<crate::model::CreateSpokeRequest>);
 
@@ -3314,6 +3923,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::update_spoke][super::super::client::HubService::update_spoke] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::UpdateSpoke;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSpoke {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSpoke(RequestBuilder<crate::model::UpdateSpokeRequest>);
 
@@ -3417,6 +4042,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::reject_hub_spoke][super::super::client::HubService::reject_hub_spoke] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::RejectHubSpoke;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RejectHubSpoke {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RejectHubSpoke(RequestBuilder<crate::model::RejectHubSpokeRequest>);
 
@@ -3525,6 +4166,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::accept_hub_spoke][super::super::client::HubService::accept_hub_spoke] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::AcceptHubSpoke;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AcceptHubSpoke {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AcceptHubSpoke(RequestBuilder<crate::model::AcceptHubSpokeRequest>);
 
@@ -3627,6 +4284,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::accept_spoke_update][super::super::client::HubService::accept_spoke_update] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::AcceptSpokeUpdate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AcceptSpokeUpdate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AcceptSpokeUpdate(RequestBuilder<crate::model::AcceptSpokeUpdateRequest>);
 
@@ -3740,6 +4413,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::reject_spoke_update][super::super::client::HubService::reject_spoke_update] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::RejectSpokeUpdate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RejectSpokeUpdate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RejectSpokeUpdate(RequestBuilder<crate::model::RejectSpokeUpdateRequest>);
 
@@ -3859,6 +4548,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::delete_spoke][super::super::client::HubService::delete_spoke] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::DeleteSpoke;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSpoke {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSpoke(RequestBuilder<crate::model::DeleteSpokeRequest>);
 
@@ -3952,6 +4657,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_route_table][super::super::client::HubService::get_route_table] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetRouteTable;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRouteTable {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRouteTable(RequestBuilder<crate::model::GetRouteTableRequest>);
 
@@ -3999,6 +4719,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_route][super::super::client::HubService::get_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRoute(RequestBuilder<crate::model::GetRouteRequest>);
 
@@ -4046,6 +4781,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_routes][super::super::client::HubService::list_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRoutes(RequestBuilder<crate::model::ListRoutesRequest>);
 
@@ -4141,6 +4895,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_route_tables][super::super::client::HubService::list_route_tables] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListRouteTables;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRouteTables {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRouteTables(RequestBuilder<crate::model::ListRouteTablesRequest>);
 
@@ -4236,6 +5009,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_group][super::super::client::HubService::get_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -4283,6 +5071,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_groups][super::super::client::HubService::list_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -4378,6 +5185,22 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::update_group][super::super::client::HubService::update_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::UpdateGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -4481,6 +5304,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_locations][super::super::client::HubService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4571,6 +5413,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_location][super::super::client::HubService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4616,6 +5473,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::set_iam_policy][super::super::client::HubService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4683,6 +5555,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_iam_policy][super::super::client::HubService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4739,6 +5626,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::test_iam_permissions][super::super::client::HubService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4802,6 +5704,25 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::list_operations][super::super::client::HubService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4894,6 +5815,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::get_operation][super::super::client::HubService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4942,6 +5878,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::delete_operation][super::super::client::HubService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4990,6 +5941,21 @@ pub mod hub_service {
     }
 
     /// The request builder for [HubService::cancel_operation][super::super::client::HubService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::hub_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5093,6 +6059,25 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::list_policy_based_routes][super::super::client::PolicyBasedRoutingService::list_policy_based_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::ListPolicyBasedRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPolicyBasedRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPolicyBasedRoutes(RequestBuilder<crate::model::ListPolicyBasedRoutesRequest>);
 
@@ -5193,6 +6178,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::get_policy_based_route][super::super::client::PolicyBasedRoutingService::get_policy_based_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::GetPolicyBasedRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPolicyBasedRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPolicyBasedRoute(RequestBuilder<crate::model::GetPolicyBasedRouteRequest>);
 
@@ -5243,6 +6243,22 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::create_policy_based_route][super::super::client::PolicyBasedRoutingService::create_policy_based_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::CreatePolicyBasedRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePolicyBasedRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePolicyBasedRoute(RequestBuilder<crate::model::CreatePolicyBasedRouteRequest>);
 
@@ -5361,6 +6377,22 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::delete_policy_based_route][super::super::client::PolicyBasedRoutingService::delete_policy_based_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::DeletePolicyBasedRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkconnectivity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePolicyBasedRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePolicyBasedRoute(RequestBuilder<crate::model::DeletePolicyBasedRouteRequest>);
 
@@ -5457,6 +6489,25 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::list_locations][super::super::client::PolicyBasedRoutingService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5547,6 +6598,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::get_location][super::super::client::PolicyBasedRoutingService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5592,6 +6658,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::set_iam_policy][super::super::client::PolicyBasedRoutingService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5659,6 +6740,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::get_iam_policy][super::super::client::PolicyBasedRoutingService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5715,6 +6811,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::test_iam_permissions][super::super::client::PolicyBasedRoutingService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5778,6 +6889,25 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::list_operations][super::super::client::PolicyBasedRoutingService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5870,6 +7000,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::get_operation][super::super::client::PolicyBasedRoutingService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5918,6 +7063,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::delete_operation][super::super::client::PolicyBasedRoutingService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5966,6 +7126,21 @@ pub mod policy_based_routing_service {
     }
 
     /// The request builder for [PolicyBasedRoutingService::cancel_operation][super::super::client::PolicyBasedRoutingService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkconnectivity_v1::builder;
+    /// use builder::policy_based_routing_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networkmanagement/v1/src/builder.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::list_connectivity_tests][super::super::client::ReachabilityService::list_connectivity_tests] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::ListConnectivityTests;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnectivityTests {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnectivityTests(RequestBuilder<crate::model::ListConnectivityTestsRequest>);
 
@@ -169,6 +188,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::get_connectivity_test][super::super::client::ReachabilityService::get_connectivity_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::GetConnectivityTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnectivityTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnectivityTest(RequestBuilder<crate::model::GetConnectivityTestRequest>);
 
@@ -219,6 +253,22 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::create_connectivity_test][super::super::client::ReachabilityService::create_connectivity_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::CreateConnectivityTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkmanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnectivityTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnectivityTest(RequestBuilder<crate::model::CreateConnectivityTestRequest>);
 
@@ -329,6 +379,22 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::update_connectivity_test][super::super::client::ReachabilityService::update_connectivity_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::UpdateConnectivityTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkmanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnectivityTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnectivityTest(RequestBuilder<crate::model::UpdateConnectivityTestRequest>);
 
@@ -434,6 +500,22 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::rerun_connectivity_test][super::super::client::ReachabilityService::rerun_connectivity_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::RerunConnectivityTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkmanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RerunConnectivityTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RerunConnectivityTest(RequestBuilder<crate::model::RerunConnectivityTestRequest>);
 
@@ -525,6 +607,22 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::delete_connectivity_test][super::super::client::ReachabilityService::delete_connectivity_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::DeleteConnectivityTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkmanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnectivityTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnectivityTest(RequestBuilder<crate::model::DeleteConnectivityTestRequest>);
 
@@ -615,6 +713,25 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::list_locations][super::super::client::ReachabilityService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -705,6 +822,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::get_location][super::super::client::ReachabilityService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -750,6 +882,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::set_iam_policy][super::super::client::ReachabilityService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -817,6 +964,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::get_iam_policy][super::super::client::ReachabilityService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -873,6 +1035,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::test_iam_permissions][super::super::client::ReachabilityService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -936,6 +1113,25 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::list_operations][super::super::client::ReachabilityService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1028,6 +1224,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::get_operation][super::super::client::ReachabilityService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1076,6 +1287,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::delete_operation][super::super::client::ReachabilityService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1124,6 +1350,21 @@ pub mod reachability_service {
     }
 
     /// The request builder for [ReachabilityService::cancel_operation][super::super::client::ReachabilityService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::reachability_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1227,6 +1468,25 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::list_vpc_flow_logs_configs][super::super::client::VpcFlowLogsService::list_vpc_flow_logs_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::ListVpcFlowLogsConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVpcFlowLogsConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVpcFlowLogsConfigs(RequestBuilder<crate::model::ListVpcFlowLogsConfigsRequest>);
 
@@ -1329,6 +1589,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::get_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::get_vpc_flow_logs_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::GetVpcFlowLogsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVpcFlowLogsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVpcFlowLogsConfig(RequestBuilder<crate::model::GetVpcFlowLogsConfigRequest>);
 
@@ -1379,6 +1654,22 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::create_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::create_vpc_flow_logs_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::CreateVpcFlowLogsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkmanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVpcFlowLogsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVpcFlowLogsConfig(
         RequestBuilder<crate::model::CreateVpcFlowLogsConfigRequest>,
@@ -1493,6 +1784,22 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::update_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::update_vpc_flow_logs_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::UpdateVpcFlowLogsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkmanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVpcFlowLogsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVpcFlowLogsConfig(
         RequestBuilder<crate::model::UpdateVpcFlowLogsConfigRequest>,
@@ -1602,6 +1909,22 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::delete_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::delete_vpc_flow_logs_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::DeleteVpcFlowLogsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkmanagement_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVpcFlowLogsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVpcFlowLogsConfig(
         RequestBuilder<crate::model::DeleteVpcFlowLogsConfigRequest>,
@@ -1694,6 +2017,25 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::list_locations][super::super::client::VpcFlowLogsService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1784,6 +2126,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::get_location][super::super::client::VpcFlowLogsService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1829,6 +2186,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::set_iam_policy][super::super::client::VpcFlowLogsService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1896,6 +2268,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::get_iam_policy][super::super::client::VpcFlowLogsService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1952,6 +2339,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::test_iam_permissions][super::super::client::VpcFlowLogsService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2015,6 +2417,25 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::list_operations][super::super::client::VpcFlowLogsService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2107,6 +2528,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::get_operation][super::super::client::VpcFlowLogsService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2155,6 +2591,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::delete_operation][super::super::client::VpcFlowLogsService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2203,6 +2654,21 @@ pub mod vpc_flow_logs_service {
     }
 
     /// The request builder for [VpcFlowLogsService::cancel_operation][super::super::client::VpcFlowLogsService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkmanagement_v1::builder;
+    /// use builder::vpc_flow_logs_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networksecurity/v1/src/builder.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::list_authorization_policies][super::super::client::NetworkSecurity::list_authorization_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::ListAuthorizationPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAuthorizationPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAuthorizationPolicies(
         RequestBuilder<crate::model::ListAuthorizationPoliciesRequest>,
@@ -161,6 +180,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::get_authorization_policy][super::super::client::NetworkSecurity::get_authorization_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::GetAuthorizationPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAuthorizationPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAuthorizationPolicy(RequestBuilder<crate::model::GetAuthorizationPolicyRequest>);
 
@@ -211,6 +245,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::create_authorization_policy][super::super::client::NetworkSecurity::create_authorization_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::CreateAuthorizationPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAuthorizationPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAuthorizationPolicy(
         RequestBuilder<crate::model::CreateAuthorizationPolicyRequest>,
@@ -325,6 +375,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::update_authorization_policy][super::super::client::NetworkSecurity::update_authorization_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::UpdateAuthorizationPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAuthorizationPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAuthorizationPolicy(
         RequestBuilder<crate::model::UpdateAuthorizationPolicyRequest>,
@@ -432,6 +498,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::delete_authorization_policy][super::super::client::NetworkSecurity::delete_authorization_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::DeleteAuthorizationPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAuthorizationPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAuthorizationPolicy(
         RequestBuilder<crate::model::DeleteAuthorizationPolicyRequest>,
@@ -524,6 +606,25 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::list_server_tls_policies][super::super::client::NetworkSecurity::list_server_tls_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::ListServerTlsPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServerTlsPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServerTlsPolicies(RequestBuilder<crate::model::ListServerTlsPoliciesRequest>);
 
@@ -612,6 +713,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::get_server_tls_policy][super::super::client::NetworkSecurity::get_server_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::GetServerTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServerTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServerTlsPolicy(RequestBuilder<crate::model::GetServerTlsPolicyRequest>);
 
@@ -662,6 +778,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::create_server_tls_policy][super::super::client::NetworkSecurity::create_server_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::CreateServerTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServerTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServerTlsPolicy(RequestBuilder<crate::model::CreateServerTlsPolicyRequest>);
 
@@ -774,6 +906,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::update_server_tls_policy][super::super::client::NetworkSecurity::update_server_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::UpdateServerTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServerTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServerTlsPolicy(RequestBuilder<crate::model::UpdateServerTlsPolicyRequest>);
 
@@ -879,6 +1027,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::delete_server_tls_policy][super::super::client::NetworkSecurity::delete_server_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::DeleteServerTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServerTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServerTlsPolicy(RequestBuilder<crate::model::DeleteServerTlsPolicyRequest>);
 
@@ -969,6 +1133,25 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::list_client_tls_policies][super::super::client::NetworkSecurity::list_client_tls_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::ListClientTlsPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClientTlsPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClientTlsPolicies(RequestBuilder<crate::model::ListClientTlsPoliciesRequest>);
 
@@ -1057,6 +1240,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::get_client_tls_policy][super::super::client::NetworkSecurity::get_client_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::GetClientTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetClientTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetClientTlsPolicy(RequestBuilder<crate::model::GetClientTlsPolicyRequest>);
 
@@ -1107,6 +1305,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::create_client_tls_policy][super::super::client::NetworkSecurity::create_client_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::CreateClientTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateClientTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateClientTlsPolicy(RequestBuilder<crate::model::CreateClientTlsPolicyRequest>);
 
@@ -1219,6 +1433,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::update_client_tls_policy][super::super::client::NetworkSecurity::update_client_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::UpdateClientTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateClientTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateClientTlsPolicy(RequestBuilder<crate::model::UpdateClientTlsPolicyRequest>);
 
@@ -1324,6 +1554,22 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::delete_client_tls_policy][super::super::client::NetworkSecurity::delete_client_tls_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::DeleteClientTlsPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networksecurity_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteClientTlsPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteClientTlsPolicy(RequestBuilder<crate::model::DeleteClientTlsPolicyRequest>);
 
@@ -1414,6 +1660,25 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::list_locations][super::super::client::NetworkSecurity::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1504,6 +1769,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::get_location][super::super::client::NetworkSecurity::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1549,6 +1829,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::set_iam_policy][super::super::client::NetworkSecurity::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1616,6 +1911,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::get_iam_policy][super::super::client::NetworkSecurity::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1672,6 +1982,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::test_iam_permissions][super::super::client::NetworkSecurity::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1735,6 +2060,25 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::list_operations][super::super::client::NetworkSecurity::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1827,6 +2171,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::get_operation][super::super::client::NetworkSecurity::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1875,6 +2234,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::delete_operation][super::super::client::NetworkSecurity::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1923,6 +2297,21 @@ pub mod network_security {
     }
 
     /// The request builder for [NetworkSecurity::cancel_operation][super::super::client::NetworkSecurity::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networksecurity_v1::builder;
+    /// use builder::network_security::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/networkservices/v1/src/builder.rs
+++ b/src/generated/cloud/networkservices/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::list_lb_traffic_extensions][super::super::client::DepService::list_lb_traffic_extensions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::ListLbTrafficExtensions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLbTrafficExtensions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLbTrafficExtensions(
         RequestBuilder<crate::model::ListLbTrafficExtensionsRequest>,
@@ -173,6 +192,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::get_lb_traffic_extension][super::super::client::DepService::get_lb_traffic_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::GetLbTrafficExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLbTrafficExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLbTrafficExtension(RequestBuilder<crate::model::GetLbTrafficExtensionRequest>);
 
@@ -223,6 +257,22 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::create_lb_traffic_extension][super::super::client::DepService::create_lb_traffic_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::CreateLbTrafficExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLbTrafficExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLbTrafficExtension(
         RequestBuilder<crate::model::CreateLbTrafficExtensionRequest>,
@@ -343,6 +393,22 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::update_lb_traffic_extension][super::super::client::DepService::update_lb_traffic_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::UpdateLbTrafficExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLbTrafficExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLbTrafficExtension(
         RequestBuilder<crate::model::UpdateLbTrafficExtensionRequest>,
@@ -456,6 +522,22 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::delete_lb_traffic_extension][super::super::client::DepService::delete_lb_traffic_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::DeleteLbTrafficExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLbTrafficExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLbTrafficExtension(
         RequestBuilder<crate::model::DeleteLbTrafficExtensionRequest>,
@@ -554,6 +636,25 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::list_lb_route_extensions][super::super::client::DepService::list_lb_route_extensions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::ListLbRouteExtensions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLbRouteExtensions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLbRouteExtensions(RequestBuilder<crate::model::ListLbRouteExtensionsRequest>);
 
@@ -654,6 +755,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::get_lb_route_extension][super::super::client::DepService::get_lb_route_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::GetLbRouteExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLbRouteExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLbRouteExtension(RequestBuilder<crate::model::GetLbRouteExtensionRequest>);
 
@@ -704,6 +820,22 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::create_lb_route_extension][super::super::client::DepService::create_lb_route_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::CreateLbRouteExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLbRouteExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLbRouteExtension(RequestBuilder<crate::model::CreateLbRouteExtensionRequest>);
 
@@ -822,6 +954,22 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::update_lb_route_extension][super::super::client::DepService::update_lb_route_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::UpdateLbRouteExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLbRouteExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLbRouteExtension(RequestBuilder<crate::model::UpdateLbRouteExtensionRequest>);
 
@@ -933,6 +1081,22 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::delete_lb_route_extension][super::super::client::DepService::delete_lb_route_extension] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::DeleteLbRouteExtension;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLbRouteExtension {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLbRouteExtension(RequestBuilder<crate::model::DeleteLbRouteExtensionRequest>);
 
@@ -1029,6 +1193,25 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::list_locations][super::super::client::DepService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1119,6 +1302,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::get_location][super::super::client::DepService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1164,6 +1362,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::set_iam_policy][super::super::client::DepService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1231,6 +1444,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::get_iam_policy][super::super::client::DepService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1287,6 +1515,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::test_iam_permissions][super::super::client::DepService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1350,6 +1593,25 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::list_operations][super::super::client::DepService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1442,6 +1704,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::get_operation][super::super::client::DepService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1490,6 +1767,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::delete_operation][super::super::client::DepService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1538,6 +1830,21 @@ pub mod dep_service {
     }
 
     /// The request builder for [DepService::cancel_operation][super::super::client::DepService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::dep_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1641,6 +1948,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_endpoint_policies][super::super::client::NetworkServices::list_endpoint_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListEndpointPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEndpointPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEndpointPolicies(RequestBuilder<crate::model::ListEndpointPoliciesRequest>);
 
@@ -1729,6 +2055,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_endpoint_policy][super::super::client::NetworkServices::get_endpoint_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetEndpointPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEndpointPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEndpointPolicy(RequestBuilder<crate::model::GetEndpointPolicyRequest>);
 
@@ -1779,6 +2120,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_endpoint_policy][super::super::client::NetworkServices::create_endpoint_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateEndpointPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEndpointPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEndpointPolicy(RequestBuilder<crate::model::CreateEndpointPolicyRequest>);
 
@@ -1889,6 +2246,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::update_endpoint_policy][super::super::client::NetworkServices::update_endpoint_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::UpdateEndpointPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEndpointPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEndpointPolicy(RequestBuilder<crate::model::UpdateEndpointPolicyRequest>);
 
@@ -1992,6 +2365,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_endpoint_policy][super::super::client::NetworkServices::delete_endpoint_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteEndpointPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEndpointPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEndpointPolicy(RequestBuilder<crate::model::DeleteEndpointPolicyRequest>);
 
@@ -2082,6 +2471,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_gateways][super::super::client::NetworkServices::list_gateways] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListGateways;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGateways {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGateways(RequestBuilder<crate::model::ListGatewaysRequest>);
 
@@ -2165,6 +2573,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_gateway][super::super::client::NetworkServices::get_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGateway(RequestBuilder<crate::model::GetGatewayRequest>);
 
@@ -2212,6 +2635,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_gateway][super::super::client::NetworkServices::create_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGateway(RequestBuilder<crate::model::CreateGatewayRequest>);
 
@@ -2316,6 +2755,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::update_gateway][super::super::client::NetworkServices::update_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::UpdateGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGateway(RequestBuilder<crate::model::UpdateGatewayRequest>);
 
@@ -2413,6 +2868,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_gateway][super::super::client::NetworkServices::delete_gateway] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteGateway;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGateway {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGateway(RequestBuilder<crate::model::DeleteGatewayRequest>);
 
@@ -2500,6 +2971,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_grpc_routes][super::super::client::NetworkServices::list_grpc_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListGrpcRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGrpcRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGrpcRoutes(RequestBuilder<crate::model::ListGrpcRoutesRequest>);
 
@@ -2583,6 +3073,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_grpc_route][super::super::client::NetworkServices::get_grpc_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetGrpcRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGrpcRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGrpcRoute(RequestBuilder<crate::model::GetGrpcRouteRequest>);
 
@@ -2630,6 +3135,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_grpc_route][super::super::client::NetworkServices::create_grpc_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateGrpcRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGrpcRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGrpcRoute(RequestBuilder<crate::model::CreateGrpcRouteRequest>);
 
@@ -2734,6 +3255,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::update_grpc_route][super::super::client::NetworkServices::update_grpc_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::UpdateGrpcRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGrpcRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGrpcRoute(RequestBuilder<crate::model::UpdateGrpcRouteRequest>);
 
@@ -2831,6 +3368,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_grpc_route][super::super::client::NetworkServices::delete_grpc_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteGrpcRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGrpcRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGrpcRoute(RequestBuilder<crate::model::DeleteGrpcRouteRequest>);
 
@@ -2918,6 +3471,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_http_routes][super::super::client::NetworkServices::list_http_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListHttpRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHttpRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHttpRoutes(RequestBuilder<crate::model::ListHttpRoutesRequest>);
 
@@ -3001,6 +3573,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_http_route][super::super::client::NetworkServices::get_http_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetHttpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetHttpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetHttpRoute(RequestBuilder<crate::model::GetHttpRouteRequest>);
 
@@ -3048,6 +3635,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_http_route][super::super::client::NetworkServices::create_http_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateHttpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateHttpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateHttpRoute(RequestBuilder<crate::model::CreateHttpRouteRequest>);
 
@@ -3152,6 +3755,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::update_http_route][super::super::client::NetworkServices::update_http_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::UpdateHttpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateHttpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateHttpRoute(RequestBuilder<crate::model::UpdateHttpRouteRequest>);
 
@@ -3249,6 +3868,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_http_route][super::super::client::NetworkServices::delete_http_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteHttpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteHttpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteHttpRoute(RequestBuilder<crate::model::DeleteHttpRouteRequest>);
 
@@ -3336,6 +3971,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_tcp_routes][super::super::client::NetworkServices::list_tcp_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListTcpRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTcpRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTcpRoutes(RequestBuilder<crate::model::ListTcpRoutesRequest>);
 
@@ -3419,6 +4073,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_tcp_route][super::super::client::NetworkServices::get_tcp_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetTcpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTcpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTcpRoute(RequestBuilder<crate::model::GetTcpRouteRequest>);
 
@@ -3466,6 +4135,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_tcp_route][super::super::client::NetworkServices::create_tcp_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateTcpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTcpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTcpRoute(RequestBuilder<crate::model::CreateTcpRouteRequest>);
 
@@ -3570,6 +4255,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::update_tcp_route][super::super::client::NetworkServices::update_tcp_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::UpdateTcpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTcpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTcpRoute(RequestBuilder<crate::model::UpdateTcpRouteRequest>);
 
@@ -3667,6 +4368,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_tcp_route][super::super::client::NetworkServices::delete_tcp_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteTcpRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTcpRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTcpRoute(RequestBuilder<crate::model::DeleteTcpRouteRequest>);
 
@@ -3754,6 +4471,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_tls_routes][super::super::client::NetworkServices::list_tls_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListTlsRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTlsRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTlsRoutes(RequestBuilder<crate::model::ListTlsRoutesRequest>);
 
@@ -3837,6 +4573,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_tls_route][super::super::client::NetworkServices::get_tls_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetTlsRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTlsRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTlsRoute(RequestBuilder<crate::model::GetTlsRouteRequest>);
 
@@ -3884,6 +4635,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_tls_route][super::super::client::NetworkServices::create_tls_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateTlsRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTlsRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTlsRoute(RequestBuilder<crate::model::CreateTlsRouteRequest>);
 
@@ -3988,6 +4755,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::update_tls_route][super::super::client::NetworkServices::update_tls_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::UpdateTlsRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTlsRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTlsRoute(RequestBuilder<crate::model::UpdateTlsRouteRequest>);
 
@@ -4085,6 +4868,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_tls_route][super::super::client::NetworkServices::delete_tls_route] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteTlsRoute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTlsRoute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTlsRoute(RequestBuilder<crate::model::DeleteTlsRouteRequest>);
 
@@ -4172,6 +4971,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_service_bindings][super::super::client::NetworkServices::list_service_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListServiceBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceBindings(RequestBuilder<crate::model::ListServiceBindingsRequest>);
 
@@ -4260,6 +5078,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_service_binding][super::super::client::NetworkServices::get_service_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetServiceBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceBinding(RequestBuilder<crate::model::GetServiceBindingRequest>);
 
@@ -4310,6 +5143,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_service_binding][super::super::client::NetworkServices::create_service_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateServiceBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceBinding(RequestBuilder<crate::model::CreateServiceBindingRequest>);
 
@@ -4420,6 +5269,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_service_binding][super::super::client::NetworkServices::delete_service_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteServiceBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceBinding(RequestBuilder<crate::model::DeleteServiceBindingRequest>);
 
@@ -4510,6 +5375,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_meshes][super::super::client::NetworkServices::list_meshes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListMeshes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMeshes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMeshes(RequestBuilder<crate::model::ListMeshesRequest>);
 
@@ -4593,6 +5477,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_mesh][super::super::client::NetworkServices::get_mesh] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetMesh;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMesh {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMesh(RequestBuilder<crate::model::GetMeshRequest>);
 
@@ -4640,6 +5539,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::create_mesh][super::super::client::NetworkServices::create_mesh] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CreateMesh;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMesh {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMesh(RequestBuilder<crate::model::CreateMeshRequest>);
 
@@ -4741,6 +5656,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::update_mesh][super::super::client::NetworkServices::update_mesh] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::UpdateMesh;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMesh {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMesh(RequestBuilder<crate::model::UpdateMeshRequest>);
 
@@ -4835,6 +5766,22 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_mesh][super::super::client::NetworkServices::delete_mesh] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteMesh;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_networkservices_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMesh {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMesh(RequestBuilder<crate::model::DeleteMeshRequest>);
 
@@ -4922,6 +5869,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_locations][super::super::client::NetworkServices::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5012,6 +5978,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_location][super::super::client::NetworkServices::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5057,6 +6038,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::set_iam_policy][super::super::client::NetworkServices::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5124,6 +6120,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_iam_policy][super::super::client::NetworkServices::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5180,6 +6191,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::test_iam_permissions][super::super::client::NetworkServices::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5243,6 +6269,25 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::list_operations][super::super::client::NetworkServices::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5335,6 +6380,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::get_operation][super::super::client::NetworkServices::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5383,6 +6443,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::delete_operation][super::super::client::NetworkServices::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5431,6 +6506,21 @@ pub mod network_services {
     }
 
     /// The request builder for [NetworkServices::cancel_operation][super::super::client::NetworkServices::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_networkservices_v1::builder;
+    /// use builder::network_services::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/notebooks/v2/src/builder.rs
+++ b/src/generated/cloud/notebooks/v2/src/builder.rs
@@ -69,6 +69,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_instances][super::super::client::NotebookService::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -164,6 +183,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_instance][super::super::client::NotebookService::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -211,6 +245,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::create_instance][super::super::client::NotebookService::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -321,6 +371,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::update_instance][super::super::client::NotebookService::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -426,6 +492,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::delete_instance][super::super::client::NotebookService::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -519,6 +601,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::start_instance][super::super::client::NotebookService::start_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::StartInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartInstance(RequestBuilder<crate::model::StartInstanceRequest>);
 
@@ -604,6 +702,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::stop_instance][super::super::client::NotebookService::stop_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::StopInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopInstance(RequestBuilder<crate::model::StopInstanceRequest>);
 
@@ -689,6 +803,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::reset_instance][super::super::client::NotebookService::reset_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::ResetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetInstance(RequestBuilder<crate::model::ResetInstanceRequest>);
 
@@ -774,6 +904,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::check_instance_upgradability][super::super::client::NotebookService::check_instance_upgradability] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::CheckInstanceUpgradability;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckInstanceUpgradability {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckInstanceUpgradability(
         RequestBuilder<crate::model::CheckInstanceUpgradabilityRequest>,
@@ -826,6 +971,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::upgrade_instance][super::super::client::NotebookService::upgrade_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::UpgradeInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpgradeInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpgradeInstance(RequestBuilder<crate::model::UpgradeInstanceRequest>);
 
@@ -911,6 +1072,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::rollback_instance][super::super::client::NotebookService::rollback_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::RollbackInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RollbackInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RollbackInstance(RequestBuilder<crate::model::RollbackInstanceRequest>);
 
@@ -1015,6 +1192,22 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::diagnose_instance][super::super::client::NotebookService::diagnose_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::DiagnoseInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_notebooks_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiagnoseInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiagnoseInstance(RequestBuilder<crate::model::DiagnoseInstanceRequest>);
 
@@ -1122,6 +1315,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_locations][super::super::client::NotebookService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1212,6 +1424,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_location][super::super::client::NotebookService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1257,6 +1484,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::set_iam_policy][super::super::client::NotebookService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1324,6 +1566,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_iam_policy][super::super::client::NotebookService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1380,6 +1637,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::test_iam_permissions][super::super::client::NotebookService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1443,6 +1715,25 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::list_operations][super::super::client::NotebookService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1535,6 +1826,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::get_operation][super::super::client::NotebookService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1583,6 +1889,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::delete_operation][super::super::client::NotebookService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1631,6 +1952,21 @@ pub mod notebook_service {
     }
 
     /// The request builder for [NotebookService::cancel_operation][super::super::client::NotebookService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_notebooks_v2::builder;
+    /// use builder::notebook_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/optimization/v1/src/builder.rs
+++ b/src/generated/cloud/optimization/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod fleet_routing {
     }
 
     /// The request builder for [FleetRouting::optimize_tours][super::super::client::FleetRouting::optimize_tours] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_optimization_v1::builder;
+    /// use builder::fleet_routing::OptimizeTours;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> OptimizeTours {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct OptimizeTours(RequestBuilder<crate::model::OptimizeToursRequest>);
 
@@ -258,6 +273,22 @@ pub mod fleet_routing {
     }
 
     /// The request builder for [FleetRouting::batch_optimize_tours][super::super::client::FleetRouting::batch_optimize_tours] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_optimization_v1::builder;
+    /// use builder::fleet_routing::BatchOptimizeTours;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_optimization_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchOptimizeTours {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchOptimizeTours(RequestBuilder<crate::model::BatchOptimizeToursRequest>);
 
@@ -362,6 +393,21 @@ pub mod fleet_routing {
     }
 
     /// The request builder for [FleetRouting::get_operation][super::super::client::FleetRouting::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_optimization_v1::builder;
+    /// use builder::fleet_routing::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/oracledatabase/v1/src/builder.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_cloud_exadata_infrastructures][super::super::client::OracleDatabase::list_cloud_exadata_infrastructures] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListCloudExadataInfrastructures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCloudExadataInfrastructures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCloudExadataInfrastructures(
         RequestBuilder<crate::model::ListCloudExadataInfrastructuresRequest>,
@@ -161,6 +180,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::get_cloud_exadata_infrastructure][super::super::client::OracleDatabase::get_cloud_exadata_infrastructure] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::GetCloudExadataInfrastructure;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCloudExadataInfrastructure {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCloudExadataInfrastructure(
         RequestBuilder<crate::model::GetCloudExadataInfrastructureRequest>,
@@ -213,6 +247,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::create_cloud_exadata_infrastructure][super::super::client::OracleDatabase::create_cloud_exadata_infrastructure] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::CreateCloudExadataInfrastructure;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCloudExadataInfrastructure {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCloudExadataInfrastructure(
         RequestBuilder<crate::model::CreateCloudExadataInfrastructureRequest>,
@@ -336,6 +386,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::delete_cloud_exadata_infrastructure][super::super::client::OracleDatabase::delete_cloud_exadata_infrastructure] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::DeleteCloudExadataInfrastructure;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCloudExadataInfrastructure {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCloudExadataInfrastructure(
         RequestBuilder<crate::model::DeleteCloudExadataInfrastructureRequest>,
@@ -440,6 +506,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_cloud_vm_clusters][super::super::client::OracleDatabase::list_cloud_vm_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListCloudVmClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCloudVmClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCloudVmClusters(RequestBuilder<crate::model::ListCloudVmClustersRequest>);
 
@@ -534,6 +619,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::get_cloud_vm_cluster][super::super::client::OracleDatabase::get_cloud_vm_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::GetCloudVmCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCloudVmCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCloudVmCluster(RequestBuilder<crate::model::GetCloudVmClusterRequest>);
 
@@ -584,6 +684,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::create_cloud_vm_cluster][super::super::client::OracleDatabase::create_cloud_vm_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::CreateCloudVmCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCloudVmCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCloudVmCluster(RequestBuilder<crate::model::CreateCloudVmClusterRequest>);
 
@@ -700,6 +816,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::delete_cloud_vm_cluster][super::super::client::OracleDatabase::delete_cloud_vm_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::DeleteCloudVmCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCloudVmCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCloudVmCluster(RequestBuilder<crate::model::DeleteCloudVmClusterRequest>);
 
@@ -802,6 +934,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_entitlements][super::super::client::OracleDatabase::list_entitlements] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListEntitlements;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntitlements {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntitlements(RequestBuilder<crate::model::ListEntitlementsRequest>);
 
@@ -888,6 +1039,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_db_servers][super::super::client::OracleDatabase::list_db_servers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListDbServers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDbServers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDbServers(RequestBuilder<crate::model::ListDbServersRequest>);
 
@@ -971,6 +1141,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_db_nodes][super::super::client::OracleDatabase::list_db_nodes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListDbNodes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDbNodes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDbNodes(RequestBuilder<crate::model::ListDbNodesRequest>);
 
@@ -1054,6 +1243,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_gi_versions][super::super::client::OracleDatabase::list_gi_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListGiVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGiVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGiVersions(RequestBuilder<crate::model::ListGiVersionsRequest>);
 
@@ -1137,6 +1345,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_db_system_shapes][super::super::client::OracleDatabase::list_db_system_shapes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListDbSystemShapes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDbSystemShapes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDbSystemShapes(RequestBuilder<crate::model::ListDbSystemShapesRequest>);
 
@@ -1225,6 +1452,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_autonomous_databases][super::super::client::OracleDatabase::list_autonomous_databases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListAutonomousDatabases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAutonomousDatabases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDatabases(
         RequestBuilder<crate::model::ListAutonomousDatabasesRequest>,
@@ -1329,6 +1575,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::get_autonomous_database][super::super::client::OracleDatabase::get_autonomous_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::GetAutonomousDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAutonomousDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAutonomousDatabase(RequestBuilder<crate::model::GetAutonomousDatabaseRequest>);
 
@@ -1379,6 +1640,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::create_autonomous_database][super::super::client::OracleDatabase::create_autonomous_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::CreateAutonomousDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAutonomousDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAutonomousDatabase(
         RequestBuilder<crate::model::CreateAutonomousDatabaseRequest>,
@@ -1499,6 +1776,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::delete_autonomous_database][super::super::client::OracleDatabase::delete_autonomous_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::DeleteAutonomousDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAutonomousDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAutonomousDatabase(
         RequestBuilder<crate::model::DeleteAutonomousDatabaseRequest>,
@@ -1597,6 +1890,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::restore_autonomous_database][super::super::client::OracleDatabase::restore_autonomous_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::RestoreAutonomousDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreAutonomousDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreAutonomousDatabase(
         RequestBuilder<crate::model::RestoreAutonomousDatabaseRequest>,
@@ -1701,6 +2010,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::generate_autonomous_database_wallet][super::super::client::OracleDatabase::generate_autonomous_database_wallet] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::GenerateAutonomousDatabaseWallet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAutonomousDatabaseWallet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAutonomousDatabaseWallet(
         RequestBuilder<crate::model::GenerateAutonomousDatabaseWalletRequest>,
@@ -1773,6 +2097,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_autonomous_db_versions][super::super::client::OracleDatabase::list_autonomous_db_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListAutonomousDbVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAutonomousDbVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDbVersions(
         RequestBuilder<crate::model::ListAutonomousDbVersionsRequest>,
@@ -1865,6 +2208,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_autonomous_database_character_sets][super::super::client::OracleDatabase::list_autonomous_database_character_sets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListAutonomousDatabaseCharacterSets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAutonomousDatabaseCharacterSets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDatabaseCharacterSets(
         RequestBuilder<crate::model::ListAutonomousDatabaseCharacterSetsRequest>,
@@ -1965,6 +2327,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_autonomous_database_backups][super::super::client::OracleDatabase::list_autonomous_database_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListAutonomousDatabaseBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAutonomousDatabaseBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAutonomousDatabaseBackups(
         RequestBuilder<crate::model::ListAutonomousDatabaseBackupsRequest>,
@@ -2063,6 +2444,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::stop_autonomous_database][super::super::client::OracleDatabase::stop_autonomous_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::StopAutonomousDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopAutonomousDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopAutonomousDatabase(RequestBuilder<crate::model::StopAutonomousDatabaseRequest>);
 
@@ -2154,6 +2551,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::start_autonomous_database][super::super::client::OracleDatabase::start_autonomous_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::StartAutonomousDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartAutonomousDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartAutonomousDatabase(
         RequestBuilder<crate::model::StartAutonomousDatabaseRequest>,
@@ -2247,6 +2660,22 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::restart_autonomous_database][super::super::client::OracleDatabase::restart_autonomous_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::RestartAutonomousDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_oracledatabase_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestartAutonomousDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestartAutonomousDatabase(
         RequestBuilder<crate::model::RestartAutonomousDatabaseRequest>,
@@ -2340,6 +2769,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_locations][super::super::client::OracleDatabase::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2430,6 +2878,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::get_location][super::super::client::OracleDatabase::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2475,6 +2938,25 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::list_operations][super::super::client::OracleDatabase::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2567,6 +3049,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::get_operation][super::super::client::OracleDatabase::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2615,6 +3112,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::delete_operation][super::super::client::OracleDatabase::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2663,6 +3175,21 @@ pub mod oracle_database {
     }
 
     /// The request builder for [OracleDatabase::cancel_operation][super::super::client::OracleDatabase::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oracledatabase_v1::builder;
+    /// use builder::oracle_database::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::CreateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_orchestration_airflow_service_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEnvironment(RequestBuilder<crate::model::CreateEnvironmentRequest>);
 
@@ -166,6 +182,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::GetEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -211,6 +242,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::ListEnvironments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEnvironments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEnvironments(RequestBuilder<crate::model::ListEnvironmentsRequest>);
 
@@ -295,6 +345,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::UpdateEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_orchestration_airflow_service_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEnvironment(RequestBuilder<crate::model::UpdateEnvironmentRequest>);
 
@@ -401,6 +467,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::DeleteEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_orchestration_airflow_service_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEnvironment(RequestBuilder<crate::model::DeleteEnvironmentRequest>);
 
@@ -489,6 +571,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::execute_airflow_command][super::super::client::Environments::execute_airflow_command] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::ExecuteAirflowCommand;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExecuteAirflowCommand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExecuteAirflowCommand(RequestBuilder<crate::model::ExecuteAirflowCommandRequest>);
 
@@ -560,6 +657,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::stop_airflow_command][super::super::client::Environments::stop_airflow_command] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::StopAirflowCommand;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopAirflowCommand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopAirflowCommand(RequestBuilder<crate::model::StopAirflowCommandRequest>);
 
@@ -632,6 +744,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::poll_airflow_command][super::super::client::Environments::poll_airflow_command] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::PollAirflowCommand;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PollAirflowCommand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PollAirflowCommand(RequestBuilder<crate::model::PollAirflowCommandRequest>);
 
@@ -704,6 +831,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_workloads][super::super::client::Environments::list_workloads] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::ListWorkloads;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkloads {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkloads(RequestBuilder<crate::model::ListWorkloadsRequest>);
 
@@ -793,6 +939,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::check_upgrade][super::super::client::Environments::check_upgrade] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::CheckUpgrade;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_orchestration_airflow_service_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckUpgrade {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckUpgrade(RequestBuilder<crate::model::CheckUpgradeRequest>);
 
@@ -887,6 +1049,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::create_user_workloads_secret][super::super::client::Environments::create_user_workloads_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::CreateUserWorkloadsSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateUserWorkloadsSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateUserWorkloadsSecret(
         RequestBuilder<crate::model::CreateUserWorkloadsSecretRequest>,
@@ -952,6 +1129,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_user_workloads_secret][super::super::client::Environments::get_user_workloads_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::GetUserWorkloadsSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetUserWorkloadsSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetUserWorkloadsSecret(RequestBuilder<crate::model::GetUserWorkloadsSecretRequest>);
 
@@ -1002,6 +1194,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_user_workloads_secrets][super::super::client::Environments::list_user_workloads_secrets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::ListUserWorkloadsSecrets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUserWorkloadsSecrets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUserWorkloadsSecrets(
         RequestBuilder<crate::model::ListUserWorkloadsSecretsRequest>,
@@ -1094,6 +1305,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::update_user_workloads_secret][super::super::client::Environments::update_user_workloads_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::UpdateUserWorkloadsSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateUserWorkloadsSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateUserWorkloadsSecret(
         RequestBuilder<crate::model::UpdateUserWorkloadsSecretRequest>,
@@ -1149,6 +1375,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::delete_user_workloads_secret][super::super::client::Environments::delete_user_workloads_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::DeleteUserWorkloadsSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteUserWorkloadsSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteUserWorkloadsSecret(
         RequestBuilder<crate::model::DeleteUserWorkloadsSecretRequest>,
@@ -1201,6 +1442,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::create_user_workloads_config_map][super::super::client::Environments::create_user_workloads_config_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::CreateUserWorkloadsConfigMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateUserWorkloadsConfigMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateUserWorkloadsConfigMap(
         RequestBuilder<crate::model::CreateUserWorkloadsConfigMapRequest>,
@@ -1266,6 +1522,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_user_workloads_config_map][super::super::client::Environments::get_user_workloads_config_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::GetUserWorkloadsConfigMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetUserWorkloadsConfigMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetUserWorkloadsConfigMap(
         RequestBuilder<crate::model::GetUserWorkloadsConfigMapRequest>,
@@ -1318,6 +1589,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_user_workloads_config_maps][super::super::client::Environments::list_user_workloads_config_maps] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::ListUserWorkloadsConfigMaps;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUserWorkloadsConfigMaps {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUserWorkloadsConfigMaps(
         RequestBuilder<crate::model::ListUserWorkloadsConfigMapsRequest>,
@@ -1410,6 +1700,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::update_user_workloads_config_map][super::super::client::Environments::update_user_workloads_config_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::UpdateUserWorkloadsConfigMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateUserWorkloadsConfigMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateUserWorkloadsConfigMap(
         RequestBuilder<crate::model::UpdateUserWorkloadsConfigMapRequest>,
@@ -1465,6 +1770,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::delete_user_workloads_config_map][super::super::client::Environments::delete_user_workloads_config_map] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::DeleteUserWorkloadsConfigMap;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteUserWorkloadsConfigMap {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteUserWorkloadsConfigMap(
         RequestBuilder<crate::model::DeleteUserWorkloadsConfigMapRequest>,
@@ -1517,6 +1837,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::save_snapshot][super::super::client::Environments::save_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::SaveSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_orchestration_airflow_service_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SaveSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SaveSnapshot(RequestBuilder<crate::model::SaveSnapshotRequest>);
 
@@ -1609,6 +1945,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::load_snapshot][super::super::client::Environments::load_snapshot] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::LoadSnapshot;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_orchestration_airflow_service_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LoadSnapshot {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LoadSnapshot(RequestBuilder<crate::model::LoadSnapshotRequest>);
 
@@ -1725,6 +2077,22 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::database_failover][super::super::client::Environments::database_failover] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::DatabaseFailover;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_orchestration_airflow_service_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DatabaseFailover {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DatabaseFailover(RequestBuilder<crate::model::DatabaseFailoverRequest>);
 
@@ -1814,6 +2182,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::fetch_database_properties][super::super::client::Environments::fetch_database_properties] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::FetchDatabaseProperties;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchDatabaseProperties {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchDatabaseProperties(
         RequestBuilder<crate::model::FetchDatabasePropertiesRequest>,
@@ -1866,6 +2249,25 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1958,6 +2360,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2006,6 +2423,21 @@ pub mod environments {
     }
 
     /// The request builder for [Environments::delete_operation][super::super::client::Environments::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::environments::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2109,6 +2541,25 @@ pub mod image_versions {
     }
 
     /// The request builder for [ImageVersions::list_image_versions][super::super::client::ImageVersions::list_image_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::image_versions::ListImageVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListImageVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListImageVersions(RequestBuilder<crate::model::ListImageVersionsRequest>);
 
@@ -2199,6 +2650,25 @@ pub mod image_versions {
     }
 
     /// The request builder for [ImageVersions::list_operations][super::super::client::ImageVersions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::image_versions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2291,6 +2761,21 @@ pub mod image_versions {
     }
 
     /// The request builder for [ImageVersions::get_operation][super::super::client::ImageVersions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::image_versions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2339,6 +2824,21 @@ pub mod image_versions {
     }
 
     /// The request builder for [ImageVersions::delete_operation][super::super::client::ImageVersions::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orchestration_airflow_service_v1::builder;
+    /// use builder::image_versions::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/orgpolicy/v2/src/builder.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builder.rs
@@ -69,6 +69,25 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::list_constraints][super::super::client::OrgPolicy::list_constraints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::ListConstraints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConstraints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConstraints(RequestBuilder<crate::model::ListConstraintsRequest>);
 
@@ -152,6 +171,25 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::list_policies][super::super::client::OrgPolicy::list_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::ListPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPolicies(RequestBuilder<crate::model::ListPoliciesRequest>);
 
@@ -235,6 +273,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::get_policy][super::super::client::OrgPolicy::get_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::GetPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPolicy(RequestBuilder<crate::model::GetPolicyRequest>);
 
@@ -282,6 +335,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::get_effective_policy][super::super::client::OrgPolicy::get_effective_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::GetEffectivePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEffectivePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEffectivePolicy(RequestBuilder<crate::model::GetEffectivePolicyRequest>);
 
@@ -332,6 +400,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::create_policy][super::super::client::OrgPolicy::create_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::CreatePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePolicy(RequestBuilder<crate::model::CreatePolicyRequest>);
 
@@ -390,6 +473,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::update_policy][super::super::client::OrgPolicy::update_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::UpdatePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePolicy(RequestBuilder<crate::model::UpdatePolicyRequest>);
 
@@ -449,6 +547,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::delete_policy][super::super::client::OrgPolicy::delete_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::DeletePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePolicy(RequestBuilder<crate::model::DeletePolicyRequest>);
 
@@ -502,6 +615,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::create_custom_constraint][super::super::client::OrgPolicy::create_custom_constraint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::CreateCustomConstraint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCustomConstraint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCustomConstraint(RequestBuilder<crate::model::CreateCustomConstraintRequest>);
 
@@ -565,6 +693,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::update_custom_constraint][super::super::client::OrgPolicy::update_custom_constraint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::UpdateCustomConstraint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCustomConstraint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCustomConstraint(RequestBuilder<crate::model::UpdateCustomConstraintRequest>);
 
@@ -620,6 +763,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::get_custom_constraint][super::super::client::OrgPolicy::get_custom_constraint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::GetCustomConstraint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCustomConstraint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCustomConstraint(RequestBuilder<crate::model::GetCustomConstraintRequest>);
 
@@ -670,6 +828,25 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::list_custom_constraints][super::super::client::OrgPolicy::list_custom_constraints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::ListCustomConstraints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCustomConstraints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCustomConstraints(RequestBuilder<crate::model::ListCustomConstraintsRequest>);
 
@@ -758,6 +935,21 @@ pub mod org_policy {
     }
 
     /// The request builder for [OrgPolicy::delete_custom_constraint][super::super::client::OrgPolicy::delete_custom_constraint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_orgpolicy_v2::builder;
+    /// use builder::org_policy::DeleteCustomConstraint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCustomConstraint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCustomConstraint(RequestBuilder<crate::model::DeleteCustomConstraintRequest>);
 

--- a/src/generated/cloud/osconfig/v1/src/builder.rs
+++ b/src/generated/cloud/osconfig/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::execute_patch_job][super::super::client::OsConfigService::execute_patch_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::ExecutePatchJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExecutePatchJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExecutePatchJob(RequestBuilder<crate::model::ExecutePatchJobRequest>);
 
@@ -171,6 +186,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::get_patch_job][super::super::client::OsConfigService::get_patch_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::GetPatchJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPatchJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPatchJob(RequestBuilder<crate::model::GetPatchJobRequest>);
 
@@ -218,6 +248,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::cancel_patch_job][super::super::client::OsConfigService::cancel_patch_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::CancelPatchJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelPatchJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelPatchJob(RequestBuilder<crate::model::CancelPatchJobRequest>);
 
@@ -265,6 +310,25 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::list_patch_jobs][super::super::client::OsConfigService::list_patch_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::ListPatchJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPatchJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPatchJobs(RequestBuilder<crate::model::ListPatchJobsRequest>);
 
@@ -354,6 +418,25 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::list_patch_job_instance_details][super::super::client::OsConfigService::list_patch_job_instance_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::ListPatchJobInstanceDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPatchJobInstanceDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPatchJobInstanceDetails(
         RequestBuilder<crate::model::ListPatchJobInstanceDetailsRequest>,
@@ -452,6 +535,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::create_patch_deployment][super::super::client::OsConfigService::create_patch_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::CreatePatchDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePatchDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePatchDeployment(RequestBuilder<crate::model::CreatePatchDeploymentRequest>);
 
@@ -521,6 +619,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::get_patch_deployment][super::super::client::OsConfigService::get_patch_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::GetPatchDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPatchDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPatchDeployment(RequestBuilder<crate::model::GetPatchDeploymentRequest>);
 
@@ -571,6 +684,25 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::list_patch_deployments][super::super::client::OsConfigService::list_patch_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::ListPatchDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPatchDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPatchDeployments(RequestBuilder<crate::model::ListPatchDeploymentsRequest>);
 
@@ -659,6 +791,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::delete_patch_deployment][super::super::client::OsConfigService::delete_patch_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::DeletePatchDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePatchDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePatchDeployment(RequestBuilder<crate::model::DeletePatchDeploymentRequest>);
 
@@ -709,6 +856,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::update_patch_deployment][super::super::client::OsConfigService::update_patch_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::UpdatePatchDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePatchDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePatchDeployment(RequestBuilder<crate::model::UpdatePatchDeploymentRequest>);
 
@@ -771,6 +933,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::pause_patch_deployment][super::super::client::OsConfigService::pause_patch_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::PausePatchDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PausePatchDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PausePatchDeployment(RequestBuilder<crate::model::PausePatchDeploymentRequest>);
 
@@ -821,6 +998,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::resume_patch_deployment][super::super::client::OsConfigService::resume_patch_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::ResumePatchDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumePatchDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumePatchDeployment(RequestBuilder<crate::model::ResumePatchDeploymentRequest>);
 
@@ -871,6 +1063,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::get_operation][super::super::client::OsConfigService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -919,6 +1126,21 @@ pub mod os_config_service {
     }
 
     /// The request builder for [OsConfigService::cancel_operation][super::super::client::OsConfigService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1022,6 +1244,22 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::create_os_policy_assignment][super::super::client::OsConfigZonalService::create_os_policy_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::CreateOSPolicyAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_osconfig_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateOSPolicyAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateOSPolicyAssignment(
         RequestBuilder<crate::model::CreateOSPolicyAssignmentRequest>,
@@ -1138,6 +1376,22 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::update_os_policy_assignment][super::super::client::OsConfigZonalService::update_os_policy_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::UpdateOSPolicyAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_osconfig_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateOSPolicyAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateOSPolicyAssignment(
         RequestBuilder<crate::model::UpdateOSPolicyAssignmentRequest>,
@@ -1247,6 +1501,21 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::get_os_policy_assignment][super::super::client::OsConfigZonalService::get_os_policy_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::GetOSPolicyAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOSPolicyAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOSPolicyAssignment(RequestBuilder<crate::model::GetOSPolicyAssignmentRequest>);
 
@@ -1297,6 +1566,25 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::list_os_policy_assignments][super::super::client::OsConfigZonalService::list_os_policy_assignments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::ListOSPolicyAssignments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOSPolicyAssignments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOSPolicyAssignments(
         RequestBuilder<crate::model::ListOSPolicyAssignmentsRequest>,
@@ -1389,6 +1677,25 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::list_os_policy_assignment_revisions][super::super::client::OsConfigZonalService::list_os_policy_assignment_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::ListOSPolicyAssignmentRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOSPolicyAssignmentRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOSPolicyAssignmentRevisions(
         RequestBuilder<crate::model::ListOSPolicyAssignmentRevisionsRequest>,
@@ -1481,6 +1788,22 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::delete_os_policy_assignment][super::super::client::OsConfigZonalService::delete_os_policy_assignment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::DeleteOSPolicyAssignment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_osconfig_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOSPolicyAssignment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOSPolicyAssignment(
         RequestBuilder<crate::model::DeleteOSPolicyAssignmentRequest>,
@@ -1578,6 +1901,21 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::get_os_policy_assignment_report][super::super::client::OsConfigZonalService::get_os_policy_assignment_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::GetOSPolicyAssignmentReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOSPolicyAssignmentReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOSPolicyAssignmentReport(
         RequestBuilder<crate::model::GetOSPolicyAssignmentReportRequest>,
@@ -1630,6 +1968,25 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::list_os_policy_assignment_reports][super::super::client::OsConfigZonalService::list_os_policy_assignment_reports] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::ListOSPolicyAssignmentReports;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOSPolicyAssignmentReports {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOSPolicyAssignmentReports(
         RequestBuilder<crate::model::ListOSPolicyAssignmentReportsRequest>,
@@ -1728,6 +2085,21 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::get_inventory][super::super::client::OsConfigZonalService::get_inventory] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::GetInventory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInventory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInventory(RequestBuilder<crate::model::GetInventoryRequest>);
 
@@ -1781,6 +2153,25 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::list_inventories][super::super::client::OsConfigZonalService::list_inventories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::ListInventories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInventories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInventories(RequestBuilder<crate::model::ListInventoriesRequest>);
 
@@ -1876,6 +2267,21 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::get_vulnerability_report][super::super::client::OsConfigZonalService::get_vulnerability_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::GetVulnerabilityReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVulnerabilityReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVulnerabilityReport(RequestBuilder<crate::model::GetVulnerabilityReportRequest>);
 
@@ -1926,6 +2332,25 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::list_vulnerability_reports][super::super::client::OsConfigZonalService::list_vulnerability_reports] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::ListVulnerabilityReports;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVulnerabilityReports {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVulnerabilityReports(
         RequestBuilder<crate::model::ListVulnerabilityReportsRequest>,
@@ -2024,6 +2449,21 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::get_operation][super::super::client::OsConfigZonalService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2072,6 +2512,21 @@ pub mod os_config_zonal_service {
     }
 
     /// The request builder for [OsConfigZonalService::cancel_operation][super::super::client::OsConfigZonalService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_osconfig_v1::builder;
+    /// use builder::os_config_zonal_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/oslogin/v1/src/builder.rs
+++ b/src/generated/cloud/oslogin/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod os_login_service {
     }
 
     /// The request builder for [OsLoginService::create_ssh_public_key][super::super::client::OsLoginService::create_ssh_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oslogin_v1::builder;
+    /// use builder::os_login_service::CreateSshPublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSshPublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSshPublicKey(RequestBuilder<crate::model::CreateSshPublicKeyRequest>);
 
@@ -132,6 +147,21 @@ pub mod os_login_service {
     }
 
     /// The request builder for [OsLoginService::delete_posix_account][super::super::client::OsLoginService::delete_posix_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oslogin_v1::builder;
+    /// use builder::os_login_service::DeletePosixAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePosixAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePosixAccount(RequestBuilder<crate::model::DeletePosixAccountRequest>);
 
@@ -182,6 +212,21 @@ pub mod os_login_service {
     }
 
     /// The request builder for [OsLoginService::delete_ssh_public_key][super::super::client::OsLoginService::delete_ssh_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oslogin_v1::builder;
+    /// use builder::os_login_service::DeleteSshPublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSshPublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSshPublicKey(RequestBuilder<crate::model::DeleteSshPublicKeyRequest>);
 
@@ -232,6 +277,21 @@ pub mod os_login_service {
     }
 
     /// The request builder for [OsLoginService::get_login_profile][super::super::client::OsLoginService::get_login_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oslogin_v1::builder;
+    /// use builder::os_login_service::GetLoginProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLoginProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLoginProfile(RequestBuilder<crate::model::GetLoginProfileRequest>);
 
@@ -291,6 +351,21 @@ pub mod os_login_service {
     }
 
     /// The request builder for [OsLoginService::get_ssh_public_key][super::super::client::OsLoginService::get_ssh_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oslogin_v1::builder;
+    /// use builder::os_login_service::GetSshPublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSshPublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSshPublicKey(RequestBuilder<crate::model::GetSshPublicKeyRequest>);
 
@@ -338,6 +413,21 @@ pub mod os_login_service {
     }
 
     /// The request builder for [OsLoginService::import_ssh_public_key][super::super::client::OsLoginService::import_ssh_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oslogin_v1::builder;
+    /// use builder::os_login_service::ImportSshPublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportSshPublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportSshPublicKey(RequestBuilder<crate::model::ImportSshPublicKeyRequest>);
 
@@ -416,6 +506,21 @@ pub mod os_login_service {
     }
 
     /// The request builder for [OsLoginService::update_ssh_public_key][super::super::client::OsLoginService::update_ssh_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_oslogin_v1::builder;
+    /// use builder::os_login_service::UpdateSshPublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSshPublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSshPublicKey(RequestBuilder<crate::model::UpdateSshPublicKeyRequest>);
 

--- a/src/generated/cloud/parallelstore/v1/src/builder.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::list_instances][super::super::client::Parallelstore::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -164,6 +183,21 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::get_instance][super::super::client::Parallelstore::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -211,6 +245,22 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::create_instance][super::super::client::Parallelstore::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_parallelstore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -321,6 +371,22 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::update_instance][super::super::client::Parallelstore::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_parallelstore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -426,6 +492,22 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::delete_instance][super::super::client::Parallelstore::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_parallelstore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -519,6 +601,22 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::import_data][super::super::client::Parallelstore::import_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::ImportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_parallelstore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportData(RequestBuilder<crate::model::ImportDataRequest>);
 
@@ -673,6 +771,22 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::export_data][super::super::client::Parallelstore::export_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::ExportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_parallelstore_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportData(RequestBuilder<crate::model::ExportDataRequest>);
 
@@ -827,6 +941,25 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::list_locations][super::super::client::Parallelstore::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -917,6 +1050,21 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::get_location][super::super::client::Parallelstore::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -962,6 +1110,25 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::list_operations][super::super::client::Parallelstore::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1054,6 +1221,21 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::get_operation][super::super::client::Parallelstore::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1102,6 +1284,21 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::delete_operation][super::super::client::Parallelstore::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1150,6 +1347,21 @@ pub mod parallelstore {
     }
 
     /// The request builder for [Parallelstore::cancel_operation][super::super::client::Parallelstore::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parallelstore_v1::builder;
+    /// use builder::parallelstore::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/parametermanager/v1/src/builder.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::list_parameters][super::super::client::ParameterManager::list_parameters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::ListParameters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListParameters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListParameters(RequestBuilder<crate::model::ListParametersRequest>);
 
@@ -164,6 +183,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::get_parameter][super::super::client::ParameterManager::get_parameter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::GetParameter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetParameter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetParameter(RequestBuilder<crate::model::GetParameterRequest>);
 
@@ -211,6 +245,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::create_parameter][super::super::client::ParameterManager::create_parameter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::CreateParameter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateParameter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateParameter(RequestBuilder<crate::model::CreateParameterRequest>);
 
@@ -283,6 +332,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::update_parameter][super::super::client::ParameterManager::update_parameter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::UpdateParameter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateParameter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateParameter(RequestBuilder<crate::model::UpdateParameterRequest>);
 
@@ -348,6 +412,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::delete_parameter][super::super::client::ParameterManager::delete_parameter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::DeleteParameter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteParameter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteParameter(RequestBuilder<crate::model::DeleteParameterRequest>);
 
@@ -401,6 +480,25 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::list_parameter_versions][super::super::client::ParameterManager::list_parameter_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::ListParameterVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListParameterVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListParameterVersions(RequestBuilder<crate::model::ListParameterVersionsRequest>);
 
@@ -501,6 +599,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::get_parameter_version][super::super::client::ParameterManager::get_parameter_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::GetParameterVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetParameterVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetParameterVersion(RequestBuilder<crate::model::GetParameterVersionRequest>);
 
@@ -557,6 +670,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::render_parameter_version][super::super::client::ParameterManager::render_parameter_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::RenderParameterVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RenderParameterVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RenderParameterVersion(RequestBuilder<crate::model::RenderParameterVersionRequest>);
 
@@ -607,6 +735,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::create_parameter_version][super::super::client::ParameterManager::create_parameter_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::CreateParameterVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateParameterVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateParameterVersion(RequestBuilder<crate::model::CreateParameterVersionRequest>);
 
@@ -684,6 +827,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::update_parameter_version][super::super::client::ParameterManager::update_parameter_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::UpdateParameterVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateParameterVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateParameterVersion(RequestBuilder<crate::model::UpdateParameterVersionRequest>);
 
@@ -754,6 +912,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::delete_parameter_version][super::super::client::ParameterManager::delete_parameter_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::DeleteParameterVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteParameterVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteParameterVersion(RequestBuilder<crate::model::DeleteParameterVersionRequest>);
 
@@ -810,6 +983,25 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::list_locations][super::super::client::ParameterManager::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -900,6 +1092,21 @@ pub mod parameter_manager {
     }
 
     /// The request builder for [ParameterManager::get_location][super::super::client::ParameterManager::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_parametermanager_v1::builder;
+    /// use builder::parameter_manager::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/policysimulator/v1/src/builder.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod simulator {
     }
 
     /// The request builder for [Simulator::get_replay][super::super::client::Simulator::get_replay] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_policysimulator_v1::builder;
+    /// use builder::simulator::GetReplay;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReplay {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReplay(RequestBuilder<crate::model::GetReplayRequest>);
 
@@ -116,6 +131,22 @@ pub mod simulator {
     }
 
     /// The request builder for [Simulator::create_replay][super::super::client::Simulator::create_replay] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_policysimulator_v1::builder;
+    /// use builder::simulator::CreateReplay;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_policysimulator_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReplay {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReplay(RequestBuilder<crate::model::CreateReplayRequest>);
 
@@ -214,6 +245,25 @@ pub mod simulator {
     }
 
     /// The request builder for [Simulator::list_replay_results][super::super::client::Simulator::list_replay_results] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_policysimulator_v1::builder;
+    /// use builder::simulator::ListReplayResults;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReplayResults {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReplayResults(RequestBuilder<crate::model::ListReplayResultsRequest>);
 
@@ -300,6 +350,25 @@ pub mod simulator {
     }
 
     /// The request builder for [Simulator::list_operations][super::super::client::Simulator::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_policysimulator_v1::builder;
+    /// use builder::simulator::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -392,6 +461,21 @@ pub mod simulator {
     }
 
     /// The request builder for [Simulator::get_operation][super::super::client::Simulator::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_policysimulator_v1::builder;
+    /// use builder::simulator::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
@@ -69,6 +69,21 @@ pub mod policy_troubleshooter {
     }
 
     /// The request builder for [PolicyTroubleshooter::troubleshoot_iam_policy][super::super::client::PolicyTroubleshooter::troubleshoot_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_policytroubleshooter_iam_v3::builder;
+    /// use builder::policy_troubleshooter::TroubleshootIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TroubleshootIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TroubleshootIamPolicy(RequestBuilder<crate::model::TroubleshootIamPolicyRequest>);
 

--- a/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod iam_checker {
     }
 
     /// The request builder for [IamChecker::troubleshoot_iam_policy][super::super::client::IamChecker::troubleshoot_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_policytroubleshooter_v1::builder;
+    /// use builder::iam_checker::TroubleshootIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TroubleshootIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TroubleshootIamPolicy(RequestBuilder<crate::model::TroubleshootIamPolicyRequest>);
 

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::check_onboarding_status][super::super::client::PrivilegedAccessManager::check_onboarding_status] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::CheckOnboardingStatus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckOnboardingStatus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckOnboardingStatus(RequestBuilder<crate::model::CheckOnboardingStatusRequest>);
 
@@ -119,6 +134,25 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::list_entitlements][super::super::client::PrivilegedAccessManager::list_entitlements] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::ListEntitlements;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEntitlements {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEntitlements(RequestBuilder<crate::model::ListEntitlementsRequest>);
 
@@ -217,6 +251,25 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::search_entitlements][super::super::client::PrivilegedAccessManager::search_entitlements] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::SearchEntitlements;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchEntitlements {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchEntitlements(RequestBuilder<crate::model::SearchEntitlementsRequest>);
 
@@ -324,6 +377,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::get_entitlement][super::super::client::PrivilegedAccessManager::get_entitlement] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::GetEntitlement;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEntitlement {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEntitlement(RequestBuilder<crate::model::GetEntitlementRequest>);
 
@@ -371,6 +439,22 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::create_entitlement][super::super::client::PrivilegedAccessManager::create_entitlement] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::CreateEntitlement;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_privilegedaccessmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEntitlement {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEntitlement(RequestBuilder<crate::model::CreateEntitlementRequest>);
 
@@ -486,6 +570,22 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::delete_entitlement][super::super::client::PrivilegedAccessManager::delete_entitlement] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::DeleteEntitlement;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_privilegedaccessmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEntitlement {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEntitlement(RequestBuilder<crate::model::DeleteEntitlementRequest>);
 
@@ -588,6 +688,22 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::update_entitlement][super::super::client::PrivilegedAccessManager::update_entitlement] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::UpdateEntitlement;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_privilegedaccessmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEntitlement {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEntitlement(RequestBuilder<crate::model::UpdateEntitlementRequest>);
 
@@ -692,6 +808,25 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::list_grants][super::super::client::PrivilegedAccessManager::list_grants] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::ListGrants;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGrants {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGrants(RequestBuilder<crate::model::ListGrantsRequest>);
 
@@ -787,6 +922,25 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::search_grants][super::super::client::PrivilegedAccessManager::search_grants] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::SearchGrants;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchGrants {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchGrants(RequestBuilder<crate::model::SearchGrantsRequest>);
 
@@ -889,6 +1043,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::get_grant][super::super::client::PrivilegedAccessManager::get_grant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::GetGrant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGrant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGrant(RequestBuilder<crate::model::GetGrantRequest>);
 
@@ -936,6 +1105,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::create_grant][super::super::client::PrivilegedAccessManager::create_grant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::CreateGrant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGrant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGrant(RequestBuilder<crate::model::CreateGrantRequest>);
 
@@ -1000,6 +1184,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::approve_grant][super::super::client::PrivilegedAccessManager::approve_grant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::ApproveGrant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApproveGrant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApproveGrant(RequestBuilder<crate::model::ApproveGrantRequest>);
 
@@ -1053,6 +1252,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::deny_grant][super::super::client::PrivilegedAccessManager::deny_grant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::DenyGrant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DenyGrant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DenyGrant(RequestBuilder<crate::model::DenyGrantRequest>);
 
@@ -1106,6 +1320,22 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::revoke_grant][super::super::client::PrivilegedAccessManager::revoke_grant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::RevokeGrant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_privilegedaccessmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RevokeGrant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RevokeGrant(RequestBuilder<crate::model::RevokeGrantRequest>);
 
@@ -1197,6 +1427,25 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::list_locations][super::super::client::PrivilegedAccessManager::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1287,6 +1536,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::get_location][super::super::client::PrivilegedAccessManager::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1332,6 +1596,25 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::list_operations][super::super::client::PrivilegedAccessManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1424,6 +1707,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::get_operation][super::super::client::PrivilegedAccessManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1472,6 +1770,21 @@ pub mod privileged_access_manager {
     }
 
     /// The request builder for [PrivilegedAccessManager::delete_operation][super::super::client::PrivilegedAccessManager::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privilegedaccessmanager_v1::builder;
+    /// use builder::privileged_access_manager::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::create_collector][super::super::client::RapidMigrationAssessment::create_collector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::CreateCollector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_rapidmigrationassessment_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCollector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCollector(RequestBuilder<crate::model::CreateCollectorRequest>);
 
@@ -179,6 +195,22 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::create_annotation][super::super::client::RapidMigrationAssessment::create_annotation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::CreateAnnotation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_rapidmigrationassessment_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAnnotation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAnnotation(RequestBuilder<crate::model::CreateAnnotationRequest>);
 
@@ -284,6 +316,21 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::get_annotation][super::super::client::RapidMigrationAssessment::get_annotation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::GetAnnotation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAnnotation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAnnotation(RequestBuilder<crate::model::GetAnnotationRequest>);
 
@@ -331,6 +378,25 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::list_collectors][super::super::client::RapidMigrationAssessment::list_collectors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::ListCollectors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCollectors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCollectors(RequestBuilder<crate::model::ListCollectorsRequest>);
 
@@ -426,6 +492,21 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::get_collector][super::super::client::RapidMigrationAssessment::get_collector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::GetCollector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCollector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCollector(RequestBuilder<crate::model::GetCollectorRequest>);
 
@@ -473,6 +554,22 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::update_collector][super::super::client::RapidMigrationAssessment::update_collector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::UpdateCollector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_rapidmigrationassessment_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCollector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCollector(RequestBuilder<crate::model::UpdateCollectorRequest>);
 
@@ -578,6 +675,22 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::delete_collector][super::super::client::RapidMigrationAssessment::delete_collector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::DeleteCollector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_rapidmigrationassessment_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCollector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCollector(RequestBuilder<crate::model::DeleteCollectorRequest>);
 
@@ -669,6 +782,22 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::resume_collector][super::super::client::RapidMigrationAssessment::resume_collector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::ResumeCollector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_rapidmigrationassessment_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeCollector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeCollector(RequestBuilder<crate::model::ResumeCollectorRequest>);
 
@@ -760,6 +889,22 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::register_collector][super::super::client::RapidMigrationAssessment::register_collector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::RegisterCollector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_rapidmigrationassessment_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RegisterCollector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RegisterCollector(RequestBuilder<crate::model::RegisterCollectorRequest>);
 
@@ -854,6 +999,22 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::pause_collector][super::super::client::RapidMigrationAssessment::pause_collector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::PauseCollector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_rapidmigrationassessment_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseCollector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseCollector(RequestBuilder<crate::model::PauseCollectorRequest>);
 
@@ -945,6 +1106,25 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::list_locations][super::super::client::RapidMigrationAssessment::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1035,6 +1215,21 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::get_location][super::super::client::RapidMigrationAssessment::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1080,6 +1275,25 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::list_operations][super::super::client::RapidMigrationAssessment::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1172,6 +1386,21 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::get_operation][super::super::client::RapidMigrationAssessment::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1220,6 +1449,21 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::delete_operation][super::super::client::RapidMigrationAssessment::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1268,6 +1512,21 @@ pub mod rapid_migration_assessment {
     }
 
     /// The request builder for [RapidMigrationAssessment::cancel_operation][super::super::client::RapidMigrationAssessment::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_rapidmigrationassessment_v1::builder;
+    /// use builder::rapid_migration_assessment::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::create_assessment][super::super::client::RecaptchaEnterpriseService::create_assessment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::CreateAssessment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAssessment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAssessment(RequestBuilder<crate::model::CreateAssessmentRequest>);
 
@@ -130,6 +145,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::annotate_assessment][super::super::client::RecaptchaEnterpriseService::annotate_assessment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::AnnotateAssessment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnnotateAssessment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnnotateAssessment(RequestBuilder<crate::model::AnnotateAssessmentRequest>);
 
@@ -223,6 +253,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::create_key][super::super::client::RecaptchaEnterpriseService::create_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::CreateKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateKey(RequestBuilder<crate::model::CreateKeyRequest>);
 
@@ -278,6 +323,25 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::list_keys][super::super::client::RecaptchaEnterpriseService::list_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::ListKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListKeys(RequestBuilder<crate::model::ListKeysRequest>);
 
@@ -361,6 +425,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::retrieve_legacy_secret_key][super::super::client::RecaptchaEnterpriseService::retrieve_legacy_secret_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::RetrieveLegacySecretKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetrieveLegacySecretKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetrieveLegacySecretKey(
         RequestBuilder<crate::model::RetrieveLegacySecretKeyRequest>,
@@ -413,6 +492,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::get_key][super::super::client::RecaptchaEnterpriseService::get_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::GetKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetKey(RequestBuilder<crate::model::GetKeyRequest>);
 
@@ -460,6 +554,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::update_key][super::super::client::RecaptchaEnterpriseService::update_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::UpdateKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateKey(RequestBuilder<crate::model::UpdateKeyRequest>);
 
@@ -516,6 +625,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::delete_key][super::super::client::RecaptchaEnterpriseService::delete_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::DeleteKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteKey(RequestBuilder<crate::model::DeleteKeyRequest>);
 
@@ -563,6 +687,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::migrate_key][super::super::client::RecaptchaEnterpriseService::migrate_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::MigrateKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MigrateKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MigrateKey(RequestBuilder<crate::model::MigrateKeyRequest>);
 
@@ -616,6 +755,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::add_ip_override][super::super::client::RecaptchaEnterpriseService::add_ip_override] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::AddIpOverride;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddIpOverride {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddIpOverride(RequestBuilder<crate::model::AddIpOverrideRequest>);
 
@@ -674,6 +828,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::remove_ip_override][super::super::client::RecaptchaEnterpriseService::remove_ip_override] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::RemoveIpOverride;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveIpOverride {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveIpOverride(RequestBuilder<crate::model::RemoveIpOverrideRequest>);
 
@@ -735,6 +904,25 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::list_ip_overrides][super::super::client::RecaptchaEnterpriseService::list_ip_overrides] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::ListIpOverrides;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIpOverrides {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIpOverrides(RequestBuilder<crate::model::ListIpOverridesRequest>);
 
@@ -818,6 +1006,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::get_metrics][super::super::client::RecaptchaEnterpriseService::get_metrics] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::GetMetrics;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMetrics {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMetrics(RequestBuilder<crate::model::GetMetricsRequest>);
 
@@ -865,6 +1068,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::create_firewall_policy][super::super::client::RecaptchaEnterpriseService::create_firewall_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::CreateFirewallPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFirewallPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFirewallPolicy(RequestBuilder<crate::model::CreateFirewallPolicyRequest>);
 
@@ -926,6 +1144,25 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::list_firewall_policies][super::super::client::RecaptchaEnterpriseService::list_firewall_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::ListFirewallPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFirewallPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFirewallPolicies(RequestBuilder<crate::model::ListFirewallPoliciesRequest>);
 
@@ -1014,6 +1251,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::get_firewall_policy][super::super::client::RecaptchaEnterpriseService::get_firewall_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::GetFirewallPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFirewallPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFirewallPolicy(RequestBuilder<crate::model::GetFirewallPolicyRequest>);
 
@@ -1064,6 +1316,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::update_firewall_policy][super::super::client::RecaptchaEnterpriseService::update_firewall_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::UpdateFirewallPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFirewallPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFirewallPolicy(RequestBuilder<crate::model::UpdateFirewallPolicyRequest>);
 
@@ -1126,6 +1393,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::delete_firewall_policy][super::super::client::RecaptchaEnterpriseService::delete_firewall_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::DeleteFirewallPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFirewallPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFirewallPolicy(RequestBuilder<crate::model::DeleteFirewallPolicyRequest>);
 
@@ -1176,6 +1458,21 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::reorder_firewall_policies][super::super::client::RecaptchaEnterpriseService::reorder_firewall_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::ReorderFirewallPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReorderFirewallPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReorderFirewallPolicies(
         RequestBuilder<crate::model::ReorderFirewallPoliciesRequest>,
@@ -1241,6 +1538,25 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::list_related_account_groups][super::super::client::RecaptchaEnterpriseService::list_related_account_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::ListRelatedAccountGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRelatedAccountGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRelatedAccountGroups(
         RequestBuilder<crate::model::ListRelatedAccountGroupsRequest>,
@@ -1333,6 +1649,25 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::list_related_account_group_memberships][super::super::client::RecaptchaEnterpriseService::list_related_account_group_memberships] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::ListRelatedAccountGroupMemberships;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRelatedAccountGroupMemberships {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRelatedAccountGroupMemberships(
         RequestBuilder<crate::model::ListRelatedAccountGroupMembershipsRequest>,
@@ -1427,6 +1762,25 @@ pub mod recaptcha_enterprise_service {
     }
 
     /// The request builder for [RecaptchaEnterpriseService::search_related_account_group_memberships][super::super::client::RecaptchaEnterpriseService::search_related_account_group_memberships] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recaptchaenterprise_v1::builder;
+    /// use builder::recaptcha_enterprise_service::SearchRelatedAccountGroupMemberships;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchRelatedAccountGroupMemberships {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchRelatedAccountGroupMemberships(
         RequestBuilder<crate::model::SearchRelatedAccountGroupMembershipsRequest>,

--- a/src/generated/cloud/recommender/v1/src/builder.rs
+++ b/src/generated/cloud/recommender/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::list_insights][super::super::client::Recommender::list_insights] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::ListInsights;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInsights {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInsights(RequestBuilder<crate::model::ListInsightsRequest>);
 
@@ -158,6 +177,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::get_insight][super::super::client::Recommender::get_insight] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::GetInsight;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInsight {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInsight(RequestBuilder<crate::model::GetInsightRequest>);
 
@@ -205,6 +239,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::mark_insight_accepted][super::super::client::Recommender::mark_insight_accepted] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::MarkInsightAccepted;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MarkInsightAccepted {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MarkInsightAccepted(RequestBuilder<crate::model::MarkInsightAcceptedRequest>);
 
@@ -275,6 +324,25 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::list_recommendations][super::super::client::Recommender::list_recommendations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::ListRecommendations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRecommendations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRecommendations(RequestBuilder<crate::model::ListRecommendationsRequest>);
 
@@ -369,6 +437,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::get_recommendation][super::super::client::Recommender::get_recommendation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::GetRecommendation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRecommendation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRecommendation(RequestBuilder<crate::model::GetRecommendationRequest>);
 
@@ -419,6 +502,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::mark_recommendation_dismissed][super::super::client::Recommender::mark_recommendation_dismissed] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::MarkRecommendationDismissed;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MarkRecommendationDismissed {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationDismissed(
         RequestBuilder<crate::model::MarkRecommendationDismissedRequest>,
@@ -477,6 +575,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::mark_recommendation_claimed][super::super::client::Recommender::mark_recommendation_claimed] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::MarkRecommendationClaimed;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MarkRecommendationClaimed {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationClaimed(
         RequestBuilder<crate::model::MarkRecommendationClaimedRequest>,
@@ -549,6 +662,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::mark_recommendation_succeeded][super::super::client::Recommender::mark_recommendation_succeeded] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::MarkRecommendationSucceeded;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MarkRecommendationSucceeded {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationSucceeded(
         RequestBuilder<crate::model::MarkRecommendationSucceededRequest>,
@@ -621,6 +749,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::mark_recommendation_failed][super::super::client::Recommender::mark_recommendation_failed] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::MarkRecommendationFailed;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MarkRecommendationFailed {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MarkRecommendationFailed(
         RequestBuilder<crate::model::MarkRecommendationFailedRequest>,
@@ -693,6 +836,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::get_recommender_config][super::super::client::Recommender::get_recommender_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::GetRecommenderConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRecommenderConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRecommenderConfig(RequestBuilder<crate::model::GetRecommenderConfigRequest>);
 
@@ -743,6 +901,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::update_recommender_config][super::super::client::Recommender::update_recommender_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::UpdateRecommenderConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRecommenderConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRecommenderConfig(
         RequestBuilder<crate::model::UpdateRecommenderConfigRequest>,
@@ -815,6 +988,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::get_insight_type_config][super::super::client::Recommender::get_insight_type_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::GetInsightTypeConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInsightTypeConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInsightTypeConfig(RequestBuilder<crate::model::GetInsightTypeConfigRequest>);
 
@@ -865,6 +1053,21 @@ pub mod recommender {
     }
 
     /// The request builder for [Recommender::update_insight_type_config][super::super::client::Recommender::update_insight_type_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_recommender_v1::builder;
+    /// use builder::recommender::UpdateInsightTypeConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInsightTypeConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInsightTypeConfig(
         RequestBuilder<crate::model::UpdateInsightTypeConfigRequest>,

--- a/src/generated/cloud/redis/cluster/v1/src/builder.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::list_clusters][super::super::client::CloudRedisCluster::list_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::ListClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -152,6 +171,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::get_cluster][super::super::client::CloudRedisCluster::get_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::GetCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -199,6 +233,22 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::update_cluster][super::super::client::CloudRedisCluster::update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::UpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_cluster_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -301,6 +351,22 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::delete_cluster][super::super::client::CloudRedisCluster::delete_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::DeleteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_cluster_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -394,6 +460,22 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::create_cluster][super::super::client::CloudRedisCluster::create_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::CreateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_cluster_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -501,6 +583,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::get_cluster_certificate_authority][super::super::client::CloudRedisCluster::get_cluster_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::GetClusterCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetClusterCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetClusterCertificateAuthority(
         RequestBuilder<crate::model::GetClusterCertificateAuthorityRequest>,
@@ -553,6 +650,22 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::reschedule_cluster_maintenance][super::super::client::CloudRedisCluster::reschedule_cluster_maintenance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::RescheduleClusterMaintenance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_cluster_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RescheduleClusterMaintenance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RescheduleClusterMaintenance(
         RequestBuilder<crate::model::RescheduleClusterMaintenanceRequest>,
@@ -662,6 +775,25 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::list_backup_collections][super::super::client::CloudRedisCluster::list_backup_collections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::ListBackupCollections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupCollections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupCollections(RequestBuilder<crate::model::ListBackupCollectionsRequest>);
 
@@ -750,6 +882,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::get_backup_collection][super::super::client::CloudRedisCluster::get_backup_collection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::GetBackupCollection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupCollection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupCollection(RequestBuilder<crate::model::GetBackupCollectionRequest>);
 
@@ -800,6 +947,25 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::list_backups][super::super::client::CloudRedisCluster::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -883,6 +1049,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::get_backup][super::super::client::CloudRedisCluster::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -930,6 +1111,22 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::delete_backup][super::super::client::CloudRedisCluster::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_cluster_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1023,6 +1220,22 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::export_backup][super::super::client::CloudRedisCluster::export_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::ExportBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_cluster_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportBackup(RequestBuilder<crate::model::ExportBackupRequest>);
 
@@ -1129,6 +1342,22 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::backup_cluster][super::super::client::CloudRedisCluster::backup_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::BackupCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_cluster_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BackupCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BackupCluster(RequestBuilder<crate::model::BackupClusterRequest>);
 
@@ -1226,6 +1455,25 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::list_locations][super::super::client::CloudRedisCluster::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1316,6 +1564,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::get_location][super::super::client::CloudRedisCluster::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1361,6 +1624,25 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::list_operations][super::super::client::CloudRedisCluster::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1453,6 +1735,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::get_operation][super::super::client::CloudRedisCluster::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1501,6 +1798,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::delete_operation][super::super::client::CloudRedisCluster::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1549,6 +1861,21 @@ pub mod cloud_redis_cluster {
     }
 
     /// The request builder for [CloudRedisCluster::cancel_operation][super::super::client::CloudRedisCluster::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_cluster_v1::builder;
+    /// use builder::cloud_redis_cluster::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/redis/v1/src/builder.rs
+++ b/src/generated/cloud/redis/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::list_instances][super::super::client::CloudRedis::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -152,6 +171,21 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::get_instance][super::super::client::CloudRedis::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -199,6 +233,21 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::get_instance_auth_string][super::super::client::CloudRedis::get_instance_auth_string] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::GetInstanceAuthString;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstanceAuthString {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstanceAuthString(RequestBuilder<crate::model::GetInstanceAuthStringRequest>);
 
@@ -249,6 +298,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::create_instance][super::super::client::CloudRedis::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -353,6 +418,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::update_instance][super::super::client::CloudRedis::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -452,6 +533,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::upgrade_instance][super::super::client::CloudRedis::upgrade_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::UpgradeInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpgradeInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpgradeInstance(RequestBuilder<crate::model::UpgradeInstanceRequest>);
 
@@ -545,6 +642,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::import_instance][super::super::client::CloudRedis::import_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::ImportInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportInstance(RequestBuilder<crate::model::ImportInstanceRequest>);
 
@@ -641,6 +754,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::export_instance][super::super::client::CloudRedis::export_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::ExportInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportInstance(RequestBuilder<crate::model::ExportInstanceRequest>);
 
@@ -737,6 +866,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::failover_instance][super::super::client::CloudRedis::failover_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::FailoverInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FailoverInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FailoverInstance(RequestBuilder<crate::model::FailoverInstanceRequest>);
 
@@ -836,6 +981,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::delete_instance][super::super::client::CloudRedis::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -923,6 +1084,22 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::reschedule_maintenance][super::super::client::CloudRedis::reschedule_maintenance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::RescheduleMaintenance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_redis_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RescheduleMaintenance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RescheduleMaintenance(RequestBuilder<crate::model::RescheduleMaintenanceRequest>);
 
@@ -1033,6 +1210,25 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::list_locations][super::super::client::CloudRedis::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1123,6 +1319,21 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::get_location][super::super::client::CloudRedis::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1168,6 +1379,25 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::list_operations][super::super::client::CloudRedis::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1260,6 +1490,21 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::get_operation][super::super::client::CloudRedis::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1308,6 +1553,21 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::delete_operation][super::super::client::CloudRedis::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1356,6 +1616,21 @@ pub mod cloud_redis {
     }
 
     /// The request builder for [CloudRedis::cancel_operation][super::super::client::CloudRedis::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_redis_v1::builder;
+    /// use builder::cloud_redis::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/resourcemanager/v3/src/builder.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builder.rs
@@ -67,6 +67,21 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::get_folder][super::super::client::Folders::get_folder] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::GetFolder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFolder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFolder(RequestBuilder<crate::model::GetFolderRequest>);
 
@@ -112,6 +127,25 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::list_folders][super::super::client::Folders::list_folders] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::ListFolders;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFolders {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFolders(RequestBuilder<crate::model::ListFoldersRequest>);
 
@@ -199,6 +233,25 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::search_folders][super::super::client::Folders::search_folders] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::SearchFolders;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchFolders {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchFolders(RequestBuilder<crate::model::SearchFoldersRequest>);
 
@@ -278,6 +331,22 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::create_folder][super::super::client::Folders::create_folder] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::CreateFolder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFolder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFolder(RequestBuilder<crate::model::CreateFolderRequest>);
 
@@ -364,6 +433,22 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::update_folder][super::super::client::Folders::update_folder] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::UpdateFolder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFolder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFolder(RequestBuilder<crate::model::UpdateFolderRequest>);
 
@@ -461,6 +546,22 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::move_folder][super::super::client::Folders::move_folder] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::MoveFolder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MoveFolder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MoveFolder(RequestBuilder<crate::model::MoveFolderRequest>);
 
@@ -552,6 +653,22 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::delete_folder][super::super::client::Folders::delete_folder] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::DeleteFolder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFolder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFolder(RequestBuilder<crate::model::DeleteFolderRequest>);
 
@@ -635,6 +752,22 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::undelete_folder][super::super::client::Folders::undelete_folder] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::UndeleteFolder;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteFolder {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteFolder(RequestBuilder<crate::model::UndeleteFolderRequest>);
 
@@ -720,6 +853,21 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::get_iam_policy][super::super::client::Folders::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -774,6 +922,21 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::set_iam_policy][super::super::client::Folders::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -839,6 +1002,21 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::test_iam_permissions][super::super::client::Folders::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -900,6 +1078,21 @@ pub mod folders {
     }
 
     /// The request builder for [Folders::get_operation][super::super::client::Folders::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::folders::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1001,6 +1194,21 @@ pub mod organizations {
     }
 
     /// The request builder for [Organizations::get_organization][super::super::client::Organizations::get_organization] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::organizations::GetOrganization;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOrganization {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOrganization(RequestBuilder<crate::model::GetOrganizationRequest>);
 
@@ -1048,6 +1256,25 @@ pub mod organizations {
     }
 
     /// The request builder for [Organizations::search_organizations][super::super::client::Organizations::search_organizations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::organizations::SearchOrganizations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchOrganizations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchOrganizations(RequestBuilder<crate::model::SearchOrganizationsRequest>);
 
@@ -1134,6 +1361,21 @@ pub mod organizations {
     }
 
     /// The request builder for [Organizations::get_iam_policy][super::super::client::Organizations::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::organizations::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1190,6 +1432,21 @@ pub mod organizations {
     }
 
     /// The request builder for [Organizations::set_iam_policy][super::super::client::Organizations::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::organizations::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1257,6 +1514,21 @@ pub mod organizations {
     }
 
     /// The request builder for [Organizations::test_iam_permissions][super::super::client::Organizations::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::organizations::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1320,6 +1592,21 @@ pub mod organizations {
     }
 
     /// The request builder for [Organizations::get_operation][super::super::client::Organizations::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::organizations::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1421,6 +1708,21 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::get_project][super::super::client::Projects::get_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::GetProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProject(RequestBuilder<crate::model::GetProjectRequest>);
 
@@ -1466,6 +1768,25 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::list_projects][super::super::client::Projects::list_projects] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::ListProjects;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProjects {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProjects(RequestBuilder<crate::model::ListProjectsRequest>);
 
@@ -1553,6 +1874,25 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::search_projects][super::super::client::Projects::search_projects] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::SearchProjects;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchProjects {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchProjects(RequestBuilder<crate::model::SearchProjectsRequest>);
 
@@ -1632,6 +1972,22 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::create_project][super::super::client::Projects::create_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::CreateProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProject(RequestBuilder<crate::model::CreateProjectRequest>);
 
@@ -1720,6 +2076,22 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::update_project][super::super::client::Projects::update_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::UpdateProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProject(RequestBuilder<crate::model::UpdateProjectRequest>);
 
@@ -1817,6 +2189,22 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::move_project][super::super::client::Projects::move_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::MoveProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MoveProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MoveProject(RequestBuilder<crate::model::MoveProjectRequest>);
 
@@ -1908,6 +2296,22 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::delete_project][super::super::client::Projects::delete_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::DeleteProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteProject(RequestBuilder<crate::model::DeleteProjectRequest>);
 
@@ -1993,6 +2397,22 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::undelete_project][super::super::client::Projects::undelete_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::UndeleteProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteProject(RequestBuilder<crate::model::UndeleteProjectRequest>);
 
@@ -2079,6 +2499,21 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::get_iam_policy][super::super::client::Projects::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2133,6 +2568,21 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::set_iam_policy][super::super::client::Projects::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2198,6 +2648,21 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::test_iam_permissions][super::super::client::Projects::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2259,6 +2724,21 @@ pub mod projects {
     }
 
     /// The request builder for [Projects::get_operation][super::super::client::Projects::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::projects::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2360,6 +2840,25 @@ pub mod tag_bindings {
     }
 
     /// The request builder for [TagBindings::list_tag_bindings][super::super::client::TagBindings::list_tag_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_bindings::ListTagBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTagBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTagBindings(RequestBuilder<crate::model::ListTagBindingsRequest>);
 
@@ -2443,6 +2942,22 @@ pub mod tag_bindings {
     }
 
     /// The request builder for [TagBindings::create_tag_binding][super::super::client::TagBindings::create_tag_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_bindings::CreateTagBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTagBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTagBinding(RequestBuilder<crate::model::CreateTagBindingRequest>);
 
@@ -2543,6 +3058,22 @@ pub mod tag_bindings {
     }
 
     /// The request builder for [TagBindings::delete_tag_binding][super::super::client::TagBindings::delete_tag_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_bindings::DeleteTagBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTagBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTagBinding(RequestBuilder<crate::model::DeleteTagBindingRequest>);
 
@@ -2634,6 +3165,25 @@ pub mod tag_bindings {
     }
 
     /// The request builder for [TagBindings::list_effective_tags][super::super::client::TagBindings::list_effective_tags] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_bindings::ListEffectiveTags;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEffectiveTags {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEffectiveTags(RequestBuilder<crate::model::ListEffectiveTagsRequest>);
 
@@ -2720,6 +3270,21 @@ pub mod tag_bindings {
     }
 
     /// The request builder for [TagBindings::get_operation][super::super::client::TagBindings::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_bindings::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2821,6 +3386,22 @@ pub mod tag_holds {
     }
 
     /// The request builder for [TagHolds::create_tag_hold][super::super::client::TagHolds::create_tag_hold] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_holds::CreateTagHold;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTagHold {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTagHold(RequestBuilder<crate::model::CreateTagHoldRequest>);
 
@@ -2923,6 +3504,22 @@ pub mod tag_holds {
     }
 
     /// The request builder for [TagHolds::delete_tag_hold][super::super::client::TagHolds::delete_tag_hold] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_holds::DeleteTagHold;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTagHold {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTagHold(RequestBuilder<crate::model::DeleteTagHoldRequest>);
 
@@ -3015,6 +3612,25 @@ pub mod tag_holds {
     }
 
     /// The request builder for [TagHolds::list_tag_holds][super::super::client::TagHolds::list_tag_holds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_holds::ListTagHolds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTagHolds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTagHolds(RequestBuilder<crate::model::ListTagHoldsRequest>);
 
@@ -3102,6 +3718,21 @@ pub mod tag_holds {
     }
 
     /// The request builder for [TagHolds::get_operation][super::super::client::TagHolds::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_holds::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3201,6 +3832,25 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::list_tag_keys][super::super::client::TagKeys::list_tag_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::ListTagKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTagKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTagKeys(RequestBuilder<crate::model::ListTagKeysRequest>);
 
@@ -3282,6 +3932,21 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::get_tag_key][super::super::client::TagKeys::get_tag_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::GetTagKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTagKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTagKey(RequestBuilder<crate::model::GetTagKeyRequest>);
 
@@ -3327,6 +3992,21 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::get_namespaced_tag_key][super::super::client::TagKeys::get_namespaced_tag_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::GetNamespacedTagKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNamespacedTagKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNamespacedTagKey(RequestBuilder<crate::model::GetNamespacedTagKeyRequest>);
 
@@ -3375,6 +4055,22 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::create_tag_key][super::super::client::TagKeys::create_tag_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::CreateTagKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTagKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTagKey(RequestBuilder<crate::model::CreateTagKeyRequest>);
 
@@ -3467,6 +4163,22 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::update_tag_key][super::super::client::TagKeys::update_tag_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::UpdateTagKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTagKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTagKey(RequestBuilder<crate::model::UpdateTagKeyRequest>);
 
@@ -3568,6 +4280,22 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::delete_tag_key][super::super::client::TagKeys::delete_tag_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::DeleteTagKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTagKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTagKey(RequestBuilder<crate::model::DeleteTagKeyRequest>);
 
@@ -3663,6 +4391,21 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::get_iam_policy][super::super::client::TagKeys::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3717,6 +4460,21 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::set_iam_policy][super::super::client::TagKeys::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3782,6 +4540,21 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::test_iam_permissions][super::super::client::TagKeys::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3843,6 +4616,21 @@ pub mod tag_keys {
     }
 
     /// The request builder for [TagKeys::get_operation][super::super::client::TagKeys::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_keys::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3944,6 +4732,25 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::list_tag_values][super::super::client::TagValues::list_tag_values] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::ListTagValues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTagValues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTagValues(RequestBuilder<crate::model::ListTagValuesRequest>);
 
@@ -4027,6 +4834,21 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::get_tag_value][super::super::client::TagValues::get_tag_value] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::GetTagValue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTagValue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTagValue(RequestBuilder<crate::model::GetTagValueRequest>);
 
@@ -4074,6 +4896,21 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::get_namespaced_tag_value][super::super::client::TagValues::get_namespaced_tag_value] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::GetNamespacedTagValue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNamespacedTagValue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNamespacedTagValue(RequestBuilder<crate::model::GetNamespacedTagValueRequest>);
 
@@ -4124,6 +4961,22 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::create_tag_value][super::super::client::TagValues::create_tag_value] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::CreateTagValue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTagValue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTagValue(RequestBuilder<crate::model::CreateTagValueRequest>);
 
@@ -4221,6 +5074,22 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::update_tag_value][super::super::client::TagValues::update_tag_value] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::UpdateTagValue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTagValue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTagValue(RequestBuilder<crate::model::UpdateTagValueRequest>);
 
@@ -4327,6 +5196,22 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::delete_tag_value][super::super::client::TagValues::delete_tag_value] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::DeleteTagValue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_resourcemanager_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTagValue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTagValue(RequestBuilder<crate::model::DeleteTagValueRequest>);
 
@@ -4427,6 +5312,21 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::get_iam_policy][super::super::client::TagValues::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4483,6 +5383,21 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::set_iam_policy][super::super::client::TagValues::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4550,6 +5465,21 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::test_iam_permissions][super::super::client::TagValues::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4613,6 +5543,21 @@ pub mod tag_values {
     }
 
     /// The request builder for [TagValues::get_operation][super::super::client::TagValues::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_resourcemanager_v3::builder;
+    /// use builder::tag_values::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/retail/v2/src/builder.rs
+++ b/src/generated/cloud/retail/v2/src/builder.rs
@@ -69,6 +69,22 @@ pub mod analytics_service {
     }
 
     /// The request builder for [AnalyticsService::export_analytics_metrics][super::super::client::AnalyticsService::export_analytics_metrics] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::analytics_service::ExportAnalyticsMetrics;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportAnalyticsMetrics {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportAnalyticsMetrics(RequestBuilder<crate::model::ExportAnalyticsMetricsRequest>);
 
@@ -177,6 +193,25 @@ pub mod analytics_service {
     }
 
     /// The request builder for [AnalyticsService::list_operations][super::super::client::AnalyticsService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::analytics_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -269,6 +304,21 @@ pub mod analytics_service {
     }
 
     /// The request builder for [AnalyticsService::get_operation][super::super::client::AnalyticsService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::analytics_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -372,6 +422,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_catalogs][super::super::client::CatalogService::list_catalogs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::ListCatalogs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCatalogs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCatalogs(RequestBuilder<crate::model::ListCatalogsRequest>);
 
@@ -455,6 +524,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::update_catalog][super::super::client::CatalogService::update_catalog] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::UpdateCatalog;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCatalog {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCatalog(RequestBuilder<crate::model::UpdateCatalogRequest>);
 
@@ -514,6 +598,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::set_default_branch][super::super::client::CatalogService::set_default_branch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::SetDefaultBranch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetDefaultBranch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetDefaultBranch(RequestBuilder<crate::model::SetDefaultBranchRequest>);
 
@@ -580,6 +679,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_default_branch][super::super::client::CatalogService::get_default_branch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::GetDefaultBranch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDefaultBranch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDefaultBranch(RequestBuilder<crate::model::GetDefaultBranchRequest>);
 
@@ -628,6 +742,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_completion_config][super::super::client::CatalogService::get_completion_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::GetCompletionConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCompletionConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCompletionConfig(RequestBuilder<crate::model::GetCompletionConfigRequest>);
 
@@ -678,6 +807,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::update_completion_config][super::super::client::CatalogService::update_completion_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::UpdateCompletionConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCompletionConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCompletionConfig(RequestBuilder<crate::model::UpdateCompletionConfigRequest>);
 
@@ -742,6 +886,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_attributes_config][super::super::client::CatalogService::get_attributes_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::GetAttributesConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAttributesConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAttributesConfig(RequestBuilder<crate::model::GetAttributesConfigRequest>);
 
@@ -792,6 +951,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::update_attributes_config][super::super::client::CatalogService::update_attributes_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::UpdateAttributesConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAttributesConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAttributesConfig(RequestBuilder<crate::model::UpdateAttributesConfigRequest>);
 
@@ -856,6 +1030,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::add_catalog_attribute][super::super::client::CatalogService::add_catalog_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::AddCatalogAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddCatalogAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddCatalogAttribute(RequestBuilder<crate::model::AddCatalogAttributeRequest>);
 
@@ -919,6 +1108,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::remove_catalog_attribute][super::super::client::CatalogService::remove_catalog_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::RemoveCatalogAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveCatalogAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveCatalogAttribute(RequestBuilder<crate::model::RemoveCatalogAttributeRequest>);
 
@@ -977,6 +1181,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::replace_catalog_attribute][super::super::client::CatalogService::replace_catalog_attribute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::ReplaceCatalogAttribute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReplaceCatalogAttribute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReplaceCatalogAttribute(
         RequestBuilder<crate::model::ReplaceCatalogAttributeRequest>,
@@ -1051,6 +1270,25 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::list_operations][super::super::client::CatalogService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1143,6 +1381,21 @@ pub mod catalog_service {
     }
 
     /// The request builder for [CatalogService::get_operation][super::super::client::CatalogService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::catalog_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1246,6 +1499,21 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::complete_query][super::super::client::CompletionService::complete_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::completion_service::CompleteQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompleteQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompleteQuery(RequestBuilder<crate::model::CompleteQueryRequest>);
 
@@ -1348,6 +1616,22 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::import_completion_data][super::super::client::CompletionService::import_completion_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::completion_service::ImportCompletionData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportCompletionData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportCompletionData(RequestBuilder<crate::model::ImportCompletionDataRequest>);
 
@@ -1458,6 +1742,25 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::list_operations][super::super::client::CompletionService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::completion_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1550,6 +1853,21 @@ pub mod completion_service {
     }
 
     /// The request builder for [CompletionService::get_operation][super::super::client::CompletionService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::completion_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1653,6 +1971,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::create_control][super::super::client::ControlService::create_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::control_service::CreateControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateControl(RequestBuilder<crate::model::CreateControlRequest>);
 
@@ -1719,6 +2052,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::delete_control][super::super::client::ControlService::delete_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::control_service::DeleteControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteControl(RequestBuilder<crate::model::DeleteControlRequest>);
 
@@ -1766,6 +2114,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::update_control][super::super::client::ControlService::update_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::control_service::UpdateControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateControl(RequestBuilder<crate::model::UpdateControlRequest>);
 
@@ -1825,6 +2188,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::get_control][super::super::client::ControlService::get_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::control_service::GetControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetControl(RequestBuilder<crate::model::GetControlRequest>);
 
@@ -1872,6 +2250,25 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::list_controls][super::super::client::ControlService::list_controls] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::control_service::ListControls;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListControls {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListControls(RequestBuilder<crate::model::ListControlsRequest>);
 
@@ -1961,6 +2358,25 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::list_operations][super::super::client::ControlService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::control_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2053,6 +2469,21 @@ pub mod control_service {
     }
 
     /// The request builder for [ControlService::get_operation][super::super::client::ControlService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::control_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2156,6 +2587,21 @@ pub mod generative_question_service {
     }
 
     /// The request builder for [GenerativeQuestionService::update_generative_questions_feature_config][super::super::client::GenerativeQuestionService::update_generative_questions_feature_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::generative_question_service::UpdateGenerativeQuestionsFeatureConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGenerativeQuestionsFeatureConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGenerativeQuestionsFeatureConfig(
         RequestBuilder<crate::model::UpdateGenerativeQuestionsFeatureConfigRequest>,
@@ -2224,6 +2670,21 @@ pub mod generative_question_service {
     }
 
     /// The request builder for [GenerativeQuestionService::get_generative_questions_feature_config][super::super::client::GenerativeQuestionService::get_generative_questions_feature_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::generative_question_service::GetGenerativeQuestionsFeatureConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGenerativeQuestionsFeatureConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGenerativeQuestionsFeatureConfig(
         RequestBuilder<crate::model::GetGenerativeQuestionsFeatureConfigRequest>,
@@ -2276,6 +2737,21 @@ pub mod generative_question_service {
     }
 
     /// The request builder for [GenerativeQuestionService::list_generative_question_configs][super::super::client::GenerativeQuestionService::list_generative_question_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::generative_question_service::ListGenerativeQuestionConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGenerativeQuestionConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGenerativeQuestionConfigs(
         RequestBuilder<crate::model::ListGenerativeQuestionConfigsRequest>,
@@ -2328,6 +2804,21 @@ pub mod generative_question_service {
     }
 
     /// The request builder for [GenerativeQuestionService::update_generative_question_config][super::super::client::GenerativeQuestionService::update_generative_question_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::generative_question_service::UpdateGenerativeQuestionConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGenerativeQuestionConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGenerativeQuestionConfig(
         RequestBuilder<crate::model::UpdateGenerativeQuestionConfigRequest>,
@@ -2394,6 +2885,21 @@ pub mod generative_question_service {
     }
 
     /// The request builder for [GenerativeQuestionService::batch_update_generative_question_configs][super::super::client::GenerativeQuestionService::batch_update_generative_question_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::generative_question_service::BatchUpdateGenerativeQuestionConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchUpdateGenerativeQuestionConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchUpdateGenerativeQuestionConfigs(
         RequestBuilder<crate::model::BatchUpdateGenerativeQuestionConfigsRequest>,
@@ -2459,6 +2965,25 @@ pub mod generative_question_service {
     }
 
     /// The request builder for [GenerativeQuestionService::list_operations][super::super::client::GenerativeQuestionService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::generative_question_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2551,6 +3076,21 @@ pub mod generative_question_service {
     }
 
     /// The request builder for [GenerativeQuestionService::get_operation][super::super::client::GenerativeQuestionService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::generative_question_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2654,6 +3194,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::create_model][super::super::client::ModelService::create_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::CreateModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateModel(RequestBuilder<crate::model::CreateModelRequest>);
 
@@ -2756,6 +3312,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::GetModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -2803,6 +3374,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::pause_model][super::super::client::ModelService::pause_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::PauseModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseModel(RequestBuilder<crate::model::PauseModelRequest>);
 
@@ -2850,6 +3436,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::resume_model][super::super::client::ModelService::resume_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::ResumeModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeModel(RequestBuilder<crate::model::ResumeModelRequest>);
 
@@ -2897,6 +3498,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::DeleteModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -2944,6 +3560,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::ListModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -3027,6 +3662,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::update_model][super::super::client::ModelService::update_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::UpdateModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateModel(RequestBuilder<crate::model::UpdateModelRequest>);
 
@@ -3086,6 +3736,22 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::tune_model][super::super::client::ModelService::tune_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::TuneModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TuneModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TuneModel(RequestBuilder<crate::model::TuneModelRequest>);
 
@@ -3174,6 +3840,25 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::list_operations][super::super::client::ModelService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3266,6 +3951,21 @@ pub mod model_service {
     }
 
     /// The request builder for [ModelService::get_operation][super::super::client::ModelService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::model_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3369,6 +4069,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::predict][super::super::client::PredictionService::predict] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::prediction_service::Predict;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Predict {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Predict(RequestBuilder<crate::model::PredictRequest>);
 
@@ -3474,6 +4189,25 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::list_operations][super::super::client::PredictionService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::prediction_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3566,6 +4300,21 @@ pub mod prediction_service {
     }
 
     /// The request builder for [PredictionService::get_operation][super::super::client::PredictionService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::prediction_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3669,6 +4418,21 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::create_product][super::super::client::ProductService::create_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::CreateProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProduct(RequestBuilder<crate::model::CreateProductRequest>);
 
@@ -3735,6 +4499,21 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::get_product][super::super::client::ProductService::get_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::GetProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProduct(RequestBuilder<crate::model::GetProductRequest>);
 
@@ -3782,6 +4561,25 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::list_products][super::super::client::ProductService::list_products] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::ListProducts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProducts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProducts(RequestBuilder<crate::model::ListProductsRequest>);
 
@@ -3877,6 +4675,21 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::update_product][super::super::client::ProductService::update_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::UpdateProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProduct(RequestBuilder<crate::model::UpdateProductRequest>);
 
@@ -3942,6 +4755,21 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::delete_product][super::super::client::ProductService::delete_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::DeleteProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteProduct(RequestBuilder<crate::model::DeleteProductRequest>);
 
@@ -3989,6 +4817,22 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::purge_products][super::super::client::ProductService::purge_products] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::PurgeProducts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeProducts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeProducts(RequestBuilder<crate::model::PurgeProductsRequest>);
 
@@ -4091,6 +4935,22 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::import_products][super::super::client::ProductService::import_products] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::ImportProducts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportProducts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportProducts(RequestBuilder<crate::model::ImportProductsRequest>);
 
@@ -4232,6 +5092,22 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::set_inventory][super::super::client::ProductService::set_inventory] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::SetInventory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetInventory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetInventory(RequestBuilder<crate::model::SetInventoryRequest>);
 
@@ -4341,6 +5217,22 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::add_fulfillment_places][super::super::client::ProductService::add_fulfillment_places] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::AddFulfillmentPlaces;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddFulfillmentPlaces {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddFulfillmentPlaces(RequestBuilder<crate::model::AddFulfillmentPlacesRequest>);
 
@@ -4467,6 +5359,22 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::remove_fulfillment_places][super::super::client::ProductService::remove_fulfillment_places] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::RemoveFulfillmentPlaces;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveFulfillmentPlaces {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveFulfillmentPlaces(
         RequestBuilder<crate::model::RemoveFulfillmentPlacesRequest>,
@@ -4598,6 +5506,22 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::add_local_inventories][super::super::client::ProductService::add_local_inventories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::AddLocalInventories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddLocalInventories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddLocalInventories(RequestBuilder<crate::model::AddLocalInventoriesRequest>);
 
@@ -4722,6 +5646,22 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::remove_local_inventories][super::super::client::ProductService::remove_local_inventories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::RemoveLocalInventories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveLocalInventories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveLocalInventories(RequestBuilder<crate::model::RemoveLocalInventoriesRequest>);
 
@@ -4843,6 +5783,25 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::list_operations][super::super::client::ProductService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4935,6 +5894,21 @@ pub mod product_service {
     }
 
     /// The request builder for [ProductService::get_operation][super::super::client::ProductService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::product_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5038,6 +6012,25 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::search][super::super::client::SearchService::search] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::search_service::Search;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Search {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Search(RequestBuilder<crate::model::SearchRequest>);
 
@@ -5329,6 +6322,25 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::list_operations][super::super::client::SearchService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::search_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5421,6 +6433,21 @@ pub mod search_service {
     }
 
     /// The request builder for [SearchService::get_operation][super::super::client::SearchService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::search_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5524,6 +6551,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::create_serving_config][super::super::client::ServingConfigService::create_serving_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::CreateServingConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServingConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServingConfig(RequestBuilder<crate::model::CreateServingConfigRequest>);
 
@@ -5593,6 +6635,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::delete_serving_config][super::super::client::ServingConfigService::delete_serving_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::DeleteServingConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServingConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServingConfig(RequestBuilder<crate::model::DeleteServingConfigRequest>);
 
@@ -5643,6 +6700,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::update_serving_config][super::super::client::ServingConfigService::update_serving_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::UpdateServingConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServingConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServingConfig(RequestBuilder<crate::model::UpdateServingConfigRequest>);
 
@@ -5705,6 +6777,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::get_serving_config][super::super::client::ServingConfigService::get_serving_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::GetServingConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServingConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServingConfig(RequestBuilder<crate::model::GetServingConfigRequest>);
 
@@ -5755,6 +6842,25 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::list_serving_configs][super::super::client::ServingConfigService::list_serving_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::ListServingConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServingConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServingConfigs(RequestBuilder<crate::model::ListServingConfigsRequest>);
 
@@ -5843,6 +6949,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::add_control][super::super::client::ServingConfigService::add_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::AddControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddControl(RequestBuilder<crate::model::AddControlRequest>);
 
@@ -5898,6 +7019,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::remove_control][super::super::client::ServingConfigService::remove_control] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::RemoveControl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveControl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveControl(RequestBuilder<crate::model::RemoveControlRequest>);
 
@@ -5953,6 +7089,25 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::list_operations][super::super::client::ServingConfigService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6045,6 +7200,21 @@ pub mod serving_config_service {
     }
 
     /// The request builder for [ServingConfigService::get_operation][super::super::client::ServingConfigService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::serving_config_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6148,6 +7318,21 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::write_user_event][super::super::client::UserEventService::write_user_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::user_event_service::WriteUserEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WriteUserEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WriteUserEvent(RequestBuilder<crate::model::WriteUserEventRequest>);
 
@@ -6212,6 +7397,21 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::collect_user_event][super::super::client::UserEventService::collect_user_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::user_event_service::CollectUserEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CollectUserEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CollectUserEvent(RequestBuilder<crate::model::CollectUserEventRequest>);
 
@@ -6315,6 +7515,22 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::purge_user_events][super::super::client::UserEventService::purge_user_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::user_event_service::PurgeUserEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeUserEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeUserEvents(RequestBuilder<crate::model::PurgeUserEventsRequest>);
 
@@ -6417,6 +7633,22 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::import_user_events][super::super::client::UserEventService::import_user_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::user_event_service::ImportUserEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportUserEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportUserEvents(RequestBuilder<crate::model::ImportUserEventsRequest>);
 
@@ -6530,6 +7762,22 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::rejoin_user_events][super::super::client::UserEventService::rejoin_user_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::user_event_service::RejoinUserEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_retail_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RejoinUserEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RejoinUserEvents(RequestBuilder<crate::model::RejoinUserEventsRequest>);
 
@@ -6634,6 +7882,25 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::list_operations][super::super::client::UserEventService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::user_event_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6726,6 +7993,21 @@ pub mod user_event_service {
     }
 
     /// The request builder for [UserEventService::get_operation][super::super::client::UserEventService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_retail_v2::builder;
+    /// use builder::user_event_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/run/v2/src/builder.rs
+++ b/src/generated/cloud/run/v2/src/builder.rs
@@ -67,6 +67,21 @@ pub mod builds {
     }
 
     /// The request builder for [Builds::submit_build][super::super::client::Builds::submit_build] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::builds::SubmitBuild;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubmitBuild {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubmitBuild(RequestBuilder<crate::model::SubmitBuildRequest>);
 
@@ -214,6 +229,25 @@ pub mod builds {
     }
 
     /// The request builder for [Builds::list_operations][super::super::client::Builds::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::builds::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -304,6 +338,21 @@ pub mod builds {
     }
 
     /// The request builder for [Builds::get_operation][super::super::client::Builds::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::builds::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -350,6 +399,21 @@ pub mod builds {
     }
 
     /// The request builder for [Builds::delete_operation][super::super::client::Builds::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::builds::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -396,6 +460,21 @@ pub mod builds {
     }
 
     /// The request builder for [Builds::wait_operation][super::super::client::Builds::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::builds::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -503,6 +582,21 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::get_execution][super::super::client::Executions::get_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::GetExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExecution(RequestBuilder<crate::model::GetExecutionRequest>);
 
@@ -550,6 +644,25 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::list_executions][super::super::client::Executions::list_executions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::ListExecutions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExecutions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExecutions(RequestBuilder<crate::model::ListExecutionsRequest>);
 
@@ -639,6 +752,22 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::delete_execution][super::super::client::Executions::delete_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::DeleteExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteExecution(RequestBuilder<crate::model::DeleteExecutionRequest>);
 
@@ -734,6 +863,22 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::cancel_execution][super::super::client::Executions::cancel_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::CancelExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelExecution(RequestBuilder<crate::model::CancelExecutionRequest>);
 
@@ -829,6 +974,25 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::list_operations][super::super::client::Executions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -921,6 +1085,21 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::get_operation][super::super::client::Executions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -969,6 +1148,21 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::delete_operation][super::super::client::Executions::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1017,6 +1211,21 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::wait_operation][super::super::client::Executions::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::executions::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -1124,6 +1333,22 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::create_job][super::super::client::Jobs::create_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::CreateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -1226,6 +1451,21 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::get_job][super::super::client::Jobs::get_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::GetJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -1271,6 +1511,25 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::list_jobs][super::super::client::Jobs::list_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::ListJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -1358,6 +1617,22 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::update_job][super::super::client::Jobs::update_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::UpdateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -1450,6 +1725,22 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::delete_job][super::super::client::Jobs::delete_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::DeleteJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -1542,6 +1833,22 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::run_job][super::super::client::Jobs::run_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::RunJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunJob(RequestBuilder<crate::model::RunJobRequest>);
 
@@ -1646,6 +1953,21 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::get_iam_policy][super::super::client::Jobs::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1700,6 +2022,21 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::set_iam_policy][super::super::client::Jobs::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1765,6 +2102,21 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::test_iam_permissions][super::super::client::Jobs::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1826,6 +2178,25 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::list_operations][super::super::client::Jobs::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1916,6 +2287,21 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::get_operation][super::super::client::Jobs::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1962,6 +2348,21 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::delete_operation][super::super::client::Jobs::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2008,6 +2409,21 @@ pub mod jobs {
     }
 
     /// The request builder for [Jobs::wait_operation][super::super::client::Jobs::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::jobs::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -2115,6 +2531,21 @@ pub mod revisions {
     }
 
     /// The request builder for [Revisions::get_revision][super::super::client::Revisions::get_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::revisions::GetRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRevision(RequestBuilder<crate::model::GetRevisionRequest>);
 
@@ -2162,6 +2593,25 @@ pub mod revisions {
     }
 
     /// The request builder for [Revisions::list_revisions][super::super::client::Revisions::list_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::revisions::ListRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRevisions(RequestBuilder<crate::model::ListRevisionsRequest>);
 
@@ -2251,6 +2701,22 @@ pub mod revisions {
     }
 
     /// The request builder for [Revisions::delete_revision][super::super::client::Revisions::delete_revision] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::revisions::DeleteRevision;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRevision {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRevision(RequestBuilder<crate::model::DeleteRevisionRequest>);
 
@@ -2346,6 +2812,25 @@ pub mod revisions {
     }
 
     /// The request builder for [Revisions::list_operations][super::super::client::Revisions::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::revisions::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2438,6 +2923,21 @@ pub mod revisions {
     }
 
     /// The request builder for [Revisions::get_operation][super::super::client::Revisions::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::revisions::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2486,6 +2986,21 @@ pub mod revisions {
     }
 
     /// The request builder for [Revisions::delete_operation][super::super::client::Revisions::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::revisions::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2534,6 +3049,21 @@ pub mod revisions {
     }
 
     /// The request builder for [Revisions::wait_operation][super::super::client::Revisions::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::revisions::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -2641,6 +3171,22 @@ pub mod services {
     }
 
     /// The request builder for [Services::create_service][super::super::client::Services::create_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::CreateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -2746,6 +3292,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::get_service][super::super::client::Services::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -2791,6 +3352,25 @@ pub mod services {
     }
 
     /// The request builder for [Services::list_services][super::super::client::Services::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -2878,6 +3458,22 @@ pub mod services {
     }
 
     /// The request builder for [Services::update_service][super::super::client::Services::update_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::UpdateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -2982,6 +3578,22 @@ pub mod services {
     }
 
     /// The request builder for [Services::delete_service][super::super::client::Services::delete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::DeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_run_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -3074,6 +3686,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::get_iam_policy][super::super::client::Services::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3128,6 +3755,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::set_iam_policy][super::super::client::Services::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3193,6 +3835,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::test_iam_permissions][super::super::client::Services::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3254,6 +3911,25 @@ pub mod services {
     }
 
     /// The request builder for [Services::list_operations][super::super::client::Services::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3344,6 +4020,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::get_operation][super::super::client::Services::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3390,6 +4081,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::delete_operation][super::super::client::Services::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3436,6 +4142,21 @@ pub mod services {
     }
 
     /// The request builder for [Services::wait_operation][super::super::client::Services::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::services::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 
@@ -3541,6 +4262,21 @@ pub mod tasks {
     }
 
     /// The request builder for [Tasks::get_task][super::super::client::Tasks::get_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::tasks::GetTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTask(RequestBuilder<crate::model::GetTaskRequest>);
 
@@ -3586,6 +4322,25 @@ pub mod tasks {
     }
 
     /// The request builder for [Tasks::list_tasks][super::super::client::Tasks::list_tasks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::tasks::ListTasks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTasks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTasks(RequestBuilder<crate::model::ListTasksRequest>);
 
@@ -3673,6 +4428,25 @@ pub mod tasks {
     }
 
     /// The request builder for [Tasks::list_operations][super::super::client::Tasks::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::tasks::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3763,6 +4537,21 @@ pub mod tasks {
     }
 
     /// The request builder for [Tasks::get_operation][super::super::client::Tasks::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::tasks::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3809,6 +4598,21 @@ pub mod tasks {
     }
 
     /// The request builder for [Tasks::delete_operation][super::super::client::Tasks::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::tasks::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3855,6 +4659,21 @@ pub mod tasks {
     }
 
     /// The request builder for [Tasks::wait_operation][super::super::client::Tasks::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_run_v2::builder;
+    /// use builder::tasks::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 

--- a/src/generated/cloud/scheduler/v1/src/builder.rs
+++ b/src/generated/cloud/scheduler/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::list_jobs][super::super::client::CloudScheduler::list_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::ListJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -152,6 +171,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::get_job][super::super::client::CloudScheduler::get_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::GetJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -199,6 +233,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::create_job][super::super::client::CloudScheduler::create_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::CreateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -254,6 +303,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::update_job][super::super::client::CloudScheduler::update_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::UpdateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -310,6 +374,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::delete_job][super::super::client::CloudScheduler::delete_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::DeleteJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -357,6 +436,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::pause_job][super::super::client::CloudScheduler::pause_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::PauseJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseJob(RequestBuilder<crate::model::PauseJobRequest>);
 
@@ -404,6 +498,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::resume_job][super::super::client::CloudScheduler::resume_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::ResumeJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeJob(RequestBuilder<crate::model::ResumeJobRequest>);
 
@@ -451,6 +560,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::run_job][super::super::client::CloudScheduler::run_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::RunJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunJob(RequestBuilder<crate::model::RunJobRequest>);
 
@@ -498,6 +622,25 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::list_locations][super::super::client::CloudScheduler::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -588,6 +731,21 @@ pub mod cloud_scheduler {
     }
 
     /// The request builder for [CloudScheduler::get_location][super::super::client::CloudScheduler::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_scheduler_v1::builder;
+    /// use builder::cloud_scheduler::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/secretmanager/v1/src/builder.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::ListSecrets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSecrets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -158,6 +177,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::CreateSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -224,6 +258,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::AddSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -285,6 +334,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::GetSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -332,6 +396,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::UpdateSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -393,6 +472,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::DeleteSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -446,6 +540,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::ListSecretVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSecretVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -540,6 +653,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::GetSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -590,6 +718,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::AccessSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AccessSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -640,6 +783,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::DisableSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -696,6 +854,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::EnableSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -752,6 +925,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::DestroySecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DestroySecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -808,6 +996,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -875,6 +1078,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -931,6 +1149,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -994,6 +1227,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1084,6 +1336,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_secretmanager_v1::builder;
+    /// use builder::secret_manager_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/securesourcemanager/v1/src/builder.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::list_instances][super::super::client::SecureSourceManager::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -164,6 +183,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::get_instance][super::super::client::SecureSourceManager::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -211,6 +245,22 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::create_instance][super::super::client::SecureSourceManager::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securesourcemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -321,6 +371,22 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::delete_instance][super::super::client::SecureSourceManager::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securesourcemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -414,6 +480,25 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::list_repositories][super::super::client::SecureSourceManager::list_repositories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::ListRepositories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRepositories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRepositories(RequestBuilder<crate::model::ListRepositoriesRequest>);
 
@@ -512,6 +597,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::get_repository][super::super::client::SecureSourceManager::get_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::GetRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRepository(RequestBuilder<crate::model::GetRepositoryRequest>);
 
@@ -559,6 +659,22 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::create_repository][super::super::client::SecureSourceManager::create_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::CreateRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securesourcemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRepository(RequestBuilder<crate::model::CreateRepositoryRequest>);
 
@@ -666,6 +782,22 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::delete_repository][super::super::client::SecureSourceManager::delete_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::DeleteRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securesourcemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRepository(RequestBuilder<crate::model::DeleteRepositoryRequest>);
 
@@ -762,6 +894,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::get_iam_policy_repo][super::super::client::SecureSourceManager::get_iam_policy_repo] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::GetIamPolicyRepo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicyRepo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicyRepo(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -818,6 +965,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::set_iam_policy_repo][super::super::client::SecureSourceManager::set_iam_policy_repo] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::SetIamPolicyRepo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicyRepo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicyRepo(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -885,6 +1047,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::test_iam_permissions_repo][super::super::client::SecureSourceManager::test_iam_permissions_repo] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::TestIamPermissionsRepo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissionsRepo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissionsRepo(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -948,6 +1125,22 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::create_branch_rule][super::super::client::SecureSourceManager::create_branch_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::CreateBranchRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securesourcemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBranchRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBranchRule(RequestBuilder<crate::model::CreateBranchRuleRequest>);
 
@@ -1055,6 +1248,25 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::list_branch_rules][super::super::client::SecureSourceManager::list_branch_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::ListBranchRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBranchRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBranchRules(RequestBuilder<crate::model::ListBranchRulesRequest>);
 
@@ -1138,6 +1350,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::get_branch_rule][super::super::client::SecureSourceManager::get_branch_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::GetBranchRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBranchRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBranchRule(RequestBuilder<crate::model::GetBranchRuleRequest>);
 
@@ -1185,6 +1412,22 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::update_branch_rule][super::super::client::SecureSourceManager::update_branch_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::UpdateBranchRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securesourcemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBranchRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBranchRule(RequestBuilder<crate::model::UpdateBranchRuleRequest>);
 
@@ -1293,6 +1536,22 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::delete_branch_rule][super::super::client::SecureSourceManager::delete_branch_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::DeleteBranchRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securesourcemanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBranchRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBranchRule(RequestBuilder<crate::model::DeleteBranchRuleRequest>);
 
@@ -1389,6 +1648,25 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::list_locations][super::super::client::SecureSourceManager::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1479,6 +1757,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::get_location][super::super::client::SecureSourceManager::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1524,6 +1817,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::set_iam_policy][super::super::client::SecureSourceManager::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1591,6 +1899,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::get_iam_policy][super::super::client::SecureSourceManager::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1647,6 +1970,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::test_iam_permissions][super::super::client::SecureSourceManager::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1710,6 +2048,25 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::list_operations][super::super::client::SecureSourceManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1802,6 +2159,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::get_operation][super::super::client::SecureSourceManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1850,6 +2222,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::delete_operation][super::super::client::SecureSourceManager::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1898,6 +2285,21 @@ pub mod secure_source_manager {
     }
 
     /// The request builder for [SecureSourceManager::cancel_operation][super::super::client::SecureSourceManager::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securesourcemanager_v1::builder;
+    /// use builder::secure_source_manager::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/security/privateca/v1/src/builder.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::create_certificate][super::super::client::CertificateAuthorityService::create_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::CreateCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCertificate(RequestBuilder<crate::model::CreateCertificateRequest>);
 
@@ -157,6 +172,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_certificate][super::super::client::CertificateAuthorityService::get_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificate(RequestBuilder<crate::model::GetCertificateRequest>);
 
@@ -204,6 +234,25 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::list_certificates][super::super::client::CertificateAuthorityService::list_certificates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ListCertificates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificates(RequestBuilder<crate::model::ListCertificatesRequest>);
 
@@ -302,6 +351,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::revoke_certificate][super::super::client::CertificateAuthorityService::revoke_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::RevokeCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RevokeCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RevokeCertificate(RequestBuilder<crate::model::RevokeCertificateRequest>);
 
@@ -366,6 +430,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::update_certificate][super::super::client::CertificateAuthorityService::update_certificate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::UpdateCertificate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCertificate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCertificate(RequestBuilder<crate::model::UpdateCertificateRequest>);
 
@@ -436,6 +515,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::activate_certificate_authority][super::super::client::CertificateAuthorityService::activate_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ActivateCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ActivateCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ActivateCertificateAuthority(
         RequestBuilder<crate::model::ActivateCertificateAuthorityRequest>,
@@ -556,6 +651,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::create_certificate_authority][super::super::client::CertificateAuthorityService::create_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::CreateCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCertificateAuthority(
         RequestBuilder<crate::model::CreateCertificateAuthorityRequest>,
@@ -676,6 +787,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::disable_certificate_authority][super::super::client::CertificateAuthorityService::disable_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::DisableCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableCertificateAuthority(
         RequestBuilder<crate::model::DisableCertificateAuthorityRequest>,
@@ -781,6 +908,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::enable_certificate_authority][super::super::client::CertificateAuthorityService::enable_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::EnableCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableCertificateAuthority(
         RequestBuilder<crate::model::EnableCertificateAuthorityRequest>,
@@ -880,6 +1023,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::fetch_certificate_authority_csr][super::super::client::CertificateAuthorityService::fetch_certificate_authority_csr] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::FetchCertificateAuthorityCsr;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchCertificateAuthorityCsr {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchCertificateAuthorityCsr(
         RequestBuilder<crate::model::FetchCertificateAuthorityCsrRequest>,
@@ -932,6 +1090,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_certificate_authority][super::super::client::CertificateAuthorityService::get_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificateAuthority(
         RequestBuilder<crate::model::GetCertificateAuthorityRequest>,
@@ -984,6 +1157,25 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::list_certificate_authorities][super::super::client::CertificateAuthorityService::list_certificate_authorities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ListCertificateAuthorities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificateAuthorities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificateAuthorities(
         RequestBuilder<crate::model::ListCertificateAuthoritiesRequest>,
@@ -1088,6 +1280,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::undelete_certificate_authority][super::super::client::CertificateAuthorityService::undelete_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::UndeleteCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteCertificateAuthority(
         RequestBuilder<crate::model::UndeleteCertificateAuthorityRequest>,
@@ -1187,6 +1395,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::delete_certificate_authority][super::super::client::CertificateAuthorityService::delete_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::DeleteCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateAuthority(
         RequestBuilder<crate::model::DeleteCertificateAuthorityRequest>,
@@ -1304,6 +1528,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::update_certificate_authority][super::super::client::CertificateAuthorityService::update_certificate_authority] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::UpdateCertificateAuthority;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCertificateAuthority {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateAuthority(
         RequestBuilder<crate::model::UpdateCertificateAuthorityRequest>,
@@ -1419,6 +1659,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::create_ca_pool][super::super::client::CertificateAuthorityService::create_ca_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::CreateCaPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCaPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCaPool(RequestBuilder<crate::model::CreateCaPoolRequest>);
 
@@ -1529,6 +1785,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::update_ca_pool][super::super::client::CertificateAuthorityService::update_ca_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::UpdateCaPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCaPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCaPool(RequestBuilder<crate::model::UpdateCaPoolRequest>);
 
@@ -1634,6 +1906,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_ca_pool][super::super::client::CertificateAuthorityService::get_ca_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetCaPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCaPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCaPool(RequestBuilder<crate::model::GetCaPoolRequest>);
 
@@ -1681,6 +1968,25 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::list_ca_pools][super::super::client::CertificateAuthorityService::list_ca_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ListCaPools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCaPools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCaPools(RequestBuilder<crate::model::ListCaPoolsRequest>);
 
@@ -1776,6 +2082,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::delete_ca_pool][super::super::client::CertificateAuthorityService::delete_ca_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::DeleteCaPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCaPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCaPool(RequestBuilder<crate::model::DeleteCaPoolRequest>);
 
@@ -1875,6 +2197,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::fetch_ca_certs][super::super::client::CertificateAuthorityService::fetch_ca_certs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::FetchCaCerts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchCaCerts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchCaCerts(RequestBuilder<crate::model::FetchCaCertsRequest>);
 
@@ -1928,6 +2265,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_certificate_revocation_list][super::super::client::CertificateAuthorityService::get_certificate_revocation_list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetCertificateRevocationList;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificateRevocationList {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificateRevocationList(
         RequestBuilder<crate::model::GetCertificateRevocationListRequest>,
@@ -1980,6 +2332,25 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::list_certificate_revocation_lists][super::super::client::CertificateAuthorityService::list_certificate_revocation_lists] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ListCertificateRevocationLists;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificateRevocationLists {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificateRevocationLists(
         RequestBuilder<crate::model::ListCertificateRevocationListsRequest>,
@@ -2084,6 +2455,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::update_certificate_revocation_list][super::super::client::CertificateAuthorityService::update_certificate_revocation_list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::UpdateCertificateRevocationList;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCertificateRevocationList {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateRevocationList(
         RequestBuilder<crate::model::UpdateCertificateRevocationListRequest>,
@@ -2199,6 +2586,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::create_certificate_template][super::super::client::CertificateAuthorityService::create_certificate_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::CreateCertificateTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCertificateTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCertificateTemplate(
         RequestBuilder<crate::model::CreateCertificateTemplateRequest>,
@@ -2319,6 +2722,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::delete_certificate_template][super::super::client::CertificateAuthorityService::delete_certificate_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::DeleteCertificateTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCertificateTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCertificateTemplate(
         RequestBuilder<crate::model::DeleteCertificateTemplateRequest>,
@@ -2417,6 +2836,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_certificate_template][super::super::client::CertificateAuthorityService::get_certificate_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetCertificateTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCertificateTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCertificateTemplate(RequestBuilder<crate::model::GetCertificateTemplateRequest>);
 
@@ -2467,6 +2901,25 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::list_certificate_templates][super::super::client::CertificateAuthorityService::list_certificate_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ListCertificateTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCertificateTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCertificateTemplates(
         RequestBuilder<crate::model::ListCertificateTemplatesRequest>,
@@ -2571,6 +3024,22 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::update_certificate_template][super::super::client::CertificateAuthorityService::update_certificate_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::UpdateCertificateTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_security_privateca_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCertificateTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCertificateTemplate(
         RequestBuilder<crate::model::UpdateCertificateTemplateRequest>,
@@ -2686,6 +3155,25 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::list_locations][super::super::client::CertificateAuthorityService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2776,6 +3264,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_location][super::super::client::CertificateAuthorityService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2821,6 +3324,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::set_iam_policy][super::super::client::CertificateAuthorityService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2888,6 +3406,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_iam_policy][super::super::client::CertificateAuthorityService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2944,6 +3477,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::test_iam_permissions][super::super::client::CertificateAuthorityService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3007,6 +3555,25 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::list_operations][super::super::client::CertificateAuthorityService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3099,6 +3666,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::get_operation][super::super::client::CertificateAuthorityService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3147,6 +3729,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::delete_operation][super::super::client::CertificateAuthorityService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3195,6 +3792,21 @@ pub mod certificate_authority_service {
     }
 
     /// The request builder for [CertificateAuthorityService::cancel_operation][super::super::client::CertificateAuthorityService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_privateca_v1::builder;
+    /// use builder::certificate_authority_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/security/publicca/v1/src/builder.rs
+++ b/src/generated/cloud/security/publicca/v1/src/builder.rs
@@ -71,6 +71,21 @@ pub mod public_certificate_authority_service {
     }
 
     /// The request builder for [PublicCertificateAuthorityService::create_external_account_key][super::super::client::PublicCertificateAuthorityService::create_external_account_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_security_publicca_v1::builder;
+    /// use builder::public_certificate_authority_service::CreateExternalAccountKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExternalAccountKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExternalAccountKey(
         RequestBuilder<crate::model::CreateExternalAccountKeyRequest>,

--- a/src/generated/cloud/securitycenter/v2/src/builder.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::batch_create_resource_value_configs][super::super::client::SecurityCenter::batch_create_resource_value_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::BatchCreateResourceValueConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateResourceValueConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateResourceValueConfigs(
         RequestBuilder<crate::model::BatchCreateResourceValueConfigsRequest>,
@@ -134,6 +149,22 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::bulk_mute_findings][super::super::client::SecurityCenter::bulk_mute_findings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::BulkMuteFindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securitycenter_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BulkMuteFindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BulkMuteFindings(RequestBuilder<crate::model::BulkMuteFindingsRequest>);
 
@@ -240,6 +271,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::create_big_query_export][super::super::client::SecurityCenter::create_big_query_export] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::CreateBigQueryExport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBigQueryExport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBigQueryExport(RequestBuilder<crate::model::CreateBigQueryExportRequest>);
 
@@ -309,6 +355,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::create_finding][super::super::client::SecurityCenter::create_finding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::CreateFinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateFinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateFinding(RequestBuilder<crate::model::CreateFindingRequest>);
 
@@ -375,6 +436,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::create_mute_config][super::super::client::SecurityCenter::create_mute_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::CreateMuteConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMuteConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMuteConfig(RequestBuilder<crate::model::CreateMuteConfigRequest>);
 
@@ -444,6 +520,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::create_notification_config][super::super::client::SecurityCenter::create_notification_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::CreateNotificationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNotificationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNotificationConfig(
         RequestBuilder<crate::model::CreateNotificationConfigRequest>,
@@ -517,6 +608,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::create_source][super::super::client::SecurityCenter::create_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::CreateSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSource(RequestBuilder<crate::model::CreateSourceRequest>);
 
@@ -575,6 +681,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::delete_big_query_export][super::super::client::SecurityCenter::delete_big_query_export] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::DeleteBigQueryExport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBigQueryExport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBigQueryExport(RequestBuilder<crate::model::DeleteBigQueryExportRequest>);
 
@@ -625,6 +746,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::delete_mute_config][super::super::client::SecurityCenter::delete_mute_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::DeleteMuteConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMuteConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMuteConfig(RequestBuilder<crate::model::DeleteMuteConfigRequest>);
 
@@ -675,6 +811,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::delete_notification_config][super::super::client::SecurityCenter::delete_notification_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::DeleteNotificationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNotificationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNotificationConfig(
         RequestBuilder<crate::model::DeleteNotificationConfigRequest>,
@@ -727,6 +878,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::delete_resource_value_config][super::super::client::SecurityCenter::delete_resource_value_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::DeleteResourceValueConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteResourceValueConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteResourceValueConfig(
         RequestBuilder<crate::model::DeleteResourceValueConfigRequest>,
@@ -779,6 +945,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_big_query_export][super::super::client::SecurityCenter::get_big_query_export] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetBigQueryExport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBigQueryExport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBigQueryExport(RequestBuilder<crate::model::GetBigQueryExportRequest>);
 
@@ -829,6 +1010,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_simulation][super::super::client::SecurityCenter::get_simulation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetSimulation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSimulation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSimulation(RequestBuilder<crate::model::GetSimulationRequest>);
 
@@ -876,6 +1072,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_valued_resource][super::super::client::SecurityCenter::get_valued_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetValuedResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetValuedResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetValuedResource(RequestBuilder<crate::model::GetValuedResourceRequest>);
 
@@ -926,6 +1137,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_iam_policy][super::super::client::SecurityCenter::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -982,6 +1208,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_mute_config][super::super::client::SecurityCenter::get_mute_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetMuteConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMuteConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMuteConfig(RequestBuilder<crate::model::GetMuteConfigRequest>);
 
@@ -1029,6 +1270,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_notification_config][super::super::client::SecurityCenter::get_notification_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetNotificationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotificationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotificationConfig(RequestBuilder<crate::model::GetNotificationConfigRequest>);
 
@@ -1079,6 +1335,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_resource_value_config][super::super::client::SecurityCenter::get_resource_value_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetResourceValueConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetResourceValueConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetResourceValueConfig(RequestBuilder<crate::model::GetResourceValueConfigRequest>);
 
@@ -1129,6 +1400,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_source][super::super::client::SecurityCenter::get_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSource(RequestBuilder<crate::model::GetSourceRequest>);
 
@@ -1176,6 +1462,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::group_findings][super::super::client::SecurityCenter::group_findings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GroupFindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GroupFindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GroupFindings(RequestBuilder<crate::model::GroupFindingsRequest>);
 
@@ -1273,6 +1578,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_attack_paths][super::super::client::SecurityCenter::list_attack_paths] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListAttackPaths;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAttackPaths {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAttackPaths(RequestBuilder<crate::model::ListAttackPathsRequest>);
 
@@ -1362,6 +1686,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_big_query_exports][super::super::client::SecurityCenter::list_big_query_exports] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListBigQueryExports;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBigQueryExports {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBigQueryExports(RequestBuilder<crate::model::ListBigQueryExportsRequest>);
 
@@ -1450,6 +1793,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_findings][super::super::client::SecurityCenter::list_findings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListFindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFindings(RequestBuilder<crate::model::ListFindingsRequest>);
 
@@ -1554,6 +1916,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_mute_configs][super::super::client::SecurityCenter::list_mute_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListMuteConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMuteConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMuteConfigs(RequestBuilder<crate::model::ListMuteConfigsRequest>);
 
@@ -1637,6 +2018,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_notification_configs][super::super::client::SecurityCenter::list_notification_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListNotificationConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotificationConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotificationConfigs(
         RequestBuilder<crate::model::ListNotificationConfigsRequest>,
@@ -1729,6 +2129,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_resource_value_configs][super::super::client::SecurityCenter::list_resource_value_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListResourceValueConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListResourceValueConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListResourceValueConfigs(
         RequestBuilder<crate::model::ListResourceValueConfigsRequest>,
@@ -1821,6 +2240,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_sources][super::super::client::SecurityCenter::list_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSources(RequestBuilder<crate::model::ListSourcesRequest>);
 
@@ -1904,6 +2342,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_valued_resources][super::super::client::SecurityCenter::list_valued_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListValuedResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListValuedResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListValuedResources(RequestBuilder<crate::model::ListValuedResourcesRequest>);
 
@@ -2004,6 +2461,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::set_finding_state][super::super::client::SecurityCenter::set_finding_state] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::SetFindingState;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetFindingState {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetFindingState(RequestBuilder<crate::model::SetFindingStateRequest>);
 
@@ -2059,6 +2531,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::set_iam_policy][super::super::client::SecurityCenter::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2126,6 +2613,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::set_mute][super::super::client::SecurityCenter::set_mute] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::SetMute;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetMute {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetMute(RequestBuilder<crate::model::SetMuteRequest>);
 
@@ -2181,6 +2683,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::test_iam_permissions][super::super::client::SecurityCenter::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2244,6 +2761,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_big_query_export][super::super::client::SecurityCenter::update_big_query_export] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateBigQueryExport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBigQueryExport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBigQueryExport(RequestBuilder<crate::model::UpdateBigQueryExportRequest>);
 
@@ -2306,6 +2838,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_external_system][super::super::client::SecurityCenter::update_external_system] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateExternalSystem;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExternalSystem {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExternalSystem(RequestBuilder<crate::model::UpdateExternalSystemRequest>);
 
@@ -2368,6 +2915,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_finding][super::super::client::SecurityCenter::update_finding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateFinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFinding(RequestBuilder<crate::model::UpdateFindingRequest>);
 
@@ -2427,6 +2989,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_mute_config][super::super::client::SecurityCenter::update_mute_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateMuteConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMuteConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMuteConfig(RequestBuilder<crate::model::UpdateMuteConfigRequest>);
 
@@ -2489,6 +3066,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_notification_config][super::super::client::SecurityCenter::update_notification_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateNotificationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNotificationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNotificationConfig(
         RequestBuilder<crate::model::UpdateNotificationConfigRequest>,
@@ -2555,6 +3147,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_resource_value_config][super::super::client::SecurityCenter::update_resource_value_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateResourceValueConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateResourceValueConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateResourceValueConfig(
         RequestBuilder<crate::model::UpdateResourceValueConfigRequest>,
@@ -2621,6 +3228,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_security_marks][super::super::client::SecurityCenter::update_security_marks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateSecurityMarks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSecurityMarks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSecurityMarks(RequestBuilder<crate::model::UpdateSecurityMarksRequest>);
 
@@ -2683,6 +3305,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::update_source][super::super::client::SecurityCenter::update_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::UpdateSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSource(RequestBuilder<crate::model::UpdateSourceRequest>);
 
@@ -2742,6 +3379,25 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::list_operations][super::super::client::SecurityCenter::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2834,6 +3490,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::get_operation][super::super::client::SecurityCenter::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2882,6 +3553,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::delete_operation][super::super::client::SecurityCenter::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2930,6 +3616,21 @@ pub mod security_center {
     }
 
     /// The request builder for [SecurityCenter::cancel_operation][super::super::client::SecurityCenter::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securitycenter_v2::builder;
+    /// use builder::security_center::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/securityposture/v1/src/builder.rs
+++ b/src/generated/cloud/securityposture/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::list_postures][super::super::client::SecurityPosture::list_postures] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::ListPostures;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPostures {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPostures(RequestBuilder<crate::model::ListPosturesRequest>);
 
@@ -152,6 +171,25 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::list_posture_revisions][super::super::client::SecurityPosture::list_posture_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::ListPostureRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPostureRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPostureRevisions(RequestBuilder<crate::model::ListPostureRevisionsRequest>);
 
@@ -240,6 +278,21 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::get_posture][super::super::client::SecurityPosture::get_posture] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::GetPosture;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPosture {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPosture(RequestBuilder<crate::model::GetPostureRequest>);
 
@@ -293,6 +346,22 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::create_posture][super::super::client::SecurityPosture::create_posture] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::CreatePosture;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securityposture_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePosture {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePosture(RequestBuilder<crate::model::CreatePostureRequest>);
 
@@ -397,6 +466,22 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::update_posture][super::super::client::SecurityPosture::update_posture] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::UpdatePosture;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securityposture_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePosture {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePosture(RequestBuilder<crate::model::UpdatePostureRequest>);
 
@@ -504,6 +589,22 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::delete_posture][super::super::client::SecurityPosture::delete_posture] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::DeletePosture;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securityposture_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePosture {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePosture(RequestBuilder<crate::model::DeletePostureRequest>);
 
@@ -597,6 +698,22 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::extract_posture][super::super::client::SecurityPosture::extract_posture] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::ExtractPosture;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securityposture_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExtractPosture {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExtractPosture(RequestBuilder<crate::model::ExtractPostureRequest>);
 
@@ -698,6 +815,25 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::list_posture_deployments][super::super::client::SecurityPosture::list_posture_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::ListPostureDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPostureDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPostureDeployments(RequestBuilder<crate::model::ListPostureDeploymentsRequest>);
 
@@ -794,6 +930,21 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::get_posture_deployment][super::super::client::SecurityPosture::get_posture_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::GetPostureDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPostureDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPostureDeployment(RequestBuilder<crate::model::GetPostureDeploymentRequest>);
 
@@ -844,6 +995,22 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::create_posture_deployment][super::super::client::SecurityPosture::create_posture_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::CreatePostureDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securityposture_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePostureDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePostureDeployment(
         RequestBuilder<crate::model::CreatePostureDeploymentRequest>,
@@ -958,6 +1125,22 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::update_posture_deployment][super::super::client::SecurityPosture::update_posture_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::UpdatePostureDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securityposture_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePostureDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePostureDeployment(
         RequestBuilder<crate::model::UpdatePostureDeploymentRequest>,
@@ -1067,6 +1250,22 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::delete_posture_deployment][super::super::client::SecurityPosture::delete_posture_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::DeletePostureDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_securityposture_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePostureDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePostureDeployment(
         RequestBuilder<crate::model::DeletePostureDeploymentRequest>,
@@ -1165,6 +1364,25 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::list_posture_templates][super::super::client::SecurityPosture::list_posture_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::ListPostureTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPostureTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPostureTemplates(RequestBuilder<crate::model::ListPostureTemplatesRequest>);
 
@@ -1259,6 +1477,21 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::get_posture_template][super::super::client::SecurityPosture::get_posture_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::GetPostureTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPostureTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPostureTemplate(RequestBuilder<crate::model::GetPostureTemplateRequest>);
 
@@ -1315,6 +1548,25 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::list_locations][super::super::client::SecurityPosture::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1405,6 +1657,21 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::get_location][super::super::client::SecurityPosture::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1450,6 +1717,25 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::list_operations][super::super::client::SecurityPosture::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1542,6 +1828,21 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::get_operation][super::super::client::SecurityPosture::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1590,6 +1891,21 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::delete_operation][super::super::client::SecurityPosture::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1638,6 +1954,21 @@ pub mod security_posture {
     }
 
     /// The request builder for [SecurityPosture::cancel_operation][super::super::client::SecurityPosture::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_securityposture_v1::builder;
+    /// use builder::security_posture::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/servicedirectory/v1/src/builder.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod lookup_service {
     }
 
     /// The request builder for [LookupService::resolve_service][super::super::client::LookupService::resolve_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::lookup_service::ResolveService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResolveService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResolveService(RequestBuilder<crate::model::ResolveServiceRequest>);
 
@@ -128,6 +143,25 @@ pub mod lookup_service {
     }
 
     /// The request builder for [LookupService::list_locations][super::super::client::LookupService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::lookup_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -218,6 +252,21 @@ pub mod lookup_service {
     }
 
     /// The request builder for [LookupService::get_location][super::super::client::LookupService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::lookup_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -318,6 +367,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::create_namespace][super::super::client::RegistrationService::create_namespace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::CreateNamespace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNamespace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNamespace(RequestBuilder<crate::model::CreateNamespaceRequest>);
 
@@ -384,6 +448,25 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::list_namespaces][super::super::client::RegistrationService::list_namespaces] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::ListNamespaces;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNamespaces {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNamespaces(RequestBuilder<crate::model::ListNamespacesRequest>);
 
@@ -479,6 +562,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::get_namespace][super::super::client::RegistrationService::get_namespace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::GetNamespace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNamespace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNamespace(RequestBuilder<crate::model::GetNamespaceRequest>);
 
@@ -526,6 +624,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::update_namespace][super::super::client::RegistrationService::update_namespace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::UpdateNamespace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNamespace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNamespace(RequestBuilder<crate::model::UpdateNamespaceRequest>);
 
@@ -587,6 +700,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::delete_namespace][super::super::client::RegistrationService::delete_namespace] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::DeleteNamespace;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNamespace {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNamespace(RequestBuilder<crate::model::DeleteNamespaceRequest>);
 
@@ -634,6 +762,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::create_service][super::super::client::RegistrationService::create_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::CreateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -700,6 +843,25 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::list_services][super::super::client::RegistrationService::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -795,6 +957,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::get_service][super::super::client::RegistrationService::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -842,6 +1019,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::update_service][super::super::client::RegistrationService::update_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::UpdateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -903,6 +1095,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::delete_service][super::super::client::RegistrationService::delete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::DeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -950,6 +1157,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::create_endpoint][super::super::client::RegistrationService::create_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::CreateEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEndpoint(RequestBuilder<crate::model::CreateEndpointRequest>);
 
@@ -1016,6 +1238,25 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::list_endpoints][super::super::client::RegistrationService::list_endpoints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::ListEndpoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEndpoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEndpoints(RequestBuilder<crate::model::ListEndpointsRequest>);
 
@@ -1111,6 +1352,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::get_endpoint][super::super::client::RegistrationService::get_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::GetEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEndpoint(RequestBuilder<crate::model::GetEndpointRequest>);
 
@@ -1158,6 +1414,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::update_endpoint][super::super::client::RegistrationService::update_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::UpdateEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateEndpoint(RequestBuilder<crate::model::UpdateEndpointRequest>);
 
@@ -1219,6 +1490,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::delete_endpoint][super::super::client::RegistrationService::delete_endpoint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::DeleteEndpoint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEndpoint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEndpoint(RequestBuilder<crate::model::DeleteEndpointRequest>);
 
@@ -1266,6 +1552,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::get_iam_policy][super::super::client::RegistrationService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1322,6 +1623,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::set_iam_policy][super::super::client::RegistrationService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1389,6 +1705,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::test_iam_permissions][super::super::client::RegistrationService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1452,6 +1783,25 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::list_locations][super::super::client::RegistrationService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1542,6 +1892,21 @@ pub mod registration_service {
     }
 
     /// The request builder for [RegistrationService::get_location][super::super::client::RegistrationService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicedirectory_v1::builder;
+    /// use builder::registration_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/servicehealth/v1/src/builder.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::list_events][super::super::client::ServiceHealth::list_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::ListEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEvents(RequestBuilder<crate::model::ListEventsRequest>);
 
@@ -164,6 +183,21 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::get_event][super::super::client::ServiceHealth::get_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::GetEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEvent(RequestBuilder<crate::model::GetEventRequest>);
 
@@ -211,6 +245,25 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::list_organization_events][super::super::client::ServiceHealth::list_organization_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::ListOrganizationEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOrganizationEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOrganizationEvents(RequestBuilder<crate::model::ListOrganizationEventsRequest>);
 
@@ -313,6 +366,21 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::get_organization_event][super::super::client::ServiceHealth::get_organization_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::GetOrganizationEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOrganizationEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOrganizationEvent(RequestBuilder<crate::model::GetOrganizationEventRequest>);
 
@@ -363,6 +431,25 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::list_organization_impacts][super::super::client::ServiceHealth::list_organization_impacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::ListOrganizationImpacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOrganizationImpacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOrganizationImpacts(
         RequestBuilder<crate::model::ListOrganizationImpactsRequest>,
@@ -461,6 +548,21 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::get_organization_impact][super::super::client::ServiceHealth::get_organization_impact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::GetOrganizationImpact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOrganizationImpact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOrganizationImpact(RequestBuilder<crate::model::GetOrganizationImpactRequest>);
 
@@ -511,6 +613,25 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::list_locations][super::super::client::ServiceHealth::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -601,6 +722,21 @@ pub mod service_health {
     }
 
     /// The request builder for [ServiceHealth::get_location][super::super::client::ServiceHealth::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_servicehealth_v1::builder;
+    /// use builder::service_health::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/shell/v1/src/builder.rs
+++ b/src/generated/cloud/shell/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod cloud_shell_service {
     }
 
     /// The request builder for [CloudShellService::get_environment][super::super::client::CloudShellService::get_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_shell_v1::builder;
+    /// use builder::cloud_shell_service::GetEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnvironment(RequestBuilder<crate::model::GetEnvironmentRequest>);
 
@@ -116,6 +131,22 @@ pub mod cloud_shell_service {
     }
 
     /// The request builder for [CloudShellService::start_environment][super::super::client::CloudShellService::start_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_shell_v1::builder;
+    /// use builder::cloud_shell_service::StartEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_shell_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartEnvironment(RequestBuilder<crate::model::StartEnvironmentRequest>);
 
@@ -224,6 +255,22 @@ pub mod cloud_shell_service {
     }
 
     /// The request builder for [CloudShellService::authorize_environment][super::super::client::CloudShellService::authorize_environment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_shell_v1::builder;
+    /// use builder::cloud_shell_service::AuthorizeEnvironment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_shell_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AuthorizeEnvironment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AuthorizeEnvironment(RequestBuilder<crate::model::AuthorizeEnvironmentRequest>);
 
@@ -336,6 +383,22 @@ pub mod cloud_shell_service {
     }
 
     /// The request builder for [CloudShellService::add_public_key][super::super::client::CloudShellService::add_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_shell_v1::builder;
+    /// use builder::cloud_shell_service::AddPublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_shell_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddPublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddPublicKey(RequestBuilder<crate::model::AddPublicKeyRequest>);
 
@@ -428,6 +491,22 @@ pub mod cloud_shell_service {
     }
 
     /// The request builder for [CloudShellService::remove_public_key][super::super::client::CloudShellService::remove_public_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_shell_v1::builder;
+    /// use builder::cloud_shell_service::RemovePublicKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_shell_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemovePublicKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemovePublicKey(RequestBuilder<crate::model::RemovePublicKeyRequest>);
 
@@ -520,6 +599,21 @@ pub mod cloud_shell_service {
     }
 
     /// The request builder for [CloudShellService::get_operation][super::super::client::CloudShellService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_shell_v1::builder;
+    /// use builder::cloud_shell_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/speech/v2/src/builder.rs
+++ b/src/generated/cloud/speech/v2/src/builder.rs
@@ -67,6 +67,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::create_recognizer][super::super::client::Speech::create_recognizer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::CreateRecognizer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRecognizer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRecognizer(RequestBuilder<crate::model::CreateRecognizerRequest>);
 
@@ -176,6 +192,25 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::list_recognizers][super::super::client::Speech::list_recognizers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::ListRecognizers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRecognizers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRecognizers(RequestBuilder<crate::model::ListRecognizersRequest>);
 
@@ -263,6 +298,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::get_recognizer][super::super::client::Speech::get_recognizer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::GetRecognizer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRecognizer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRecognizer(RequestBuilder<crate::model::GetRecognizerRequest>);
 
@@ -308,6 +358,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::update_recognizer][super::super::client::Speech::update_recognizer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::UpdateRecognizer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRecognizer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRecognizer(RequestBuilder<crate::model::UpdateRecognizerRequest>);
 
@@ -412,6 +478,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::delete_recognizer][super::super::client::Speech::delete_recognizer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::DeleteRecognizer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRecognizer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRecognizer(RequestBuilder<crate::model::DeleteRecognizerRequest>);
 
@@ -516,6 +598,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::undelete_recognizer][super::super::client::Speech::undelete_recognizer] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::UndeleteRecognizer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteRecognizer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteRecognizer(RequestBuilder<crate::model::UndeleteRecognizerRequest>);
 
@@ -614,6 +712,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::recognize][super::super::client::Speech::recognize] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::Recognize;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Recognize {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Recognize(RequestBuilder<crate::model::RecognizeRequest>);
 
@@ -709,6 +822,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::batch_recognize][super::super::client::Speech::batch_recognize] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::BatchRecognize;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchRecognize {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchRecognize(RequestBuilder<crate::model::BatchRecognizeRequest>);
 
@@ -846,6 +975,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::get_config][super::super::client::Speech::get_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::GetConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConfig(RequestBuilder<crate::model::GetConfigRequest>);
 
@@ -891,6 +1035,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::update_config][super::super::client::Speech::update_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::UpdateConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConfig(RequestBuilder<crate::model::UpdateConfigRequest>);
 
@@ -948,6 +1107,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::create_custom_class][super::super::client::Speech::create_custom_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::CreateCustomClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCustomClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCustomClass(RequestBuilder<crate::model::CreateCustomClassRequest>);
 
@@ -1059,6 +1234,25 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::list_custom_classes][super::super::client::Speech::list_custom_classes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::ListCustomClasses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCustomClasses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCustomClasses(RequestBuilder<crate::model::ListCustomClassesRequest>);
 
@@ -1149,6 +1343,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::get_custom_class][super::super::client::Speech::get_custom_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::GetCustomClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCustomClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCustomClass(RequestBuilder<crate::model::GetCustomClassRequest>);
 
@@ -1194,6 +1403,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::update_custom_class][super::super::client::Speech::update_custom_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::UpdateCustomClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCustomClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCustomClass(RequestBuilder<crate::model::UpdateCustomClassRequest>);
 
@@ -1300,6 +1525,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::delete_custom_class][super::super::client::Speech::delete_custom_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::DeleteCustomClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCustomClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCustomClass(RequestBuilder<crate::model::DeleteCustomClassRequest>);
 
@@ -1406,6 +1647,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::undelete_custom_class][super::super::client::Speech::undelete_custom_class] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::UndeleteCustomClass;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteCustomClass {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteCustomClass(RequestBuilder<crate::model::UndeleteCustomClassRequest>);
 
@@ -1506,6 +1763,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::create_phrase_set][super::super::client::Speech::create_phrase_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::CreatePhraseSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePhraseSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePhraseSet(RequestBuilder<crate::model::CreatePhraseSetRequest>);
 
@@ -1612,6 +1885,25 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::list_phrase_sets][super::super::client::Speech::list_phrase_sets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::ListPhraseSets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPhraseSets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPhraseSets(RequestBuilder<crate::model::ListPhraseSetsRequest>);
 
@@ -1699,6 +1991,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::get_phrase_set][super::super::client::Speech::get_phrase_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::GetPhraseSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPhraseSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPhraseSet(RequestBuilder<crate::model::GetPhraseSetRequest>);
 
@@ -1744,6 +2051,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::update_phrase_set][super::super::client::Speech::update_phrase_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::UpdatePhraseSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePhraseSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePhraseSet(RequestBuilder<crate::model::UpdatePhraseSetRequest>);
 
@@ -1845,6 +2168,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::delete_phrase_set][super::super::client::Speech::delete_phrase_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::DeletePhraseSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePhraseSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePhraseSet(RequestBuilder<crate::model::DeletePhraseSetRequest>);
 
@@ -1946,6 +2285,22 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::undelete_phrase_set][super::super::client::Speech::undelete_phrase_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::UndeletePhraseSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_speech_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeletePhraseSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeletePhraseSet(RequestBuilder<crate::model::UndeletePhraseSetRequest>);
 
@@ -2044,6 +2399,25 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::list_locations][super::super::client::Speech::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2132,6 +2506,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::get_location][super::super::client::Speech::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2175,6 +2564,25 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::list_operations][super::super::client::Speech::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2265,6 +2673,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::get_operation][super::super::client::Speech::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2311,6 +2734,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::delete_operation][super::super::client::Speech::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2357,6 +2795,21 @@ pub mod speech {
     }
 
     /// The request builder for [Speech::cancel_operation][super::super::client::Speech::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_speech_v2::builder;
+    /// use builder::speech::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/sql/v1/src/builder.rs
+++ b/src/generated/cloud/sql/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod sql_backup_runs_service {
     }
 
     /// The request builder for [SqlBackupRunsService::delete][super::super::client::SqlBackupRunsService::delete] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_backup_runs_service::Delete;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Delete {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlBackupRunsDeleteRequest>);
 
@@ -129,6 +144,21 @@ pub mod sql_backup_runs_service {
     }
 
     /// The request builder for [SqlBackupRunsService::get][super::super::client::SqlBackupRunsService::get] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_backup_runs_service::Get;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Get {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlBackupRunsGetRequest>);
 
@@ -189,6 +219,21 @@ pub mod sql_backup_runs_service {
     }
 
     /// The request builder for [SqlBackupRunsService::insert][super::super::client::SqlBackupRunsService::insert] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_backup_runs_service::Insert;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Insert {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlBackupRunsInsertRequest>);
 
@@ -252,6 +297,25 @@ pub mod sql_backup_runs_service {
     }
 
     /// The request builder for [SqlBackupRunsService::list][super::super::client::SqlBackupRunsService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_backup_runs_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlBackupRunsListRequest>);
 
@@ -397,6 +461,21 @@ pub mod sql_connect_service {
     }
 
     /// The request builder for [SqlConnectService::get_connect_settings][super::super::client::SqlConnectService::get_connect_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_connect_service::GetConnectSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnectSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnectSettings(RequestBuilder<crate::model::GetConnectSettingsRequest>);
 
@@ -457,6 +536,21 @@ pub mod sql_connect_service {
     }
 
     /// The request builder for [SqlConnectService::generate_ephemeral_cert][super::super::client::SqlConnectService::generate_ephemeral_cert] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_connect_service::GenerateEphemeralCert;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateEphemeralCert {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateEphemeralCert(RequestBuilder<crate::model::GenerateEphemeralCertRequest>);
 
@@ -593,6 +687,21 @@ pub mod sql_databases_service {
     }
 
     /// The request builder for [SqlDatabasesService::delete][super::super::client::SqlDatabasesService::delete] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_databases_service::Delete;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Delete {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlDatabasesDeleteRequest>);
 
@@ -653,6 +762,21 @@ pub mod sql_databases_service {
     }
 
     /// The request builder for [SqlDatabasesService::get][super::super::client::SqlDatabasesService::get] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_databases_service::Get;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Get {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlDatabasesGetRequest>);
 
@@ -710,6 +834,21 @@ pub mod sql_databases_service {
     }
 
     /// The request builder for [SqlDatabasesService::insert][super::super::client::SqlDatabasesService::insert] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_databases_service::Insert;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Insert {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlDatabasesInsertRequest>);
 
@@ -773,6 +912,21 @@ pub mod sql_databases_service {
     }
 
     /// The request builder for [SqlDatabasesService::list][super::super::client::SqlDatabasesService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_databases_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlDatabasesListRequest>);
 
@@ -827,6 +981,21 @@ pub mod sql_databases_service {
     }
 
     /// The request builder for [SqlDatabasesService::patch][super::super::client::SqlDatabasesService::patch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_databases_service::Patch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Patch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Patch(RequestBuilder<crate::model::SqlDatabasesUpdateRequest>);
 
@@ -896,6 +1065,21 @@ pub mod sql_databases_service {
     }
 
     /// The request builder for [SqlDatabasesService::update][super::super::client::SqlDatabasesService::update] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_databases_service::Update;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Update {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Update(RequestBuilder<crate::model::SqlDatabasesUpdateRequest>);
 
@@ -1020,6 +1204,21 @@ pub mod sql_flags_service {
     }
 
     /// The request builder for [SqlFlagsService::list][super::super::client::SqlFlagsService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_flags_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlFlagsListRequest>);
 
@@ -1120,6 +1319,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::add_server_ca][super::super::client::SqlInstancesService::add_server_ca] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::AddServerCa;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddServerCa {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddServerCa(RequestBuilder<crate::model::SqlInstancesAddServerCaRequest>);
 
@@ -1174,6 +1388,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::clone][super::super::client::SqlInstancesService::clone] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Clone;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Clone {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Clone(RequestBuilder<crate::model::SqlInstancesCloneRequest>);
 
@@ -1237,6 +1466,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::delete][super::super::client::SqlInstancesService::delete] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Delete;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Delete {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlInstancesDeleteRequest>);
 
@@ -1291,6 +1535,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::demote_master][super::super::client::SqlInstancesService::demote_master] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::DemoteMaster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DemoteMaster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DemoteMaster(RequestBuilder<crate::model::SqlInstancesDemoteMasterRequest>);
 
@@ -1356,6 +1615,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::demote][super::super::client::SqlInstancesService::demote] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Demote;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Demote {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Demote(RequestBuilder<crate::model::SqlInstancesDemoteRequest>);
 
@@ -1425,6 +1699,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::export][super::super::client::SqlInstancesService::export] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Export;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Export {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Export(RequestBuilder<crate::model::SqlInstancesExportRequest>);
 
@@ -1488,6 +1777,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::failover][super::super::client::SqlInstancesService::failover] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Failover;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Failover {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Failover(RequestBuilder<crate::model::SqlInstancesFailoverRequest>);
 
@@ -1551,6 +1855,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::reencrypt][super::super::client::SqlInstancesService::reencrypt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Reencrypt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Reencrypt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Reencrypt(RequestBuilder<crate::model::SqlInstancesReencryptRequest>);
 
@@ -1614,6 +1933,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::get][super::super::client::SqlInstancesService::get] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Get;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Get {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlInstancesGetRequest>);
 
@@ -1665,6 +1999,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::import][super::super::client::SqlInstancesService::import] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Import;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Import {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Import(RequestBuilder<crate::model::SqlInstancesImportRequest>);
 
@@ -1728,6 +2077,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::insert][super::super::client::SqlInstancesService::insert] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Insert;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Insert {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlInstancesInsertRequest>);
 
@@ -1785,6 +2149,25 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::list][super::super::client::SqlInstancesService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlInstancesListRequest>);
 
@@ -1875,6 +2258,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::list_server_cas][super::super::client::SqlInstancesService::list_server_cas] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::ListServerCas;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServerCas {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServerCas(RequestBuilder<crate::model::SqlInstancesListServerCasRequest>);
 
@@ -1929,6 +2327,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::patch][super::super::client::SqlInstancesService::patch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Patch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Patch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Patch(RequestBuilder<crate::model::SqlInstancesPatchRequest>);
 
@@ -1992,6 +2405,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::promote_replica][super::super::client::SqlInstancesService::promote_replica] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::PromoteReplica;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PromoteReplica {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PromoteReplica(RequestBuilder<crate::model::SqlInstancesPromoteReplicaRequest>);
 
@@ -2052,6 +2480,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::switchover][super::super::client::SqlInstancesService::switchover] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Switchover;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Switchover {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Switchover(RequestBuilder<crate::model::SqlInstancesSwitchoverRequest>);
 
@@ -2112,6 +2555,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::reset_ssl_config][super::super::client::SqlInstancesService::reset_ssl_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::ResetSslConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetSslConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetSslConfig(RequestBuilder<crate::model::SqlInstancesResetSslConfigRequest>);
 
@@ -2166,6 +2624,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::restart][super::super::client::SqlInstancesService::restart] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Restart;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Restart {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Restart(RequestBuilder<crate::model::SqlInstancesRestartRequest>);
 
@@ -2220,6 +2693,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::restore_backup][super::super::client::SqlInstancesService::restore_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::RestoreBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreBackup(RequestBuilder<crate::model::SqlInstancesRestoreBackupRequest>);
 
@@ -2285,6 +2773,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::rotate_server_ca][super::super::client::SqlInstancesService::rotate_server_ca] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::RotateServerCa;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RotateServerCa {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RotateServerCa(RequestBuilder<crate::model::SqlInstancesRotateServerCaRequest>);
 
@@ -2350,6 +2853,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::start_replica][super::super::client::SqlInstancesService::start_replica] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::StartReplica;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartReplica {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartReplica(RequestBuilder<crate::model::SqlInstancesStartReplicaRequest>);
 
@@ -2404,6 +2922,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::stop_replica][super::super::client::SqlInstancesService::stop_replica] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::StopReplica;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopReplica {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopReplica(RequestBuilder<crate::model::SqlInstancesStopReplicaRequest>);
 
@@ -2458,6 +2991,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::truncate_log][super::super::client::SqlInstancesService::truncate_log] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::TruncateLog;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TruncateLog {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TruncateLog(RequestBuilder<crate::model::SqlInstancesTruncateLogRequest>);
 
@@ -2521,6 +3069,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::update][super::super::client::SqlInstancesService::update] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::Update;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Update {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Update(RequestBuilder<crate::model::SqlInstancesUpdateRequest>);
 
@@ -2584,6 +3147,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::create_ephemeral][super::super::client::SqlInstancesService::create_ephemeral] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::CreateEphemeral;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEphemeral {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEphemeral(
         RequestBuilder<crate::model::SqlInstancesCreateEphemeralCertRequest>,
@@ -2651,6 +3229,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::reschedule_maintenance][super::super::client::SqlInstancesService::reschedule_maintenance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::RescheduleMaintenance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RescheduleMaintenance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RescheduleMaintenance(
         RequestBuilder<crate::model::SqlInstancesRescheduleMaintenanceRequest>,
@@ -2718,6 +3311,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::verify_external_sync_settings][super::super::client::SqlInstancesService::verify_external_sync_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::VerifyExternalSyncSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyExternalSyncSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyExternalSyncSettings(
         RequestBuilder<crate::model::SqlInstancesVerifyExternalSyncSettingsRequest>,
@@ -2856,6 +3464,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::start_external_sync][super::super::client::SqlInstancesService::start_external_sync] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::StartExternalSync;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartExternalSync {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartExternalSync(
         RequestBuilder<crate::model::SqlInstancesStartExternalSyncRequest>,
@@ -2980,6 +3603,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::perform_disk_shrink][super::super::client::SqlInstancesService::perform_disk_shrink] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::PerformDiskShrink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PerformDiskShrink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PerformDiskShrink(
         RequestBuilder<crate::model::SqlInstancesPerformDiskShrinkRequest>,
@@ -3045,6 +3683,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::get_disk_shrink_config][super::super::client::SqlInstancesService::get_disk_shrink_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::GetDiskShrinkConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDiskShrinkConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDiskShrinkConfig(
         RequestBuilder<crate::model::SqlInstancesGetDiskShrinkConfigRequest>,
@@ -3101,6 +3754,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::reset_replica_size][super::super::client::SqlInstancesService::reset_replica_size] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::ResetReplicaSize;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetReplicaSize {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetReplicaSize(RequestBuilder<crate::model::SqlInstancesResetReplicaSizeRequest>);
 
@@ -3155,6 +3823,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::get_latest_recovery_time][super::super::client::SqlInstancesService::get_latest_recovery_time] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::GetLatestRecoveryTime;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLatestRecoveryTime {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLatestRecoveryTime(
         RequestBuilder<crate::model::SqlInstancesGetLatestRecoveryTimeRequest>,
@@ -3211,6 +3894,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::acquire_ssrs_lease][super::super::client::SqlInstancesService::acquire_ssrs_lease] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::AcquireSsrsLease;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AcquireSsrsLease {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AcquireSsrsLease(RequestBuilder<crate::model::SqlInstancesAcquireSsrsLeaseRequest>);
 
@@ -3282,6 +3980,21 @@ pub mod sql_instances_service {
     }
 
     /// The request builder for [SqlInstancesService::release_ssrs_lease][super::super::client::SqlInstancesService::release_ssrs_lease] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_instances_service::ReleaseSsrsLease;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReleaseSsrsLease {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReleaseSsrsLease(RequestBuilder<crate::model::SqlInstancesReleaseSsrsLeaseRequest>);
 
@@ -3395,6 +4108,21 @@ pub mod sql_operations_service {
     }
 
     /// The request builder for [SqlOperationsService::get][super::super::client::SqlOperationsService::get] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_operations_service::Get;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Get {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlOperationsGetRequest>);
 
@@ -3449,6 +4177,25 @@ pub mod sql_operations_service {
     }
 
     /// The request builder for [SqlOperationsService::list][super::super::client::SqlOperationsService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_operations_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlOperationsListRequest>);
 
@@ -3539,6 +4286,21 @@ pub mod sql_operations_service {
     }
 
     /// The request builder for [SqlOperationsService::cancel][super::super::client::SqlOperationsService::cancel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_operations_service::Cancel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Cancel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Cancel(RequestBuilder<crate::model::SqlOperationsCancelRequest>);
 
@@ -3648,6 +4410,21 @@ pub mod sql_ssl_certs_service {
     }
 
     /// The request builder for [SqlSslCertsService::delete][super::super::client::SqlSslCertsService::delete] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_ssl_certs_service::Delete;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Delete {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlSslCertsDeleteRequest>);
 
@@ -3708,6 +4485,21 @@ pub mod sql_ssl_certs_service {
     }
 
     /// The request builder for [SqlSslCertsService::get][super::super::client::SqlSslCertsService::get] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_ssl_certs_service::Get;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Get {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlSslCertsGetRequest>);
 
@@ -3765,6 +4557,21 @@ pub mod sql_ssl_certs_service {
     }
 
     /// The request builder for [SqlSslCertsService::insert][super::super::client::SqlSslCertsService::insert] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_ssl_certs_service::Insert;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Insert {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlSslCertsInsertRequest>);
 
@@ -3828,6 +4635,21 @@ pub mod sql_ssl_certs_service {
     }
 
     /// The request builder for [SqlSslCertsService::list][super::super::client::SqlSslCertsService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_ssl_certs_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlSslCertsListRequest>);
 
@@ -3934,6 +4756,21 @@ pub mod sql_tiers_service {
     }
 
     /// The request builder for [SqlTiersService::list][super::super::client::SqlTiersService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_tiers_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlTiersListRequest>);
 
@@ -4034,6 +4871,21 @@ pub mod sql_users_service {
     }
 
     /// The request builder for [SqlUsersService::delete][super::super::client::SqlUsersService::delete] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_users_service::Delete;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Delete {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Delete(RequestBuilder<crate::model::SqlUsersDeleteRequest>);
 
@@ -4097,6 +4949,21 @@ pub mod sql_users_service {
     }
 
     /// The request builder for [SqlUsersService::get][super::super::client::SqlUsersService::get] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_users_service::Get;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Get {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Get(RequestBuilder<crate::model::SqlUsersGetRequest>);
 
@@ -4160,6 +5027,21 @@ pub mod sql_users_service {
     }
 
     /// The request builder for [SqlUsersService::insert][super::super::client::SqlUsersService::insert] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_users_service::Insert;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Insert {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Insert(RequestBuilder<crate::model::SqlUsersInsertRequest>);
 
@@ -4217,6 +5099,21 @@ pub mod sql_users_service {
     }
 
     /// The request builder for [SqlUsersService::list][super::super::client::SqlUsersService::list] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_users_service::List;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> List {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct List(RequestBuilder<crate::model::SqlUsersListRequest>);
 
@@ -4268,6 +5165,21 @@ pub mod sql_users_service {
     }
 
     /// The request builder for [SqlUsersService::update][super::super::client::SqlUsersService::update] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_sql_v1::builder;
+    /// use builder::sql_users_service::Update;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Update {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Update(RequestBuilder<crate::model::SqlUsersUpdateRequest>);
 

--- a/src/generated/cloud/storagebatchoperations/v1/src/builder.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::list_jobs][super::super::client::StorageBatchOperations::list_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::ListJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -164,6 +183,21 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::get_job][super::super::client::StorageBatchOperations::get_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::GetJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -211,6 +245,22 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::create_job][super::super::client::StorageBatchOperations::create_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::CreateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_storagebatchoperations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -318,6 +368,21 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::delete_job][super::super::client::StorageBatchOperations::delete_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::DeleteJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -371,6 +436,21 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::cancel_job][super::super::client::StorageBatchOperations::cancel_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::CancelJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelJob(RequestBuilder<crate::model::CancelJobRequest>);
 
@@ -424,6 +504,25 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::list_locations][super::super::client::StorageBatchOperations::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -514,6 +613,21 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::get_location][super::super::client::StorageBatchOperations::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -559,6 +673,25 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::list_operations][super::super::client::StorageBatchOperations::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -651,6 +784,21 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::get_operation][super::super::client::StorageBatchOperations::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -699,6 +847,21 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::delete_operation][super::super::client::StorageBatchOperations::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -747,6 +910,21 @@ pub mod storage_batch_operations {
     }
 
     /// The request builder for [StorageBatchOperations::cancel_operation][super::super::client::StorageBatchOperations::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagebatchoperations_v1::builder;
+    /// use builder::storage_batch_operations::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/storageinsights/v1/src/builder.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::list_report_configs][super::super::client::StorageInsights::list_report_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::ListReportConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReportConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReportConfigs(RequestBuilder<crate::model::ListReportConfigsRequest>);
 
@@ -167,6 +186,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::get_report_config][super::super::client::StorageInsights::get_report_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::GetReportConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReportConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReportConfig(RequestBuilder<crate::model::GetReportConfigRequest>);
 
@@ -214,6 +248,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::create_report_config][super::super::client::StorageInsights::create_report_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::CreateReportConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReportConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReportConfig(RequestBuilder<crate::model::CreateReportConfigRequest>);
 
@@ -281,6 +330,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::update_report_config][super::super::client::StorageInsights::update_report_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::UpdateReportConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateReportConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateReportConfig(RequestBuilder<crate::model::UpdateReportConfigRequest>);
 
@@ -351,6 +415,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::delete_report_config][super::super::client::StorageInsights::delete_report_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::DeleteReportConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteReportConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteReportConfig(RequestBuilder<crate::model::DeleteReportConfigRequest>);
 
@@ -413,6 +492,25 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::list_report_details][super::super::client::StorageInsights::list_report_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::ListReportDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReportDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReportDetails(RequestBuilder<crate::model::ListReportDetailsRequest>);
 
@@ -511,6 +609,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::get_report_detail][super::super::client::StorageInsights::get_report_detail] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::GetReportDetail;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReportDetail {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReportDetail(RequestBuilder<crate::model::GetReportDetailRequest>);
 
@@ -558,6 +671,25 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::list_locations][super::super::client::StorageInsights::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -648,6 +780,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::get_location][super::super::client::StorageInsights::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -693,6 +840,25 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::list_operations][super::super::client::StorageInsights::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -785,6 +951,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::get_operation][super::super::client::StorageInsights::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -833,6 +1014,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::delete_operation][super::super::client::StorageInsights::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -881,6 +1077,21 @@ pub mod storage_insights {
     }
 
     /// The request builder for [StorageInsights::cancel_operation][super::super::client::StorageInsights::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storageinsights_v1::builder;
+    /// use builder::storage_insights::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/support/v2/src/builder.rs
+++ b/src/generated/cloud/support/v2/src/builder.rs
@@ -69,6 +69,25 @@ pub mod case_attachment_service {
     }
 
     /// The request builder for [CaseAttachmentService::list_attachments][super::super::client::CaseAttachmentService::list_attachments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_attachment_service::ListAttachments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAttachments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAttachments(RequestBuilder<crate::model::ListAttachmentsRequest>);
 
@@ -207,6 +226,21 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::get_case][super::super::client::CaseService::get_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::GetCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCase(RequestBuilder<crate::model::GetCaseRequest>);
 
@@ -254,6 +288,25 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::list_cases][super::super::client::CaseService::list_cases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::ListCases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCases(RequestBuilder<crate::model::ListCasesRequest>);
 
@@ -343,6 +396,25 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::search_cases][super::super::client::CaseService::search_cases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::SearchCases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchCases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchCases(RequestBuilder<crate::model::SearchCasesRequest>);
 
@@ -430,6 +502,21 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::create_case][super::super::client::CaseService::create_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::CreateCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCase(RequestBuilder<crate::model::CreateCaseRequest>);
 
@@ -485,6 +572,21 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::update_case][super::super::client::CaseService::update_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::UpdateCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCase(RequestBuilder<crate::model::UpdateCaseRequest>);
 
@@ -541,6 +643,21 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::escalate_case][super::super::client::CaseService::escalate_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::EscalateCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EscalateCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EscalateCase(RequestBuilder<crate::model::EscalateCaseRequest>);
 
@@ -597,6 +714,21 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::close_case][super::super::client::CaseService::close_case] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::CloseCase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CloseCase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CloseCase(RequestBuilder<crate::model::CloseCaseRequest>);
 
@@ -644,6 +776,25 @@ pub mod case_service {
     }
 
     /// The request builder for [CaseService::search_case_classifications][super::super::client::CaseService::search_case_classifications] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::case_service::SearchCaseClassifications;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchCaseClassifications {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchCaseClassifications(
         RequestBuilder<crate::model::SearchCaseClassificationsRequest>,
@@ -789,6 +940,25 @@ pub mod comment_service {
     }
 
     /// The request builder for [CommentService::list_comments][super::super::client::CommentService::list_comments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::comment_service::ListComments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListComments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListComments(RequestBuilder<crate::model::ListCommentsRequest>);
 
@@ -872,6 +1042,21 @@ pub mod comment_service {
     }
 
     /// The request builder for [CommentService::create_comment][super::super::client::CommentService::create_comment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_support_v2::builder;
+    /// use builder::comment_service::CreateComment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateComment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateComment(RequestBuilder<crate::model::CreateCommentRequest>);
 

--- a/src/generated/cloud/talent/v4/src/builder.rs
+++ b/src/generated/cloud/talent/v4/src/builder.rs
@@ -69,6 +69,21 @@ pub mod company_service {
     }
 
     /// The request builder for [CompanyService::create_company][super::super::client::CompanyService::create_company] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::company_service::CreateCompany;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCompany {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCompany(RequestBuilder<crate::model::CreateCompanyRequest>);
 
@@ -127,6 +142,21 @@ pub mod company_service {
     }
 
     /// The request builder for [CompanyService::get_company][super::super::client::CompanyService::get_company] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::company_service::GetCompany;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCompany {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCompany(RequestBuilder<crate::model::GetCompanyRequest>);
 
@@ -174,6 +204,21 @@ pub mod company_service {
     }
 
     /// The request builder for [CompanyService::update_company][super::super::client::CompanyService::update_company] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::company_service::UpdateCompany;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCompany {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCompany(RequestBuilder<crate::model::UpdateCompanyRequest>);
 
@@ -233,6 +278,21 @@ pub mod company_service {
     }
 
     /// The request builder for [CompanyService::delete_company][super::super::client::CompanyService::delete_company] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::company_service::DeleteCompany;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCompany {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCompany(RequestBuilder<crate::model::DeleteCompanyRequest>);
 
@@ -280,6 +340,25 @@ pub mod company_service {
     }
 
     /// The request builder for [CompanyService::list_companies][super::super::client::CompanyService::list_companies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::company_service::ListCompanies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCompanies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCompanies(RequestBuilder<crate::model::ListCompaniesRequest>);
 
@@ -369,6 +448,21 @@ pub mod company_service {
     }
 
     /// The request builder for [CompanyService::get_operation][super::super::client::CompanyService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::company_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -472,6 +566,21 @@ pub mod completion {
     }
 
     /// The request builder for [Completion::complete_query][super::super::client::Completion::complete_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::completion::CompleteQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompleteQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompleteQuery(RequestBuilder<crate::model::CompleteQueryRequest>);
 
@@ -570,6 +679,21 @@ pub mod completion {
     }
 
     /// The request builder for [Completion::get_operation][super::super::client::Completion::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::completion::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -673,6 +797,21 @@ pub mod event_service {
     }
 
     /// The request builder for [EventService::create_client_event][super::super::client::EventService::create_client_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::event_service::CreateClientEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateClientEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateClientEvent(RequestBuilder<crate::model::CreateClientEventRequest>);
 
@@ -734,6 +873,21 @@ pub mod event_service {
     }
 
     /// The request builder for [EventService::get_operation][super::super::client::EventService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::event_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -837,6 +991,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::create_job][super::super::client::JobService::create_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::CreateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -892,6 +1061,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::batch_create_jobs][super::super::client::JobService::batch_create_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::BatchCreateJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_talent_v4::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateJobs(RequestBuilder<crate::model::BatchCreateJobsRequest>);
 
@@ -993,6 +1178,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_job][super::super::client::JobService::get_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::GetJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -1040,6 +1240,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::update_job][super::super::client::JobService::update_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::UpdateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateJob(RequestBuilder<crate::model::UpdateJobRequest>);
 
@@ -1096,6 +1311,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::batch_update_jobs][super::super::client::JobService::batch_update_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::BatchUpdateJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_talent_v4::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchUpdateJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchUpdateJobs(RequestBuilder<crate::model::BatchUpdateJobsRequest>);
 
@@ -1206,6 +1437,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::delete_job][super::super::client::JobService::delete_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::DeleteJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -1253,6 +1499,22 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::batch_delete_jobs][super::super::client::JobService::batch_delete_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::BatchDeleteJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_talent_v4::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteJobs(RequestBuilder<crate::model::BatchDeleteJobsRequest>);
 
@@ -1352,6 +1614,25 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::list_jobs][super::super::client::JobService::list_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::ListJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -1449,6 +1730,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::search_jobs][super::super::client::JobService::search_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::SearchJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchJobs(RequestBuilder<crate::model::SearchJobsRequest>);
 
@@ -1623,6 +1919,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::search_jobs_for_alert][super::super::client::JobService::search_jobs_for_alert] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::SearchJobsForAlert;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchJobsForAlert {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchJobsForAlert(RequestBuilder<crate::model::SearchJobsRequest>);
 
@@ -1797,6 +2108,21 @@ pub mod job_service {
     }
 
     /// The request builder for [JobService::get_operation][super::super::client::JobService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::job_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1900,6 +2226,21 @@ pub mod tenant_service {
     }
 
     /// The request builder for [TenantService::create_tenant][super::super::client::TenantService::create_tenant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::tenant_service::CreateTenant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTenant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTenant(RequestBuilder<crate::model::CreateTenantRequest>);
 
@@ -1958,6 +2299,21 @@ pub mod tenant_service {
     }
 
     /// The request builder for [TenantService::get_tenant][super::super::client::TenantService::get_tenant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::tenant_service::GetTenant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTenant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTenant(RequestBuilder<crate::model::GetTenantRequest>);
 
@@ -2005,6 +2361,21 @@ pub mod tenant_service {
     }
 
     /// The request builder for [TenantService::update_tenant][super::super::client::TenantService::update_tenant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::tenant_service::UpdateTenant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTenant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTenant(RequestBuilder<crate::model::UpdateTenantRequest>);
 
@@ -2064,6 +2435,21 @@ pub mod tenant_service {
     }
 
     /// The request builder for [TenantService::delete_tenant][super::super::client::TenantService::delete_tenant] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::tenant_service::DeleteTenant;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTenant {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTenant(RequestBuilder<crate::model::DeleteTenantRequest>);
 
@@ -2111,6 +2497,25 @@ pub mod tenant_service {
     }
 
     /// The request builder for [TenantService::list_tenants][super::super::client::TenantService::list_tenants] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::tenant_service::ListTenants;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTenants {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTenants(RequestBuilder<crate::model::ListTenantsRequest>);
 
@@ -2194,6 +2599,21 @@ pub mod tenant_service {
     }
 
     /// The request builder for [TenantService::get_operation][super::super::client::TenantService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_talent_v4::builder;
+    /// use builder::tenant_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/tasks/v2/src/builder.rs
+++ b/src/generated/cloud/tasks/v2/src/builder.rs
@@ -69,6 +69,25 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::list_queues][super::super::client::CloudTasks::list_queues] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::ListQueues;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListQueues {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListQueues(RequestBuilder<crate::model::ListQueuesRequest>);
 
@@ -158,6 +177,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::get_queue][super::super::client::CloudTasks::get_queue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::GetQueue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetQueue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetQueue(RequestBuilder<crate::model::GetQueueRequest>);
 
@@ -205,6 +239,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::create_queue][super::super::client::CloudTasks::create_queue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::CreateQueue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateQueue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateQueue(RequestBuilder<crate::model::CreateQueueRequest>);
 
@@ -263,6 +312,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::update_queue][super::super::client::CloudTasks::update_queue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::UpdateQueue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateQueue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateQueue(RequestBuilder<crate::model::UpdateQueueRequest>);
 
@@ -322,6 +386,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::delete_queue][super::super::client::CloudTasks::delete_queue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::DeleteQueue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteQueue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteQueue(RequestBuilder<crate::model::DeleteQueueRequest>);
 
@@ -369,6 +448,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::purge_queue][super::super::client::CloudTasks::purge_queue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::PurgeQueue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeQueue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeQueue(RequestBuilder<crate::model::PurgeQueueRequest>);
 
@@ -416,6 +510,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::pause_queue][super::super::client::CloudTasks::pause_queue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::PauseQueue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseQueue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseQueue(RequestBuilder<crate::model::PauseQueueRequest>);
 
@@ -463,6 +572,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::resume_queue][super::super::client::CloudTasks::resume_queue] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::ResumeQueue;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeQueue {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeQueue(RequestBuilder<crate::model::ResumeQueueRequest>);
 
@@ -510,6 +634,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::get_iam_policy][super::super::client::CloudTasks::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -566,6 +705,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::set_iam_policy][super::super::client::CloudTasks::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -633,6 +787,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::test_iam_permissions][super::super::client::CloudTasks::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -696,6 +865,25 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::list_tasks][super::super::client::CloudTasks::list_tasks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::ListTasks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTasks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTasks(RequestBuilder<crate::model::ListTasksRequest>);
 
@@ -785,6 +973,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::get_task][super::super::client::CloudTasks::get_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::GetTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTask(RequestBuilder<crate::model::GetTaskRequest>);
 
@@ -838,6 +1041,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::create_task][super::super::client::CloudTasks::create_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::CreateTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTask(RequestBuilder<crate::model::CreateTaskRequest>);
 
@@ -899,6 +1117,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::delete_task][super::super::client::CloudTasks::delete_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::DeleteTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTask(RequestBuilder<crate::model::DeleteTaskRequest>);
 
@@ -946,6 +1179,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::run_task][super::super::client::CloudTasks::run_task] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::RunTask;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunTask {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunTask(RequestBuilder<crate::model::RunTaskRequest>);
 
@@ -999,6 +1247,25 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::list_locations][super::super::client::CloudTasks::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1089,6 +1356,21 @@ pub mod cloud_tasks {
     }
 
     /// The request builder for [CloudTasks::get_location][super::super::client::CloudTasks::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tasks_v2::builder;
+    /// use builder::cloud_tasks::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 

--- a/src/generated/cloud/telcoautomation/v1/src/builder.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_orchestration_clusters][super::super::client::TelcoAutomation::list_orchestration_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListOrchestrationClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOrchestrationClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOrchestrationClusters(
         RequestBuilder<crate::model::ListOrchestrationClustersRequest>,
@@ -173,6 +192,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_orchestration_cluster][super::super::client::TelcoAutomation::get_orchestration_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetOrchestrationCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOrchestrationCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOrchestrationCluster(
         RequestBuilder<crate::model::GetOrchestrationClusterRequest>,
@@ -225,6 +259,22 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::create_orchestration_cluster][super::super::client::TelcoAutomation::create_orchestration_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::CreateOrchestrationCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_telcoautomation_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateOrchestrationCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateOrchestrationCluster(
         RequestBuilder<crate::model::CreateOrchestrationClusterRequest>,
@@ -345,6 +395,22 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::delete_orchestration_cluster][super::super::client::TelcoAutomation::delete_orchestration_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::DeleteOrchestrationCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_telcoautomation_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOrchestrationCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOrchestrationCluster(
         RequestBuilder<crate::model::DeleteOrchestrationClusterRequest>,
@@ -443,6 +509,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_edge_slms][super::super::client::TelcoAutomation::list_edge_slms] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListEdgeSlms;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEdgeSlms {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEdgeSlms(RequestBuilder<crate::model::ListEdgeSlmsRequest>);
 
@@ -538,6 +623,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_edge_slm][super::super::client::TelcoAutomation::get_edge_slm] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetEdgeSlm;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEdgeSlm {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEdgeSlm(RequestBuilder<crate::model::GetEdgeSlmRequest>);
 
@@ -585,6 +685,22 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::create_edge_slm][super::super::client::TelcoAutomation::create_edge_slm] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::CreateEdgeSlm;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_telcoautomation_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEdgeSlm {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEdgeSlm(RequestBuilder<crate::model::CreateEdgeSlmRequest>);
 
@@ -695,6 +811,22 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::delete_edge_slm][super::super::client::TelcoAutomation::delete_edge_slm] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::DeleteEdgeSlm;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_telcoautomation_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEdgeSlm {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEdgeSlm(RequestBuilder<crate::model::DeleteEdgeSlmRequest>);
 
@@ -788,6 +920,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::create_blueprint][super::super::client::TelcoAutomation::create_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::CreateBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBlueprint(RequestBuilder<crate::model::CreateBlueprintRequest>);
 
@@ -852,6 +999,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::update_blueprint][super::super::client::TelcoAutomation::update_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::UpdateBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBlueprint(RequestBuilder<crate::model::UpdateBlueprintRequest>);
 
@@ -913,6 +1075,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_blueprint][super::super::client::TelcoAutomation::get_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBlueprint(RequestBuilder<crate::model::GetBlueprintRequest>);
 
@@ -966,6 +1143,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::delete_blueprint][super::super::client::TelcoAutomation::delete_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::DeleteBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBlueprint(RequestBuilder<crate::model::DeleteBlueprintRequest>);
 
@@ -1013,6 +1205,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_blueprints][super::super::client::TelcoAutomation::list_blueprints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListBlueprints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBlueprints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBlueprints(RequestBuilder<crate::model::ListBlueprintsRequest>);
 
@@ -1102,6 +1313,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::approve_blueprint][super::super::client::TelcoAutomation::approve_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ApproveBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApproveBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApproveBlueprint(RequestBuilder<crate::model::ApproveBlueprintRequest>);
 
@@ -1152,6 +1378,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::propose_blueprint][super::super::client::TelcoAutomation::propose_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ProposeBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ProposeBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ProposeBlueprint(RequestBuilder<crate::model::ProposeBlueprintRequest>);
 
@@ -1202,6 +1443,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::reject_blueprint][super::super::client::TelcoAutomation::reject_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::RejectBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RejectBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RejectBlueprint(RequestBuilder<crate::model::RejectBlueprintRequest>);
 
@@ -1249,6 +1505,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_blueprint_revisions][super::super::client::TelcoAutomation::list_blueprint_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListBlueprintRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBlueprintRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBlueprintRevisions(RequestBuilder<crate::model::ListBlueprintRevisionsRequest>);
 
@@ -1339,6 +1614,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::search_blueprint_revisions][super::super::client::TelcoAutomation::search_blueprint_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::SearchBlueprintRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchBlueprintRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchBlueprintRevisions(
         RequestBuilder<crate::model::SearchBlueprintRevisionsRequest>,
@@ -1439,6 +1733,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::search_deployment_revisions][super::super::client::TelcoAutomation::search_deployment_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::SearchDeploymentRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchDeploymentRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchDeploymentRevisions(
         RequestBuilder<crate::model::SearchDeploymentRevisionsRequest>,
@@ -1539,6 +1852,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::discard_blueprint_changes][super::super::client::TelcoAutomation::discard_blueprint_changes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::DiscardBlueprintChanges;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiscardBlueprintChanges {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiscardBlueprintChanges(
         RequestBuilder<crate::model::DiscardBlueprintChangesRequest>,
@@ -1591,6 +1919,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_public_blueprints][super::super::client::TelcoAutomation::list_public_blueprints] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListPublicBlueprints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPublicBlueprints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPublicBlueprints(RequestBuilder<crate::model::ListPublicBlueprintsRequest>);
 
@@ -1679,6 +2026,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_public_blueprint][super::super::client::TelcoAutomation::get_public_blueprint] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetPublicBlueprint;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPublicBlueprint {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPublicBlueprint(RequestBuilder<crate::model::GetPublicBlueprintRequest>);
 
@@ -1729,6 +2091,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::create_deployment][super::super::client::TelcoAutomation::create_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::CreateDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeployment(RequestBuilder<crate::model::CreateDeploymentRequest>);
 
@@ -1796,6 +2173,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::update_deployment][super::super::client::TelcoAutomation::update_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::UpdateDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDeployment(RequestBuilder<crate::model::UpdateDeploymentRequest>);
 
@@ -1860,6 +2252,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_deployment][super::super::client::TelcoAutomation::get_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeployment(RequestBuilder<crate::model::GetDeploymentRequest>);
 
@@ -1913,6 +2320,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::remove_deployment][super::super::client::TelcoAutomation::remove_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::RemoveDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveDeployment(RequestBuilder<crate::model::RemoveDeploymentRequest>);
 
@@ -1963,6 +2385,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_deployments][super::super::client::TelcoAutomation::list_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeployments(RequestBuilder<crate::model::ListDeploymentsRequest>);
 
@@ -2052,6 +2493,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_deployment_revisions][super::super::client::TelcoAutomation::list_deployment_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListDeploymentRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeploymentRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeploymentRevisions(
         RequestBuilder<crate::model::ListDeploymentRevisionsRequest>,
@@ -2144,6 +2604,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::discard_deployment_changes][super::super::client::TelcoAutomation::discard_deployment_changes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::DiscardDeploymentChanges;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DiscardDeploymentChanges {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DiscardDeploymentChanges(
         RequestBuilder<crate::model::DiscardDeploymentChangesRequest>,
@@ -2196,6 +2671,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::apply_deployment][super::super::client::TelcoAutomation::apply_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ApplyDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApplyDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApplyDeployment(RequestBuilder<crate::model::ApplyDeploymentRequest>);
 
@@ -2243,6 +2733,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::compute_deployment_status][super::super::client::TelcoAutomation::compute_deployment_status] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ComputeDeploymentStatus;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ComputeDeploymentStatus {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ComputeDeploymentStatus(
         RequestBuilder<crate::model::ComputeDeploymentStatusRequest>,
@@ -2295,6 +2800,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::rollback_deployment][super::super::client::TelcoAutomation::rollback_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::RollbackDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RollbackDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RollbackDeployment(RequestBuilder<crate::model::RollbackDeploymentRequest>);
 
@@ -2353,6 +2873,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_hydrated_deployment][super::super::client::TelcoAutomation::get_hydrated_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetHydratedDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetHydratedDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetHydratedDeployment(RequestBuilder<crate::model::GetHydratedDeploymentRequest>);
 
@@ -2403,6 +2938,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_hydrated_deployments][super::super::client::TelcoAutomation::list_hydrated_deployments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListHydratedDeployments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHydratedDeployments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHydratedDeployments(
         RequestBuilder<crate::model::ListHydratedDeploymentsRequest>,
@@ -2495,6 +3049,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::update_hydrated_deployment][super::super::client::TelcoAutomation::update_hydrated_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::UpdateHydratedDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateHydratedDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateHydratedDeployment(
         RequestBuilder<crate::model::UpdateHydratedDeploymentRequest>,
@@ -2563,6 +3132,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::apply_hydrated_deployment][super::super::client::TelcoAutomation::apply_hydrated_deployment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ApplyHydratedDeployment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApplyHydratedDeployment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApplyHydratedDeployment(
         RequestBuilder<crate::model::ApplyHydratedDeploymentRequest>,
@@ -2615,6 +3199,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_locations][super::super::client::TelcoAutomation::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2705,6 +3308,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_location][super::super::client::TelcoAutomation::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2750,6 +3368,25 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::list_operations][super::super::client::TelcoAutomation::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2842,6 +3479,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::get_operation][super::super::client::TelcoAutomation::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2890,6 +3542,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::delete_operation][super::super::client::TelcoAutomation::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2938,6 +3605,21 @@ pub mod telco_automation {
     }
 
     /// The request builder for [TelcoAutomation::cancel_operation][super::super::client::TelcoAutomation::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_telcoautomation_v1::builder;
+    /// use builder::telco_automation::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/texttospeech/v1/src/builder.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod text_to_speech {
     }
 
     /// The request builder for [TextToSpeech::list_voices][super::super::client::TextToSpeech::list_voices] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_texttospeech_v1::builder;
+    /// use builder::text_to_speech::ListVoices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVoices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVoices(RequestBuilder<crate::model::ListVoicesRequest>);
 
@@ -114,6 +129,21 @@ pub mod text_to_speech {
     }
 
     /// The request builder for [TextToSpeech::synthesize_speech][super::super::client::TextToSpeech::synthesize_speech] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_texttospeech_v1::builder;
+    /// use builder::text_to_speech::SynthesizeSpeech;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SynthesizeSpeech {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SynthesizeSpeech(RequestBuilder<crate::model::SynthesizeSpeechRequest>);
 
@@ -200,6 +230,25 @@ pub mod text_to_speech {
     }
 
     /// The request builder for [TextToSpeech::list_operations][super::super::client::TextToSpeech::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_texttospeech_v1::builder;
+    /// use builder::text_to_speech::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -292,6 +341,21 @@ pub mod text_to_speech {
     }
 
     /// The request builder for [TextToSpeech::get_operation][super::super::client::TextToSpeech::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_texttospeech_v1::builder;
+    /// use builder::text_to_speech::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -395,6 +459,22 @@ pub mod text_to_speech_long_audio_synthesize {
     }
 
     /// The request builder for [TextToSpeechLongAudioSynthesize::synthesize_long_audio][super::super::client::TextToSpeechLongAudioSynthesize::synthesize_long_audio] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_texttospeech_v1::builder;
+    /// use builder::text_to_speech_long_audio_synthesize::SynthesizeLongAudio;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_texttospeech_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SynthesizeLongAudio {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SynthesizeLongAudio(RequestBuilder<crate::model::SynthesizeLongAudioRequest>);
 
@@ -527,6 +607,25 @@ pub mod text_to_speech_long_audio_synthesize {
     }
 
     /// The request builder for [TextToSpeechLongAudioSynthesize::list_operations][super::super::client::TextToSpeechLongAudioSynthesize::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_texttospeech_v1::builder;
+    /// use builder::text_to_speech_long_audio_synthesize::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -619,6 +718,21 @@ pub mod text_to_speech_long_audio_synthesize {
     }
 
     /// The request builder for [TextToSpeechLongAudioSynthesize::get_operation][super::super::client::TextToSpeechLongAudioSynthesize::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_texttospeech_v1::builder;
+    /// use builder::text_to_speech_long_audio_synthesize::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod timeseries_insights_controller {
     }
 
     /// The request builder for [TimeseriesInsightsController::list_data_sets][super::super::client::TimeseriesInsightsController::list_data_sets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_timeseriesinsights_v1::builder;
+    /// use builder::timeseries_insights_controller::ListDataSets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDataSets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDataSets(RequestBuilder<crate::model::ListDataSetsRequest>);
 
@@ -152,6 +171,21 @@ pub mod timeseries_insights_controller {
     }
 
     /// The request builder for [TimeseriesInsightsController::create_data_set][super::super::client::TimeseriesInsightsController::create_data_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_timeseriesinsights_v1::builder;
+    /// use builder::timeseries_insights_controller::CreateDataSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataSet(RequestBuilder<crate::model::CreateDataSetRequest>);
 
@@ -210,6 +244,21 @@ pub mod timeseries_insights_controller {
     }
 
     /// The request builder for [TimeseriesInsightsController::delete_data_set][super::super::client::TimeseriesInsightsController::delete_data_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_timeseriesinsights_v1::builder;
+    /// use builder::timeseries_insights_controller::DeleteDataSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataSet(RequestBuilder<crate::model::DeleteDataSetRequest>);
 
@@ -257,6 +306,21 @@ pub mod timeseries_insights_controller {
     }
 
     /// The request builder for [TimeseriesInsightsController::append_events][super::super::client::TimeseriesInsightsController::append_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_timeseriesinsights_v1::builder;
+    /// use builder::timeseries_insights_controller::AppendEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AppendEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AppendEvents(RequestBuilder<crate::model::AppendEventsRequest>);
 
@@ -315,6 +379,21 @@ pub mod timeseries_insights_controller {
     }
 
     /// The request builder for [TimeseriesInsightsController::query_data_set][super::super::client::TimeseriesInsightsController::query_data_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_timeseriesinsights_v1::builder;
+    /// use builder::timeseries_insights_controller::QueryDataSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryDataSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryDataSet(RequestBuilder<crate::model::QueryDataSetRequest>);
 
@@ -414,6 +493,21 @@ pub mod timeseries_insights_controller {
     }
 
     /// The request builder for [TimeseriesInsightsController::evaluate_slice][super::super::client::TimeseriesInsightsController::evaluate_slice] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_timeseriesinsights_v1::builder;
+    /// use builder::timeseries_insights_controller::EvaluateSlice;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EvaluateSlice {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EvaluateSlice(RequestBuilder<crate::model::EvaluateSliceRequest>);
 
@@ -505,6 +599,21 @@ pub mod timeseries_insights_controller {
     }
 
     /// The request builder for [TimeseriesInsightsController::evaluate_timeseries][super::super::client::TimeseriesInsightsController::evaluate_timeseries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_timeseriesinsights_v1::builder;
+    /// use builder::timeseries_insights_controller::EvaluateTimeseries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EvaluateTimeseries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EvaluateTimeseries(RequestBuilder<crate::model::EvaluateTimeseriesRequest>);
 

--- a/src/generated/cloud/tpu/v2/src/builder.rs
+++ b/src/generated/cloud/tpu/v2/src/builder.rs
@@ -67,6 +67,25 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::list_nodes][super::super::client::Tpu::list_nodes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::ListNodes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNodes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNodes(RequestBuilder<crate::model::ListNodesRequest>);
 
@@ -148,6 +167,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::get_node][super::super::client::Tpu::get_node] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GetNode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNode(RequestBuilder<crate::model::GetNodeRequest>);
 
@@ -193,6 +227,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::create_node][super::super::client::Tpu::create_node] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::CreateNode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNode(RequestBuilder<crate::model::CreateNodeRequest>);
 
@@ -290,6 +340,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::delete_node][super::super::client::Tpu::delete_node] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::DeleteNode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNode(RequestBuilder<crate::model::DeleteNodeRequest>);
 
@@ -375,6 +441,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::stop_node][super::super::client::Tpu::stop_node] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::StopNode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopNode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopNode(RequestBuilder<crate::model::StopNodeRequest>);
 
@@ -458,6 +540,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::start_node][super::super::client::Tpu::start_node] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::StartNode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartNode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartNode(RequestBuilder<crate::model::StartNodeRequest>);
 
@@ -541,6 +639,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::update_node][super::super::client::Tpu::update_node] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::UpdateNode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNode(RequestBuilder<crate::model::UpdateNodeRequest>);
 
@@ -635,6 +749,25 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::list_queued_resources][super::super::client::Tpu::list_queued_resources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::ListQueuedResources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListQueuedResources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListQueuedResources(RequestBuilder<crate::model::ListQueuedResourcesRequest>);
 
@@ -721,6 +854,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::get_queued_resource][super::super::client::Tpu::get_queued_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GetQueuedResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetQueuedResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetQueuedResource(RequestBuilder<crate::model::GetQueuedResourceRequest>);
 
@@ -769,6 +917,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::create_queued_resource][super::super::client::Tpu::create_queued_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::CreateQueuedResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateQueuedResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateQueuedResource(RequestBuilder<crate::model::CreateQueuedResourceRequest>);
 
@@ -881,6 +1045,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::delete_queued_resource][super::super::client::Tpu::delete_queued_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::DeleteQueuedResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteQueuedResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteQueuedResource(RequestBuilder<crate::model::DeleteQueuedResourceRequest>);
 
@@ -981,6 +1161,22 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::reset_queued_resource][super::super::client::Tpu::reset_queued_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::ResetQueuedResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_tpu_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetQueuedResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetQueuedResource(RequestBuilder<crate::model::ResetQueuedResourceRequest>);
 
@@ -1070,6 +1266,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::generate_service_identity][super::super::client::Tpu::generate_service_identity] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GenerateServiceIdentity;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateServiceIdentity {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateServiceIdentity(
         RequestBuilder<crate::model::GenerateServiceIdentityRequest>,
@@ -1120,6 +1331,25 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::list_accelerator_types][super::super::client::Tpu::list_accelerator_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::ListAcceleratorTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAcceleratorTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAcceleratorTypes(RequestBuilder<crate::model::ListAcceleratorTypesRequest>);
 
@@ -1218,6 +1448,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::get_accelerator_type][super::super::client::Tpu::get_accelerator_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GetAcceleratorType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAcceleratorType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAcceleratorType(RequestBuilder<crate::model::GetAcceleratorTypeRequest>);
 
@@ -1266,6 +1511,25 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::list_runtime_versions][super::super::client::Tpu::list_runtime_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::ListRuntimeVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRuntimeVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRuntimeVersions(RequestBuilder<crate::model::ListRuntimeVersionsRequest>);
 
@@ -1364,6 +1628,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::get_runtime_version][super::super::client::Tpu::get_runtime_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GetRuntimeVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRuntimeVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRuntimeVersion(RequestBuilder<crate::model::GetRuntimeVersionRequest>);
 
@@ -1412,6 +1691,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::get_guest_attributes][super::super::client::Tpu::get_guest_attributes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GetGuestAttributes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGuestAttributes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGuestAttributes(RequestBuilder<crate::model::GetGuestAttributesRequest>);
 
@@ -1477,6 +1771,25 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::list_locations][super::super::client::Tpu::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1565,6 +1878,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::get_location][super::super::client::Tpu::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1608,6 +1936,25 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::list_operations][super::super::client::Tpu::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1698,6 +2045,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::get_operation][super::super::client::Tpu::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1744,6 +2106,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::delete_operation][super::super::client::Tpu::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1790,6 +2167,21 @@ pub mod tpu {
     }
 
     /// The request builder for [Tpu::cancel_operation][super::super::client::Tpu::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_tpu_v2::builder;
+    /// use builder::tpu::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/translate/v3/src/builder.rs
+++ b/src/generated/cloud/translate/v3/src/builder.rs
@@ -69,6 +69,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::translate_text][super::super::client::TranslationService::translate_text] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::TranslateText;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TranslateText {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TranslateText(RequestBuilder<crate::model::TranslateTextRequest>);
 
@@ -188,6 +203,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::romanize_text][super::super::client::TranslationService::romanize_text] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::RomanizeText;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RomanizeText {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RomanizeText(RequestBuilder<crate::model::RomanizeTextRequest>);
 
@@ -254,6 +284,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::detect_language][super::super::client::TranslationService::detect_language] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DetectLanguage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DetectLanguage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DetectLanguage(RequestBuilder<crate::model::DetectLanguageRequest>);
 
@@ -346,6 +391,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_supported_languages][super::super::client::TranslationService::get_supported_languages] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetSupportedLanguages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSupportedLanguages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSupportedLanguages(RequestBuilder<crate::model::GetSupportedLanguagesRequest>);
 
@@ -408,6 +468,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::translate_document][super::super::client::TranslationService::translate_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::TranslateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TranslateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TranslateDocument(RequestBuilder<crate::model::TranslateDocumentRequest>);
 
@@ -548,6 +623,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::batch_translate_text][super::super::client::TranslationService::batch_translate_text] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::BatchTranslateText;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchTranslateText {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchTranslateText(RequestBuilder<crate::model::BatchTranslateTextRequest>);
 
@@ -717,6 +808,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::batch_translate_document][super::super::client::TranslationService::batch_translate_document] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::BatchTranslateDocument;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchTranslateDocument {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchTranslateDocument(RequestBuilder<crate::model::BatchTranslateDocumentRequest>);
 
@@ -909,6 +1016,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::create_glossary][super::super::client::TranslationService::create_glossary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::CreateGlossary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGlossary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGlossary(RequestBuilder<crate::model::CreateGlossaryRequest>);
 
@@ -1008,6 +1131,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::update_glossary][super::super::client::TranslationService::update_glossary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::UpdateGlossary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGlossary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGlossary(RequestBuilder<crate::model::UpdateGlossaryRequest>);
 
@@ -1108,6 +1247,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_glossaries][super::super::client::TranslationService::list_glossaries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListGlossaries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGlossaries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGlossaries(RequestBuilder<crate::model::ListGlossariesRequest>);
 
@@ -1197,6 +1355,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_glossary][super::super::client::TranslationService::get_glossary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetGlossary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGlossary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGlossary(RequestBuilder<crate::model::GetGlossaryRequest>);
 
@@ -1244,6 +1417,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::delete_glossary][super::super::client::TranslationService::delete_glossary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DeleteGlossary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGlossary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGlossary(RequestBuilder<crate::model::DeleteGlossaryRequest>);
 
@@ -1332,6 +1521,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_glossary_entry][super::super::client::TranslationService::get_glossary_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetGlossaryEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGlossaryEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGlossaryEntry(RequestBuilder<crate::model::GetGlossaryEntryRequest>);
 
@@ -1382,6 +1586,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_glossary_entries][super::super::client::TranslationService::list_glossary_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListGlossaryEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGlossaryEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGlossaryEntries(RequestBuilder<crate::model::ListGlossaryEntriesRequest>);
 
@@ -1470,6 +1693,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::create_glossary_entry][super::super::client::TranslationService::create_glossary_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::CreateGlossaryEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGlossaryEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGlossaryEntry(RequestBuilder<crate::model::CreateGlossaryEntryRequest>);
 
@@ -1531,6 +1769,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::update_glossary_entry][super::super::client::TranslationService::update_glossary_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::UpdateGlossaryEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGlossaryEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGlossaryEntry(RequestBuilder<crate::model::UpdateGlossaryEntryRequest>);
 
@@ -1584,6 +1837,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::delete_glossary_entry][super::super::client::TranslationService::delete_glossary_entry] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DeleteGlossaryEntry;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGlossaryEntry {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGlossaryEntry(RequestBuilder<crate::model::DeleteGlossaryEntryRequest>);
 
@@ -1634,6 +1902,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::create_dataset][super::super::client::TranslationService::create_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::CreateDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDataset(RequestBuilder<crate::model::CreateDatasetRequest>);
 
@@ -1732,6 +2016,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_dataset][super::super::client::TranslationService::get_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDataset(RequestBuilder<crate::model::GetDatasetRequest>);
 
@@ -1779,6 +2078,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_datasets][super::super::client::TranslationService::list_datasets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListDatasets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatasets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatasets(RequestBuilder<crate::model::ListDatasetsRequest>);
 
@@ -1862,6 +2180,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::delete_dataset][super::super::client::TranslationService::delete_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DeleteDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDataset(RequestBuilder<crate::model::DeleteDatasetRequest>);
 
@@ -1950,6 +2284,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::create_adaptive_mt_dataset][super::super::client::TranslationService::create_adaptive_mt_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::CreateAdaptiveMtDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAdaptiveMtDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAdaptiveMtDataset(
         RequestBuilder<crate::model::CreateAdaptiveMtDatasetRequest>,
@@ -2015,6 +2364,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::delete_adaptive_mt_dataset][super::super::client::TranslationService::delete_adaptive_mt_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DeleteAdaptiveMtDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAdaptiveMtDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAdaptiveMtDataset(
         RequestBuilder<crate::model::DeleteAdaptiveMtDatasetRequest>,
@@ -2067,6 +2431,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_adaptive_mt_dataset][super::super::client::TranslationService::get_adaptive_mt_dataset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetAdaptiveMtDataset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAdaptiveMtDataset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAdaptiveMtDataset(RequestBuilder<crate::model::GetAdaptiveMtDatasetRequest>);
 
@@ -2117,6 +2496,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_adaptive_mt_datasets][super::super::client::TranslationService::list_adaptive_mt_datasets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListAdaptiveMtDatasets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAdaptiveMtDatasets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAdaptiveMtDatasets(RequestBuilder<crate::model::ListAdaptiveMtDatasetsRequest>);
 
@@ -2213,6 +2611,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::adaptive_mt_translate][super::super::client::TranslationService::adaptive_mt_translate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::AdaptiveMtTranslate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AdaptiveMtTranslate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AdaptiveMtTranslate(RequestBuilder<crate::model::AdaptiveMtTranslateRequest>);
 
@@ -2310,6 +2723,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_adaptive_mt_file][super::super::client::TranslationService::get_adaptive_mt_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetAdaptiveMtFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAdaptiveMtFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAdaptiveMtFile(RequestBuilder<crate::model::GetAdaptiveMtFileRequest>);
 
@@ -2360,6 +2788,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::delete_adaptive_mt_file][super::super::client::TranslationService::delete_adaptive_mt_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DeleteAdaptiveMtFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAdaptiveMtFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAdaptiveMtFile(RequestBuilder<crate::model::DeleteAdaptiveMtFileRequest>);
 
@@ -2410,6 +2853,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::import_adaptive_mt_file][super::super::client::TranslationService::import_adaptive_mt_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ImportAdaptiveMtFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportAdaptiveMtFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportAdaptiveMtFile(RequestBuilder<crate::model::ImportAdaptiveMtFileRequest>);
 
@@ -2504,6 +2962,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_adaptive_mt_files][super::super::client::TranslationService::list_adaptive_mt_files] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListAdaptiveMtFiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAdaptiveMtFiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAdaptiveMtFiles(RequestBuilder<crate::model::ListAdaptiveMtFilesRequest>);
 
@@ -2592,6 +3069,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_adaptive_mt_sentences][super::super::client::TranslationService::list_adaptive_mt_sentences] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListAdaptiveMtSentences;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAdaptiveMtSentences {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAdaptiveMtSentences(
         RequestBuilder<crate::model::ListAdaptiveMtSentencesRequest>,
@@ -2684,6 +3180,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::import_data][super::super::client::TranslationService::import_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ImportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportData(RequestBuilder<crate::model::ImportDataRequest>);
 
@@ -2782,6 +3294,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::export_data][super::super::client::TranslationService::export_data] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ExportData;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportData {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportData(RequestBuilder<crate::model::ExportDataRequest>);
 
@@ -2882,6 +3410,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_examples][super::super::client::TranslationService::list_examples] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListExamples;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExamples {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExamples(RequestBuilder<crate::model::ListExamplesRequest>);
 
@@ -2971,6 +3518,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::create_model][super::super::client::TranslationService::create_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::CreateModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateModel(RequestBuilder<crate::model::CreateModelRequest>);
 
@@ -3067,6 +3630,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_models][super::super::client::TranslationService::list_models] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListModels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListModels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListModels(RequestBuilder<crate::model::ListModelsRequest>);
 
@@ -3156,6 +3738,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_model][super::super::client::TranslationService::get_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetModel(RequestBuilder<crate::model::GetModelRequest>);
 
@@ -3203,6 +3800,22 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::delete_model][super::super::client::TranslationService::delete_model] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DeleteModel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_translation_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteModel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteModel(RequestBuilder<crate::model::DeleteModelRequest>);
 
@@ -3291,6 +3904,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_locations][super::super::client::TranslationService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3381,6 +4013,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_location][super::super::client::TranslationService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3426,6 +4073,25 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::list_operations][super::super::client::TranslationService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3518,6 +4184,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::get_operation][super::super::client::TranslationService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3566,6 +4247,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::delete_operation][super::super::client::TranslationService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3614,6 +4310,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::cancel_operation][super::super::client::TranslationService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3662,6 +4373,21 @@ pub mod translation_service {
     }
 
     /// The request builder for [TranslationService::wait_operation][super::super::client::TranslationService::wait_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_translation_v3::builder;
+    /// use builder::translation_service::WaitOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WaitOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WaitOperation(RequestBuilder<longrunning::model::WaitOperationRequest>);
 

--- a/src/generated/cloud/video/livestream/v1/src/builder.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::create_channel][super::super::client::LivestreamService::create_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::CreateChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateChannel(RequestBuilder<crate::model::CreateChannelRequest>);
 
@@ -179,6 +195,25 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::list_channels][super::super::client::LivestreamService::list_channels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::ListChannels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListChannels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListChannels(RequestBuilder<crate::model::ListChannelsRequest>);
 
@@ -274,6 +309,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_channel][super::super::client::LivestreamService::get_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetChannel(RequestBuilder<crate::model::GetChannelRequest>);
 
@@ -321,6 +371,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::delete_channel][super::super::client::LivestreamService::delete_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::DeleteChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteChannel(RequestBuilder<crate::model::DeleteChannelRequest>);
 
@@ -420,6 +486,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::update_channel][super::super::client::LivestreamService::update_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::UpdateChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateChannel(RequestBuilder<crate::model::UpdateChannelRequest>);
 
@@ -523,6 +605,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::start_channel][super::super::client::LivestreamService::start_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::StartChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartChannel(RequestBuilder<crate::model::StartChannelRequest>);
 
@@ -617,6 +715,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::stop_channel][super::super::client::LivestreamService::stop_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::StopChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopChannel(RequestBuilder<crate::model::StopChannelRequest>);
 
@@ -711,6 +825,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::create_input][super::super::client::LivestreamService::create_input] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::CreateInput;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInput {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInput(RequestBuilder<crate::model::CreateInputRequest>);
 
@@ -821,6 +951,25 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::list_inputs][super::super::client::LivestreamService::list_inputs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::ListInputs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInputs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInputs(RequestBuilder<crate::model::ListInputsRequest>);
 
@@ -916,6 +1065,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_input][super::super::client::LivestreamService::get_input] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetInput;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInput {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInput(RequestBuilder<crate::model::GetInputRequest>);
 
@@ -963,6 +1127,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::delete_input][super::super::client::LivestreamService::delete_input] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::DeleteInput;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInput {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInput(RequestBuilder<crate::model::DeleteInputRequest>);
 
@@ -1056,6 +1236,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::update_input][super::super::client::LivestreamService::update_input] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::UpdateInput;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInput {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInput(RequestBuilder<crate::model::UpdateInputRequest>);
 
@@ -1159,6 +1355,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::create_event][super::super::client::LivestreamService::create_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::CreateEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateEvent(RequestBuilder<crate::model::CreateEventRequest>);
 
@@ -1231,6 +1442,25 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::list_events][super::super::client::LivestreamService::list_events] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::ListEvents;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListEvents {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListEvents(RequestBuilder<crate::model::ListEventsRequest>);
 
@@ -1326,6 +1556,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_event][super::super::client::LivestreamService::get_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEvent(RequestBuilder<crate::model::GetEventRequest>);
 
@@ -1373,6 +1618,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::delete_event][super::super::client::LivestreamService::delete_event] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::DeleteEvent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteEvent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteEvent(RequestBuilder<crate::model::DeleteEventRequest>);
 
@@ -1426,6 +1686,25 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::list_clips][super::super::client::LivestreamService::list_clips] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::ListClips;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClips {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClips(RequestBuilder<crate::model::ListClipsRequest>);
 
@@ -1521,6 +1800,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_clip][super::super::client::LivestreamService::get_clip] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetClip;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetClip {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetClip(RequestBuilder<crate::model::GetClipRequest>);
 
@@ -1568,6 +1862,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::create_clip][super::super::client::LivestreamService::create_clip] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::CreateClip;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateClip {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateClip(RequestBuilder<crate::model::CreateClipRequest>);
 
@@ -1675,6 +1985,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::delete_clip][super::super::client::LivestreamService::delete_clip] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::DeleteClip;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteClip {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteClip(RequestBuilder<crate::model::DeleteClipRequest>);
 
@@ -1768,6 +2094,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::create_asset][super::super::client::LivestreamService::create_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::CreateAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAsset(RequestBuilder<crate::model::CreateAssetRequest>);
 
@@ -1878,6 +2220,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::delete_asset][super::super::client::LivestreamService::delete_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::DeleteAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAsset(RequestBuilder<crate::model::DeleteAssetRequest>);
 
@@ -1971,6 +2329,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_asset][super::super::client::LivestreamService::get_asset] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetAsset;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAsset {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAsset(RequestBuilder<crate::model::GetAssetRequest>);
 
@@ -2018,6 +2391,25 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::list_assets][super::super::client::LivestreamService::list_assets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::ListAssets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAssets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAssets(RequestBuilder<crate::model::ListAssetsRequest>);
 
@@ -2113,6 +2505,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_pool][super::super::client::LivestreamService::get_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPool(RequestBuilder<crate::model::GetPoolRequest>);
 
@@ -2160,6 +2567,22 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::update_pool][super::super::client::LivestreamService::update_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::UpdatePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_livestream_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePool(RequestBuilder<crate::model::UpdatePoolRequest>);
 
@@ -2260,6 +2683,25 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::list_locations][super::super::client::LivestreamService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2350,6 +2792,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_location][super::super::client::LivestreamService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2395,6 +2852,25 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::list_operations][super::super::client::LivestreamService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2487,6 +2963,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::get_operation][super::super::client::LivestreamService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2535,6 +3026,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::delete_operation][super::super::client::LivestreamService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2583,6 +3089,21 @@ pub mod livestream_service {
     }
 
     /// The request builder for [LivestreamService::cancel_operation][super::super::client::LivestreamService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_livestream_v1::builder;
+    /// use builder::livestream_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/video/stitcher/v1/src/builder.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::create_cdn_key][super::super::client::VideoStitcherService::create_cdn_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::CreateCdnKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCdnKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCdnKey(RequestBuilder<crate::model::CreateCdnKeyRequest>);
 
@@ -173,6 +189,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_cdn_keys][super::super::client::VideoStitcherService::list_cdn_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListCdnKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCdnKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCdnKeys(RequestBuilder<crate::model::ListCdnKeysRequest>);
 
@@ -268,6 +303,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_cdn_key][super::super::client::VideoStitcherService::get_cdn_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetCdnKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCdnKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCdnKey(RequestBuilder<crate::model::GetCdnKeyRequest>);
 
@@ -315,6 +365,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::delete_cdn_key][super::super::client::VideoStitcherService::delete_cdn_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::DeleteCdnKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCdnKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCdnKey(RequestBuilder<crate::model::DeleteCdnKeyRequest>);
 
@@ -402,6 +468,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::update_cdn_key][super::super::client::VideoStitcherService::update_cdn_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::UpdateCdnKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCdnKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCdnKey(RequestBuilder<crate::model::UpdateCdnKeyRequest>);
 
@@ -501,6 +583,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::create_vod_session][super::super::client::VideoStitcherService::create_vod_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::CreateVodSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVodSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVodSession(RequestBuilder<crate::model::CreateVodSessionRequest>);
 
@@ -562,6 +659,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_vod_session][super::super::client::VideoStitcherService::get_vod_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetVodSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVodSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVodSession(RequestBuilder<crate::model::GetVodSessionRequest>);
 
@@ -609,6 +721,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_vod_stitch_details][super::super::client::VideoStitcherService::list_vod_stitch_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListVodStitchDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVodStitchDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVodStitchDetails(RequestBuilder<crate::model::ListVodStitchDetailsRequest>);
 
@@ -697,6 +828,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_vod_stitch_detail][super::super::client::VideoStitcherService::get_vod_stitch_detail] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetVodStitchDetail;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVodStitchDetail {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVodStitchDetail(RequestBuilder<crate::model::GetVodStitchDetailRequest>);
 
@@ -747,6 +893,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_vod_ad_tag_details][super::super::client::VideoStitcherService::list_vod_ad_tag_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListVodAdTagDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVodAdTagDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVodAdTagDetails(RequestBuilder<crate::model::ListVodAdTagDetailsRequest>);
 
@@ -835,6 +1000,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_vod_ad_tag_detail][super::super::client::VideoStitcherService::get_vod_ad_tag_detail] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetVodAdTagDetail;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVodAdTagDetail {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVodAdTagDetail(RequestBuilder<crate::model::GetVodAdTagDetailRequest>);
 
@@ -885,6 +1065,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_live_ad_tag_details][super::super::client::VideoStitcherService::list_live_ad_tag_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListLiveAdTagDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLiveAdTagDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLiveAdTagDetails(RequestBuilder<crate::model::ListLiveAdTagDetailsRequest>);
 
@@ -973,6 +1172,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_live_ad_tag_detail][super::super::client::VideoStitcherService::get_live_ad_tag_detail] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetLiveAdTagDetail;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLiveAdTagDetail {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLiveAdTagDetail(RequestBuilder<crate::model::GetLiveAdTagDetailRequest>);
 
@@ -1023,6 +1237,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::create_slate][super::super::client::VideoStitcherService::create_slate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::CreateSlate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSlate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSlate(RequestBuilder<crate::model::CreateSlateRequest>);
 
@@ -1133,6 +1363,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_slates][super::super::client::VideoStitcherService::list_slates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListSlates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSlates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSlates(RequestBuilder<crate::model::ListSlatesRequest>);
 
@@ -1228,6 +1477,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_slate][super::super::client::VideoStitcherService::get_slate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetSlate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSlate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSlate(RequestBuilder<crate::model::GetSlateRequest>);
 
@@ -1275,6 +1539,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::update_slate][super::super::client::VideoStitcherService::update_slate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::UpdateSlate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSlate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSlate(RequestBuilder<crate::model::UpdateSlateRequest>);
 
@@ -1374,6 +1654,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::delete_slate][super::super::client::VideoStitcherService::delete_slate] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::DeleteSlate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSlate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSlate(RequestBuilder<crate::model::DeleteSlateRequest>);
 
@@ -1461,6 +1757,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::create_live_session][super::super::client::VideoStitcherService::create_live_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::CreateLiveSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLiveSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLiveSession(RequestBuilder<crate::model::CreateLiveSessionRequest>);
 
@@ -1522,6 +1833,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_live_session][super::super::client::VideoStitcherService::get_live_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetLiveSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLiveSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLiveSession(RequestBuilder<crate::model::GetLiveSessionRequest>);
 
@@ -1569,6 +1895,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::create_live_config][super::super::client::VideoStitcherService::create_live_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::CreateLiveConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLiveConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLiveConfig(RequestBuilder<crate::model::CreateLiveConfigRequest>);
 
@@ -1682,6 +2024,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_live_configs][super::super::client::VideoStitcherService::list_live_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListLiveConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLiveConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLiveConfigs(RequestBuilder<crate::model::ListLiveConfigsRequest>);
 
@@ -1777,6 +2138,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_live_config][super::super::client::VideoStitcherService::get_live_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetLiveConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLiveConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLiveConfig(RequestBuilder<crate::model::GetLiveConfigRequest>);
 
@@ -1824,6 +2200,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::delete_live_config][super::super::client::VideoStitcherService::delete_live_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::DeleteLiveConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLiveConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLiveConfig(RequestBuilder<crate::model::DeleteLiveConfigRequest>);
 
@@ -1914,6 +2306,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::update_live_config][super::super::client::VideoStitcherService::update_live_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::UpdateLiveConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLiveConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLiveConfig(RequestBuilder<crate::model::UpdateLiveConfigRequest>);
 
@@ -2016,6 +2424,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::create_vod_config][super::super::client::VideoStitcherService::create_vod_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::CreateVodConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVodConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVodConfig(RequestBuilder<crate::model::CreateVodConfigRequest>);
 
@@ -2126,6 +2550,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_vod_configs][super::super::client::VideoStitcherService::list_vod_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListVodConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVodConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVodConfigs(RequestBuilder<crate::model::ListVodConfigsRequest>);
 
@@ -2221,6 +2664,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_vod_config][super::super::client::VideoStitcherService::get_vod_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetVodConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVodConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVodConfig(RequestBuilder<crate::model::GetVodConfigRequest>);
 
@@ -2268,6 +2726,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::delete_vod_config][super::super::client::VideoStitcherService::delete_vod_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::DeleteVodConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVodConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVodConfig(RequestBuilder<crate::model::DeleteVodConfigRequest>);
 
@@ -2355,6 +2829,22 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::update_vod_config][super::super::client::VideoStitcherService::update_vod_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::UpdateVodConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_video_stitcher_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVodConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVodConfig(RequestBuilder<crate::model::UpdateVodConfigRequest>);
 
@@ -2454,6 +2944,25 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::list_operations][super::super::client::VideoStitcherService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2546,6 +3055,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::get_operation][super::super::client::VideoStitcherService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2594,6 +3118,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::delete_operation][super::super::client::VideoStitcherService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2642,6 +3181,21 @@ pub mod video_stitcher_service {
     }
 
     /// The request builder for [VideoStitcherService::cancel_operation][super::super::client::VideoStitcherService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_stitcher_v1::builder;
+    /// use builder::video_stitcher_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/video/transcoder/v1/src/builder.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::create_job][super::super::client::TranscoderService::create_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::CreateJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateJob(RequestBuilder<crate::model::CreateJobRequest>);
 
@@ -124,6 +139,25 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::list_jobs][super::super::client::TranscoderService::list_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::ListJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobs(RequestBuilder<crate::model::ListJobsRequest>);
 
@@ -219,6 +253,21 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::get_job][super::super::client::TranscoderService::get_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::GetJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJob(RequestBuilder<crate::model::GetJobRequest>);
 
@@ -266,6 +315,21 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::delete_job][super::super::client::TranscoderService::delete_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::DeleteJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJob(RequestBuilder<crate::model::DeleteJobRequest>);
 
@@ -319,6 +383,21 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::create_job_template][super::super::client::TranscoderService::create_job_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::CreateJobTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateJobTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateJobTemplate(RequestBuilder<crate::model::CreateJobTemplateRequest>);
 
@@ -388,6 +467,25 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::list_job_templates][super::super::client::TranscoderService::list_job_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::ListJobTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobTemplates(RequestBuilder<crate::model::ListJobTemplatesRequest>);
 
@@ -486,6 +584,21 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::get_job_template][super::super::client::TranscoderService::get_job_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::GetJobTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJobTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJobTemplate(RequestBuilder<crate::model::GetJobTemplateRequest>);
 
@@ -533,6 +646,21 @@ pub mod transcoder_service {
     }
 
     /// The request builder for [TranscoderService::delete_job_template][super::super::client::TranscoderService::delete_job_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_video_transcoder_v1::builder;
+    /// use builder::transcoder_service::DeleteJobTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJobTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJobTemplate(RequestBuilder<crate::model::DeleteJobTemplateRequest>);
 

--- a/src/generated/cloud/videointelligence/v1/src/builder.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod video_intelligence_service {
     }
 
     /// The request builder for [VideoIntelligenceService::annotate_video][super::super::client::VideoIntelligenceService::annotate_video] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_videointelligence_v1::builder;
+    /// use builder::video_intelligence_service::AnnotateVideo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_videointelligence_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AnnotateVideo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AnnotateVideo(RequestBuilder<crate::model::AnnotateVideoRequest>);
 
@@ -195,6 +211,25 @@ pub mod video_intelligence_service {
     }
 
     /// The request builder for [VideoIntelligenceService::list_operations][super::super::client::VideoIntelligenceService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_videointelligence_v1::builder;
+    /// use builder::video_intelligence_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -287,6 +322,21 @@ pub mod video_intelligence_service {
     }
 
     /// The request builder for [VideoIntelligenceService::get_operation][super::super::client::VideoIntelligenceService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_videointelligence_v1::builder;
+    /// use builder::video_intelligence_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -335,6 +385,21 @@ pub mod video_intelligence_service {
     }
 
     /// The request builder for [VideoIntelligenceService::delete_operation][super::super::client::VideoIntelligenceService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_videointelligence_v1::builder;
+    /// use builder::video_intelligence_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -383,6 +448,21 @@ pub mod video_intelligence_service {
     }
 
     /// The request builder for [VideoIntelligenceService::cancel_operation][super::super::client::VideoIntelligenceService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_videointelligence_v1::builder;
+    /// use builder::video_intelligence_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/vision/v1/src/builder.rs
+++ b/src/generated/cloud/vision/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod image_annotator {
     }
 
     /// The request builder for [ImageAnnotator::batch_annotate_images][super::super::client::ImageAnnotator::batch_annotate_images] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::image_annotator::BatchAnnotateImages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchAnnotateImages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchAnnotateImages(RequestBuilder<crate::model::BatchAnnotateImagesRequest>);
 
@@ -141,6 +156,21 @@ pub mod image_annotator {
     }
 
     /// The request builder for [ImageAnnotator::batch_annotate_files][super::super::client::ImageAnnotator::batch_annotate_files] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::image_annotator::BatchAnnotateFiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchAnnotateFiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchAnnotateFiles(RequestBuilder<crate::model::BatchAnnotateFilesRequest>);
 
@@ -213,6 +243,22 @@ pub mod image_annotator {
     }
 
     /// The request builder for [ImageAnnotator::async_batch_annotate_images][super::super::client::ImageAnnotator::async_batch_annotate_images] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::image_annotator::AsyncBatchAnnotateImages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vision_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AsyncBatchAnnotateImages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AsyncBatchAnnotateImages(
         RequestBuilder<crate::model::AsyncBatchAnnotateImagesRequest>,
@@ -341,6 +387,22 @@ pub mod image_annotator {
     }
 
     /// The request builder for [ImageAnnotator::async_batch_annotate_files][super::super::client::ImageAnnotator::async_batch_annotate_files] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::image_annotator::AsyncBatchAnnotateFiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vision_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AsyncBatchAnnotateFiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AsyncBatchAnnotateFiles(
         RequestBuilder<crate::model::AsyncBatchAnnotateFilesRequest>,
@@ -458,6 +520,21 @@ pub mod image_annotator {
     }
 
     /// The request builder for [ImageAnnotator::get_operation][super::super::client::ImageAnnotator::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::image_annotator::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -561,6 +638,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::create_product_set][super::super::client::ProductSearch::create_product_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::CreateProductSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProductSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProductSet(RequestBuilder<crate::model::CreateProductSetRequest>);
 
@@ -628,6 +720,25 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::list_product_sets][super::super::client::ProductSearch::list_product_sets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::ListProductSets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProductSets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProductSets(RequestBuilder<crate::model::ListProductSetsRequest>);
 
@@ -711,6 +822,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::get_product_set][super::super::client::ProductSearch::get_product_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::GetProductSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProductSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProductSet(RequestBuilder<crate::model::GetProductSetRequest>);
 
@@ -758,6 +884,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::update_product_set][super::super::client::ProductSearch::update_product_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::UpdateProductSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProductSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProductSet(RequestBuilder<crate::model::UpdateProductSetRequest>);
 
@@ -820,6 +961,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::delete_product_set][super::super::client::ProductSearch::delete_product_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::DeleteProductSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteProductSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteProductSet(RequestBuilder<crate::model::DeleteProductSetRequest>);
 
@@ -870,6 +1026,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::create_product][super::super::client::ProductSearch::create_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::CreateProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProduct(RequestBuilder<crate::model::CreateProductRequest>);
 
@@ -934,6 +1105,25 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::list_products][super::super::client::ProductSearch::list_products] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::ListProducts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProducts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProducts(RequestBuilder<crate::model::ListProductsRequest>);
 
@@ -1017,6 +1207,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::get_product][super::super::client::ProductSearch::get_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::GetProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProduct(RequestBuilder<crate::model::GetProductRequest>);
 
@@ -1064,6 +1269,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::update_product][super::super::client::ProductSearch::update_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::UpdateProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProduct(RequestBuilder<crate::model::UpdateProductRequest>);
 
@@ -1123,6 +1343,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::delete_product][super::super::client::ProductSearch::delete_product] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::DeleteProduct;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteProduct {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteProduct(RequestBuilder<crate::model::DeleteProductRequest>);
 
@@ -1170,6 +1405,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::create_reference_image][super::super::client::ProductSearch::create_reference_image] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::CreateReferenceImage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateReferenceImage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateReferenceImage(RequestBuilder<crate::model::CreateReferenceImageRequest>);
 
@@ -1237,6 +1487,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::delete_reference_image][super::super::client::ProductSearch::delete_reference_image] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::DeleteReferenceImage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteReferenceImage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteReferenceImage(RequestBuilder<crate::model::DeleteReferenceImageRequest>);
 
@@ -1287,6 +1552,25 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::list_reference_images][super::super::client::ProductSearch::list_reference_images] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::ListReferenceImages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReferenceImages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReferenceImages(RequestBuilder<crate::model::ListReferenceImagesRequest>);
 
@@ -1375,6 +1659,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::get_reference_image][super::super::client::ProductSearch::get_reference_image] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::GetReferenceImage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReferenceImage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReferenceImage(RequestBuilder<crate::model::GetReferenceImageRequest>);
 
@@ -1425,6 +1724,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::add_product_to_product_set][super::super::client::ProductSearch::add_product_to_product_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::AddProductToProductSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddProductToProductSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddProductToProductSet(RequestBuilder<crate::model::AddProductToProductSetRequest>);
 
@@ -1483,6 +1797,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::remove_product_from_product_set][super::super::client::ProductSearch::remove_product_from_product_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::RemoveProductFromProductSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveProductFromProductSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveProductFromProductSet(
         RequestBuilder<crate::model::RemoveProductFromProductSetRequest>,
@@ -1543,6 +1872,25 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::list_products_in_product_set][super::super::client::ProductSearch::list_products_in_product_set] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::ListProductsInProductSet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProductsInProductSet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProductsInProductSet(
         RequestBuilder<crate::model::ListProductsInProductSetRequest>,
@@ -1635,6 +1983,22 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::import_product_sets][super::super::client::ProductSearch::import_product_sets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::ImportProductSets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vision_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportProductSets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportProductSets(RequestBuilder<crate::model::ImportProductSetsRequest>);
 
@@ -1741,6 +2105,22 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::purge_products][super::super::client::ProductSearch::purge_products] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::PurgeProducts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vision_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PurgeProducts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PurgeProducts(RequestBuilder<crate::model::PurgeProductsRequest>);
 
@@ -1872,6 +2252,21 @@ pub mod product_search {
     }
 
     /// The request builder for [ProductSearch::get_operation][super::super::client::ProductSearch::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vision_v1::builder;
+    /// use builder::product_search::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/vmmigration/v1/src/builder.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_sources][super::super::client::VmMigration::list_sources] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListSources;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSources {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSources(RequestBuilder<crate::model::ListSourcesRequest>);
 
@@ -166,6 +185,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_source][super::super::client::VmMigration::get_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSource(RequestBuilder<crate::model::GetSourceRequest>);
 
@@ -213,6 +247,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_source][super::super::client::VmMigration::create_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSource(RequestBuilder<crate::model::CreateSourceRequest>);
 
@@ -323,6 +373,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::update_source][super::super::client::VmMigration::update_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::UpdateSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSource(RequestBuilder<crate::model::UpdateSourceRequest>);
 
@@ -426,6 +492,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::delete_source][super::super::client::VmMigration::delete_source] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::DeleteSource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSource(RequestBuilder<crate::model::DeleteSourceRequest>);
 
@@ -519,6 +601,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::fetch_inventory][super::super::client::VmMigration::fetch_inventory] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::FetchInventory;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchInventory {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchInventory(RequestBuilder<crate::model::FetchInventoryRequest>);
 
@@ -572,6 +669,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_utilization_reports][super::super::client::VmMigration::list_utilization_reports] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListUtilizationReports;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUtilizationReports {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUtilizationReports(RequestBuilder<crate::model::ListUtilizationReportsRequest>);
 
@@ -682,6 +798,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_utilization_report][super::super::client::VmMigration::get_utilization_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetUtilizationReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetUtilizationReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetUtilizationReport(RequestBuilder<crate::model::GetUtilizationReportRequest>);
 
@@ -738,6 +869,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_utilization_report][super::super::client::VmMigration::create_utilization_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateUtilizationReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateUtilizationReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateUtilizationReport(
         RequestBuilder<crate::model::CreateUtilizationReportRequest>,
@@ -858,6 +1005,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::delete_utilization_report][super::super::client::VmMigration::delete_utilization_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::DeleteUtilizationReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteUtilizationReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteUtilizationReport(
         RequestBuilder<crate::model::DeleteUtilizationReportRequest>,
@@ -956,6 +1119,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_datacenter_connectors][super::super::client::VmMigration::list_datacenter_connectors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListDatacenterConnectors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatacenterConnectors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatacenterConnectors(
         RequestBuilder<crate::model::ListDatacenterConnectorsRequest>,
@@ -1062,6 +1244,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_datacenter_connector][super::super::client::VmMigration::get_datacenter_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetDatacenterConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDatacenterConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDatacenterConnector(RequestBuilder<crate::model::GetDatacenterConnectorRequest>);
 
@@ -1112,6 +1309,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_datacenter_connector][super::super::client::VmMigration::create_datacenter_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateDatacenterConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDatacenterConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDatacenterConnector(
         RequestBuilder<crate::model::CreateDatacenterConnectorRequest>,
@@ -1232,6 +1445,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::delete_datacenter_connector][super::super::client::VmMigration::delete_datacenter_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::DeleteDatacenterConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDatacenterConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDatacenterConnector(
         RequestBuilder<crate::model::DeleteDatacenterConnectorRequest>,
@@ -1330,6 +1559,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::upgrade_appliance][super::super::client::VmMigration::upgrade_appliance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::UpgradeAppliance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpgradeAppliance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpgradeAppliance(RequestBuilder<crate::model::UpgradeApplianceRequest>);
 
@@ -1427,6 +1672,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_migrating_vm][super::super::client::VmMigration::create_migrating_vm] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateMigratingVm;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMigratingVm {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMigratingVm(RequestBuilder<crate::model::CreateMigratingVmRequest>);
 
@@ -1542,6 +1803,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_migrating_vms][super::super::client::VmMigration::list_migrating_vms] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListMigratingVms;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMigratingVms {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMigratingVms(RequestBuilder<crate::model::ListMigratingVmsRequest>);
 
@@ -1648,6 +1928,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_migrating_vm][super::super::client::VmMigration::get_migrating_vm] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetMigratingVm;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMigratingVm {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMigratingVm(RequestBuilder<crate::model::GetMigratingVmRequest>);
 
@@ -1701,6 +1996,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::update_migrating_vm][super::super::client::VmMigration::update_migrating_vm] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::UpdateMigratingVm;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMigratingVm {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMigratingVm(RequestBuilder<crate::model::UpdateMigratingVmRequest>);
 
@@ -1809,6 +2120,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::delete_migrating_vm][super::super::client::VmMigration::delete_migrating_vm] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::DeleteMigratingVm;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMigratingVm {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMigratingVm(RequestBuilder<crate::model::DeleteMigratingVmRequest>);
 
@@ -1899,6 +2226,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::start_migration][super::super::client::VmMigration::start_migration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::StartMigration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartMigration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartMigration(RequestBuilder<crate::model::StartMigrationRequest>);
 
@@ -1987,6 +2330,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::resume_migration][super::super::client::VmMigration::resume_migration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ResumeMigration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeMigration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeMigration(RequestBuilder<crate::model::ResumeMigrationRequest>);
 
@@ -2075,6 +2434,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::pause_migration][super::super::client::VmMigration::pause_migration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::PauseMigration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseMigration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseMigration(RequestBuilder<crate::model::PauseMigrationRequest>);
 
@@ -2163,6 +2538,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::finalize_migration][super::super::client::VmMigration::finalize_migration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::FinalizeMigration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FinalizeMigration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FinalizeMigration(RequestBuilder<crate::model::FinalizeMigrationRequest>);
 
@@ -2254,6 +2645,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_clone_job][super::super::client::VmMigration::create_clone_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateCloneJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCloneJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCloneJob(RequestBuilder<crate::model::CreateCloneJobRequest>);
 
@@ -2364,6 +2771,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::cancel_clone_job][super::super::client::VmMigration::cancel_clone_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CancelCloneJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelCloneJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelCloneJob(RequestBuilder<crate::model::CancelCloneJobRequest>);
 
@@ -2452,6 +2875,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_clone_jobs][super::super::client::VmMigration::list_clone_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListCloneJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCloneJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCloneJobs(RequestBuilder<crate::model::ListCloneJobsRequest>);
 
@@ -2549,6 +2991,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_clone_job][super::super::client::VmMigration::get_clone_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetCloneJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCloneJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCloneJob(RequestBuilder<crate::model::GetCloneJobRequest>);
 
@@ -2596,6 +3053,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_cutover_job][super::super::client::VmMigration::create_cutover_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateCutoverJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCutoverJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCutoverJob(RequestBuilder<crate::model::CreateCutoverJobRequest>);
 
@@ -2709,6 +3182,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::cancel_cutover_job][super::super::client::VmMigration::cancel_cutover_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CancelCutoverJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelCutoverJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelCutoverJob(RequestBuilder<crate::model::CancelCutoverJobRequest>);
 
@@ -2800,6 +3289,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_cutover_jobs][super::super::client::VmMigration::list_cutover_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListCutoverJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCutoverJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCutoverJobs(RequestBuilder<crate::model::ListCutoverJobsRequest>);
 
@@ -2897,6 +3405,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_cutover_job][super::super::client::VmMigration::get_cutover_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetCutoverJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCutoverJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCutoverJob(RequestBuilder<crate::model::GetCutoverJobRequest>);
 
@@ -2944,6 +3467,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_groups][super::super::client::VmMigration::list_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -3041,6 +3583,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_group][super::super::client::VmMigration::get_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -3088,6 +3645,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_group][super::super::client::VmMigration::create_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGroup(RequestBuilder<crate::model::CreateGroupRequest>);
 
@@ -3198,6 +3771,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::update_group][super::super::client::VmMigration::update_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::UpdateGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -3301,6 +3890,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::delete_group][super::super::client::VmMigration::delete_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::DeleteGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGroup(RequestBuilder<crate::model::DeleteGroupRequest>);
 
@@ -3394,6 +3999,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::add_group_migration][super::super::client::VmMigration::add_group_migration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::AddGroupMigration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddGroupMigration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddGroupMigration(RequestBuilder<crate::model::AddGroupMigrationRequest>);
 
@@ -3491,6 +4112,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::remove_group_migration][super::super::client::VmMigration::remove_group_migration] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::RemoveGroupMigration;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RemoveGroupMigration {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RemoveGroupMigration(RequestBuilder<crate::model::RemoveGroupMigrationRequest>);
 
@@ -3588,6 +4225,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_target_projects][super::super::client::VmMigration::list_target_projects] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListTargetProjects;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTargetProjects {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTargetProjects(RequestBuilder<crate::model::ListTargetProjectsRequest>);
 
@@ -3690,6 +4346,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_target_project][super::super::client::VmMigration::get_target_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetTargetProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTargetProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTargetProject(RequestBuilder<crate::model::GetTargetProjectRequest>);
 
@@ -3740,6 +4411,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::create_target_project][super::super::client::VmMigration::create_target_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CreateTargetProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTargetProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTargetProject(RequestBuilder<crate::model::CreateTargetProjectRequest>);
 
@@ -3856,6 +4543,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::update_target_project][super::super::client::VmMigration::update_target_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::UpdateTargetProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTargetProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTargetProject(RequestBuilder<crate::model::UpdateTargetProjectRequest>);
 
@@ -3965,6 +4668,22 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::delete_target_project][super::super::client::VmMigration::delete_target_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::DeleteTargetProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmmigration_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTargetProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTargetProject(RequestBuilder<crate::model::DeleteTargetProjectRequest>);
 
@@ -4061,6 +4780,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_replication_cycles][super::super::client::VmMigration::list_replication_cycles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListReplicationCycles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListReplicationCycles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListReplicationCycles(RequestBuilder<crate::model::ListReplicationCyclesRequest>);
 
@@ -4163,6 +4901,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_replication_cycle][super::super::client::VmMigration::get_replication_cycle] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetReplicationCycle;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetReplicationCycle {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetReplicationCycle(RequestBuilder<crate::model::GetReplicationCycleRequest>);
 
@@ -4213,6 +4966,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_locations][super::super::client::VmMigration::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4303,6 +5075,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_location][super::super::client::VmMigration::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4348,6 +5135,25 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::list_operations][super::super::client::VmMigration::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4440,6 +5246,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::get_operation][super::super::client::VmMigration::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4488,6 +5309,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::delete_operation][super::super::client::VmMigration::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4536,6 +5372,21 @@ pub mod vm_migration {
     }
 
     /// The request builder for [VmMigration::cancel_operation][super::super::client::VmMigration::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmmigration_v1::builder;
+    /// use builder::vm_migration::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/vmwareengine/v1/src/builder.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_private_clouds][super::super::client::VmwareEngine::list_private_clouds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListPrivateClouds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPrivateClouds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPrivateClouds(RequestBuilder<crate::model::ListPrivateCloudsRequest>);
 
@@ -167,6 +186,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_private_cloud][super::super::client::VmwareEngine::get_private_cloud] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetPrivateCloud;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPrivateCloud {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPrivateCloud(RequestBuilder<crate::model::GetPrivateCloudRequest>);
 
@@ -214,6 +248,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_private_cloud][super::super::client::VmwareEngine::create_private_cloud] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreatePrivateCloud;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePrivateCloud {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePrivateCloud(RequestBuilder<crate::model::CreatePrivateCloudRequest>);
 
@@ -335,6 +385,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_private_cloud][super::super::client::VmwareEngine::update_private_cloud] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdatePrivateCloud;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePrivateCloud {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePrivateCloud(RequestBuilder<crate::model::UpdatePrivateCloudRequest>);
 
@@ -445,6 +511,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_private_cloud][super::super::client::VmwareEngine::delete_private_cloud] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeletePrivateCloud;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePrivateCloud {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePrivateCloud(RequestBuilder<crate::model::DeletePrivateCloudRequest>);
 
@@ -553,6 +635,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::undelete_private_cloud][super::super::client::VmwareEngine::undelete_private_cloud] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UndeletePrivateCloud;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeletePrivateCloud {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeletePrivateCloud(RequestBuilder<crate::model::UndeletePrivateCloudRequest>);
 
@@ -649,6 +747,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_clusters][super::super::client::VmwareEngine::list_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -744,6 +861,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_cluster][super::super::client::VmwareEngine::get_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -791,6 +923,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_cluster][super::super::client::VmwareEngine::create_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -907,6 +1055,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_cluster][super::super::client::VmwareEngine::update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -1018,6 +1182,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_cluster][super::super::client::VmwareEngine::delete_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -1111,6 +1291,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_nodes][super::super::client::VmwareEngine::list_nodes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListNodes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNodes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNodes(RequestBuilder<crate::model::ListNodesRequest>);
 
@@ -1194,6 +1393,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_node][super::super::client::VmwareEngine::get_node] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetNode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNode(RequestBuilder<crate::model::GetNodeRequest>);
 
@@ -1241,6 +1455,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_external_addresses][super::super::client::VmwareEngine::list_external_addresses] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListExternalAddresses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExternalAddresses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExternalAddresses(RequestBuilder<crate::model::ListExternalAddressesRequest>);
 
@@ -1341,6 +1574,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::fetch_network_policy_external_addresses][super::super::client::VmwareEngine::fetch_network_policy_external_addresses] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::FetchNetworkPolicyExternalAddresses;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchNetworkPolicyExternalAddresses {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchNetworkPolicyExternalAddresses(
         RequestBuilder<crate::model::FetchNetworkPolicyExternalAddressesRequest>,
@@ -1435,6 +1687,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_external_address][super::super::client::VmwareEngine::get_external_address] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetExternalAddress;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExternalAddress {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExternalAddress(RequestBuilder<crate::model::GetExternalAddressRequest>);
 
@@ -1485,6 +1752,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_external_address][super::super::client::VmwareEngine::create_external_address] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateExternalAddress;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExternalAddress {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExternalAddress(RequestBuilder<crate::model::CreateExternalAddressRequest>);
 
@@ -1601,6 +1884,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_external_address][super::super::client::VmwareEngine::update_external_address] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateExternalAddress;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExternalAddress {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExternalAddress(RequestBuilder<crate::model::UpdateExternalAddressRequest>);
 
@@ -1712,6 +2011,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_external_address][super::super::client::VmwareEngine::delete_external_address] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteExternalAddress;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteExternalAddress {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteExternalAddress(RequestBuilder<crate::model::DeleteExternalAddressRequest>);
 
@@ -1808,6 +2123,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_subnets][super::super::client::VmwareEngine::list_subnets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListSubnets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSubnets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSubnets(RequestBuilder<crate::model::ListSubnetsRequest>);
 
@@ -1891,6 +2225,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_subnet][super::super::client::VmwareEngine::get_subnet] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetSubnet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSubnet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSubnet(RequestBuilder<crate::model::GetSubnetRequest>);
 
@@ -1938,6 +2287,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_subnet][super::super::client::VmwareEngine::update_subnet] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateSubnet;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSubnet {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSubnet(RequestBuilder<crate::model::UpdateSubnetRequest>);
 
@@ -2037,6 +2402,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_external_access_rules][super::super::client::VmwareEngine::list_external_access_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListExternalAccessRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExternalAccessRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExternalAccessRules(
         RequestBuilder<crate::model::ListExternalAccessRulesRequest>,
@@ -2141,6 +2525,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_external_access_rule][super::super::client::VmwareEngine::get_external_access_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetExternalAccessRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExternalAccessRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExternalAccessRule(RequestBuilder<crate::model::GetExternalAccessRuleRequest>);
 
@@ -2191,6 +2590,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_external_access_rule][super::super::client::VmwareEngine::create_external_access_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateExternalAccessRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExternalAccessRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExternalAccessRule(
         RequestBuilder<crate::model::CreateExternalAccessRuleRequest>,
@@ -2311,6 +2726,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_external_access_rule][super::super::client::VmwareEngine::update_external_access_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateExternalAccessRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExternalAccessRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExternalAccessRule(
         RequestBuilder<crate::model::UpdateExternalAccessRuleRequest>,
@@ -2426,6 +2857,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_external_access_rule][super::super::client::VmwareEngine::delete_external_access_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteExternalAccessRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteExternalAccessRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteExternalAccessRule(
         RequestBuilder<crate::model::DeleteExternalAccessRuleRequest>,
@@ -2524,6 +2971,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_logging_servers][super::super::client::VmwareEngine::list_logging_servers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListLoggingServers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLoggingServers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLoggingServers(RequestBuilder<crate::model::ListLoggingServersRequest>);
 
@@ -2624,6 +3090,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_logging_server][super::super::client::VmwareEngine::get_logging_server] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetLoggingServer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLoggingServer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLoggingServer(RequestBuilder<crate::model::GetLoggingServerRequest>);
 
@@ -2674,6 +3155,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_logging_server][super::super::client::VmwareEngine::create_logging_server] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateLoggingServer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLoggingServer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLoggingServer(RequestBuilder<crate::model::CreateLoggingServerRequest>);
 
@@ -2790,6 +3287,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_logging_server][super::super::client::VmwareEngine::update_logging_server] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateLoggingServer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLoggingServer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLoggingServer(RequestBuilder<crate::model::UpdateLoggingServerRequest>);
 
@@ -2901,6 +3414,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_logging_server][super::super::client::VmwareEngine::delete_logging_server] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteLoggingServer;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLoggingServer {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLoggingServer(RequestBuilder<crate::model::DeleteLoggingServerRequest>);
 
@@ -2997,6 +3526,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_node_types][super::super::client::VmwareEngine::list_node_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListNodeTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNodeTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNodeTypes(RequestBuilder<crate::model::ListNodeTypesRequest>);
 
@@ -3086,6 +3634,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_node_type][super::super::client::VmwareEngine::get_node_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetNodeType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNodeType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNodeType(RequestBuilder<crate::model::GetNodeTypeRequest>);
 
@@ -3133,6 +3696,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::show_nsx_credentials][super::super::client::VmwareEngine::show_nsx_credentials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ShowNsxCredentials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ShowNsxCredentials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ShowNsxCredentials(RequestBuilder<crate::model::ShowNsxCredentialsRequest>);
 
@@ -3183,6 +3761,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::show_vcenter_credentials][super::super::client::VmwareEngine::show_vcenter_credentials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ShowVcenterCredentials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ShowVcenterCredentials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ShowVcenterCredentials(RequestBuilder<crate::model::ShowVcenterCredentialsRequest>);
 
@@ -3239,6 +3832,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::reset_nsx_credentials][super::super::client::VmwareEngine::reset_nsx_credentials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ResetNsxCredentials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetNsxCredentials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetNsxCredentials(RequestBuilder<crate::model::ResetNsxCredentialsRequest>);
 
@@ -3335,6 +3944,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::reset_vcenter_credentials][super::super::client::VmwareEngine::reset_vcenter_credentials] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ResetVcenterCredentials;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetVcenterCredentials {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetVcenterCredentials(
         RequestBuilder<crate::model::ResetVcenterCredentialsRequest>,
@@ -3439,6 +4064,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_dns_forwarding][super::super::client::VmwareEngine::get_dns_forwarding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetDnsForwarding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDnsForwarding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDnsForwarding(RequestBuilder<crate::model::GetDnsForwardingRequest>);
 
@@ -3489,6 +4129,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_dns_forwarding][super::super::client::VmwareEngine::update_dns_forwarding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateDnsForwarding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDnsForwarding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDnsForwarding(RequestBuilder<crate::model::UpdateDnsForwardingRequest>);
 
@@ -3600,6 +4256,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_network_peering][super::super::client::VmwareEngine::get_network_peering] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetNetworkPeering;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNetworkPeering {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNetworkPeering(RequestBuilder<crate::model::GetNetworkPeeringRequest>);
 
@@ -3650,6 +4321,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_network_peerings][super::super::client::VmwareEngine::list_network_peerings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListNetworkPeerings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNetworkPeerings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNetworkPeerings(RequestBuilder<crate::model::ListNetworkPeeringsRequest>);
 
@@ -3750,6 +4440,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_network_peering][super::super::client::VmwareEngine::create_network_peering] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateNetworkPeering;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNetworkPeering {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNetworkPeering(RequestBuilder<crate::model::CreateNetworkPeeringRequest>);
 
@@ -3866,6 +4572,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_network_peering][super::super::client::VmwareEngine::delete_network_peering] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteNetworkPeering;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNetworkPeering {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNetworkPeering(RequestBuilder<crate::model::DeleteNetworkPeeringRequest>);
 
@@ -3962,6 +4684,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_network_peering][super::super::client::VmwareEngine::update_network_peering] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateNetworkPeering;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNetworkPeering {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNetworkPeering(RequestBuilder<crate::model::UpdateNetworkPeeringRequest>);
 
@@ -4073,6 +4811,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_peering_routes][super::super::client::VmwareEngine::list_peering_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListPeeringRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPeeringRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPeeringRoutes(RequestBuilder<crate::model::ListPeeringRoutesRequest>);
 
@@ -4165,6 +4922,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_hcx_activation_key][super::super::client::VmwareEngine::create_hcx_activation_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateHcxActivationKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateHcxActivationKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateHcxActivationKey(RequestBuilder<crate::model::CreateHcxActivationKeyRequest>);
 
@@ -4283,6 +5056,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_hcx_activation_keys][super::super::client::VmwareEngine::list_hcx_activation_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListHcxActivationKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListHcxActivationKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListHcxActivationKeys(RequestBuilder<crate::model::ListHcxActivationKeysRequest>);
 
@@ -4371,6 +5163,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_hcx_activation_key][super::super::client::VmwareEngine::get_hcx_activation_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetHcxActivationKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetHcxActivationKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetHcxActivationKey(RequestBuilder<crate::model::GetHcxActivationKeyRequest>);
 
@@ -4421,6 +5228,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_network_policy][super::super::client::VmwareEngine::get_network_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetNetworkPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNetworkPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNetworkPolicy(RequestBuilder<crate::model::GetNetworkPolicyRequest>);
 
@@ -4471,6 +5293,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_network_policies][super::super::client::VmwareEngine::list_network_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListNetworkPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNetworkPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNetworkPolicies(RequestBuilder<crate::model::ListNetworkPoliciesRequest>);
 
@@ -4571,6 +5412,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_network_policy][super::super::client::VmwareEngine::create_network_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateNetworkPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNetworkPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNetworkPolicy(RequestBuilder<crate::model::CreateNetworkPolicyRequest>);
 
@@ -4687,6 +5544,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_network_policy][super::super::client::VmwareEngine::update_network_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateNetworkPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNetworkPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNetworkPolicy(RequestBuilder<crate::model::UpdateNetworkPolicyRequest>);
 
@@ -4798,6 +5671,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_network_policy][super::super::client::VmwareEngine::delete_network_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteNetworkPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNetworkPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNetworkPolicy(RequestBuilder<crate::model::DeleteNetworkPolicyRequest>);
 
@@ -4894,6 +5783,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_management_dns_zone_bindings][super::super::client::VmwareEngine::list_management_dns_zone_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListManagementDnsZoneBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListManagementDnsZoneBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListManagementDnsZoneBindings(
         RequestBuilder<crate::model::ListManagementDnsZoneBindingsRequest>,
@@ -4998,6 +5906,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_management_dns_zone_binding][super::super::client::VmwareEngine::get_management_dns_zone_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetManagementDnsZoneBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetManagementDnsZoneBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetManagementDnsZoneBinding(
         RequestBuilder<crate::model::GetManagementDnsZoneBindingRequest>,
@@ -5050,6 +5973,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_management_dns_zone_binding][super::super::client::VmwareEngine::create_management_dns_zone_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateManagementDnsZoneBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateManagementDnsZoneBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateManagementDnsZoneBinding(
         RequestBuilder<crate::model::CreateManagementDnsZoneBindingRequest>,
@@ -5173,6 +6112,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_management_dns_zone_binding][super::super::client::VmwareEngine::update_management_dns_zone_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateManagementDnsZoneBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateManagementDnsZoneBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateManagementDnsZoneBinding(
         RequestBuilder<crate::model::UpdateManagementDnsZoneBindingRequest>,
@@ -5288,6 +6243,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_management_dns_zone_binding][super::super::client::VmwareEngine::delete_management_dns_zone_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteManagementDnsZoneBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteManagementDnsZoneBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteManagementDnsZoneBinding(
         RequestBuilder<crate::model::DeleteManagementDnsZoneBindingRequest>,
@@ -5386,6 +6357,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::repair_management_dns_zone_binding][super::super::client::VmwareEngine::repair_management_dns_zone_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::RepairManagementDnsZoneBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepairManagementDnsZoneBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepairManagementDnsZoneBinding(
         RequestBuilder<crate::model::RepairManagementDnsZoneBindingRequest>,
@@ -5485,6 +6472,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_vmware_engine_network][super::super::client::VmwareEngine::create_vmware_engine_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreateVmwareEngineNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateVmwareEngineNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateVmwareEngineNetwork(
         RequestBuilder<crate::model::CreateVmwareEngineNetworkRequest>,
@@ -5605,6 +6608,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_vmware_engine_network][super::super::client::VmwareEngine::update_vmware_engine_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdateVmwareEngineNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVmwareEngineNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVmwareEngineNetwork(
         RequestBuilder<crate::model::UpdateVmwareEngineNetworkRequest>,
@@ -5720,6 +6739,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_vmware_engine_network][super::super::client::VmwareEngine::delete_vmware_engine_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteVmwareEngineNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVmwareEngineNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVmwareEngineNetwork(
         RequestBuilder<crate::model::DeleteVmwareEngineNetworkRequest>,
@@ -5824,6 +6859,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_vmware_engine_network][super::super::client::VmwareEngine::get_vmware_engine_network] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetVmwareEngineNetwork;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVmwareEngineNetwork {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVmwareEngineNetwork(RequestBuilder<crate::model::GetVmwareEngineNetworkRequest>);
 
@@ -5874,6 +6924,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_vmware_engine_networks][super::super::client::VmwareEngine::list_vmware_engine_networks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListVmwareEngineNetworks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVmwareEngineNetworks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVmwareEngineNetworks(
         RequestBuilder<crate::model::ListVmwareEngineNetworksRequest>,
@@ -5978,6 +7047,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::create_private_connection][super::super::client::VmwareEngine::create_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::CreatePrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePrivateConnection(
         RequestBuilder<crate::model::CreatePrivateConnectionRequest>,
@@ -6098,6 +7183,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_private_connection][super::super::client::VmwareEngine::get_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetPrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPrivateConnection(RequestBuilder<crate::model::GetPrivateConnectionRequest>);
 
@@ -6148,6 +7248,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_private_connections][super::super::client::VmwareEngine::list_private_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListPrivateConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPrivateConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnections(RequestBuilder<crate::model::ListPrivateConnectionsRequest>);
 
@@ -6250,6 +7369,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::update_private_connection][super::super::client::VmwareEngine::update_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::UpdatePrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePrivateConnection(
         RequestBuilder<crate::model::UpdatePrivateConnectionRequest>,
@@ -6365,6 +7500,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_private_connection][super::super::client::VmwareEngine::delete_private_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeletePrivateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePrivateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePrivateConnection(
         RequestBuilder<crate::model::DeletePrivateConnectionRequest>,
@@ -6463,6 +7614,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_private_connection_peering_routes][super::super::client::VmwareEngine::list_private_connection_peering_routes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListPrivateConnectionPeeringRoutes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPrivateConnectionPeeringRoutes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPrivateConnectionPeeringRoutes(
         RequestBuilder<crate::model::ListPrivateConnectionPeeringRoutesRequest>,
@@ -6557,6 +7727,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::grant_dns_bind_permission][super::super::client::VmwareEngine::grant_dns_bind_permission] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GrantDnsBindPermission;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GrantDnsBindPermission {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GrantDnsBindPermission(RequestBuilder<crate::model::GrantDnsBindPermissionRequest>);
 
@@ -6665,6 +7851,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_dns_bind_permission][super::super::client::VmwareEngine::get_dns_bind_permission] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetDnsBindPermission;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDnsBindPermission {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDnsBindPermission(RequestBuilder<crate::model::GetDnsBindPermissionRequest>);
 
@@ -6715,6 +7916,22 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::revoke_dns_bind_permission][super::super::client::VmwareEngine::revoke_dns_bind_permission] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::RevokeDnsBindPermission;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vmwareengine_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RevokeDnsBindPermission {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RevokeDnsBindPermission(
         RequestBuilder<crate::model::RevokeDnsBindPermissionRequest>,
@@ -6825,6 +8042,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_locations][super::super::client::VmwareEngine::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6915,6 +8151,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_location][super::super::client::VmwareEngine::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6960,6 +8211,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::set_iam_policy][super::super::client::VmwareEngine::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -7027,6 +8293,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_iam_policy][super::super::client::VmwareEngine::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -7083,6 +8364,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::test_iam_permissions][super::super::client::VmwareEngine::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -7146,6 +8442,25 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::list_operations][super::super::client::VmwareEngine::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -7238,6 +8553,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::get_operation][super::super::client::VmwareEngine::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -7286,6 +8616,21 @@ pub mod vmware_engine {
     }
 
     /// The request builder for [VmwareEngine::delete_operation][super::super::client::VmwareEngine::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vmwareengine_v1::builder;
+    /// use builder::vmware_engine::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/vpcaccess/v1/src/builder.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod vpc_access_service {
     }
 
     /// The request builder for [VpcAccessService::create_connector][super::super::client::VpcAccessService::create_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vpcaccess_v1::builder;
+    /// use builder::vpc_access_service::CreateConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vpcaccess_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnector(RequestBuilder<crate::model::CreateConnectorRequest>);
 
@@ -173,6 +189,21 @@ pub mod vpc_access_service {
     }
 
     /// The request builder for [VpcAccessService::get_connector][super::super::client::VpcAccessService::get_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vpcaccess_v1::builder;
+    /// use builder::vpc_access_service::GetConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnector(RequestBuilder<crate::model::GetConnectorRequest>);
 
@@ -220,6 +251,25 @@ pub mod vpc_access_service {
     }
 
     /// The request builder for [VpcAccessService::list_connectors][super::super::client::VpcAccessService::list_connectors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vpcaccess_v1::builder;
+    /// use builder::vpc_access_service::ListConnectors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnectors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnectors(RequestBuilder<crate::model::ListConnectorsRequest>);
 
@@ -303,6 +353,22 @@ pub mod vpc_access_service {
     }
 
     /// The request builder for [VpcAccessService::delete_connector][super::super::client::VpcAccessService::delete_connector] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vpcaccess_v1::builder;
+    /// use builder::vpc_access_service::DeleteConnector;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_vpcaccess_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnector {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnector(RequestBuilder<crate::model::DeleteConnectorRequest>);
 
@@ -390,6 +456,25 @@ pub mod vpc_access_service {
     }
 
     /// The request builder for [VpcAccessService::list_locations][super::super::client::VpcAccessService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vpcaccess_v1::builder;
+    /// use builder::vpc_access_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -480,6 +565,25 @@ pub mod vpc_access_service {
     }
 
     /// The request builder for [VpcAccessService::list_operations][super::super::client::VpcAccessService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vpcaccess_v1::builder;
+    /// use builder::vpc_access_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -572,6 +676,21 @@ pub mod vpc_access_service {
     }
 
     /// The request builder for [VpcAccessService::get_operation][super::super::client::VpcAccessService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_vpcaccess_v1::builder;
+    /// use builder::vpc_access_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/cloud/webrisk/v1/src/builder.rs
+++ b/src/generated/cloud/webrisk/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::compute_threat_list_diff][super::super::client::WebRiskService::compute_threat_list_diff] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::ComputeThreatListDiff;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ComputeThreatListDiff {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ComputeThreatListDiff(RequestBuilder<crate::model::ComputeThreatListDiffRequest>);
 
@@ -138,6 +153,21 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::search_uris][super::super::client::WebRiskService::search_uris] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::SearchUris;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchUris {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchUris(RequestBuilder<crate::model::SearchUrisRequest>);
 
@@ -198,6 +228,21 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::search_hashes][super::super::client::WebRiskService::search_hashes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::SearchHashes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchHashes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchHashes(RequestBuilder<crate::model::SearchHashesRequest>);
 
@@ -256,6 +301,21 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::create_submission][super::super::client::WebRiskService::create_submission] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::CreateSubmission;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSubmission {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSubmission(RequestBuilder<crate::model::CreateSubmissionRequest>);
 
@@ -317,6 +377,22 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::submit_uri][super::super::client::WebRiskService::submit_uri] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::SubmitUri;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_webrisk_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SubmitUri {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SubmitUri(RequestBuilder<crate::model::SubmitUriRequest>);
 
@@ -431,6 +507,25 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::list_operations][super::super::client::WebRiskService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -523,6 +618,21 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::get_operation][super::super::client::WebRiskService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -571,6 +681,21 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::delete_operation][super::super::client::WebRiskService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -619,6 +744,21 @@ pub mod web_risk_service {
     }
 
     /// The request builder for [WebRiskService::cancel_operation][super::super::client::WebRiskService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_webrisk_v1::builder;
+    /// use builder::web_risk_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/cloud/websecurityscanner/v1/src/builder.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::create_scan_config][super::super::client::WebSecurityScanner::create_scan_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::CreateScanConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateScanConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateScanConfig(RequestBuilder<crate::model::CreateScanConfigRequest>);
 
@@ -126,6 +141,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::delete_scan_config][super::super::client::WebSecurityScanner::delete_scan_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::DeleteScanConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteScanConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteScanConfig(RequestBuilder<crate::model::DeleteScanConfigRequest>);
 
@@ -174,6 +204,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::get_scan_config][super::super::client::WebSecurityScanner::get_scan_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::GetScanConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetScanConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetScanConfig(RequestBuilder<crate::model::GetScanConfigRequest>);
 
@@ -219,6 +264,25 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::list_scan_configs][super::super::client::WebSecurityScanner::list_scan_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::ListScanConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListScanConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListScanConfigs(RequestBuilder<crate::model::ListScanConfigsRequest>);
 
@@ -300,6 +364,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::update_scan_config][super::super::client::WebSecurityScanner::update_scan_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::UpdateScanConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateScanConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateScanConfig(RequestBuilder<crate::model::UpdateScanConfigRequest>);
 
@@ -360,6 +439,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::start_scan_run][super::super::client::WebSecurityScanner::start_scan_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::StartScanRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartScanRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartScanRun(RequestBuilder<crate::model::StartScanRunRequest>);
 
@@ -405,6 +499,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::get_scan_run][super::super::client::WebSecurityScanner::get_scan_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::GetScanRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetScanRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetScanRun(RequestBuilder<crate::model::GetScanRunRequest>);
 
@@ -450,6 +559,25 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::list_scan_runs][super::super::client::WebSecurityScanner::list_scan_runs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::ListScanRuns;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListScanRuns {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListScanRuns(RequestBuilder<crate::model::ListScanRunsRequest>);
 
@@ -531,6 +659,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::stop_scan_run][super::super::client::WebSecurityScanner::stop_scan_run] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::StopScanRun;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopScanRun {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopScanRun(RequestBuilder<crate::model::StopScanRunRequest>);
 
@@ -576,6 +719,25 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::list_crawled_urls][super::super::client::WebSecurityScanner::list_crawled_urls] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::ListCrawledUrls;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListCrawledUrls {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListCrawledUrls(RequestBuilder<crate::model::ListCrawledUrlsRequest>);
 
@@ -657,6 +819,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::get_finding][super::super::client::WebSecurityScanner::get_finding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::GetFinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFinding(RequestBuilder<crate::model::GetFindingRequest>);
 
@@ -702,6 +879,25 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::list_findings][super::super::client::WebSecurityScanner::list_findings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::ListFindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFindings(RequestBuilder<crate::model::ListFindingsRequest>);
 
@@ -789,6 +985,21 @@ pub mod web_security_scanner {
     }
 
     /// The request builder for [WebSecurityScanner::list_finding_type_stats][super::super::client::WebSecurityScanner::list_finding_type_stats] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_websecurityscanner_v1::builder;
+    /// use builder::web_security_scanner::ListFindingTypeStats;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFindingTypeStats {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFindingTypeStats(RequestBuilder<crate::model::ListFindingTypeStatsRequest>);
 

--- a/src/generated/cloud/workflows/executions/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::list_executions][super::super::client::Executions::list_executions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_executions_v1::builder;
+    /// use builder::executions::ListExecutions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExecutions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExecutions(RequestBuilder<crate::model::ListExecutionsRequest>);
 
@@ -170,6 +189,21 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::create_execution][super::super::client::Executions::create_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_executions_v1::builder;
+    /// use builder::executions::CreateExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExecution(RequestBuilder<crate::model::CreateExecutionRequest>);
 
@@ -228,6 +262,21 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::get_execution][super::super::client::Executions::get_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_executions_v1::builder;
+    /// use builder::executions::GetExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExecution(RequestBuilder<crate::model::GetExecutionRequest>);
 
@@ -281,6 +330,21 @@ pub mod executions {
     }
 
     /// The request builder for [Executions::cancel_execution][super::super::client::Executions::cancel_execution] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_executions_v1::builder;
+    /// use builder::executions::CancelExecution;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelExecution {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelExecution(RequestBuilder<crate::model::CancelExecutionRequest>);
 

--- a/src/generated/cloud/workflows/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::list_workflows][super::super::client::Workflows::list_workflows] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::ListWorkflows;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkflows {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkflows(RequestBuilder<crate::model::ListWorkflowsRequest>);
 
@@ -164,6 +183,21 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::get_workflow][super::super::client::Workflows::get_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::GetWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkflow(RequestBuilder<crate::model::GetWorkflowRequest>);
 
@@ -217,6 +251,22 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::create_workflow][super::super::client::Workflows::create_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::CreateWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workflows_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkflow(RequestBuilder<crate::model::CreateWorkflowRequest>);
 
@@ -321,6 +371,22 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::delete_workflow][super::super::client::Workflows::delete_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::DeleteWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workflows_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkflow(RequestBuilder<crate::model::DeleteWorkflowRequest>);
 
@@ -408,6 +474,22 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::update_workflow][super::super::client::Workflows::update_workflow] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::UpdateWorkflow;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workflows_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkflow {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkflow(RequestBuilder<crate::model::UpdateWorkflowRequest>);
 
@@ -505,6 +587,25 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::list_workflow_revisions][super::super::client::Workflows::list_workflow_revisions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::ListWorkflowRevisions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkflowRevisions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkflowRevisions(RequestBuilder<crate::model::ListWorkflowRevisionsRequest>);
 
@@ -593,6 +694,25 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::list_locations][super::super::client::Workflows::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -683,6 +803,21 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::get_location][super::super::client::Workflows::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -728,6 +863,25 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::list_operations][super::super::client::Workflows::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -820,6 +974,21 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::get_operation][super::super::client::Workflows::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -868,6 +1037,21 @@ pub mod workflows {
     }
 
     /// The request builder for [Workflows::delete_operation][super::super::client::Workflows::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workflows_v1::builder;
+    /// use builder::workflows::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 

--- a/src/generated/cloud/workstations/v1/src/builder.rs
+++ b/src/generated/cloud/workstations/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::get_workstation_cluster][super::super::client::Workstations::get_workstation_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::GetWorkstationCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkstationCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkstationCluster(RequestBuilder<crate::model::GetWorkstationClusterRequest>);
 
@@ -119,6 +134,25 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::list_workstation_clusters][super::super::client::Workstations::list_workstation_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::ListWorkstationClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkstationClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkstationClusters(
         RequestBuilder<crate::model::ListWorkstationClustersRequest>,
@@ -211,6 +245,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::create_workstation_cluster][super::super::client::Workstations::create_workstation_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::CreateWorkstationCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkstationCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkstationCluster(
         RequestBuilder<crate::model::CreateWorkstationClusterRequest>,
@@ -331,6 +381,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::update_workstation_cluster][super::super::client::Workstations::update_workstation_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::UpdateWorkstationCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkstationCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkstationCluster(
         RequestBuilder<crate::model::UpdateWorkstationClusterRequest>,
@@ -452,6 +518,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::delete_workstation_cluster][super::super::client::Workstations::delete_workstation_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::DeleteWorkstationCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkstationCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkstationCluster(
         RequestBuilder<crate::model::DeleteWorkstationClusterRequest>,
@@ -563,6 +645,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::get_workstation_config][super::super::client::Workstations::get_workstation_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::GetWorkstationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkstationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkstationConfig(RequestBuilder<crate::model::GetWorkstationConfigRequest>);
 
@@ -613,6 +710,25 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::list_workstation_configs][super::super::client::Workstations::list_workstation_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::ListWorkstationConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkstationConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkstationConfigs(RequestBuilder<crate::model::ListWorkstationConfigsRequest>);
 
@@ -703,6 +819,25 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::list_usable_workstation_configs][super::super::client::Workstations::list_usable_workstation_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::ListUsableWorkstationConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUsableWorkstationConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUsableWorkstationConfigs(
         RequestBuilder<crate::model::ListUsableWorkstationConfigsRequest>,
@@ -795,6 +930,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::create_workstation_config][super::super::client::Workstations::create_workstation_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::CreateWorkstationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkstationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkstationConfig(
         RequestBuilder<crate::model::CreateWorkstationConfigRequest>,
@@ -915,6 +1066,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::update_workstation_config][super::super::client::Workstations::update_workstation_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::UpdateWorkstationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkstationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkstationConfig(
         RequestBuilder<crate::model::UpdateWorkstationConfigRequest>,
@@ -1036,6 +1203,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::delete_workstation_config][super::super::client::Workstations::delete_workstation_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::DeleteWorkstationConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkstationConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkstationConfig(
         RequestBuilder<crate::model::DeleteWorkstationConfigRequest>,
@@ -1147,6 +1330,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::get_workstation][super::super::client::Workstations::get_workstation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::GetWorkstation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkstation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkstation(RequestBuilder<crate::model::GetWorkstationRequest>);
 
@@ -1194,6 +1392,25 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::list_workstations][super::super::client::Workstations::list_workstations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::ListWorkstations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkstations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkstations(RequestBuilder<crate::model::ListWorkstationsRequest>);
 
@@ -1280,6 +1497,25 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::list_usable_workstations][super::super::client::Workstations::list_usable_workstations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::ListUsableWorkstations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUsableWorkstations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUsableWorkstations(RequestBuilder<crate::model::ListUsableWorkstationsRequest>);
 
@@ -1370,6 +1606,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::create_workstation][super::super::client::Workstations::create_workstation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::CreateWorkstation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkstation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkstation(RequestBuilder<crate::model::CreateWorkstationRequest>);
 
@@ -1485,6 +1737,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::update_workstation][super::super::client::Workstations::update_workstation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::UpdateWorkstation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkstation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkstation(RequestBuilder<crate::model::UpdateWorkstationRequest>);
 
@@ -1601,6 +1869,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::delete_workstation][super::super::client::Workstations::delete_workstation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::DeleteWorkstation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkstation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkstation(RequestBuilder<crate::model::DeleteWorkstationRequest>);
 
@@ -1703,6 +1987,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::start_workstation][super::super::client::Workstations::start_workstation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::StartWorkstation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartWorkstation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartWorkstation(RequestBuilder<crate::model::StartWorkstationRequest>);
 
@@ -1805,6 +2105,22 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::stop_workstation][super::super::client::Workstations::stop_workstation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::StopWorkstation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_workstations_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StopWorkstation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StopWorkstation(RequestBuilder<crate::model::StopWorkstationRequest>);
 
@@ -1904,6 +2220,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::generate_access_token][super::super::client::Workstations::generate_access_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::GenerateAccessToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAccessToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAccessToken(RequestBuilder<crate::model::GenerateAccessTokenRequest>);
 
@@ -1994,6 +2325,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::set_iam_policy][super::super::client::Workstations::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2061,6 +2407,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::get_iam_policy][super::super::client::Workstations::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2117,6 +2478,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::test_iam_permissions][super::super::client::Workstations::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2180,6 +2556,25 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::list_operations][super::super::client::Workstations::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2272,6 +2667,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::get_operation][super::super::client::Workstations::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2320,6 +2730,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::delete_operation][super::super::client::Workstations::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2368,6 +2793,21 @@ pub mod workstations {
     }
 
     /// The request builder for [Workstations::cancel_operation][super::super::client::Workstations::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_workstations_v1::builder;
+    /// use builder::workstations::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/container/v1/src/builder.rs
+++ b/src/generated/container/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::list_clusters][super::super::client::ClusterManager::list_clusters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::ListClusters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListClusters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListClusters(RequestBuilder<crate::model::ListClustersRequest>);
 
@@ -128,6 +143,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::get_cluster][super::super::client::ClusterManager::get_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::GetCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCluster(RequestBuilder<crate::model::GetClusterRequest>);
 
@@ -194,6 +224,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::create_cluster][super::super::client::ClusterManager::create_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::CreateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateCluster(RequestBuilder<crate::model::CreateClusterRequest>);
 
@@ -264,6 +309,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::update_cluster][super::super::client::ClusterManager::update_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::UpdateCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCluster(RequestBuilder<crate::model::UpdateClusterRequest>);
 
@@ -341,6 +401,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::update_node_pool][super::super::client::ClusterManager::update_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::UpdateNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNodePool(RequestBuilder<crate::model::UpdateNodePoolRequest>);
 
@@ -669,6 +744,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_node_pool_autoscaling][super::super::client::ClusterManager::set_node_pool_autoscaling] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetNodePoolAutoscaling;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetNodePoolAutoscaling {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetNodePoolAutoscaling(RequestBuilder<crate::model::SetNodePoolAutoscalingRequest>);
 
@@ -756,6 +846,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_logging_service][super::super::client::ClusterManager::set_logging_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetLoggingService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetLoggingService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetLoggingService(RequestBuilder<crate::model::SetLoggingServiceRequest>);
 
@@ -833,6 +938,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_monitoring_service][super::super::client::ClusterManager::set_monitoring_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetMonitoringService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetMonitoringService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetMonitoringService(RequestBuilder<crate::model::SetMonitoringServiceRequest>);
 
@@ -910,6 +1030,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_addons_config][super::super::client::ClusterManager::set_addons_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetAddonsConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetAddonsConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetAddonsConfig(RequestBuilder<crate::model::SetAddonsConfigRequest>);
 
@@ -987,6 +1122,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_locations][super::super::client::ClusterManager::set_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetLocations(RequestBuilder<crate::model::SetLocationsRequest>);
 
@@ -1066,6 +1216,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::update_master][super::super::client::ClusterManager::update_master] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::UpdateMaster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateMaster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateMaster(RequestBuilder<crate::model::UpdateMasterRequest>);
 
@@ -1140,6 +1305,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_master_auth][super::super::client::ClusterManager::set_master_auth] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetMasterAuth;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetMasterAuth {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetMasterAuth(RequestBuilder<crate::model::SetMasterAuthRequest>);
 
@@ -1228,6 +1408,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::delete_cluster][super::super::client::ClusterManager::delete_cluster] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::DeleteCluster;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteCluster {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteCluster(RequestBuilder<crate::model::DeleteClusterRequest>);
 
@@ -1294,6 +1489,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::list_operations][super::super::client::ClusterManager::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<crate::model::ListOperationsRequest>);
 
@@ -1353,6 +1563,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::get_operation][super::super::client::ClusterManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<crate::model::GetOperationRequest>);
 
@@ -1419,6 +1644,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::cancel_operation][super::super::client::ClusterManager::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<crate::model::CancelOperationRequest>);
 
@@ -1485,6 +1725,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::get_server_config][super::super::client::ClusterManager::get_server_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::GetServerConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServerConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServerConfig(RequestBuilder<crate::model::GetServerConfigRequest>);
 
@@ -1544,6 +1799,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::get_json_web_keys][super::super::client::ClusterManager::get_json_web_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::GetJSONWebKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJSONWebKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJSONWebKeys(RequestBuilder<crate::model::GetJSONWebKeysRequest>);
 
@@ -1589,6 +1859,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::list_node_pools][super::super::client::ClusterManager::list_node_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::ListNodePools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNodePools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNodePools(RequestBuilder<crate::model::ListNodePoolsRequest>);
 
@@ -1655,6 +1940,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::get_node_pool][super::super::client::ClusterManager::get_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::GetNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNodePool(RequestBuilder<crate::model::GetNodePoolRequest>);
 
@@ -1728,6 +2028,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::create_node_pool][super::super::client::ClusterManager::create_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::CreateNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNodePool(RequestBuilder<crate::model::CreateNodePoolRequest>);
 
@@ -1805,6 +2120,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::delete_node_pool][super::super::client::ClusterManager::delete_node_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::DeleteNodePool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNodePool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNodePool(RequestBuilder<crate::model::DeleteNodePoolRequest>);
 
@@ -1878,6 +2208,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::complete_node_pool_upgrade][super::super::client::ClusterManager::complete_node_pool_upgrade] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::CompleteNodePoolUpgrade;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompleteNodePoolUpgrade {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompleteNodePoolUpgrade(
         RequestBuilder<crate::model::CompleteNodePoolUpgradeRequest>,
@@ -1928,6 +2273,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::rollback_node_pool_upgrade][super::super::client::ClusterManager::rollback_node_pool_upgrade] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::RollbackNodePoolUpgrade;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RollbackNodePoolUpgrade {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RollbackNodePoolUpgrade(
         RequestBuilder<crate::model::RollbackNodePoolUpgradeRequest>,
@@ -2012,6 +2372,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_node_pool_management][super::super::client::ClusterManager::set_node_pool_management] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetNodePoolManagement;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetNodePoolManagement {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetNodePoolManagement(RequestBuilder<crate::model::SetNodePoolManagementRequest>);
 
@@ -2099,6 +2474,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_labels][super::super::client::ClusterManager::set_labels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetLabels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetLabels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetLabels(RequestBuilder<crate::model::SetLabelsRequest>);
 
@@ -2187,6 +2577,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_legacy_abac][super::super::client::ClusterManager::set_legacy_abac] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetLegacyAbac;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetLegacyAbac {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetLegacyAbac(RequestBuilder<crate::model::SetLegacyAbacRequest>);
 
@@ -2261,6 +2666,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::start_ip_rotation][super::super::client::ClusterManager::start_ip_rotation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::StartIPRotation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> StartIPRotation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct StartIPRotation(RequestBuilder<crate::model::StartIPRotationRequest>);
 
@@ -2333,6 +2753,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::complete_ip_rotation][super::super::client::ClusterManager::complete_ip_rotation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::CompleteIPRotation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CompleteIPRotation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CompleteIPRotation(RequestBuilder<crate::model::CompleteIPRotationRequest>);
 
@@ -2402,6 +2837,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_node_pool_size][super::super::client::ClusterManager::set_node_pool_size] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetNodePoolSize;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetNodePoolSize {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetNodePoolSize(RequestBuilder<crate::model::SetNodePoolSizeRequest>);
 
@@ -2483,6 +2933,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_network_policy][super::super::client::ClusterManager::set_network_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetNetworkPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetNetworkPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetNetworkPolicy(RequestBuilder<crate::model::SetNetworkPolicyRequest>);
 
@@ -2563,6 +3028,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::set_maintenance_policy][super::super::client::ClusterManager::set_maintenance_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::SetMaintenancePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetMaintenancePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetMaintenancePolicy(RequestBuilder<crate::model::SetMaintenancePolicyRequest>);
 
@@ -2648,6 +3128,25 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::list_usable_subnetworks][super::super::client::ClusterManager::list_usable_subnetworks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::ListUsableSubnetworks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUsableSubnetworks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUsableSubnetworks(RequestBuilder<crate::model::ListUsableSubnetworksRequest>);
 
@@ -2740,6 +3239,21 @@ pub mod cluster_manager {
     }
 
     /// The request builder for [ClusterManager::check_autopilot_compatibility][super::super::client::ClusterManager::check_autopilot_compatibility] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_container_v1::builder;
+    /// use builder::cluster_manager::CheckAutopilotCompatibility;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CheckAutopilotCompatibility {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CheckAutopilotCompatibility(
         RequestBuilder<crate::model::CheckAutopilotCompatibilityRequest>,

--- a/src/generated/datastore/admin/v1/src/builder.rs
+++ b/src/generated/datastore/admin/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::export_entities][super::super::client::DatastoreAdmin::export_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::ExportEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportEntities(RequestBuilder<crate::model::ExportEntitiesRequest>);
 
@@ -185,6 +201,22 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::import_entities][super::super::client::DatastoreAdmin::import_entities] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::ImportEntities;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportEntities {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportEntities(RequestBuilder<crate::model::ImportEntitiesRequest>);
 
@@ -301,6 +333,22 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::create_index][super::super::client::DatastoreAdmin::create_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::CreateIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIndex(RequestBuilder<crate::model::CreateIndexRequest>);
 
@@ -393,6 +441,22 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::delete_index][super::super::client::DatastoreAdmin::delete_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::DeleteIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_datastore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIndex(RequestBuilder<crate::model::DeleteIndexRequest>);
 
@@ -482,6 +546,21 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::get_index][super::super::client::DatastoreAdmin::get_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::GetIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIndex(RequestBuilder<crate::model::GetIndexRequest>);
 
@@ -533,6 +612,25 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::list_indexes][super::super::client::DatastoreAdmin::list_indexes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::ListIndexes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIndexes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIndexes(RequestBuilder<crate::model::ListIndexesRequest>);
 
@@ -620,6 +718,25 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::list_operations][super::super::client::DatastoreAdmin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -712,6 +829,21 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::get_operation][super::super::client::DatastoreAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -760,6 +892,21 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::delete_operation][super::super::client::DatastoreAdmin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -808,6 +955,21 @@ pub mod datastore_admin {
     }
 
     /// The request builder for [DatastoreAdmin::cancel_operation][super::super::client::DatastoreAdmin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_datastore_admin_v1::builder;
+    /// use builder::datastore_admin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/devtools/artifactregistry/v1/src/builder.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_docker_images][super::super::client::ArtifactRegistry::list_docker_images] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListDockerImages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDockerImages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDockerImages(RequestBuilder<crate::model::ListDockerImagesRequest>);
 
@@ -161,6 +180,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_docker_image][super::super::client::ArtifactRegistry::get_docker_image] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetDockerImage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDockerImage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDockerImage(RequestBuilder<crate::model::GetDockerImageRequest>);
 
@@ -208,6 +242,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_maven_artifacts][super::super::client::ArtifactRegistry::list_maven_artifacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListMavenArtifacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMavenArtifacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMavenArtifacts(RequestBuilder<crate::model::ListMavenArtifactsRequest>);
 
@@ -296,6 +349,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_maven_artifact][super::super::client::ArtifactRegistry::get_maven_artifact] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetMavenArtifact;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMavenArtifact {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMavenArtifact(RequestBuilder<crate::model::GetMavenArtifactRequest>);
 
@@ -346,6 +414,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_npm_packages][super::super::client::ArtifactRegistry::list_npm_packages] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListNpmPackages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNpmPackages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNpmPackages(RequestBuilder<crate::model::ListNpmPackagesRequest>);
 
@@ -429,6 +516,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_npm_package][super::super::client::ArtifactRegistry::get_npm_package] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetNpmPackage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNpmPackage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNpmPackage(RequestBuilder<crate::model::GetNpmPackageRequest>);
 
@@ -476,6 +578,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_python_packages][super::super::client::ArtifactRegistry::list_python_packages] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListPythonPackages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPythonPackages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPythonPackages(RequestBuilder<crate::model::ListPythonPackagesRequest>);
 
@@ -564,6 +685,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_python_package][super::super::client::ArtifactRegistry::get_python_package] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetPythonPackage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPythonPackage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPythonPackage(RequestBuilder<crate::model::GetPythonPackageRequest>);
 
@@ -614,6 +750,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::import_apt_artifacts][super::super::client::ArtifactRegistry::import_apt_artifacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ImportAptArtifacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportAptArtifacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportAptArtifacts(RequestBuilder<crate::model::ImportAptArtifactsRequest>);
 
@@ -732,6 +884,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::import_yum_artifacts][super::super::client::ArtifactRegistry::import_yum_artifacts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ImportYumArtifacts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportYumArtifacts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportYumArtifacts(RequestBuilder<crate::model::ImportYumArtifactsRequest>);
 
@@ -850,6 +1018,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_repositories][super::super::client::ArtifactRegistry::list_repositories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListRepositories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRepositories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRepositories(RequestBuilder<crate::model::ListRepositoriesRequest>);
 
@@ -948,6 +1135,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_repository][super::super::client::ArtifactRegistry::get_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRepository(RequestBuilder<crate::model::GetRepositoryRequest>);
 
@@ -995,6 +1197,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::create_repository][super::super::client::ArtifactRegistry::create_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::CreateRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRepository(RequestBuilder<crate::model::CreateRepositoryRequest>);
 
@@ -1102,6 +1320,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_repository][super::super::client::ArtifactRegistry::update_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdateRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRepository(RequestBuilder<crate::model::UpdateRepositoryRequest>);
 
@@ -1162,6 +1395,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::delete_repository][super::super::client::ArtifactRegistry::delete_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::DeleteRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRepository(RequestBuilder<crate::model::DeleteRepositoryRequest>);
 
@@ -1252,6 +1501,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_packages][super::super::client::ArtifactRegistry::list_packages] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListPackages;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPackages {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPackages(RequestBuilder<crate::model::ListPackagesRequest>);
 
@@ -1347,6 +1615,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_package][super::super::client::ArtifactRegistry::get_package] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetPackage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPackage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPackage(RequestBuilder<crate::model::GetPackageRequest>);
 
@@ -1394,6 +1677,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::delete_package][super::super::client::ArtifactRegistry::delete_package] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::DeletePackage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePackage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePackage(RequestBuilder<crate::model::DeletePackageRequest>);
 
@@ -1481,6 +1780,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_versions][super::super::client::ArtifactRegistry::list_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListVersions(RequestBuilder<crate::model::ListVersionsRequest>);
 
@@ -1580,6 +1898,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_version][super::super::client::ArtifactRegistry::get_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVersion(RequestBuilder<crate::model::GetVersionRequest>);
 
@@ -1631,6 +1964,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::delete_version][super::super::client::ArtifactRegistry::delete_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::DeleteVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteVersion(RequestBuilder<crate::model::DeleteVersionRequest>);
 
@@ -1722,6 +2071,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::batch_delete_versions][super::super::client::ArtifactRegistry::batch_delete_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::BatchDeleteVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchDeleteVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchDeleteVersions(RequestBuilder<crate::model::BatchDeleteVersionsRequest>);
 
@@ -1830,6 +2195,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_version][super::super::client::ArtifactRegistry::update_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdateVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVersion(RequestBuilder<crate::model::UpdateVersionRequest>);
 
@@ -1889,6 +2269,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_files][super::super::client::ArtifactRegistry::list_files] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListFiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFiles(RequestBuilder<crate::model::ListFilesRequest>);
 
@@ -1984,6 +2383,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_file][super::super::client::ArtifactRegistry::get_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFile(RequestBuilder<crate::model::GetFileRequest>);
 
@@ -2031,6 +2445,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::delete_file][super::super::client::ArtifactRegistry::delete_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::DeleteFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFile(RequestBuilder<crate::model::DeleteFileRequest>);
 
@@ -2118,6 +2548,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_file][super::super::client::ArtifactRegistry::update_file] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdateFile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateFile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateFile(RequestBuilder<crate::model::UpdateFileRequest>);
 
@@ -2176,6 +2621,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_tags][super::super::client::ArtifactRegistry::list_tags] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListTags;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTags {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTags(RequestBuilder<crate::model::ListTagsRequest>);
 
@@ -2263,6 +2727,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_tag][super::super::client::ArtifactRegistry::get_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTag(RequestBuilder<crate::model::GetTagRequest>);
 
@@ -2308,6 +2787,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::create_tag][super::super::client::ArtifactRegistry::create_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::CreateTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTag(RequestBuilder<crate::model::CreateTagRequest>);
 
@@ -2365,6 +2859,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_tag][super::super::client::ArtifactRegistry::update_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdateTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTag(RequestBuilder<crate::model::UpdateTagRequest>);
 
@@ -2419,6 +2928,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::delete_tag][super::super::client::ArtifactRegistry::delete_tag] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::DeleteTag;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTag {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTag(RequestBuilder<crate::model::DeleteTagRequest>);
 
@@ -2464,6 +2988,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::create_rule][super::super::client::ArtifactRegistry::create_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::CreateRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRule(RequestBuilder<crate::model::CreateRuleRequest>);
 
@@ -2523,6 +3062,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_rules][super::super::client::ArtifactRegistry::list_rules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListRules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRules(RequestBuilder<crate::model::ListRulesRequest>);
 
@@ -2606,6 +3164,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_rule][super::super::client::ArtifactRegistry::get_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRule(RequestBuilder<crate::model::GetRuleRequest>);
 
@@ -2653,6 +3226,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_rule][super::super::client::ArtifactRegistry::update_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdateRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRule(RequestBuilder<crate::model::UpdateRuleRequest>);
 
@@ -2707,6 +3295,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::delete_rule][super::super::client::ArtifactRegistry::delete_rule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::DeleteRule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRule(RequestBuilder<crate::model::DeleteRuleRequest>);
 
@@ -2754,6 +3357,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::set_iam_policy][super::super::client::ArtifactRegistry::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2821,6 +3439,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_iam_policy][super::super::client::ArtifactRegistry::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2877,6 +3510,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::test_iam_permissions][super::super::client::ArtifactRegistry::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2940,6 +3588,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_project_settings][super::super::client::ArtifactRegistry::get_project_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetProjectSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProjectSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProjectSettings(RequestBuilder<crate::model::GetProjectSettingsRequest>);
 
@@ -2990,6 +3653,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_project_settings][super::super::client::ArtifactRegistry::update_project_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdateProjectSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProjectSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProjectSettings(RequestBuilder<crate::model::UpdateProjectSettingsRequest>);
 
@@ -3050,6 +3728,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_vpcsc_config][super::super::client::ArtifactRegistry::get_vpcsc_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetVPCSCConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVPCSCConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVPCSCConfig(RequestBuilder<crate::model::GetVPCSCConfigRequest>);
 
@@ -3097,6 +3790,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_vpcsc_config][super::super::client::ArtifactRegistry::update_vpcsc_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdateVPCSCConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateVPCSCConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateVPCSCConfig(RequestBuilder<crate::model::UpdateVPCSCConfigRequest>);
 
@@ -3157,6 +3865,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::update_package][super::super::client::ArtifactRegistry::update_package] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::UpdatePackage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePackage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePackage(RequestBuilder<crate::model::UpdatePackageRequest>);
 
@@ -3214,6 +3937,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_attachments][super::super::client::ArtifactRegistry::list_attachments] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListAttachments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAttachments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAttachments(RequestBuilder<crate::model::ListAttachmentsRequest>);
 
@@ -3303,6 +4045,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_attachment][super::super::client::ArtifactRegistry::get_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAttachment(RequestBuilder<crate::model::GetAttachmentRequest>);
 
@@ -3350,6 +4107,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::create_attachment][super::super::client::ArtifactRegistry::create_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::CreateAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAttachment(RequestBuilder<crate::model::CreateAttachmentRequest>);
 
@@ -3457,6 +4230,22 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::delete_attachment][super::super::client::ArtifactRegistry::delete_attachment] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::DeleteAttachment;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_artifactregistry_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAttachment {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAttachment(RequestBuilder<crate::model::DeleteAttachmentRequest>);
 
@@ -3547,6 +4336,25 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::list_locations][super::super::client::ArtifactRegistry::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3637,6 +4445,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_location][super::super::client::ArtifactRegistry::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3682,6 +4505,21 @@ pub mod artifact_registry {
     }
 
     /// The request builder for [ArtifactRegistry::get_operation][super::super::client::ArtifactRegistry::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_artifactregistry_v1::builder;
+    /// use builder::artifact_registry::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/devtools/cloudbuild/v1/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::create_build][super::super::client::CloudBuild::create_build] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::CreateBuild;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBuild {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBuild(RequestBuilder<crate::model::CreateBuildRequest>);
 
@@ -171,6 +187,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::get_build][super::super::client::CloudBuild::get_build] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::GetBuild;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBuild {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBuild(RequestBuilder<crate::model::GetBuildRequest>);
 
@@ -232,6 +263,25 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::list_builds][super::super::client::CloudBuild::list_builds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::ListBuilds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBuilds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBuilds(RequestBuilder<crate::model::ListBuildsRequest>);
 
@@ -327,6 +377,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::cancel_build][super::super::client::CloudBuild::cancel_build] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::CancelBuild;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelBuild {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelBuild(RequestBuilder<crate::model::CancelBuildRequest>);
 
@@ -388,6 +453,22 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::retry_build][super::super::client::CloudBuild::retry_build] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::RetryBuild;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RetryBuild {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RetryBuild(RequestBuilder<crate::model::RetryBuildRequest>);
 
@@ -487,6 +568,22 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::approve_build][super::super::client::CloudBuild::approve_build] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::ApproveBuild;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ApproveBuild {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ApproveBuild(RequestBuilder<crate::model::ApproveBuildRequest>);
 
@@ -581,6 +678,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::create_build_trigger][super::super::client::CloudBuild::create_build_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::CreateBuildTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBuildTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBuildTrigger(RequestBuilder<crate::model::CreateBuildTriggerRequest>);
 
@@ -648,6 +760,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::get_build_trigger][super::super::client::CloudBuild::get_build_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::GetBuildTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBuildTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBuildTrigger(RequestBuilder<crate::model::GetBuildTriggerRequest>);
 
@@ -709,6 +836,25 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::list_build_triggers][super::super::client::CloudBuild::list_build_triggers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::ListBuildTriggers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBuildTriggers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBuildTriggers(RequestBuilder<crate::model::ListBuildTriggersRequest>);
 
@@ -801,6 +947,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::delete_build_trigger][super::super::client::CloudBuild::delete_build_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::DeleteBuildTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBuildTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBuildTrigger(RequestBuilder<crate::model::DeleteBuildTriggerRequest>);
 
@@ -865,6 +1026,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::update_build_trigger][super::super::client::CloudBuild::update_build_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::UpdateBuildTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBuildTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBuildTrigger(RequestBuilder<crate::model::UpdateBuildTriggerRequest>);
 
@@ -943,6 +1119,22 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::run_build_trigger][super::super::client::CloudBuild::run_build_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::RunBuildTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunBuildTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunBuildTrigger(RequestBuilder<crate::model::RunBuildTriggerRequest>);
 
@@ -1051,6 +1243,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::receive_trigger_webhook][super::super::client::CloudBuild::receive_trigger_webhook] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::ReceiveTriggerWebhook;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReceiveTriggerWebhook {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReceiveTriggerWebhook(RequestBuilder<crate::model::ReceiveTriggerWebhookRequest>);
 
@@ -1126,6 +1333,22 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::create_worker_pool][super::super::client::CloudBuild::create_worker_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::CreateWorkerPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateWorkerPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateWorkerPool(RequestBuilder<crate::model::CreateWorkerPoolRequest>);
 
@@ -1242,6 +1465,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::get_worker_pool][super::super::client::CloudBuild::get_worker_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::GetWorkerPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetWorkerPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetWorkerPool(RequestBuilder<crate::model::GetWorkerPoolRequest>);
 
@@ -1289,6 +1527,22 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::delete_worker_pool][super::super::client::CloudBuild::delete_worker_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::DeleteWorkerPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteWorkerPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteWorkerPool(RequestBuilder<crate::model::DeleteWorkerPoolRequest>);
 
@@ -1402,6 +1656,22 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::update_worker_pool][super::super::client::CloudBuild::update_worker_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::UpdateWorkerPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateWorkerPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateWorkerPool(RequestBuilder<crate::model::UpdateWorkerPoolRequest>);
 
@@ -1511,6 +1781,25 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::list_worker_pools][super::super::client::CloudBuild::list_worker_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::ListWorkerPools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListWorkerPools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListWorkerPools(RequestBuilder<crate::model::ListWorkerPoolsRequest>);
 
@@ -1594,6 +1883,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::get_operation][super::super::client::CloudBuild::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1642,6 +1946,21 @@ pub mod cloud_build {
     }
 
     /// The request builder for [CloudBuild::cancel_operation][super::super::client::CloudBuild::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v1::builder;
+    /// use builder::cloud_build::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/devtools/cloudbuild/v2/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builder.rs
@@ -69,6 +69,22 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::create_connection][super::super::client::RepositoryManager::create_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::CreateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -176,6 +192,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::get_connection][super::super::client::RepositoryManager::get_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::GetConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -223,6 +254,25 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::list_connections][super::super::client::RepositoryManager::list_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::ListConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -306,6 +356,22 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::update_connection][super::super::client::RepositoryManager::update_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::UpdateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 
@@ -418,6 +484,22 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::delete_connection][super::super::client::RepositoryManager::delete_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::DeleteConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -520,6 +602,22 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::create_repository][super::super::client::RepositoryManager::create_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::CreateRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRepository(RequestBuilder<crate::model::CreateRepositoryRequest>);
 
@@ -627,6 +725,22 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::batch_create_repositories][super::super::client::RepositoryManager::batch_create_repositories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::BatchCreateRepositories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateRepositories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateRepositories(
         RequestBuilder<crate::model::BatchCreateRepositoriesRequest>,
@@ -735,6 +849,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::get_repository][super::super::client::RepositoryManager::get_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::GetRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRepository(RequestBuilder<crate::model::GetRepositoryRequest>);
 
@@ -782,6 +911,25 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::list_repositories][super::super::client::RepositoryManager::list_repositories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::ListRepositories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRepositories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRepositories(RequestBuilder<crate::model::ListRepositoriesRequest>);
 
@@ -874,6 +1022,22 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::delete_repository][super::super::client::RepositoryManager::delete_repository] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::DeleteRepository;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_build_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRepository {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRepository(RequestBuilder<crate::model::DeleteRepositoryRequest>);
 
@@ -976,6 +1140,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::fetch_read_write_token][super::super::client::RepositoryManager::fetch_read_write_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::FetchReadWriteToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchReadWriteToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchReadWriteToken(RequestBuilder<crate::model::FetchReadWriteTokenRequest>);
 
@@ -1026,6 +1205,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::fetch_read_token][super::super::client::RepositoryManager::fetch_read_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::FetchReadToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchReadToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchReadToken(RequestBuilder<crate::model::FetchReadTokenRequest>);
 
@@ -1073,6 +1267,25 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::fetch_linkable_repositories][super::super::client::RepositoryManager::fetch_linkable_repositories] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::FetchLinkableRepositories;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchLinkableRepositories {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchLinkableRepositories(
         RequestBuilder<crate::model::FetchLinkableRepositoriesRequest>,
@@ -1165,6 +1378,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::fetch_git_refs][super::super::client::RepositoryManager::fetch_git_refs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::FetchGitRefs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FetchGitRefs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FetchGitRefs(RequestBuilder<crate::model::FetchGitRefsRequest>);
 
@@ -1221,6 +1449,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::set_iam_policy][super::super::client::RepositoryManager::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1288,6 +1531,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::get_iam_policy][super::super::client::RepositoryManager::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1344,6 +1602,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::test_iam_permissions][super::super::client::RepositoryManager::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1407,6 +1680,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::get_operation][super::super::client::RepositoryManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1455,6 +1743,21 @@ pub mod repository_manager {
     }
 
     /// The request builder for [RepositoryManager::cancel_operation][super::super::client::RepositoryManager::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_build_v2::builder;
+    /// use builder::repository_manager::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/devtools/cloudprofiler/v2/src/builder.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod profiler_service {
     }
 
     /// The request builder for [ProfilerService::create_profile][super::super::client::ProfilerService::create_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_profiler_v2::builder;
+    /// use builder::profiler_service::CreateProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateProfile(RequestBuilder<crate::model::CreateProfileRequest>);
 
@@ -134,6 +149,21 @@ pub mod profiler_service {
     }
 
     /// The request builder for [ProfilerService::create_offline_profile][super::super::client::ProfilerService::create_offline_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_profiler_v2::builder;
+    /// use builder::profiler_service::CreateOfflineProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateOfflineProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateOfflineProfile(RequestBuilder<crate::model::CreateOfflineProfileRequest>);
 
@@ -191,6 +221,21 @@ pub mod profiler_service {
     }
 
     /// The request builder for [ProfilerService::update_profile][super::super::client::ProfilerService::update_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_profiler_v2::builder;
+    /// use builder::profiler_service::UpdateProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateProfile(RequestBuilder<crate::model::UpdateProfileRequest>);
 
@@ -303,6 +348,25 @@ pub mod export_service {
     }
 
     /// The request builder for [ExportService::list_profiles][super::super::client::ExportService::list_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_profiler_v2::builder;
+    /// use builder::export_service::ListProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProfiles(RequestBuilder<crate::model::ListProfilesRequest>);
 

--- a/src/generated/devtools/cloudtrace/v2/src/builder.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod trace_service {
     }
 
     /// The request builder for [TraceService::batch_write_spans][super::super::client::TraceService::batch_write_spans] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_trace_v2::builder;
+    /// use builder::trace_service::BatchWriteSpans;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchWriteSpans {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchWriteSpans(RequestBuilder<crate::model::BatchWriteSpansRequest>);
 
@@ -129,6 +144,21 @@ pub mod trace_service {
     }
 
     /// The request builder for [TraceService::create_span][super::super::client::TraceService::create_span] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_trace_v2::builder;
+    /// use builder::trace_service::CreateSpan;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSpan {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSpan(RequestBuilder<crate::model::Span>);
 

--- a/src/generated/devtools/containeranalysis/v1/src/builder.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod container_analysis {
     }
 
     /// The request builder for [ContainerAnalysis::set_iam_policy][super::super::client::ContainerAnalysis::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_containeranalysis_v1::builder;
+    /// use builder::container_analysis::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -136,6 +151,21 @@ pub mod container_analysis {
     }
 
     /// The request builder for [ContainerAnalysis::get_iam_policy][super::super::client::ContainerAnalysis::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_containeranalysis_v1::builder;
+    /// use builder::container_analysis::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -192,6 +222,21 @@ pub mod container_analysis {
     }
 
     /// The request builder for [ContainerAnalysis::test_iam_permissions][super::super::client::ContainerAnalysis::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_containeranalysis_v1::builder;
+    /// use builder::container_analysis::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -255,6 +300,21 @@ pub mod container_analysis {
     }
 
     /// The request builder for [ContainerAnalysis::get_vulnerability_occurrences_summary][super::super::client::ContainerAnalysis::get_vulnerability_occurrences_summary] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_containeranalysis_v1::builder;
+    /// use builder::container_analysis::GetVulnerabilityOccurrencesSummary;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetVulnerabilityOccurrencesSummary {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetVulnerabilityOccurrencesSummary(
         RequestBuilder<crate::model::GetVulnerabilityOccurrencesSummaryRequest>,
@@ -313,6 +373,21 @@ pub mod container_analysis {
     }
 
     /// The request builder for [ContainerAnalysis::export_sbom][super::super::client::ContainerAnalysis::export_sbom] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_containeranalysis_v1::builder;
+    /// use builder::container_analysis::ExportSBOM;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportSBOM {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportSBOM(RequestBuilder<crate::model::ExportSBOMRequest>);
 

--- a/src/generated/firestore/admin/v1/src/builder.rs
+++ b/src/generated/firestore/admin/v1/src/builder.rs
@@ -69,6 +69,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::create_index][super::super::client::FirestoreAdmin::create_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::CreateIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateIndex(RequestBuilder<crate::model::CreateIndexRequest>);
 
@@ -165,6 +181,25 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::list_indexes][super::super::client::FirestoreAdmin::list_indexes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ListIndexes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListIndexes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListIndexes(RequestBuilder<crate::model::ListIndexesRequest>);
 
@@ -254,6 +289,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::get_index][super::super::client::FirestoreAdmin::get_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::GetIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIndex(RequestBuilder<crate::model::GetIndexRequest>);
 
@@ -301,6 +351,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::delete_index][super::super::client::FirestoreAdmin::delete_index] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::DeleteIndex;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteIndex {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteIndex(RequestBuilder<crate::model::DeleteIndexRequest>);
 
@@ -348,6 +413,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::get_field][super::super::client::FirestoreAdmin::get_field] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::GetField;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetField {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetField(RequestBuilder<crate::model::GetFieldRequest>);
 
@@ -395,6 +475,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::update_field][super::super::client::FirestoreAdmin::update_field] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::UpdateField;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateField {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateField(RequestBuilder<crate::model::UpdateFieldRequest>);
 
@@ -492,6 +588,25 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::list_fields][super::super::client::FirestoreAdmin::list_fields] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ListFields;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFields {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFields(RequestBuilder<crate::model::ListFieldsRequest>);
 
@@ -581,6 +696,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::export_documents][super::super::client::FirestoreAdmin::export_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ExportDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ExportDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ExportDocuments(RequestBuilder<crate::model::ExportDocumentsRequest>);
 
@@ -706,6 +837,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::import_documents][super::super::client::FirestoreAdmin::import_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ImportDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ImportDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ImportDocuments(RequestBuilder<crate::model::ImportDocumentsRequest>);
 
@@ -822,6 +969,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::bulk_delete_documents][super::super::client::FirestoreAdmin::bulk_delete_documents] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::BulkDeleteDocuments;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BulkDeleteDocuments {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BulkDeleteDocuments(RequestBuilder<crate::model::BulkDeleteDocumentsRequest>);
 
@@ -937,6 +1100,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::create_database][super::super::client::FirestoreAdmin::create_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::CreateDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDatabase(RequestBuilder<crate::model::CreateDatabaseRequest>);
 
@@ -1044,6 +1223,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::get_database][super::super::client::FirestoreAdmin::get_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::GetDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDatabase(RequestBuilder<crate::model::GetDatabaseRequest>);
 
@@ -1091,6 +1285,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::list_databases][super::super::client::FirestoreAdmin::list_databases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ListDatabases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatabases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatabases(RequestBuilder<crate::model::ListDatabasesRequest>);
 
@@ -1144,6 +1353,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::update_database][super::super::client::FirestoreAdmin::update_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::UpdateDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDatabase(RequestBuilder<crate::model::UpdateDatabaseRequest>);
 
@@ -1244,6 +1469,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::delete_database][super::super::client::FirestoreAdmin::delete_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::DeleteDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDatabase(RequestBuilder<crate::model::DeleteDatabaseRequest>);
 
@@ -1338,6 +1579,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::create_user_creds][super::super::client::FirestoreAdmin::create_user_creds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::CreateUserCreds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateUserCreds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateUserCreds(RequestBuilder<crate::model::CreateUserCredsRequest>);
 
@@ -1404,6 +1660,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::get_user_creds][super::super::client::FirestoreAdmin::get_user_creds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::GetUserCreds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetUserCreds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetUserCreds(RequestBuilder<crate::model::GetUserCredsRequest>);
 
@@ -1451,6 +1722,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::list_user_creds][super::super::client::FirestoreAdmin::list_user_creds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ListUserCreds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUserCreds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUserCreds(RequestBuilder<crate::model::ListUserCredsRequest>);
 
@@ -1498,6 +1784,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::enable_user_creds][super::super::client::FirestoreAdmin::enable_user_creds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::EnableUserCreds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableUserCreds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableUserCreds(RequestBuilder<crate::model::EnableUserCredsRequest>);
 
@@ -1545,6 +1846,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::disable_user_creds][super::super::client::FirestoreAdmin::disable_user_creds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::DisableUserCreds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableUserCreds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableUserCreds(RequestBuilder<crate::model::DisableUserCredsRequest>);
 
@@ -1595,6 +1911,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::reset_user_password][super::super::client::FirestoreAdmin::reset_user_password] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ResetUserPassword;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResetUserPassword {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResetUserPassword(RequestBuilder<crate::model::ResetUserPasswordRequest>);
 
@@ -1645,6 +1976,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::delete_user_creds][super::super::client::FirestoreAdmin::delete_user_creds] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::DeleteUserCreds;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteUserCreds {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteUserCreds(RequestBuilder<crate::model::DeleteUserCredsRequest>);
 
@@ -1692,6 +2038,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::get_backup][super::super::client::FirestoreAdmin::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1739,6 +2100,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::list_backups][super::super::client::FirestoreAdmin::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1792,6 +2168,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::delete_backup][super::super::client::FirestoreAdmin::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1839,6 +2230,22 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::restore_database][super::super::client::FirestoreAdmin::restore_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::RestoreDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_firestore_admin_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreDatabase(RequestBuilder<crate::model::RestoreDatabaseRequest>);
 
@@ -1954,6 +2361,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::create_backup_schedule][super::super::client::FirestoreAdmin::create_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::CreateBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupSchedule(RequestBuilder<crate::model::CreateBackupScheduleRequest>);
 
@@ -2015,6 +2437,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::get_backup_schedule][super::super::client::FirestoreAdmin::get_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::GetBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupSchedule(RequestBuilder<crate::model::GetBackupScheduleRequest>);
 
@@ -2065,6 +2502,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::list_backup_schedules][super::super::client::FirestoreAdmin::list_backup_schedules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ListBackupSchedules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupSchedules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupSchedules(RequestBuilder<crate::model::ListBackupSchedulesRequest>);
 
@@ -2115,6 +2567,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::update_backup_schedule][super::super::client::FirestoreAdmin::update_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::UpdateBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackupSchedule(RequestBuilder<crate::model::UpdateBackupScheduleRequest>);
 
@@ -2177,6 +2644,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::delete_backup_schedule][super::super::client::FirestoreAdmin::delete_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::DeleteBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupSchedule(RequestBuilder<crate::model::DeleteBackupScheduleRequest>);
 
@@ -2227,6 +2709,25 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::list_operations][super::super::client::FirestoreAdmin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2319,6 +2820,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::get_operation][super::super::client::FirestoreAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2367,6 +2883,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::delete_operation][super::super::client::FirestoreAdmin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2415,6 +2946,21 @@ pub mod firestore_admin {
     }
 
     /// The request builder for [FirestoreAdmin::cancel_operation][super::super::client::FirestoreAdmin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_firestore_admin_v1::builder;
+    /// use builder::firestore_admin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/grafeas/v1/src/builder.rs
+++ b/src/generated/grafeas/v1/src/builder.rs
@@ -67,6 +67,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::get_occurrence][super::super::client::Grafeas::get_occurrence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::GetOccurrence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOccurrence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOccurrence(RequestBuilder<crate::model::GetOccurrenceRequest>);
 
@@ -112,6 +127,25 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::list_occurrences][super::super::client::Grafeas::list_occurrences] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::ListOccurrences;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOccurrences {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOccurrences(RequestBuilder<crate::model::ListOccurrencesRequest>);
 
@@ -199,6 +233,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::delete_occurrence][super::super::client::Grafeas::delete_occurrence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::DeleteOccurrence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOccurrence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOccurrence(RequestBuilder<crate::model::DeleteOccurrenceRequest>);
 
@@ -247,6 +296,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::create_occurrence][super::super::client::Grafeas::create_occurrence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::CreateOccurrence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateOccurrence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateOccurrence(RequestBuilder<crate::model::CreateOccurrenceRequest>);
 
@@ -306,6 +370,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::batch_create_occurrences][super::super::client::Grafeas::batch_create_occurrences] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::BatchCreateOccurrences;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateOccurrences {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateOccurrences(RequestBuilder<crate::model::BatchCreateOccurrencesRequest>);
 
@@ -367,6 +446,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::update_occurrence][super::super::client::Grafeas::update_occurrence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::UpdateOccurrence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateOccurrence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateOccurrence(RequestBuilder<crate::model::UpdateOccurrenceRequest>);
 
@@ -435,6 +529,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::get_occurrence_note][super::super::client::Grafeas::get_occurrence_note] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::GetOccurrenceNote;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOccurrenceNote {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOccurrenceNote(RequestBuilder<crate::model::GetOccurrenceNoteRequest>);
 
@@ -483,6 +592,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::get_note][super::super::client::Grafeas::get_note] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::GetNote;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNote {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNote(RequestBuilder<crate::model::GetNoteRequest>);
 
@@ -528,6 +652,25 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::list_notes][super::super::client::Grafeas::list_notes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::ListNotes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotes(RequestBuilder<crate::model::ListNotesRequest>);
 
@@ -615,6 +758,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::delete_note][super::super::client::Grafeas::delete_note] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::DeleteNote;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNote {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNote(RequestBuilder<crate::model::DeleteNoteRequest>);
 
@@ -660,6 +818,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::create_note][super::super::client::Grafeas::create_note] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::CreateNote;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNote {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNote(RequestBuilder<crate::model::CreateNoteRequest>);
 
@@ -721,6 +894,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::batch_create_notes][super::super::client::Grafeas::batch_create_notes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::BatchCreateNotes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> BatchCreateNotes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct BatchCreateNotes(RequestBuilder<crate::model::BatchCreateNotesRequest>);
 
@@ -782,6 +970,21 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::update_note][super::super::client::Grafeas::update_note] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::UpdateNote;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNote {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNote(RequestBuilder<crate::model::UpdateNoteRequest>);
 
@@ -844,6 +1047,25 @@ pub mod grafeas {
     }
 
     /// The request builder for [Grafeas::list_note_occurrences][super::super::client::Grafeas::list_note_occurrences] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_grafeas_v1::builder;
+    /// use builder::grafeas::ListNoteOccurrences;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNoteOccurrences {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNoteOccurrences(RequestBuilder<crate::model::ListNoteOccurrencesRequest>);
 

--- a/src/generated/iam/admin/v1/src/builder.rs
+++ b/src/generated/iam/admin/v1/src/builder.rs
@@ -67,6 +67,25 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::list_service_accounts][super::super::client::Iam::list_service_accounts] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::ListServiceAccounts;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceAccounts {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceAccounts(RequestBuilder<crate::model::ListServiceAccountsRequest>);
 
@@ -153,6 +172,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::get_service_account][super::super::client::Iam::get_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::GetServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceAccount(RequestBuilder<crate::model::GetServiceAccountRequest>);
 
@@ -201,6 +235,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::create_service_account][super::super::client::Iam::create_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::CreateServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceAccount(RequestBuilder<crate::model::CreateServiceAccountRequest>);
 
@@ -266,6 +315,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::update_service_account][super::super::client::Iam::update_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::UpdateServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServiceAccount(RequestBuilder<crate::model::ServiceAccount>);
 
@@ -358,6 +422,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::patch_service_account][super::super::client::Iam::patch_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::PatchServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PatchServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PatchServiceAccount(RequestBuilder<crate::model::PatchServiceAccountRequest>);
 
@@ -416,6 +495,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::delete_service_account][super::super::client::Iam::delete_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::DeleteServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceAccount(RequestBuilder<crate::model::DeleteServiceAccountRequest>);
 
@@ -464,6 +558,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::undelete_service_account][super::super::client::Iam::undelete_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::UndeleteServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteServiceAccount(RequestBuilder<crate::model::UndeleteServiceAccountRequest>);
 
@@ -510,6 +619,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::enable_service_account][super::super::client::Iam::enable_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::EnableServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableServiceAccount(RequestBuilder<crate::model::EnableServiceAccountRequest>);
 
@@ -556,6 +680,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::disable_service_account][super::super::client::Iam::disable_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::DisableServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableServiceAccount(RequestBuilder<crate::model::DisableServiceAccountRequest>);
 
@@ -602,6 +741,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::list_service_account_keys][super::super::client::Iam::list_service_account_keys] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::ListServiceAccountKeys;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceAccountKeys {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceAccountKeys(RequestBuilder<crate::model::ListServiceAccountKeysRequest>);
 
@@ -661,6 +815,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::get_service_account_key][super::super::client::Iam::get_service_account_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::GetServiceAccountKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceAccountKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceAccountKey(RequestBuilder<crate::model::GetServiceAccountKeyRequest>);
 
@@ -718,6 +887,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::create_service_account_key][super::super::client::Iam::create_service_account_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::CreateServiceAccountKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceAccountKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceAccountKey(
         RequestBuilder<crate::model::CreateServiceAccountKeyRequest>,
@@ -786,6 +970,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::upload_service_account_key][super::super::client::Iam::upload_service_account_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::UploadServiceAccountKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UploadServiceAccountKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UploadServiceAccountKey(
         RequestBuilder<crate::model::UploadServiceAccountKeyRequest>,
@@ -840,6 +1039,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::delete_service_account_key][super::super::client::Iam::delete_service_account_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::DeleteServiceAccountKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceAccountKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceAccountKey(
         RequestBuilder<crate::model::DeleteServiceAccountKeyRequest>,
@@ -890,6 +1104,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::disable_service_account_key][super::super::client::Iam::disable_service_account_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::DisableServiceAccountKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableServiceAccountKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableServiceAccountKey(
         RequestBuilder<crate::model::DisableServiceAccountKeyRequest>,
@@ -940,6 +1169,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::enable_service_account_key][super::super::client::Iam::enable_service_account_key] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::EnableServiceAccountKey;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableServiceAccountKey {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableServiceAccountKey(
         RequestBuilder<crate::model::EnableServiceAccountKeyRequest>,
@@ -990,6 +1234,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::sign_blob][super::super::client::Iam::sign_blob] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::SignBlob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SignBlob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SignBlob(RequestBuilder<crate::model::SignBlobRequest>);
 
@@ -1045,6 +1304,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::sign_jwt][super::super::client::Iam::sign_jwt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::SignJwt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SignJwt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SignJwt(RequestBuilder<crate::model::SignJwtRequest>);
 
@@ -1100,6 +1374,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::get_iam_policy][super::super::client::Iam::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1154,6 +1443,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::set_iam_policy][super::super::client::Iam::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1219,6 +1523,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::test_iam_permissions][super::super::client::Iam::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1280,6 +1599,25 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::query_grantable_roles][super::super::client::Iam::query_grantable_roles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::QueryGrantableRoles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryGrantableRoles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryGrantableRoles(RequestBuilder<crate::model::QueryGrantableRolesRequest>);
 
@@ -1372,6 +1710,25 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::list_roles][super::super::client::Iam::list_roles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::ListRoles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRoles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRoles(RequestBuilder<crate::model::ListRolesRequest>);
 
@@ -1463,6 +1820,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::get_role][super::super::client::Iam::get_role] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::GetRole;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRole {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRole(RequestBuilder<crate::model::GetRoleRequest>);
 
@@ -1506,6 +1878,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::create_role][super::super::client::Iam::create_role] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::CreateRole;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRole {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRole(RequestBuilder<crate::model::CreateRoleRequest>);
 
@@ -1561,6 +1948,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::update_role][super::super::client::Iam::update_role] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::UpdateRole;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRole {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRole(RequestBuilder<crate::model::UpdateRoleRequest>);
 
@@ -1619,6 +2021,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::delete_role][super::super::client::Iam::delete_role] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::DeleteRole;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRole {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRole(RequestBuilder<crate::model::DeleteRoleRequest>);
 
@@ -1668,6 +2085,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::undelete_role][super::super::client::Iam::undelete_role] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::UndeleteRole;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteRole {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteRole(RequestBuilder<crate::model::UndeleteRoleRequest>);
 
@@ -1717,6 +2149,25 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::query_testable_permissions][super::super::client::Iam::query_testable_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::QueryTestablePermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryTestablePermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryTestablePermissions(
         RequestBuilder<crate::model::QueryTestablePermissionsRequest>,
@@ -1805,6 +2256,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::query_auditable_services][super::super::client::Iam::query_auditable_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::QueryAuditableServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryAuditableServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryAuditableServices(RequestBuilder<crate::model::QueryAuditableServicesRequest>);
 
@@ -1851,6 +2317,21 @@ pub mod iam {
     }
 
     /// The request builder for [Iam::lint_policy][super::super::client::Iam::lint_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_admin_v1::builder;
+    /// use builder::iam::LintPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> LintPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct LintPolicy(RequestBuilder<crate::model::LintPolicyRequest>);
 

--- a/src/generated/iam/credentials/v1/src/builder.rs
+++ b/src/generated/iam/credentials/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod iam_credentials {
     }
 
     /// The request builder for [IAMCredentials::generate_access_token][super::super::client::IAMCredentials::generate_access_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_credentials_v1::builder;
+    /// use builder::iam_credentials::GenerateAccessToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateAccessToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateAccessToken(RequestBuilder<crate::model::GenerateAccessTokenRequest>);
 
@@ -149,6 +164,21 @@ pub mod iam_credentials {
     }
 
     /// The request builder for [IAMCredentials::generate_id_token][super::super::client::IAMCredentials::generate_id_token] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_credentials_v1::builder;
+    /// use builder::iam_credentials::GenerateIdToken;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GenerateIdToken {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GenerateIdToken(RequestBuilder<crate::model::GenerateIdTokenRequest>);
 
@@ -221,6 +251,21 @@ pub mod iam_credentials {
     }
 
     /// The request builder for [IAMCredentials::sign_blob][super::super::client::IAMCredentials::sign_blob] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_credentials_v1::builder;
+    /// use builder::iam_credentials::SignBlob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SignBlob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SignBlob(RequestBuilder<crate::model::SignBlobRequest>);
 
@@ -287,6 +332,21 @@ pub mod iam_credentials {
     }
 
     /// The request builder for [IAMCredentials::sign_jwt][super::super::client::IAMCredentials::sign_jwt] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_credentials_v1::builder;
+    /// use builder::iam_credentials::SignJwt;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SignJwt {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SignJwt(RequestBuilder<crate::model::SignJwtRequest>);
 

--- a/src/generated/iam/v1/src/builder.rs
+++ b/src/generated/iam/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod iam_policy {
     }
 
     /// The request builder for [IAMPolicy::set_iam_policy][super::super::client::IAMPolicy::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v1::builder;
+    /// use builder::iam_policy::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -136,6 +151,21 @@ pub mod iam_policy {
     }
 
     /// The request builder for [IAMPolicy::get_iam_policy][super::super::client::IAMPolicy::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v1::builder;
+    /// use builder::iam_policy::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -192,6 +222,21 @@ pub mod iam_policy {
     }
 
     /// The request builder for [IAMPolicy::test_iam_permissions][super::super::client::IAMPolicy::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v1::builder;
+    /// use builder::iam_policy::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 

--- a/src/generated/iam/v2/src/builder.rs
+++ b/src/generated/iam/v2/src/builder.rs
@@ -67,6 +67,25 @@ pub mod policies {
     }
 
     /// The request builder for [Policies::list_policies][super::super::client::Policies::list_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v2::builder;
+    /// use builder::policies::ListPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPolicies(RequestBuilder<crate::model::ListPoliciesRequest>);
 
@@ -148,6 +167,21 @@ pub mod policies {
     }
 
     /// The request builder for [Policies::get_policy][super::super::client::Policies::get_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v2::builder;
+    /// use builder::policies::GetPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPolicy(RequestBuilder<crate::model::GetPolicyRequest>);
 
@@ -193,6 +227,22 @@ pub mod policies {
     }
 
     /// The request builder for [Policies::create_policy][super::super::client::Policies::create_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v2::builder;
+    /// use builder::policies::CreatePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePolicy(RequestBuilder<crate::model::CreatePolicyRequest>);
 
@@ -295,6 +345,22 @@ pub mod policies {
     }
 
     /// The request builder for [Policies::update_policy][super::super::client::Policies::update_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v2::builder;
+    /// use builder::policies::UpdatePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePolicy(RequestBuilder<crate::model::UpdatePolicyRequest>);
 
@@ -383,6 +449,22 @@ pub mod policies {
     }
 
     /// The request builder for [Policies::delete_policy][super::super::client::Policies::delete_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v2::builder;
+    /// use builder::policies::DeletePolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePolicy(RequestBuilder<crate::model::DeletePolicyRequest>);
 
@@ -474,6 +556,21 @@ pub mod policies {
     }
 
     /// The request builder for [Policies::get_operation][super::super::client::Policies::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v2::builder;
+    /// use builder::policies::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/iam/v3/src/builder.rs
+++ b/src/generated/iam/v3/src/builder.rs
@@ -69,6 +69,22 @@ pub mod policy_bindings {
     }
 
     /// The request builder for [PolicyBindings::create_policy_binding][super::super::client::PolicyBindings::create_policy_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::policy_bindings::CreatePolicyBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePolicyBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePolicyBinding(RequestBuilder<crate::model::CreatePolicyBindingRequest>);
 
@@ -185,6 +201,21 @@ pub mod policy_bindings {
     }
 
     /// The request builder for [PolicyBindings::get_policy_binding][super::super::client::PolicyBindings::get_policy_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::policy_bindings::GetPolicyBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPolicyBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPolicyBinding(RequestBuilder<crate::model::GetPolicyBindingRequest>);
 
@@ -235,6 +266,22 @@ pub mod policy_bindings {
     }
 
     /// The request builder for [PolicyBindings::update_policy_binding][super::super::client::PolicyBindings::update_policy_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::policy_bindings::UpdatePolicyBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePolicyBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePolicyBinding(RequestBuilder<crate::model::UpdatePolicyBindingRequest>);
 
@@ -344,6 +391,22 @@ pub mod policy_bindings {
     }
 
     /// The request builder for [PolicyBindings::delete_policy_binding][super::super::client::PolicyBindings::delete_policy_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::policy_bindings::DeletePolicyBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePolicyBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePolicyBinding(RequestBuilder<crate::model::DeletePolicyBindingRequest>);
 
@@ -446,6 +509,25 @@ pub mod policy_bindings {
     }
 
     /// The request builder for [PolicyBindings::list_policy_bindings][super::super::client::PolicyBindings::list_policy_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::policy_bindings::ListPolicyBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPolicyBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPolicyBindings(RequestBuilder<crate::model::ListPolicyBindingsRequest>);
 
@@ -540,6 +622,25 @@ pub mod policy_bindings {
     }
 
     /// The request builder for [PolicyBindings::search_target_policy_bindings][super::super::client::PolicyBindings::search_target_policy_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::policy_bindings::SearchTargetPolicyBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchTargetPolicyBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchTargetPolicyBindings(
         RequestBuilder<crate::model::SearchTargetPolicyBindingsRequest>,
@@ -640,6 +741,21 @@ pub mod policy_bindings {
     }
 
     /// The request builder for [PolicyBindings::get_operation][super::super::client::PolicyBindings::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::policy_bindings::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -743,6 +859,22 @@ pub mod principal_access_boundary_policies {
     }
 
     /// The request builder for [PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::principal_access_boundary_policies::CreatePrincipalAccessBoundaryPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreatePrincipalAccessBoundaryPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreatePrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::CreatePrincipalAccessBoundaryPolicyRequest>,
@@ -866,6 +998,21 @@ pub mod principal_access_boundary_policies {
     }
 
     /// The request builder for [PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::principal_access_boundary_policies::GetPrincipalAccessBoundaryPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetPrincipalAccessBoundaryPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetPrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::GetPrincipalAccessBoundaryPolicyRequest>,
@@ -918,6 +1065,22 @@ pub mod principal_access_boundary_policies {
     }
 
     /// The request builder for [PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::principal_access_boundary_policies::UpdatePrincipalAccessBoundaryPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdatePrincipalAccessBoundaryPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdatePrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::UpdatePrincipalAccessBoundaryPolicyRequest>,
@@ -1031,6 +1194,22 @@ pub mod principal_access_boundary_policies {
     }
 
     /// The request builder for [PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::principal_access_boundary_policies::DeletePrincipalAccessBoundaryPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_iam_v3::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeletePrincipalAccessBoundaryPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeletePrincipalAccessBoundaryPolicy(
         RequestBuilder<crate::model::DeletePrincipalAccessBoundaryPolicyRequest>,
@@ -1141,6 +1320,25 @@ pub mod principal_access_boundary_policies {
     }
 
     /// The request builder for [PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies][super::super::client::PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::principal_access_boundary_policies::ListPrincipalAccessBoundaryPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListPrincipalAccessBoundaryPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListPrincipalAccessBoundaryPolicies(
         RequestBuilder<crate::model::ListPrincipalAccessBoundaryPoliciesRequest>,
@@ -1235,6 +1433,25 @@ pub mod principal_access_boundary_policies {
     }
 
     /// The request builder for [PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings][super::super::client::PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::principal_access_boundary_policies::SearchPrincipalAccessBoundaryPolicyBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchPrincipalAccessBoundaryPolicyBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchPrincipalAccessBoundaryPolicyBindings(
         RequestBuilder<crate::model::SearchPrincipalAccessBoundaryPolicyBindingsRequest>,
@@ -1331,6 +1548,21 @@ pub mod principal_access_boundary_policies {
     }
 
     /// The request builder for [PrincipalAccessBoundaryPolicies::get_operation][super::super::client::PrincipalAccessBoundaryPolicies::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_iam_v3::builder;
+    /// use builder::principal_access_boundary_policies::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/identity/accesscontextmanager/v1/src/builder.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::list_access_policies][super::super::client::AccessContextManager::list_access_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::ListAccessPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAccessPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAccessPolicies(RequestBuilder<crate::model::ListAccessPoliciesRequest>);
 
@@ -157,6 +176,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::get_access_policy][super::super::client::AccessContextManager::get_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::GetAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAccessPolicy(RequestBuilder<crate::model::GetAccessPolicyRequest>);
 
@@ -204,6 +238,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::create_access_policy][super::super::client::AccessContextManager::create_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::CreateAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAccessPolicy(RequestBuilder<crate::model::AccessPolicy>);
 
@@ -339,6 +389,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::update_access_policy][super::super::client::AccessContextManager::update_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::UpdateAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAccessPolicy(RequestBuilder<crate::model::UpdateAccessPolicyRequest>);
 
@@ -446,6 +512,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::delete_access_policy][super::super::client::AccessContextManager::delete_access_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::DeleteAccessPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAccessPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAccessPolicy(RequestBuilder<crate::model::DeleteAccessPolicyRequest>);
 
@@ -541,6 +623,25 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::list_access_levels][super::super::client::AccessContextManager::list_access_levels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::ListAccessLevels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAccessLevels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAccessLevels(RequestBuilder<crate::model::ListAccessLevelsRequest>);
 
@@ -633,6 +734,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::get_access_level][super::super::client::AccessContextManager::get_access_level] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::GetAccessLevel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAccessLevel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAccessLevel(RequestBuilder<crate::model::GetAccessLevelRequest>);
 
@@ -686,6 +802,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::create_access_level][super::super::client::AccessContextManager::create_access_level] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::CreateAccessLevel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAccessLevel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAccessLevel(RequestBuilder<crate::model::CreateAccessLevelRequest>);
 
@@ -790,6 +922,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::update_access_level][super::super::client::AccessContextManager::update_access_level] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::UpdateAccessLevel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAccessLevel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAccessLevel(RequestBuilder<crate::model::UpdateAccessLevelRequest>);
 
@@ -897,6 +1045,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::delete_access_level][super::super::client::AccessContextManager::delete_access_level] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::DeleteAccessLevel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAccessLevel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAccessLevel(RequestBuilder<crate::model::DeleteAccessLevelRequest>);
 
@@ -992,6 +1156,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::replace_access_levels][super::super::client::AccessContextManager::replace_access_levels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::ReplaceAccessLevels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReplaceAccessLevels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReplaceAccessLevels(RequestBuilder<crate::model::ReplaceAccessLevelsRequest>);
 
@@ -1104,6 +1284,25 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::list_service_perimeters][super::super::client::AccessContextManager::list_service_perimeters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::ListServicePerimeters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServicePerimeters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServicePerimeters(RequestBuilder<crate::model::ListServicePerimetersRequest>);
 
@@ -1192,6 +1391,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::get_service_perimeter][super::super::client::AccessContextManager::get_service_perimeter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::GetServicePerimeter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServicePerimeter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServicePerimeter(RequestBuilder<crate::model::GetServicePerimeterRequest>);
 
@@ -1242,6 +1456,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::create_service_perimeter][super::super::client::AccessContextManager::create_service_perimeter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::CreateServicePerimeter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServicePerimeter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServicePerimeter(RequestBuilder<crate::model::CreateServicePerimeterRequest>);
 
@@ -1348,6 +1578,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::update_service_perimeter][super::super::client::AccessContextManager::update_service_perimeter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::UpdateServicePerimeter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServicePerimeter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServicePerimeter(RequestBuilder<crate::model::UpdateServicePerimeterRequest>);
 
@@ -1457,6 +1703,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::delete_service_perimeter][super::super::client::AccessContextManager::delete_service_perimeter] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::DeleteServicePerimeter;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServicePerimeter {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServicePerimeter(RequestBuilder<crate::model::DeleteServicePerimeterRequest>);
 
@@ -1552,6 +1814,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::replace_service_perimeters][super::super::client::AccessContextManager::replace_service_perimeters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::ReplaceServicePerimeters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReplaceServicePerimeters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReplaceServicePerimeters(
         RequestBuilder<crate::model::ReplaceServicePerimetersRequest>,
@@ -1666,6 +1944,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::commit_service_perimeters][super::super::client::AccessContextManager::commit_service_perimeters] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::CommitServicePerimeters;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CommitServicePerimeters {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CommitServicePerimeters(
         RequestBuilder<crate::model::CommitServicePerimetersRequest>,
@@ -1767,6 +2061,25 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::list_gcp_user_access_bindings][super::super::client::AccessContextManager::list_gcp_user_access_bindings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::ListGcpUserAccessBindings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGcpUserAccessBindings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGcpUserAccessBindings(
         RequestBuilder<crate::model::ListGcpUserAccessBindingsRequest>,
@@ -1859,6 +2172,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::get_gcp_user_access_binding][super::super::client::AccessContextManager::get_gcp_user_access_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::GetGcpUserAccessBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGcpUserAccessBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGcpUserAccessBinding(
         RequestBuilder<crate::model::GetGcpUserAccessBindingRequest>,
@@ -1911,6 +2239,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::create_gcp_user_access_binding][super::super::client::AccessContextManager::create_gcp_user_access_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::CreateGcpUserAccessBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGcpUserAccessBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGcpUserAccessBinding(
         RequestBuilder<crate::model::CreateGcpUserAccessBindingRequest>,
@@ -2019,6 +2363,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::update_gcp_user_access_binding][super::super::client::AccessContextManager::update_gcp_user_access_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::UpdateGcpUserAccessBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGcpUserAccessBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGcpUserAccessBinding(
         RequestBuilder<crate::model::UpdateGcpUserAccessBindingRequest>,
@@ -2130,6 +2490,22 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::delete_gcp_user_access_binding][super::super::client::AccessContextManager::delete_gcp_user_access_binding] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::DeleteGcpUserAccessBinding;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_identity_accesscontextmanager_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGcpUserAccessBinding {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGcpUserAccessBinding(
         RequestBuilder<crate::model::DeleteGcpUserAccessBindingRequest>,
@@ -2227,6 +2603,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::set_iam_policy][super::super::client::AccessContextManager::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2294,6 +2685,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::get_iam_policy][super::super::client::AccessContextManager::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2350,6 +2756,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::test_iam_permissions][super::super::client::AccessContextManager::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2413,6 +2834,21 @@ pub mod access_context_manager {
     }
 
     /// The request builder for [AccessContextManager::get_operation][super::super::client::AccessContextManager::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_identity_accesscontextmanager_v1::builder;
+    /// use builder::access_context_manager::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/logging/v2/src/builder.rs
+++ b/src/generated/logging/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::delete_log][super::super::client::LoggingServiceV2::delete_log] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::DeleteLog;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLog {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLog(RequestBuilder<crate::model::DeleteLogRequest>);
 
@@ -116,6 +131,21 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::write_log_entries][super::super::client::LoggingServiceV2::write_log_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::WriteLogEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> WriteLogEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct WriteLogEntries(RequestBuilder<crate::model::WriteLogEntriesRequest>);
 
@@ -206,6 +236,25 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::list_log_entries][super::super::client::LoggingServiceV2::list_log_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::ListLogEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLogEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLogEntries(RequestBuilder<crate::model::ListLogEntriesRequest>);
 
@@ -306,6 +355,25 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::list_monitored_resource_descriptors][super::super::client::LoggingServiceV2::list_monitored_resource_descriptors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::ListMonitoredResourceDescriptors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMonitoredResourceDescriptors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMonitoredResourceDescriptors(
         RequestBuilder<crate::model::ListMonitoredResourceDescriptorsRequest>,
@@ -390,6 +458,21 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::list_logs][super::super::client::LoggingServiceV2::list_logs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::ListLogs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLogs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLogs(RequestBuilder<crate::model::ListLogsRequest>);
 
@@ -460,6 +543,25 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::list_operations][super::super::client::LoggingServiceV2::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -552,6 +654,21 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::get_operation][super::super::client::LoggingServiceV2::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -600,6 +717,21 @@ pub mod logging_service_v_2 {
     }
 
     /// The request builder for [LoggingServiceV2::cancel_operation][super::super::client::LoggingServiceV2::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::logging_service_v_2::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -703,6 +835,25 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::list_buckets][super::super::client::ConfigServiceV2::list_buckets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::ListBuckets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBuckets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBuckets(RequestBuilder<crate::model::ListBucketsRequest>);
 
@@ -786,6 +937,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_bucket][super::super::client::ConfigServiceV2::get_bucket] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetBucket;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBucket {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBucket(RequestBuilder<crate::model::GetBucketRequest>);
 
@@ -833,6 +999,22 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::create_bucket_async][super::super::client::ConfigServiceV2::create_bucket_async] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CreateBucketAsync;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_logging_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBucketAsync {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBucketAsync(RequestBuilder<crate::model::CreateBucketRequest>);
 
@@ -937,6 +1119,22 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::update_bucket_async][super::super::client::ConfigServiceV2::update_bucket_async] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UpdateBucketAsync;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_logging_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBucketAsync {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBucketAsync(RequestBuilder<crate::model::UpdateBucketRequest>);
 
@@ -1044,6 +1242,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::create_bucket][super::super::client::ConfigServiceV2::create_bucket] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CreateBucket;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBucket {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBucket(RequestBuilder<crate::model::CreateBucketRequest>);
 
@@ -1110,6 +1323,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::update_bucket][super::super::client::ConfigServiceV2::update_bucket] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UpdateBucket;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBucket {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBucket(RequestBuilder<crate::model::UpdateBucketRequest>);
 
@@ -1179,6 +1407,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::delete_bucket][super::super::client::ConfigServiceV2::delete_bucket] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::DeleteBucket;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBucket {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBucket(RequestBuilder<crate::model::DeleteBucketRequest>);
 
@@ -1226,6 +1469,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::undelete_bucket][super::super::client::ConfigServiceV2::undelete_bucket] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UndeleteBucket;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UndeleteBucket {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UndeleteBucket(RequestBuilder<crate::model::UndeleteBucketRequest>);
 
@@ -1273,6 +1531,25 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::list_views][super::super::client::ConfigServiceV2::list_views] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::ListViews;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListViews {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListViews(RequestBuilder<crate::model::ListViewsRequest>);
 
@@ -1356,6 +1633,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_view][super::super::client::ConfigServiceV2::get_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetView(RequestBuilder<crate::model::GetViewRequest>);
 
@@ -1403,6 +1695,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::create_view][super::super::client::ConfigServiceV2::create_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CreateView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateView(RequestBuilder<crate::model::CreateViewRequest>);
 
@@ -1469,6 +1776,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::update_view][super::super::client::ConfigServiceV2::update_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UpdateView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateView(RequestBuilder<crate::model::UpdateViewRequest>);
 
@@ -1536,6 +1858,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::delete_view][super::super::client::ConfigServiceV2::delete_view] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::DeleteView;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteView {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteView(RequestBuilder<crate::model::DeleteViewRequest>);
 
@@ -1583,6 +1920,25 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::list_sinks][super::super::client::ConfigServiceV2::list_sinks] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::ListSinks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSinks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSinks(RequestBuilder<crate::model::ListSinksRequest>);
 
@@ -1666,6 +2022,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_sink][super::super::client::ConfigServiceV2::get_sink] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetSink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSink(RequestBuilder<crate::model::GetSinkRequest>);
 
@@ -1713,6 +2084,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::create_sink][super::super::client::ConfigServiceV2::create_sink] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CreateSink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSink(RequestBuilder<crate::model::CreateSinkRequest>);
 
@@ -1777,6 +2163,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::update_sink][super::super::client::ConfigServiceV2::update_sink] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UpdateSink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSink(RequestBuilder<crate::model::UpdateSinkRequest>);
 
@@ -1850,6 +2251,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::delete_sink][super::super::client::ConfigServiceV2::delete_sink] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::DeleteSink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSink(RequestBuilder<crate::model::DeleteSinkRequest>);
 
@@ -1897,6 +2313,22 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::create_link][super::super::client::ConfigServiceV2::create_link] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CreateLink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_logging_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLink(RequestBuilder<crate::model::CreateLinkRequest>);
 
@@ -1996,6 +2428,22 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::delete_link][super::super::client::ConfigServiceV2::delete_link] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::DeleteLink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_logging_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLink(RequestBuilder<crate::model::DeleteLinkRequest>);
 
@@ -2083,6 +2531,25 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::list_links][super::super::client::ConfigServiceV2::list_links] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::ListLinks;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLinks {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLinks(RequestBuilder<crate::model::ListLinksRequest>);
 
@@ -2166,6 +2633,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_link][super::super::client::ConfigServiceV2::get_link] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetLink;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLink {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLink(RequestBuilder<crate::model::GetLinkRequest>);
 
@@ -2213,6 +2695,25 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::list_exclusions][super::super::client::ConfigServiceV2::list_exclusions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::ListExclusions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListExclusions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListExclusions(RequestBuilder<crate::model::ListExclusionsRequest>);
 
@@ -2296,6 +2797,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_exclusion][super::super::client::ConfigServiceV2::get_exclusion] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetExclusion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetExclusion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetExclusion(RequestBuilder<crate::model::GetExclusionRequest>);
 
@@ -2343,6 +2859,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::create_exclusion][super::super::client::ConfigServiceV2::create_exclusion] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CreateExclusion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateExclusion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateExclusion(RequestBuilder<crate::model::CreateExclusionRequest>);
 
@@ -2401,6 +2932,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::update_exclusion][super::super::client::ConfigServiceV2::update_exclusion] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UpdateExclusion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateExclusion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateExclusion(RequestBuilder<crate::model::UpdateExclusionRequest>);
 
@@ -2470,6 +3016,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::delete_exclusion][super::super::client::ConfigServiceV2::delete_exclusion] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::DeleteExclusion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteExclusion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteExclusion(RequestBuilder<crate::model::DeleteExclusionRequest>);
 
@@ -2517,6 +3078,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_cmek_settings][super::super::client::ConfigServiceV2::get_cmek_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetCmekSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetCmekSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetCmekSettings(RequestBuilder<crate::model::GetCmekSettingsRequest>);
 
@@ -2564,6 +3140,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::update_cmek_settings][super::super::client::ConfigServiceV2::update_cmek_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UpdateCmekSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateCmekSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateCmekSettings(RequestBuilder<crate::model::UpdateCmekSettingsRequest>);
 
@@ -2634,6 +3225,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_settings][super::super::client::ConfigServiceV2::get_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSettings(RequestBuilder<crate::model::GetSettingsRequest>);
 
@@ -2681,6 +3287,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::update_settings][super::super::client::ConfigServiceV2::update_settings] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::UpdateSettings;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSettings {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSettings(RequestBuilder<crate::model::UpdateSettingsRequest>);
 
@@ -2748,6 +3369,22 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::copy_log_entries][super::super::client::ConfigServiceV2::copy_log_entries] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CopyLogEntries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_logging_v2::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CopyLogEntries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CopyLogEntries(RequestBuilder<crate::model::CopyLogEntriesRequest>);
 
@@ -2850,6 +3487,25 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::list_operations][super::super::client::ConfigServiceV2::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2942,6 +3598,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::get_operation][super::super::client::ConfigServiceV2::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2990,6 +3661,21 @@ pub mod config_service_v_2 {
     }
 
     /// The request builder for [ConfigServiceV2::cancel_operation][super::super::client::ConfigServiceV2::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::config_service_v_2::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3093,6 +3779,25 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::list_log_metrics][super::super::client::MetricsServiceV2::list_log_metrics] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::ListLogMetrics;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLogMetrics {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLogMetrics(RequestBuilder<crate::model::ListLogMetricsRequest>);
 
@@ -3176,6 +3881,21 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::get_log_metric][super::super::client::MetricsServiceV2::get_log_metric] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::GetLogMetric;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLogMetric {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLogMetric(RequestBuilder<crate::model::GetLogMetricRequest>);
 
@@ -3223,6 +3943,21 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::create_log_metric][super::super::client::MetricsServiceV2::create_log_metric] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::CreateLogMetric;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateLogMetric {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateLogMetric(RequestBuilder<crate::model::CreateLogMetricRequest>);
 
@@ -3281,6 +4016,21 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::update_log_metric][super::super::client::MetricsServiceV2::update_log_metric] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::UpdateLogMetric;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateLogMetric {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateLogMetric(RequestBuilder<crate::model::UpdateLogMetricRequest>);
 
@@ -3339,6 +4089,21 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::delete_log_metric][super::super::client::MetricsServiceV2::delete_log_metric] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::DeleteLogMetric;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteLogMetric {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteLogMetric(RequestBuilder<crate::model::DeleteLogMetricRequest>);
 
@@ -3386,6 +4151,25 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::list_operations][super::super::client::MetricsServiceV2::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3478,6 +4262,21 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::get_operation][super::super::client::MetricsServiceV2::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3526,6 +4325,21 @@ pub mod metrics_service_v_2 {
     }
 
     /// The request builder for [MetricsServiceV2::cancel_operation][super::super::client::MetricsServiceV2::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_logging_v2::builder;
+    /// use builder::metrics_service_v_2::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/longrunning/src/builder.rs
+++ b/src/generated/longrunning/src/builder.rs
@@ -69,6 +69,25 @@ pub mod operations {
     }
 
     /// The request builder for [Operations::list_operations][super::super::client::Operations::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_longrunning::builder;
+    /// use builder::operations::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<crate::model::ListOperationsRequest>);
 
@@ -156,6 +175,21 @@ pub mod operations {
     }
 
     /// The request builder for [Operations::get_operation][super::super::client::Operations::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_longrunning::builder;
+    /// use builder::operations::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<crate::model::GetOperationRequest>);
 
@@ -201,6 +235,21 @@ pub mod operations {
     }
 
     /// The request builder for [Operations::delete_operation][super::super::client::Operations::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_longrunning::builder;
+    /// use builder::operations::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<crate::model::DeleteOperationRequest>);
 
@@ -246,6 +295,21 @@ pub mod operations {
     }
 
     /// The request builder for [Operations::cancel_operation][super::super::client::Operations::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_longrunning::builder;
+    /// use builder::operations::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<crate::model::CancelOperationRequest>);
 

--- a/src/generated/monitoring/dashboard/v1/src/builder.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod dashboards_service {
     }
 
     /// The request builder for [DashboardsService::create_dashboard][super::super::client::DashboardsService::create_dashboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_dashboard_v1::builder;
+    /// use builder::dashboards_service::CreateDashboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDashboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDashboard(RequestBuilder<crate::model::CreateDashboardRequest>);
 
@@ -133,6 +148,25 @@ pub mod dashboards_service {
     }
 
     /// The request builder for [DashboardsService::list_dashboards][super::super::client::DashboardsService::list_dashboards] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_dashboard_v1::builder;
+    /// use builder::dashboards_service::ListDashboards;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDashboards {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDashboards(RequestBuilder<crate::model::ListDashboardsRequest>);
 
@@ -216,6 +250,21 @@ pub mod dashboards_service {
     }
 
     /// The request builder for [DashboardsService::get_dashboard][super::super::client::DashboardsService::get_dashboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_dashboard_v1::builder;
+    /// use builder::dashboards_service::GetDashboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDashboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDashboard(RequestBuilder<crate::model::GetDashboardRequest>);
 
@@ -263,6 +312,21 @@ pub mod dashboards_service {
     }
 
     /// The request builder for [DashboardsService::delete_dashboard][super::super::client::DashboardsService::delete_dashboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_dashboard_v1::builder;
+    /// use builder::dashboards_service::DeleteDashboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDashboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDashboard(RequestBuilder<crate::model::DeleteDashboardRequest>);
 
@@ -310,6 +374,21 @@ pub mod dashboards_service {
     }
 
     /// The request builder for [DashboardsService::update_dashboard][super::super::client::DashboardsService::update_dashboard] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_dashboard_v1::builder;
+    /// use builder::dashboards_service::UpdateDashboard;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDashboard {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDashboard(RequestBuilder<crate::model::UpdateDashboardRequest>);
 

--- a/src/generated/monitoring/metricsscope/v1/src/builder.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod metrics_scopes {
     }
 
     /// The request builder for [MetricsScopes::get_metrics_scope][super::super::client::MetricsScopes::get_metrics_scope] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_metricsscope_v1::builder;
+    /// use builder::metrics_scopes::GetMetricsScope;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMetricsScope {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMetricsScope(RequestBuilder<crate::model::GetMetricsScopeRequest>);
 
@@ -116,6 +131,21 @@ pub mod metrics_scopes {
     }
 
     /// The request builder for [MetricsScopes::list_metrics_scopes_by_monitored_project][super::super::client::MetricsScopes::list_metrics_scopes_by_monitored_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_metricsscope_v1::builder;
+    /// use builder::metrics_scopes::ListMetricsScopesByMonitoredProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMetricsScopesByMonitoredProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMetricsScopesByMonitoredProject(
         RequestBuilder<crate::model::ListMetricsScopesByMonitoredProjectRequest>,
@@ -173,6 +203,22 @@ pub mod metrics_scopes {
     }
 
     /// The request builder for [MetricsScopes::create_monitored_project][super::super::client::MetricsScopes::create_monitored_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_metricsscope_v1::builder;
+    /// use builder::metrics_scopes::CreateMonitoredProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_monitoring_metricsscope_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMonitoredProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMonitoredProject(RequestBuilder<crate::model::CreateMonitoredProjectRequest>);
 
@@ -277,6 +323,22 @@ pub mod metrics_scopes {
     }
 
     /// The request builder for [MetricsScopes::delete_monitored_project][super::super::client::MetricsScopes::delete_monitored_project] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_metricsscope_v1::builder;
+    /// use builder::metrics_scopes::DeleteMonitoredProject;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_monitoring_metricsscope_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMonitoredProject {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMonitoredProject(RequestBuilder<crate::model::DeleteMonitoredProjectRequest>);
 
@@ -367,6 +429,21 @@ pub mod metrics_scopes {
     }
 
     /// The request builder for [MetricsScopes::get_operation][super::super::client::MetricsScopes::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_metricsscope_v1::builder;
+    /// use builder::metrics_scopes::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 

--- a/src/generated/monitoring/v3/src/builder.rs
+++ b/src/generated/monitoring/v3/src/builder.rs
@@ -69,6 +69,25 @@ pub mod alert_policy_service {
     }
 
     /// The request builder for [AlertPolicyService::list_alert_policies][super::super::client::AlertPolicyService::list_alert_policies] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::alert_policy_service::ListAlertPolicies;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAlertPolicies {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAlertPolicies(RequestBuilder<crate::model::ListAlertPoliciesRequest>);
 
@@ -167,6 +186,21 @@ pub mod alert_policy_service {
     }
 
     /// The request builder for [AlertPolicyService::get_alert_policy][super::super::client::AlertPolicyService::get_alert_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::alert_policy_service::GetAlertPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAlertPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAlertPolicy(RequestBuilder<crate::model::GetAlertPolicyRequest>);
 
@@ -214,6 +248,21 @@ pub mod alert_policy_service {
     }
 
     /// The request builder for [AlertPolicyService::create_alert_policy][super::super::client::AlertPolicyService::create_alert_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::alert_policy_service::CreateAlertPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAlertPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAlertPolicy(RequestBuilder<crate::model::CreateAlertPolicyRequest>);
 
@@ -275,6 +324,21 @@ pub mod alert_policy_service {
     }
 
     /// The request builder for [AlertPolicyService::delete_alert_policy][super::super::client::AlertPolicyService::delete_alert_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::alert_policy_service::DeleteAlertPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAlertPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAlertPolicy(RequestBuilder<crate::model::DeleteAlertPolicyRequest>);
 
@@ -325,6 +389,21 @@ pub mod alert_policy_service {
     }
 
     /// The request builder for [AlertPolicyService::update_alert_policy][super::super::client::AlertPolicyService::update_alert_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::alert_policy_service::UpdateAlertPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAlertPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAlertPolicy(RequestBuilder<crate::model::UpdateAlertPolicyRequest>);
 
@@ -442,6 +521,25 @@ pub mod group_service {
     }
 
     /// The request builder for [GroupService::list_groups][super::super::client::GroupService::list_groups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::group_service::ListGroups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGroups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGroups(RequestBuilder<crate::model::ListGroupsRequest>);
 
@@ -576,6 +674,21 @@ pub mod group_service {
     }
 
     /// The request builder for [GroupService::get_group][super::super::client::GroupService::get_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::group_service::GetGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGroup(RequestBuilder<crate::model::GetGroupRequest>);
 
@@ -623,6 +736,21 @@ pub mod group_service {
     }
 
     /// The request builder for [GroupService::create_group][super::super::client::GroupService::create_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::group_service::CreateGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateGroup(RequestBuilder<crate::model::CreateGroupRequest>);
 
@@ -687,6 +815,21 @@ pub mod group_service {
     }
 
     /// The request builder for [GroupService::update_group][super::super::client::GroupService::update_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::group_service::UpdateGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateGroup(RequestBuilder<crate::model::UpdateGroupRequest>);
 
@@ -743,6 +886,21 @@ pub mod group_service {
     }
 
     /// The request builder for [GroupService::delete_group][super::super::client::GroupService::delete_group] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::group_service::DeleteGroup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteGroup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteGroup(RequestBuilder<crate::model::DeleteGroupRequest>);
 
@@ -796,6 +954,25 @@ pub mod group_service {
     }
 
     /// The request builder for [GroupService::list_group_members][super::super::client::GroupService::list_group_members] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::group_service::ListGroupMembers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListGroupMembers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListGroupMembers(RequestBuilder<crate::model::ListGroupMembersRequest>);
 
@@ -952,6 +1129,25 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::list_monitored_resource_descriptors][super::super::client::MetricService::list_monitored_resource_descriptors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::ListMonitoredResourceDescriptors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMonitoredResourceDescriptors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMonitoredResourceDescriptors(
         RequestBuilder<crate::model::ListMonitoredResourceDescriptorsRequest>,
@@ -1050,6 +1246,21 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::get_monitored_resource_descriptor][super::super::client::MetricService::get_monitored_resource_descriptor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::GetMonitoredResourceDescriptor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMonitoredResourceDescriptor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMonitoredResourceDescriptor(
         RequestBuilder<crate::model::GetMonitoredResourceDescriptorRequest>,
@@ -1102,6 +1313,25 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::list_metric_descriptors][super::super::client::MetricService::list_metric_descriptors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::ListMetricDescriptors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListMetricDescriptors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListMetricDescriptors(RequestBuilder<crate::model::ListMetricDescriptorsRequest>);
 
@@ -1202,6 +1432,21 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::get_metric_descriptor][super::super::client::MetricService::get_metric_descriptor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::GetMetricDescriptor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetMetricDescriptor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetMetricDescriptor(RequestBuilder<crate::model::GetMetricDescriptorRequest>);
 
@@ -1252,6 +1497,21 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::create_metric_descriptor][super::super::client::MetricService::create_metric_descriptor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::CreateMetricDescriptor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateMetricDescriptor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateMetricDescriptor(RequestBuilder<crate::model::CreateMetricDescriptorRequest>);
 
@@ -1313,6 +1573,21 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::delete_metric_descriptor][super::super::client::MetricService::delete_metric_descriptor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::DeleteMetricDescriptor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteMetricDescriptor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteMetricDescriptor(RequestBuilder<crate::model::DeleteMetricDescriptorRequest>);
 
@@ -1363,6 +1638,25 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::list_time_series][super::super::client::MetricService::list_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::ListTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTimeSeries(RequestBuilder<crate::model::ListTimeSeriesRequest>);
 
@@ -1502,6 +1796,21 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::create_time_series][super::super::client::MetricService::create_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::CreateTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTimeSeries(RequestBuilder<crate::model::CreateTimeSeriesRequest>);
 
@@ -1565,6 +1874,21 @@ pub mod metric_service {
     }
 
     /// The request builder for [MetricService::create_service_time_series][super::super::client::MetricService::create_service_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::metric_service::CreateServiceTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceTimeSeries(RequestBuilder<crate::model::CreateTimeSeriesRequest>);
 
@@ -1683,6 +2007,25 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::list_notification_channel_descriptors][super::super::client::NotificationChannelService::list_notification_channel_descriptors] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::ListNotificationChannelDescriptors;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotificationChannelDescriptors {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotificationChannelDescriptors(
         RequestBuilder<crate::model::ListNotificationChannelDescriptorsRequest>,
@@ -1777,6 +2120,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::get_notification_channel_descriptor][super::super::client::NotificationChannelService::get_notification_channel_descriptor] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::GetNotificationChannelDescriptor;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotificationChannelDescriptor {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotificationChannelDescriptor(
         RequestBuilder<crate::model::GetNotificationChannelDescriptorRequest>,
@@ -1829,6 +2187,25 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::list_notification_channels][super::super::client::NotificationChannelService::list_notification_channels] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::ListNotificationChannels;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListNotificationChannels {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListNotificationChannels(
         RequestBuilder<crate::model::ListNotificationChannelsRequest>,
@@ -1933,6 +2310,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::get_notification_channel][super::super::client::NotificationChannelService::get_notification_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::GetNotificationChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotificationChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotificationChannel(RequestBuilder<crate::model::GetNotificationChannelRequest>);
 
@@ -1983,6 +2375,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::create_notification_channel][super::super::client::NotificationChannelService::create_notification_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::CreateNotificationChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateNotificationChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateNotificationChannel(
         RequestBuilder<crate::model::CreateNotificationChannelRequest>,
@@ -2048,6 +2455,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::update_notification_channel][super::super::client::NotificationChannelService::update_notification_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::UpdateNotificationChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateNotificationChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateNotificationChannel(
         RequestBuilder<crate::model::UpdateNotificationChannelRequest>,
@@ -2114,6 +2536,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::delete_notification_channel][super::super::client::NotificationChannelService::delete_notification_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::DeleteNotificationChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteNotificationChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteNotificationChannel(
         RequestBuilder<crate::model::DeleteNotificationChannelRequest>,
@@ -2172,6 +2609,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::send_notification_channel_verification_code][super::super::client::NotificationChannelService::send_notification_channel_verification_code] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::SendNotificationChannelVerificationCode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SendNotificationChannelVerificationCode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SendNotificationChannelVerificationCode(
         RequestBuilder<crate::model::SendNotificationChannelVerificationCodeRequest>,
@@ -2226,6 +2678,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::get_notification_channel_verification_code][super::super::client::NotificationChannelService::get_notification_channel_verification_code] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::GetNotificationChannelVerificationCode;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetNotificationChannelVerificationCode {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetNotificationChannelVerificationCode(
         RequestBuilder<crate::model::GetNotificationChannelVerificationCodeRequest>,
@@ -2291,6 +2758,21 @@ pub mod notification_channel_service {
     }
 
     /// The request builder for [NotificationChannelService::verify_notification_channel][super::super::client::NotificationChannelService::verify_notification_channel] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::notification_channel_service::VerifyNotificationChannel;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyNotificationChannel {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyNotificationChannel(
         RequestBuilder<crate::model::VerifyNotificationChannelRequest>,
@@ -2406,6 +2888,25 @@ pub mod query_service {
     }
 
     /// The request builder for [QueryService::query_time_series][super::super::client::QueryService::query_time_series] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::query_service::QueryTimeSeries;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> QueryTimeSeries {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct QueryTimeSeries(RequestBuilder<crate::model::QueryTimeSeriesRequest>);
 
@@ -2552,6 +3053,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::create_service][super::super::client::ServiceMonitoringService::create_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::CreateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateService(RequestBuilder<crate::model::CreateServiceRequest>);
 
@@ -2616,6 +3132,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::get_service][super::super::client::ServiceMonitoringService::get_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::GetService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetService(RequestBuilder<crate::model::GetServiceRequest>);
 
@@ -2663,6 +3194,25 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::list_services][super::super::client::ServiceMonitoringService::list_services] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::ListServices;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServices {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServices(RequestBuilder<crate::model::ListServicesRequest>);
 
@@ -2752,6 +3302,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::update_service][super::super::client::ServiceMonitoringService::update_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::UpdateService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateService(RequestBuilder<crate::model::UpdateServiceRequest>);
 
@@ -2811,6 +3376,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::delete_service][super::super::client::ServiceMonitoringService::delete_service] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::DeleteService;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteService {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteService(RequestBuilder<crate::model::DeleteServiceRequest>);
 
@@ -2858,6 +3438,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::create_service_level_objective][super::super::client::ServiceMonitoringService::create_service_level_objective] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::CreateServiceLevelObjective;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateServiceLevelObjective {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateServiceLevelObjective(
         RequestBuilder<crate::model::CreateServiceLevelObjectiveRequest>,
@@ -2932,6 +3527,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::get_service_level_objective][super::super::client::ServiceMonitoringService::get_service_level_objective] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::GetServiceLevelObjective;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetServiceLevelObjective {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetServiceLevelObjective(
         RequestBuilder<crate::model::GetServiceLevelObjectiveRequest>,
@@ -2993,6 +3603,25 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::list_service_level_objectives][super::super::client::ServiceMonitoringService::list_service_level_objectives] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::ListServiceLevelObjectives;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListServiceLevelObjectives {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListServiceLevelObjectives(
         RequestBuilder<crate::model::ListServiceLevelObjectivesRequest>,
@@ -3100,6 +3729,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::update_service_level_objective][super::super::client::ServiceMonitoringService::update_service_level_objective] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::UpdateServiceLevelObjective;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateServiceLevelObjective {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateServiceLevelObjective(
         RequestBuilder<crate::model::UpdateServiceLevelObjectiveRequest>,
@@ -3166,6 +3810,21 @@ pub mod service_monitoring_service {
     }
 
     /// The request builder for [ServiceMonitoringService::delete_service_level_objective][super::super::client::ServiceMonitoringService::delete_service_level_objective] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::service_monitoring_service::DeleteServiceLevelObjective;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteServiceLevelObjective {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteServiceLevelObjective(
         RequestBuilder<crate::model::DeleteServiceLevelObjectiveRequest>,
@@ -3273,6 +3932,21 @@ pub mod snooze_service {
     }
 
     /// The request builder for [SnoozeService::create_snooze][super::super::client::SnoozeService::create_snooze] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::snooze_service::CreateSnooze;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSnooze {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSnooze(RequestBuilder<crate::model::CreateSnoozeRequest>);
 
@@ -3331,6 +4005,25 @@ pub mod snooze_service {
     }
 
     /// The request builder for [SnoozeService::list_snoozes][super::super::client::SnoozeService::list_snoozes] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::snooze_service::ListSnoozes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSnoozes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSnoozes(RequestBuilder<crate::model::ListSnoozesRequest>);
 
@@ -3420,6 +4113,21 @@ pub mod snooze_service {
     }
 
     /// The request builder for [SnoozeService::get_snooze][super::super::client::SnoozeService::get_snooze] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::snooze_service::GetSnooze;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSnooze {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSnooze(RequestBuilder<crate::model::GetSnoozeRequest>);
 
@@ -3467,6 +4175,21 @@ pub mod snooze_service {
     }
 
     /// The request builder for [SnoozeService::update_snooze][super::super::client::SnoozeService::update_snooze] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::snooze_service::UpdateSnooze;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSnooze {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSnooze(RequestBuilder<crate::model::UpdateSnoozeRequest>);
 
@@ -3583,6 +4306,25 @@ pub mod uptime_check_service {
     }
 
     /// The request builder for [UptimeCheckService::list_uptime_check_configs][super::super::client::UptimeCheckService::list_uptime_check_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::uptime_check_service::ListUptimeCheckConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUptimeCheckConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUptimeCheckConfigs(RequestBuilder<crate::model::ListUptimeCheckConfigsRequest>);
 
@@ -3679,6 +4421,21 @@ pub mod uptime_check_service {
     }
 
     /// The request builder for [UptimeCheckService::get_uptime_check_config][super::super::client::UptimeCheckService::get_uptime_check_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::uptime_check_service::GetUptimeCheckConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetUptimeCheckConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetUptimeCheckConfig(RequestBuilder<crate::model::GetUptimeCheckConfigRequest>);
 
@@ -3729,6 +4486,21 @@ pub mod uptime_check_service {
     }
 
     /// The request builder for [UptimeCheckService::create_uptime_check_config][super::super::client::UptimeCheckService::create_uptime_check_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::uptime_check_service::CreateUptimeCheckConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateUptimeCheckConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateUptimeCheckConfig(
         RequestBuilder<crate::model::CreateUptimeCheckConfigRequest>,
@@ -3794,6 +4566,21 @@ pub mod uptime_check_service {
     }
 
     /// The request builder for [UptimeCheckService::update_uptime_check_config][super::super::client::UptimeCheckService::update_uptime_check_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::uptime_check_service::UpdateUptimeCheckConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateUptimeCheckConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateUptimeCheckConfig(
         RequestBuilder<crate::model::UpdateUptimeCheckConfigRequest>,
@@ -3860,6 +4647,21 @@ pub mod uptime_check_service {
     }
 
     /// The request builder for [UptimeCheckService::delete_uptime_check_config][super::super::client::UptimeCheckService::delete_uptime_check_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::uptime_check_service::DeleteUptimeCheckConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteUptimeCheckConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteUptimeCheckConfig(
         RequestBuilder<crate::model::DeleteUptimeCheckConfigRequest>,
@@ -3912,6 +4714,25 @@ pub mod uptime_check_service {
     }
 
     /// The request builder for [UptimeCheckService::list_uptime_check_ips][super::super::client::UptimeCheckService::list_uptime_check_ips] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_monitoring_v3::builder;
+    /// use builder::uptime_check_service::ListUptimeCheckIps;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUptimeCheckIps {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUptimeCheckIps(RequestBuilder<crate::model::ListUptimeCheckIpsRequest>);
 

--- a/src/generated/openapi-validation/src/builder.rs
+++ b/src/generated/openapi-validation/src/builder.rs
@@ -69,6 +69,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<crate::model::ListLocationsRequest>);
 
@@ -164,6 +183,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<crate::model::GetLocationRequest>);
 
@@ -219,6 +253,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::ListSecrets;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSecrets {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSecrets(RequestBuilder<crate::model::ListSecretsRequest>);
 
@@ -314,6 +367,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::CreateSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSecret(RequestBuilder<crate::model::CreateSecretRequest>);
 
@@ -378,6 +446,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_secrets_by_project_and_location][super::super::client::SecretManagerService::list_secrets_by_project_and_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::ListSecretsByProjectAndLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSecretsByProjectAndLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSecretsByProjectAndLocation(
         RequestBuilder<crate::model::ListSecretsByProjectAndLocationRequest>,
@@ -486,6 +573,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::create_secret_by_project_and_location][super::super::client::SecretManagerService::create_secret_by_project_and_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::CreateSecretByProjectAndLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSecretByProjectAndLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSecretByProjectAndLocation(
         RequestBuilder<crate::model::CreateSecretByProjectAndLocationRequest>,
@@ -563,6 +665,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::AddSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddSecretVersion(RequestBuilder<crate::model::AddSecretVersionRequest>);
 
@@ -638,6 +755,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::add_secret_version_by_project_and_location_and_secret][super::super::client::SecretManagerService::add_secret_version_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::AddSecretVersionByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddSecretVersionByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddSecretVersionByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::AddSecretVersionRequest>,
@@ -718,6 +850,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::GetSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSecret(RequestBuilder<crate::model::GetSecretRequest>);
 
@@ -773,6 +920,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::DeleteSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSecret(RequestBuilder<crate::model::DeleteSecretRequest>);
 
@@ -834,6 +996,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::UpdateSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSecret(RequestBuilder<crate::model::UpdateSecretRequest>);
 
@@ -906,6 +1083,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_secret_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::GetSecretByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSecretByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSecretByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::GetSecretByProjectAndLocationAndSecretRequest>,
@@ -976,6 +1168,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::delete_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::delete_secret_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::DeleteSecretByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSecretByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSecretByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::DeleteSecretByProjectAndLocationAndSecretRequest>,
@@ -1052,6 +1259,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::update_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::update_secret_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::UpdateSecretByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateSecretByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateSecretByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::UpdateSecretByProjectAndLocationAndSecretRequest>,
@@ -1139,6 +1361,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::ListSecretVersions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSecretVersions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSecretVersions(RequestBuilder<crate::model::ListSecretVersionsRequest>);
 
@@ -1247,6 +1488,25 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::list_secret_versions_by_project_and_location_and_secret][super::super::client::SecretManagerService::list_secret_versions_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::ListSecretVersionsByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSecretVersionsByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSecretVersionsByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::ListSecretVersionsByProjectAndLocationAndSecretRequest>,
@@ -1370,6 +1630,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::GetSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSecretVersion(RequestBuilder<crate::model::GetSecretVersionRequest>);
 
@@ -1436,6 +1711,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::GetSecretVersionByProjectAndLocationAndSecretAndVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSecretVersionByProjectAndLocationAndSecretAndVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<
@@ -1521,6 +1811,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::AccessSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AccessSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersion(RequestBuilder<crate::model::AccessSecretVersionRequest>);
 
@@ -1587,6 +1892,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::AccessSecretVersionByProjectAndLocationAndSecretAndVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AccessSecretVersionByProjectAndLocationAndSecretAndVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AccessSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<
@@ -1672,6 +1992,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::DisableSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersion(RequestBuilder<crate::model::DisableSecretVersionRequest>);
 
@@ -1752,6 +2087,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::DisableSecretVersionByProjectAndLocationAndSecretAndVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DisableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DisableSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<crate::model::DisableSecretVersionRequest>,
@@ -1839,6 +2189,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::EnableSecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableSecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersion(RequestBuilder<crate::model::EnableSecretVersionRequest>);
 
@@ -1919,6 +2284,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::EnableSecretVersionByProjectAndLocationAndSecretAndVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EnableSecretVersionByProjectAndLocationAndSecretAndVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EnableSecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<crate::model::EnableSecretVersionRequest>,
@@ -2006,6 +2386,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::DestroySecretVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DestroySecretVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersion(RequestBuilder<crate::model::DestroySecretVersionRequest>);
 
@@ -2086,6 +2481,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::DestroySecretVersionByProjectAndLocationAndSecretAndVersion;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DestroySecretVersionByProjectAndLocationAndSecretAndVersion {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DestroySecretVersionByProjectAndLocationAndSecretAndVersion(
         RequestBuilder<crate::model::DestroySecretVersionRequest>,
@@ -2173,6 +2583,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<crate::model::SetIamPolicyRequest>);
 
@@ -2254,6 +2679,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::set_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::set_iam_policy_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::SetIamPolicyByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicyByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicyByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::SetIamPolicyRequest>,
@@ -2337,6 +2777,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<crate::model::GetIamPolicyRequest>);
 
@@ -2401,6 +2856,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::get_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_iam_policy_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::GetIamPolicyByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicyByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicyByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::GetIamPolicyByProjectAndLocationAndSecretRequest>,
@@ -2480,6 +2950,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<crate::model::TestIamPermissionsRequest>);
 
@@ -2557,6 +3042,21 @@ pub mod secret_manager_service {
     }
 
     /// The request builder for [SecretManagerService::test_iam_permissions_by_project_and_location_and_secret][super::super::client::SecretManagerService::test_iam_permissions_by_project_and_location_and_secret] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use secretmanager_openapi_v1::builder;
+    /// use builder::secret_manager_service::TestIamPermissionsByProjectAndLocationAndSecret;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissionsByProjectAndLocationAndSecret {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissionsByProjectAndLocationAndSecret(
         RequestBuilder<crate::model::TestIamPermissionsRequest>,

--- a/src/generated/privacy/dlp/v2/src/builder.rs
+++ b/src/generated/privacy/dlp/v2/src/builder.rs
@@ -69,6 +69,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::inspect_content][super::super::client::DlpService::inspect_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::InspectContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> InspectContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct InspectContent(RequestBuilder<crate::model::InspectContentRequest>);
 
@@ -144,6 +159,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::redact_image][super::super::client::DlpService::redact_image] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::RedactImage;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RedactImage {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RedactImage(RequestBuilder<crate::model::RedactImageRequest>);
 
@@ -230,6 +260,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::deidentify_content][super::super::client::DlpService::deidentify_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeidentifyContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeidentifyContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeidentifyContent(RequestBuilder<crate::model::DeidentifyContentRequest>);
 
@@ -325,6 +370,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::reidentify_content][super::super::client::DlpService::reidentify_content] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ReidentifyContent;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReidentifyContent {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReidentifyContent(RequestBuilder<crate::model::ReidentifyContentRequest>);
 
@@ -422,6 +482,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_info_types][super::super::client::DlpService::list_info_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListInfoTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInfoTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInfoTypes(RequestBuilder<crate::model::ListInfoTypesRequest>);
 
@@ -485,6 +560,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::create_inspect_template][super::super::client::DlpService::create_inspect_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CreateInspectTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInspectTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInspectTemplate(RequestBuilder<crate::model::CreateInspectTemplateRequest>);
 
@@ -558,6 +648,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::update_inspect_template][super::super::client::DlpService::update_inspect_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::UpdateInspectTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInspectTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInspectTemplate(RequestBuilder<crate::model::UpdateInspectTemplateRequest>);
 
@@ -626,6 +731,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_inspect_template][super::super::client::DlpService::get_inspect_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetInspectTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInspectTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInspectTemplate(RequestBuilder<crate::model::GetInspectTemplateRequest>);
 
@@ -676,6 +796,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_inspect_templates][super::super::client::DlpService::list_inspect_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListInspectTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInspectTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInspectTemplates(RequestBuilder<crate::model::ListInspectTemplatesRequest>);
 
@@ -776,6 +915,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_inspect_template][super::super::client::DlpService::delete_inspect_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteInspectTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInspectTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInspectTemplate(RequestBuilder<crate::model::DeleteInspectTemplateRequest>);
 
@@ -826,6 +980,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::create_deidentify_template][super::super::client::DlpService::create_deidentify_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CreateDeidentifyTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDeidentifyTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDeidentifyTemplate(
         RequestBuilder<crate::model::CreateDeidentifyTemplateRequest>,
@@ -903,6 +1072,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::update_deidentify_template][super::super::client::DlpService::update_deidentify_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::UpdateDeidentifyTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDeidentifyTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDeidentifyTemplate(
         RequestBuilder<crate::model::UpdateDeidentifyTemplateRequest>,
@@ -975,6 +1159,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_deidentify_template][super::super::client::DlpService::get_deidentify_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetDeidentifyTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDeidentifyTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDeidentifyTemplate(RequestBuilder<crate::model::GetDeidentifyTemplateRequest>);
 
@@ -1025,6 +1224,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_deidentify_templates][super::super::client::DlpService::list_deidentify_templates] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListDeidentifyTemplates;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDeidentifyTemplates {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDeidentifyTemplates(
         RequestBuilder<crate::model::ListDeidentifyTemplatesRequest>,
@@ -1129,6 +1347,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_deidentify_template][super::super::client::DlpService::delete_deidentify_template] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteDeidentifyTemplate;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDeidentifyTemplate {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDeidentifyTemplate(
         RequestBuilder<crate::model::DeleteDeidentifyTemplateRequest>,
@@ -1181,6 +1414,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::create_job_trigger][super::super::client::DlpService::create_job_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CreateJobTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateJobTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateJobTrigger(RequestBuilder<crate::model::CreateJobTriggerRequest>);
 
@@ -1254,6 +1502,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::update_job_trigger][super::super::client::DlpService::update_job_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::UpdateJobTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateJobTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateJobTrigger(RequestBuilder<crate::model::UpdateJobTriggerRequest>);
 
@@ -1322,6 +1585,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::hybrid_inspect_job_trigger][super::super::client::DlpService::hybrid_inspect_job_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::HybridInspectJobTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> HybridInspectJobTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct HybridInspectJobTrigger(
         RequestBuilder<crate::model::HybridInspectJobTriggerRequest>,
@@ -1383,6 +1661,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_job_trigger][super::super::client::DlpService::get_job_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetJobTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetJobTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetJobTrigger(RequestBuilder<crate::model::GetJobTriggerRequest>);
 
@@ -1430,6 +1723,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_job_triggers][super::super::client::DlpService::list_job_triggers] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListJobTriggers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListJobTriggers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListJobTriggers(RequestBuilder<crate::model::ListJobTriggersRequest>);
 
@@ -1537,6 +1849,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_job_trigger][super::super::client::DlpService::delete_job_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteJobTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteJobTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteJobTrigger(RequestBuilder<crate::model::DeleteJobTriggerRequest>);
 
@@ -1587,6 +1914,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::activate_job_trigger][super::super::client::DlpService::activate_job_trigger] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ActivateJobTrigger;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ActivateJobTrigger {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ActivateJobTrigger(RequestBuilder<crate::model::ActivateJobTriggerRequest>);
 
@@ -1637,6 +1979,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::create_discovery_config][super::super::client::DlpService::create_discovery_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CreateDiscoveryConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDiscoveryConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDiscoveryConfig(RequestBuilder<crate::model::CreateDiscoveryConfigRequest>);
 
@@ -1704,6 +2061,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::update_discovery_config][super::super::client::DlpService::update_discovery_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::UpdateDiscoveryConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDiscoveryConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDiscoveryConfig(RequestBuilder<crate::model::UpdateDiscoveryConfigRequest>);
 
@@ -1774,6 +2146,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_discovery_config][super::super::client::DlpService::get_discovery_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetDiscoveryConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDiscoveryConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDiscoveryConfig(RequestBuilder<crate::model::GetDiscoveryConfigRequest>);
 
@@ -1824,6 +2211,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_discovery_configs][super::super::client::DlpService::list_discovery_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListDiscoveryConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDiscoveryConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDiscoveryConfigs(RequestBuilder<crate::model::ListDiscoveryConfigsRequest>);
 
@@ -1918,6 +2324,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_discovery_config][super::super::client::DlpService::delete_discovery_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteDiscoveryConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDiscoveryConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDiscoveryConfig(RequestBuilder<crate::model::DeleteDiscoveryConfigRequest>);
 
@@ -1968,6 +2389,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::create_dlp_job][super::super::client::DlpService::create_dlp_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CreateDlpJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDlpJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDlpJob(RequestBuilder<crate::model::CreateDlpJobRequest>);
 
@@ -2069,6 +2505,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_dlp_jobs][super::super::client::DlpService::list_dlp_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListDlpJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDlpJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDlpJobs(RequestBuilder<crate::model::ListDlpJobsRequest>);
 
@@ -2176,6 +2631,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_dlp_job][super::super::client::DlpService::get_dlp_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetDlpJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDlpJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDlpJob(RequestBuilder<crate::model::GetDlpJobRequest>);
 
@@ -2223,6 +2693,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_dlp_job][super::super::client::DlpService::delete_dlp_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteDlpJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteDlpJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteDlpJob(RequestBuilder<crate::model::DeleteDlpJobRequest>);
 
@@ -2270,6 +2755,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::cancel_dlp_job][super::super::client::DlpService::cancel_dlp_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CancelDlpJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelDlpJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelDlpJob(RequestBuilder<crate::model::CancelDlpJobRequest>);
 
@@ -2317,6 +2817,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::create_stored_info_type][super::super::client::DlpService::create_stored_info_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CreateStoredInfoType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateStoredInfoType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateStoredInfoType(RequestBuilder<crate::model::CreateStoredInfoTypeRequest>);
 
@@ -2390,6 +2905,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::update_stored_info_type][super::super::client::DlpService::update_stored_info_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::UpdateStoredInfoType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateStoredInfoType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateStoredInfoType(RequestBuilder<crate::model::UpdateStoredInfoTypeRequest>);
 
@@ -2458,6 +2988,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_stored_info_type][super::super::client::DlpService::get_stored_info_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetStoredInfoType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStoredInfoType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStoredInfoType(RequestBuilder<crate::model::GetStoredInfoTypeRequest>);
 
@@ -2508,6 +3053,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_stored_info_types][super::super::client::DlpService::list_stored_info_types] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListStoredInfoTypes;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListStoredInfoTypes {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListStoredInfoTypes(RequestBuilder<crate::model::ListStoredInfoTypesRequest>);
 
@@ -2608,6 +3172,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_stored_info_type][super::super::client::DlpService::delete_stored_info_type] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteStoredInfoType;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteStoredInfoType {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteStoredInfoType(RequestBuilder<crate::model::DeleteStoredInfoTypeRequest>);
 
@@ -2658,6 +3237,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_project_data_profiles][super::super::client::DlpService::list_project_data_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListProjectDataProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListProjectDataProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListProjectDataProfiles(
         RequestBuilder<crate::model::ListProjectDataProfilesRequest>,
@@ -2762,6 +3360,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_table_data_profiles][super::super::client::DlpService::list_table_data_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListTableDataProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTableDataProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTableDataProfiles(RequestBuilder<crate::model::ListTableDataProfilesRequest>);
 
@@ -2862,6 +3479,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_column_data_profiles][super::super::client::DlpService::list_column_data_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListColumnDataProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListColumnDataProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListColumnDataProfiles(RequestBuilder<crate::model::ListColumnDataProfilesRequest>);
 
@@ -2964,6 +3600,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_project_data_profile][super::super::client::DlpService::get_project_data_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetProjectDataProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetProjectDataProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetProjectDataProfile(RequestBuilder<crate::model::GetProjectDataProfileRequest>);
 
@@ -3014,6 +3665,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_file_store_data_profiles][super::super::client::DlpService::list_file_store_data_profiles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListFileStoreDataProfiles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListFileStoreDataProfiles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListFileStoreDataProfiles(
         RequestBuilder<crate::model::ListFileStoreDataProfilesRequest>,
@@ -3118,6 +3788,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_file_store_data_profile][super::super::client::DlpService::get_file_store_data_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetFileStoreDataProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetFileStoreDataProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetFileStoreDataProfile(
         RequestBuilder<crate::model::GetFileStoreDataProfileRequest>,
@@ -3170,6 +3855,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_file_store_data_profile][super::super::client::DlpService::delete_file_store_data_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteFileStoreDataProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteFileStoreDataProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteFileStoreDataProfile(
         RequestBuilder<crate::model::DeleteFileStoreDataProfileRequest>,
@@ -3222,6 +3922,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_table_data_profile][super::super::client::DlpService::get_table_data_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetTableDataProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTableDataProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTableDataProfile(RequestBuilder<crate::model::GetTableDataProfileRequest>);
 
@@ -3272,6 +3987,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_column_data_profile][super::super::client::DlpService::get_column_data_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetColumnDataProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetColumnDataProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetColumnDataProfile(RequestBuilder<crate::model::GetColumnDataProfileRequest>);
 
@@ -3322,6 +4052,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_table_data_profile][super::super::client::DlpService::delete_table_data_profile] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteTableDataProfile;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTableDataProfile {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTableDataProfile(RequestBuilder<crate::model::DeleteTableDataProfileRequest>);
 
@@ -3372,6 +4117,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::hybrid_inspect_dlp_job][super::super::client::DlpService::hybrid_inspect_dlp_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::HybridInspectDlpJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> HybridInspectDlpJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct HybridInspectDlpJob(RequestBuilder<crate::model::HybridInspectDlpJobRequest>);
 
@@ -3431,6 +4191,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::finish_dlp_job][super::super::client::DlpService::finish_dlp_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::FinishDlpJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FinishDlpJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FinishDlpJob(RequestBuilder<crate::model::FinishDlpJobRequest>);
 
@@ -3478,6 +4253,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::create_connection][super::super::client::DlpService::create_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::CreateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateConnection(RequestBuilder<crate::model::CreateConnectionRequest>);
 
@@ -3539,6 +4329,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::get_connection][super::super::client::DlpService::get_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::GetConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetConnection(RequestBuilder<crate::model::GetConnectionRequest>);
 
@@ -3586,6 +4391,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::list_connections][super::super::client::DlpService::list_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::ListConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListConnections(RequestBuilder<crate::model::ListConnectionsRequest>);
 
@@ -3675,6 +4499,25 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::search_connections][super::super::client::DlpService::search_connections] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::SearchConnections;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchConnections {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchConnections(RequestBuilder<crate::model::SearchConnectionsRequest>);
 
@@ -3767,6 +4610,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::delete_connection][super::super::client::DlpService::delete_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::DeleteConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteConnection(RequestBuilder<crate::model::DeleteConnectionRequest>);
 
@@ -3817,6 +4675,21 @@ pub mod dlp_service {
     }
 
     /// The request builder for [DlpService::update_connection][super::super::client::DlpService::update_connection] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_privacy_dlp_v2::builder;
+    /// use builder::dlp_service::UpdateConnection;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateConnection {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateConnection(RequestBuilder<crate::model::UpdateConnectionRequest>);
 

--- a/src/generated/showcase/src/builder.rs
+++ b/src/generated/showcase/src/builder.rs
@@ -69,6 +69,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_body][super::super::client::Compliance::repeat_data_body] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataBody;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataBody {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataBody(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -174,6 +189,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_body_info][super::super::client::Compliance::repeat_data_body_info] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataBodyInfo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataBodyInfo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataBodyInfo(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -279,6 +309,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_query][super::super::client::Compliance::repeat_data_query] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataQuery;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataQuery {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataQuery(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -384,6 +429,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_simple_path][super::super::client::Compliance::repeat_data_simple_path] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataSimplePath;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataSimplePath {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataSimplePath(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -489,6 +549,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_path_resource][super::super::client::Compliance::repeat_data_path_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataPathResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataPathResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataPathResource(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -594,6 +669,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_path_trailing_resource][super::super::client::Compliance::repeat_data_path_trailing_resource] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataPathTrailingResource;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataPathTrailingResource {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataPathTrailingResource(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -699,6 +789,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_body_put][super::super::client::Compliance::repeat_data_body_put] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataBodyPut;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataBodyPut {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataBodyPut(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -804,6 +909,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::repeat_data_body_patch][super::super::client::Compliance::repeat_data_body_patch] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::RepeatDataBodyPatch;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RepeatDataBodyPatch {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RepeatDataBodyPatch(RequestBuilder<crate::model::RepeatRequest>);
 
@@ -909,6 +1029,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::get_enum][super::super::client::Compliance::get_enum] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::GetEnum;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetEnum {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetEnum(RequestBuilder<crate::model::EnumRequest>);
 
@@ -954,6 +1089,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::verify_enum][super::super::client::Compliance::verify_enum] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::VerifyEnum;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyEnum {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyEnum(RequestBuilder<crate::model::EnumResponse>);
 
@@ -1008,6 +1158,25 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::list_locations][super::super::client::Compliance::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -1098,6 +1267,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::get_location][super::super::client::Compliance::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -1143,6 +1327,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::set_iam_policy][super::super::client::Compliance::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1210,6 +1409,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::get_iam_policy][super::super::client::Compliance::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1266,6 +1480,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::test_iam_permissions][super::super::client::Compliance::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1329,6 +1558,25 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::list_operations][super::super::client::Compliance::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1421,6 +1669,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::get_operation][super::super::client::Compliance::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1469,6 +1732,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::delete_operation][super::super::client::Compliance::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -1517,6 +1795,21 @@ pub mod compliance {
     }
 
     /// The request builder for [Compliance::cancel_operation][super::super::client::Compliance::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::compliance::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -1618,6 +1911,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::echo][super::super::client::Echo::echo] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::Echo;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Echo {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Echo(RequestBuilder<crate::model::EchoRequest>);
 
@@ -1723,6 +2031,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::echo_error_details][super::super::client::Echo::echo_error_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::EchoErrorDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> EchoErrorDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct EchoErrorDetails(RequestBuilder<crate::model::EchoErrorDetailsRequest>);
 
@@ -1780,6 +2103,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::fail_echo_with_details][super::super::client::Echo::fail_echo_with_details] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::FailEchoWithDetails;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> FailEchoWithDetails {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct FailEchoWithDetails(RequestBuilder<crate::model::FailEchoWithDetailsRequest>);
 
@@ -1826,6 +2164,25 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::paged_expand][super::super::client::Echo::paged_expand] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::PagedExpand;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PagedExpand {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PagedExpand(RequestBuilder<crate::model::PagedExpandRequest>);
 
@@ -1907,6 +2264,25 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::paged_expand_legacy][super::super::client::Echo::paged_expand_legacy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::PagedExpandLegacy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PagedExpandLegacy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PagedExpandLegacy(RequestBuilder<crate::model::PagedExpandLegacyRequest>);
 
@@ -1991,6 +2367,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::paged_expand_legacy_mapped][super::super::client::Echo::paged_expand_legacy_mapped] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::PagedExpandLegacyMapped;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PagedExpandLegacyMapped {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PagedExpandLegacyMapped(RequestBuilder<crate::model::PagedExpandRequest>);
 
@@ -2048,6 +2439,22 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::wait][super::super::client::Echo::wait] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::Wait;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_showcase_v1beta1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Wait {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Wait(RequestBuilder<crate::model::WaitRequest>);
 
@@ -2196,6 +2603,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::block][super::super::client::Echo::block] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::Block;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> Block {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct Block(RequestBuilder<crate::model::BlockRequest>);
 
@@ -2280,6 +2702,25 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::list_locations][super::super::client::Echo::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -2368,6 +2809,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::get_location][super::super::client::Echo::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -2411,6 +2867,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::set_iam_policy][super::super::client::Echo::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -2476,6 +2947,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::get_iam_policy][super::super::client::Echo::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -2530,6 +3016,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::test_iam_permissions][super::super::client::Echo::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -2591,6 +3092,25 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::list_operations][super::super::client::Echo::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2681,6 +3201,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::get_operation][super::super::client::Echo::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2727,6 +3262,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::delete_operation][super::super::client::Echo::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2773,6 +3323,21 @@ pub mod echo {
     }
 
     /// The request builder for [Echo::cancel_operation][super::super::client::Echo::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::echo::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -2872,6 +3437,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::create_user][super::super::client::Identity::create_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::CreateUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateUser(RequestBuilder<crate::model::CreateUserRequest>);
 
@@ -2915,6 +3495,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::get_user][super::super::client::Identity::get_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::GetUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetUser(RequestBuilder<crate::model::GetUserRequest>);
 
@@ -2960,6 +3555,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::update_user][super::super::client::Identity::update_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::UpdateUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateUser(RequestBuilder<crate::model::UpdateUserRequest>);
 
@@ -3012,6 +3622,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::delete_user][super::super::client::Identity::delete_user] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::DeleteUser;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteUser {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteUser(RequestBuilder<crate::model::DeleteUserRequest>);
 
@@ -3057,6 +3682,25 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::list_users][super::super::client::Identity::list_users] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::ListUsers;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListUsers {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListUsers(RequestBuilder<crate::model::ListUsersRequest>);
 
@@ -3130,6 +3774,25 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::list_locations][super::super::client::Identity::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -3218,6 +3881,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::get_location][super::super::client::Identity::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -3261,6 +3939,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::set_iam_policy][super::super::client::Identity::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -3326,6 +4019,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::get_iam_policy][super::super::client::Identity::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -3380,6 +4088,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::test_iam_permissions][super::super::client::Identity::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -3441,6 +4164,25 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::list_operations][super::super::client::Identity::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -3531,6 +4273,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::get_operation][super::super::client::Identity::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -3577,6 +4334,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::delete_operation][super::super::client::Identity::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -3623,6 +4395,21 @@ pub mod identity {
     }
 
     /// The request builder for [Identity::cancel_operation][super::super::client::Identity::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::identity::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -3724,6 +4511,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::create_room][super::super::client::Messaging::create_room] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::CreateRoom;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateRoom {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateRoom(RequestBuilder<crate::model::CreateRoomRequest>);
 
@@ -3769,6 +4571,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::get_room][super::super::client::Messaging::get_room] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::GetRoom;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetRoom {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetRoom(RequestBuilder<crate::model::GetRoomRequest>);
 
@@ -3816,6 +4633,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::update_room][super::super::client::Messaging::update_room] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::UpdateRoom;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateRoom {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateRoom(RequestBuilder<crate::model::UpdateRoomRequest>);
 
@@ -3870,6 +4702,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::delete_room][super::super::client::Messaging::delete_room] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::DeleteRoom;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteRoom {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteRoom(RequestBuilder<crate::model::DeleteRoomRequest>);
 
@@ -3917,6 +4764,25 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::list_rooms][super::super::client::Messaging::list_rooms] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::ListRooms;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListRooms {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListRooms(RequestBuilder<crate::model::ListRoomsRequest>);
 
@@ -3992,6 +4858,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::create_blurb][super::super::client::Messaging::create_blurb] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::CreateBlurb;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBlurb {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBlurb(RequestBuilder<crate::model::CreateBlurbRequest>);
 
@@ -4048,6 +4929,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::get_blurb][super::super::client::Messaging::get_blurb] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::GetBlurb;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBlurb {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBlurb(RequestBuilder<crate::model::GetBlurbRequest>);
 
@@ -4095,6 +4991,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::update_blurb][super::super::client::Messaging::update_blurb] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::UpdateBlurb;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBlurb {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBlurb(RequestBuilder<crate::model::UpdateBlurbRequest>);
 
@@ -4152,6 +5063,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::delete_blurb][super::super::client::Messaging::delete_blurb] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::DeleteBlurb;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBlurb {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBlurb(RequestBuilder<crate::model::DeleteBlurbRequest>);
 
@@ -4199,6 +5125,25 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::list_blurbs][super::super::client::Messaging::list_blurbs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::ListBlurbs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBlurbs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBlurbs(RequestBuilder<crate::model::ListBlurbsRequest>);
 
@@ -4282,6 +5227,22 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::search_blurbs][super::super::client::Messaging::search_blurbs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::SearchBlurbs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_showcase_v1beta1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SearchBlurbs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SearchBlurbs(RequestBuilder<crate::model::SearchBlurbsRequest>);
 
@@ -4388,6 +5349,25 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::list_locations][super::super::client::Messaging::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -4478,6 +5458,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::get_location][super::super::client::Messaging::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -4523,6 +5518,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::set_iam_policy][super::super::client::Messaging::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -4590,6 +5600,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::get_iam_policy][super::super::client::Messaging::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -4646,6 +5671,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::test_iam_permissions][super::super::client::Messaging::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -4709,6 +5749,25 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::list_operations][super::super::client::Messaging::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -4801,6 +5860,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::get_operation][super::super::client::Messaging::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -4849,6 +5923,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::delete_operation][super::super::client::Messaging::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -4897,6 +5986,21 @@ pub mod messaging {
     }
 
     /// The request builder for [Messaging::cancel_operation][super::super::client::Messaging::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::messaging::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5000,6 +6104,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::create_sequence][super::super::client::SequenceService::create_sequence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::CreateSequence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSequence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSequence(RequestBuilder<crate::model::CreateSequenceRequest>);
 
@@ -5048,6 +6167,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::create_streaming_sequence][super::super::client::SequenceService::create_streaming_sequence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::CreateStreamingSequence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateStreamingSequence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateStreamingSequence(
         RequestBuilder<crate::model::CreateStreamingSequenceRequest>,
@@ -5103,6 +6237,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::get_sequence_report][super::super::client::SequenceService::get_sequence_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::GetSequenceReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSequenceReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSequenceReport(RequestBuilder<crate::model::GetSequenceReportRequest>);
 
@@ -5153,6 +6302,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::get_streaming_sequence_report][super::super::client::SequenceService::get_streaming_sequence_report] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::GetStreamingSequenceReport;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetStreamingSequenceReport {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetStreamingSequenceReport(
         RequestBuilder<crate::model::GetStreamingSequenceReportRequest>,
@@ -5205,6 +6369,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::attempt_sequence][super::super::client::SequenceService::attempt_sequence] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::AttemptSequence;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AttemptSequence {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AttemptSequence(RequestBuilder<crate::model::AttemptSequenceRequest>);
 
@@ -5252,6 +6431,25 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::list_locations][super::super::client::SequenceService::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -5342,6 +6540,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::get_location][super::super::client::SequenceService::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -5387,6 +6600,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::set_iam_policy][super::super::client::SequenceService::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -5454,6 +6682,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::get_iam_policy][super::super::client::SequenceService::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -5510,6 +6753,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::test_iam_permissions][super::super::client::SequenceService::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -5573,6 +6831,25 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::list_operations][super::super::client::SequenceService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -5665,6 +6942,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::get_operation][super::super::client::SequenceService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -5713,6 +7005,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::delete_operation][super::super::client::SequenceService::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -5761,6 +7068,21 @@ pub mod sequence_service {
     }
 
     /// The request builder for [SequenceService::cancel_operation][super::super::client::SequenceService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::sequence_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 
@@ -5862,6 +7184,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::create_session][super::super::client::Testing::create_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::CreateSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateSession(RequestBuilder<crate::model::CreateSessionRequest>);
 
@@ -5908,6 +7245,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::get_session][super::super::client::Testing::get_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::GetSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetSession(RequestBuilder<crate::model::GetSessionRequest>);
 
@@ -5951,6 +7303,25 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::list_sessions][super::super::client::Testing::list_sessions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::ListSessions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListSessions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListSessions(RequestBuilder<crate::model::ListSessionsRequest>);
 
@@ -6024,6 +7395,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::delete_session][super::super::client::Testing::delete_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::DeleteSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteSession(RequestBuilder<crate::model::DeleteSessionRequest>);
 
@@ -6067,6 +7453,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::report_session][super::super::client::Testing::report_session] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::ReportSession;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ReportSession {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ReportSession(RequestBuilder<crate::model::ReportSessionRequest>);
 
@@ -6110,6 +7511,25 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::list_tests][super::super::client::Testing::list_tests] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::ListTests;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTests {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTests(RequestBuilder<crate::model::ListTestsRequest>);
 
@@ -6189,6 +7609,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::delete_test][super::super::client::Testing::delete_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::DeleteTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTest(RequestBuilder<crate::model::DeleteTestRequest>);
 
@@ -6232,6 +7667,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::verify_test][super::super::client::Testing::verify_test] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::VerifyTest;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> VerifyTest {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct VerifyTest(RequestBuilder<crate::model::VerifyTestRequest>);
 
@@ -6292,6 +7742,25 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::list_locations][super::super::client::Testing::list_locations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::ListLocations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListLocations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListLocations(RequestBuilder<location::model::ListLocationsRequest>);
 
@@ -6380,6 +7849,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::get_location][super::super::client::Testing::get_location] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::GetLocation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetLocation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetLocation(RequestBuilder<location::model::GetLocationRequest>);
 
@@ -6423,6 +7907,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::set_iam_policy][super::super::client::Testing::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -6488,6 +7987,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::get_iam_policy][super::super::client::Testing::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -6542,6 +8056,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::test_iam_permissions][super::super::client::Testing::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -6603,6 +8132,25 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::list_operations][super::super::client::Testing::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -6693,6 +8241,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::get_operation][super::super::client::Testing::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -6739,6 +8302,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::delete_operation][super::super::client::Testing::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -6785,6 +8363,21 @@ pub mod testing {
     }
 
     /// The request builder for [Testing::cancel_operation][super::super::client::Testing::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_showcase_v1beta1::builder;
+    /// use builder::testing::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/spanner/admin/database/v1/src/builder.rs
+++ b/src/generated/spanner/admin/database/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::list_databases][super::super::client::DatabaseAdmin::list_databases] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::ListDatabases;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatabases {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatabases(RequestBuilder<crate::model::ListDatabasesRequest>);
 
@@ -152,6 +171,22 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::create_database][super::super::client::DatabaseAdmin::create_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::CreateDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_database_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateDatabase(RequestBuilder<crate::model::CreateDatabaseRequest>);
 
@@ -285,6 +320,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::get_database][super::super::client::DatabaseAdmin::get_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::GetDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDatabase(RequestBuilder<crate::model::GetDatabaseRequest>);
 
@@ -332,6 +382,22 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::update_database][super::super::client::DatabaseAdmin::update_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::UpdateDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_database_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDatabase(RequestBuilder<crate::model::UpdateDatabaseRequest>);
 
@@ -434,6 +500,22 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::update_database_ddl][super::super::client::DatabaseAdmin::update_database_ddl] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::UpdateDatabaseDdl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_database_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateDatabaseDdl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateDatabaseDdl(RequestBuilder<crate::model::UpdateDatabaseDdlRequest>);
 
@@ -550,6 +632,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::drop_database][super::super::client::DatabaseAdmin::drop_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::DropDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DropDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DropDatabase(RequestBuilder<crate::model::DropDatabaseRequest>);
 
@@ -597,6 +694,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::get_database_ddl][super::super::client::DatabaseAdmin::get_database_ddl] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::GetDatabaseDdl;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetDatabaseDdl {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetDatabaseDdl(RequestBuilder<crate::model::GetDatabaseDdlRequest>);
 
@@ -644,6 +756,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::set_iam_policy][super::super::client::DatabaseAdmin::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -711,6 +838,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::get_iam_policy][super::super::client::DatabaseAdmin::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -767,6 +909,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::test_iam_permissions][super::super::client::DatabaseAdmin::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -830,6 +987,22 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::create_backup][super::super::client::DatabaseAdmin::create_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::CreateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_database_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackup(RequestBuilder<crate::model::CreateBackupRequest>);
 
@@ -945,6 +1118,22 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::copy_backup][super::super::client::DatabaseAdmin::copy_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::CopyBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_database_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CopyBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CopyBackup(RequestBuilder<crate::model::CopyBackupRequest>);
 
@@ -1068,6 +1257,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::get_backup][super::super::client::DatabaseAdmin::get_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::GetBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackup(RequestBuilder<crate::model::GetBackupRequest>);
 
@@ -1115,6 +1319,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::update_backup][super::super::client::DatabaseAdmin::update_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::UpdateBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackup(RequestBuilder<crate::model::UpdateBackupRequest>);
 
@@ -1176,6 +1395,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::delete_backup][super::super::client::DatabaseAdmin::delete_backup] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::DeleteBackup;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackup {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackup(RequestBuilder<crate::model::DeleteBackupRequest>);
 
@@ -1223,6 +1457,25 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::list_backups][super::super::client::DatabaseAdmin::list_backups] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::ListBackups;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackups {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackups(RequestBuilder<crate::model::ListBackupsRequest>);
 
@@ -1312,6 +1565,22 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::restore_database][super::super::client::DatabaseAdmin::restore_database] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::RestoreDatabase;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_database_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RestoreDatabase {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RestoreDatabase(RequestBuilder<crate::model::RestoreDatabaseRequest>);
 
@@ -1441,6 +1710,25 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::list_database_operations][super::super::client::DatabaseAdmin::list_database_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::ListDatabaseOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatabaseOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatabaseOperations(RequestBuilder<crate::model::ListDatabaseOperationsRequest>);
 
@@ -1537,6 +1825,25 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::list_backup_operations][super::super::client::DatabaseAdmin::list_backup_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::ListBackupOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupOperations(RequestBuilder<crate::model::ListBackupOperationsRequest>);
 
@@ -1631,6 +1938,25 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::list_database_roles][super::super::client::DatabaseAdmin::list_database_roles] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::ListDatabaseRoles;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListDatabaseRoles {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListDatabaseRoles(RequestBuilder<crate::model::ListDatabaseRolesRequest>);
 
@@ -1717,6 +2043,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::add_split_points][super::super::client::DatabaseAdmin::add_split_points] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::AddSplitPoints;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> AddSplitPoints {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct AddSplitPoints(RequestBuilder<crate::model::AddSplitPointsRequest>);
 
@@ -1783,6 +2124,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::create_backup_schedule][super::super::client::DatabaseAdmin::create_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::CreateBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateBackupSchedule(RequestBuilder<crate::model::CreateBackupScheduleRequest>);
 
@@ -1852,6 +2208,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::get_backup_schedule][super::super::client::DatabaseAdmin::get_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::GetBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetBackupSchedule(RequestBuilder<crate::model::GetBackupScheduleRequest>);
 
@@ -1902,6 +2273,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::update_backup_schedule][super::super::client::DatabaseAdmin::update_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::UpdateBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateBackupSchedule(RequestBuilder<crate::model::UpdateBackupScheduleRequest>);
 
@@ -1966,6 +2352,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::delete_backup_schedule][super::super::client::DatabaseAdmin::delete_backup_schedule] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::DeleteBackupSchedule;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteBackupSchedule {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteBackupSchedule(RequestBuilder<crate::model::DeleteBackupScheduleRequest>);
 
@@ -2016,6 +2417,25 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::list_backup_schedules][super::super::client::DatabaseAdmin::list_backup_schedules] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::ListBackupSchedules;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListBackupSchedules {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListBackupSchedules(RequestBuilder<crate::model::ListBackupSchedulesRequest>);
 
@@ -2104,6 +2524,25 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::list_operations][super::super::client::DatabaseAdmin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -2196,6 +2635,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::get_operation][super::super::client::DatabaseAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -2244,6 +2698,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::delete_operation][super::super::client::DatabaseAdmin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2292,6 +2761,21 @@ pub mod database_admin {
     }
 
     /// The request builder for [DatabaseAdmin::cancel_operation][super::super::client::DatabaseAdmin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_database_v1::builder;
+    /// use builder::database_admin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/spanner/admin/instance/v1/src/builder.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builder.rs
@@ -69,6 +69,25 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::list_instance_configs][super::super::client::InstanceAdmin::list_instance_configs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::ListInstanceConfigs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstanceConfigs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstanceConfigs(RequestBuilder<crate::model::ListInstanceConfigsRequest>);
 
@@ -157,6 +176,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::get_instance_config][super::super::client::InstanceAdmin::get_instance_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::GetInstanceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstanceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstanceConfig(RequestBuilder<crate::model::GetInstanceConfigRequest>);
 
@@ -207,6 +241,22 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::create_instance_config][super::super::client::InstanceAdmin::create_instance_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::CreateInstanceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_instance_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstanceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstanceConfig(RequestBuilder<crate::model::CreateInstanceConfigRequest>);
 
@@ -323,6 +373,22 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::update_instance_config][super::super::client::InstanceAdmin::update_instance_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::UpdateInstanceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_instance_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstanceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstanceConfig(RequestBuilder<crate::model::UpdateInstanceConfigRequest>);
 
@@ -434,6 +500,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::delete_instance_config][super::super::client::InstanceAdmin::delete_instance_config] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::DeleteInstanceConfig;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstanceConfig {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstanceConfig(RequestBuilder<crate::model::DeleteInstanceConfigRequest>);
 
@@ -496,6 +577,25 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::list_instance_config_operations][super::super::client::InstanceAdmin::list_instance_config_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::ListInstanceConfigOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstanceConfigOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstanceConfigOperations(
         RequestBuilder<crate::model::ListInstanceConfigOperationsRequest>,
@@ -594,6 +694,25 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::list_instances][super::super::client::InstanceAdmin::list_instances] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::ListInstances;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstances {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstances(RequestBuilder<crate::model::ListInstancesRequest>);
 
@@ -692,6 +811,25 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::list_instance_partitions][super::super::client::InstanceAdmin::list_instance_partitions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::ListInstancePartitions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstancePartitions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstancePartitions(RequestBuilder<crate::model::ListInstancePartitionsRequest>);
 
@@ -791,6 +929,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::get_instance][super::super::client::InstanceAdmin::get_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::GetInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstance(RequestBuilder<crate::model::GetInstanceRequest>);
 
@@ -847,6 +1000,22 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::create_instance][super::super::client::InstanceAdmin::create_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::CreateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_instance_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstance(RequestBuilder<crate::model::CreateInstanceRequest>);
 
@@ -954,6 +1123,22 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::update_instance][super::super::client::InstanceAdmin::update_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::UpdateInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_instance_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstance(RequestBuilder<crate::model::UpdateInstanceRequest>);
 
@@ -1056,6 +1241,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::delete_instance][super::super::client::InstanceAdmin::delete_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::DeleteInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstance(RequestBuilder<crate::model::DeleteInstanceRequest>);
 
@@ -1103,6 +1303,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::set_iam_policy][super::super::client::InstanceAdmin::set_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::SetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> SetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct SetIamPolicy(RequestBuilder<iam_v1::model::SetIamPolicyRequest>);
 
@@ -1170,6 +1385,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::get_iam_policy][super::super::client::InstanceAdmin::get_iam_policy] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::GetIamPolicy;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetIamPolicy {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetIamPolicy(RequestBuilder<iam_v1::model::GetIamPolicyRequest>);
 
@@ -1226,6 +1456,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::test_iam_permissions][super::super::client::InstanceAdmin::test_iam_permissions] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::TestIamPermissions;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> TestIamPermissions {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct TestIamPermissions(RequestBuilder<iam_v1::model::TestIamPermissionsRequest>);
 
@@ -1289,6 +1534,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::get_instance_partition][super::super::client::InstanceAdmin::get_instance_partition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::GetInstancePartition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetInstancePartition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetInstancePartition(RequestBuilder<crate::model::GetInstancePartitionRequest>);
 
@@ -1339,6 +1599,22 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::create_instance_partition][super::super::client::InstanceAdmin::create_instance_partition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::CreateInstancePartition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_instance_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateInstancePartition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateInstancePartition(
         RequestBuilder<crate::model::CreateInstancePartitionRequest>,
@@ -1455,6 +1731,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::delete_instance_partition][super::super::client::InstanceAdmin::delete_instance_partition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::DeleteInstancePartition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteInstancePartition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteInstancePartition(
         RequestBuilder<crate::model::DeleteInstancePartitionRequest>,
@@ -1513,6 +1804,22 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::update_instance_partition][super::super::client::InstanceAdmin::update_instance_partition] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::UpdateInstancePartition;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_instance_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateInstancePartition {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateInstancePartition(
         RequestBuilder<crate::model::UpdateInstancePartitionRequest>,
@@ -1624,6 +1931,25 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::list_instance_partition_operations][super::super::client::InstanceAdmin::list_instance_partition_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::ListInstancePartitionOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListInstancePartitionOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListInstancePartitionOperations(
         RequestBuilder<crate::model::ListInstancePartitionOperationsRequest>,
@@ -1731,6 +2057,22 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::move_instance][super::super::client::InstanceAdmin::move_instance] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::MoveInstance;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_spanner_admin_instance_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> MoveInstance {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct MoveInstance(RequestBuilder<crate::model::MoveInstanceRequest>);
 
@@ -1827,6 +2169,25 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::list_operations][super::super::client::InstanceAdmin::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1919,6 +2280,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::get_operation][super::super::client::InstanceAdmin::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1967,6 +2343,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::delete_operation][super::super::client::InstanceAdmin::delete_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::DeleteOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteOperation(RequestBuilder<longrunning::model::DeleteOperationRequest>);
 
@@ -2015,6 +2406,21 @@ pub mod instance_admin {
     }
 
     /// The request builder for [InstanceAdmin::cancel_operation][super::super::client::InstanceAdmin::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_spanner_admin_instance_v1::builder;
+    /// use builder::instance_admin::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 

--- a/src/generated/storagetransfer/v1/src/builder.rs
+++ b/src/generated/storagetransfer/v1/src/builder.rs
@@ -69,6 +69,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::get_google_service_account][super::super::client::StorageTransferService::get_google_service_account] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::GetGoogleServiceAccount;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetGoogleServiceAccount {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetGoogleServiceAccount(
         RequestBuilder<crate::model::GetGoogleServiceAccountRequest>,
@@ -121,6 +136,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::create_transfer_job][super::super::client::StorageTransferService::create_transfer_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::CreateTransferJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateTransferJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateTransferJob(RequestBuilder<crate::model::CreateTransferJobRequest>);
 
@@ -174,6 +204,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::update_transfer_job][super::super::client::StorageTransferService::update_transfer_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::UpdateTransferJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateTransferJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateTransferJob(RequestBuilder<crate::model::UpdateTransferJobRequest>);
 
@@ -252,6 +297,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::get_transfer_job][super::super::client::StorageTransferService::get_transfer_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::GetTransferJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetTransferJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetTransferJob(RequestBuilder<crate::model::GetTransferJobRequest>);
 
@@ -307,6 +367,25 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::list_transfer_jobs][super::super::client::StorageTransferService::list_transfer_jobs] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::ListTransferJobs;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListTransferJobs {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListTransferJobs(RequestBuilder<crate::model::ListTransferJobsRequest>);
 
@@ -393,6 +472,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::pause_transfer_operation][super::super::client::StorageTransferService::pause_transfer_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::PauseTransferOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> PauseTransferOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct PauseTransferOperation(RequestBuilder<crate::model::PauseTransferOperationRequest>);
 
@@ -443,6 +537,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::resume_transfer_operation][super::super::client::StorageTransferService::resume_transfer_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::ResumeTransferOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ResumeTransferOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ResumeTransferOperation(
         RequestBuilder<crate::model::ResumeTransferOperationRequest>,
@@ -495,6 +604,22 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::run_transfer_job][super::super::client::StorageTransferService::run_transfer_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::RunTransferJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use google_cloud_storagetransfer_v1::Poller;
+    /// let response = builder.poller().until_done().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> RunTransferJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct RunTransferJob(RequestBuilder<crate::model::RunTransferJobRequest>);
 
@@ -590,6 +715,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::delete_transfer_job][super::super::client::StorageTransferService::delete_transfer_job] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::DeleteTransferJob;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteTransferJob {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteTransferJob(RequestBuilder<crate::model::DeleteTransferJobRequest>);
 
@@ -648,6 +788,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::create_agent_pool][super::super::client::StorageTransferService::create_agent_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::CreateAgentPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CreateAgentPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CreateAgentPool(RequestBuilder<crate::model::CreateAgentPoolRequest>);
 
@@ -714,6 +869,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::update_agent_pool][super::super::client::StorageTransferService::update_agent_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::UpdateAgentPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> UpdateAgentPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct UpdateAgentPool(RequestBuilder<crate::model::UpdateAgentPoolRequest>);
 
@@ -773,6 +943,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::get_agent_pool][super::super::client::StorageTransferService::get_agent_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::GetAgentPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetAgentPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetAgentPool(RequestBuilder<crate::model::GetAgentPoolRequest>);
 
@@ -820,6 +1005,25 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::list_agent_pools][super::super::client::StorageTransferService::list_agent_pools] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::ListAgentPools;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListAgentPools {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListAgentPools(RequestBuilder<crate::model::ListAgentPoolsRequest>);
 
@@ -909,6 +1113,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::delete_agent_pool][super::super::client::StorageTransferService::delete_agent_pool] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::DeleteAgentPool;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> DeleteAgentPool {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct DeleteAgentPool(RequestBuilder<crate::model::DeleteAgentPoolRequest>);
 
@@ -956,6 +1175,25 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::list_operations][super::super::client::StorageTransferService::list_operations] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::ListOperations;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// use gax::paginator::ItemPaginator;
+    /// let mut items = builder.by_item();
+    /// while let Some(result) = items.next().await {
+    ///   let item = result?;
+    /// }
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> ListOperations {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct ListOperations(RequestBuilder<longrunning::model::ListOperationsRequest>);
 
@@ -1048,6 +1286,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::get_operation][super::super::client::StorageTransferService::get_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::GetOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> GetOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct GetOperation(RequestBuilder<longrunning::model::GetOperationRequest>);
 
@@ -1096,6 +1349,21 @@ pub mod storage_transfer_service {
     }
 
     /// The request builder for [StorageTransferService::cancel_operation][super::super::client::StorageTransferService::cancel_operation] calls.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use google_cloud_storagetransfer_v1::builder;
+    /// use builder::storage_transfer_service::CancelOperation;
+    /// # tokio_test::block_on(async {
+    /// let builder = prepare_request_builder();
+    /// let response = builder.send().await?;
+    /// # gax::Result::<()>::Ok(()) });
+    ///
+    /// fn prepare_request_builder() -> CancelOperation {
+    ///   # panic!();
+    ///   // ... details omitted ...
+    /// }
+    /// ```
     #[derive(Clone, Debug)]
     pub struct CancelOperation(RequestBuilder<longrunning::model::CancelOperationRequest>);
 


### PR DESCRIPTION
Add a little example showing how to use the request builder. I would
like to show the return types in the example, but it is too hard right
now.

The LROs and pagination APIs get slightly different examples.