### PR TITLE
feat: telemetry includes REST vs. gRPC fields

### DIFF
--- a/generator/internal/rust/templates/crate/src/lib.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/lib.rs.mustache
@@ -93,7 +93,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC, 
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -47,7 +47,7 @@ mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.grpc_header_value()
         };
     }
 }

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -30,7 +30,7 @@ mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.grpc_header_value()
         };
     }
 }

--- a/src/gax-internal/src/api_header.rs
+++ b/src/gax-internal/src/api_header.rs
@@ -36,7 +36,7 @@ mod build_info {
 
 impl XGoogApiClient {
     /// Format the struct as needed for the `x-goog-api-client` header.
-    pub fn header_value(&self) -> String {
+    pub fn rest_header_value(&self) -> String {
         // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
         // found, leave RUSTC_VERSION unchanged.
         let rustc_version = build_info::RUSTC_VERSION;
@@ -48,7 +48,25 @@ impl XGoogApiClient {
         let gax_version = build_info::PKG_VERSION;
 
         format!(
-            "gl-rust/{rustc_version} gax/{gax_version} {}/{}",
+            "gl-rust/{rustc_version} gax/{gax_version} rest/{gax_version}-reqwest {}/{}",
+            self.library_type, self.version
+        )
+    }
+
+    /// Format the struct as needed for the `x-goog-api-client` header.
+    pub fn grpc_header_value(&self) -> String {
+        // Strip out the initial "rustc " string from `RUSTC_VERSION`. If not
+        // found, leave RUSTC_VERSION unchanged.
+        let rustc_version = build_info::RUSTC_VERSION;
+        let rustc_version = rustc_version
+            .strip_prefix("rustc ")
+            .unwrap_or(build_info::RUSTC_VERSION);
+
+        // Capture the gax version too.
+        let gax_version = build_info::PKG_VERSION;
+
+        format!(
+            "gl-rust/{rustc_version} gax/{gax_version} grpc/{gax_version}-tonic {}/{}",
             self.library_type, self.version
         )
     }
@@ -69,19 +87,58 @@ mod test {
     }
 
     #[test]
-    fn test_format() {
+    fn test_format_rest() {
         let header = XGoogApiClient {
             name: "unused",
             version: "1.2.3",
             library_type: GCCL,
         };
-        let fields = breakdown(header.header_value().as_str());
+        let fields = breakdown(header.rest_header_value().as_str());
 
         let got = fields.get(GCCL).map(String::to_owned);
         assert_eq!(got.as_deref(), Some("1.2.3"));
 
         let got = fields.get("gax").map(String::to_owned);
         assert_eq!(got.as_deref(), Some(build_info::PKG_VERSION));
+
+        let got = fields.get("grpc");
+        assert!(got.is_none(), "{fields:?}");
+
+        let got = fields.get("rest");
+        assert!(got.is_some(), "{fields:?}");
+
+        let got = fields.get("gl-rust").map(String::to_owned);
+        let want = build_info::RUSTC_VERSION;
+        assert!(
+            got.as_ref()
+                .map(|s| want.contains(s) && !s.is_empty())
+                .unwrap_or(false),
+            "mismatched rustc version {} and {:?}",
+            want,
+            got
+        );
+    }
+
+    #[test]
+    fn test_format_grpc() {
+        let header = XGoogApiClient {
+            name: "unused",
+            version: "1.2.3",
+            library_type: GCCL,
+        };
+        let fields = breakdown(header.grpc_header_value().as_str());
+
+        let got = fields.get(GCCL).map(String::to_owned);
+        assert_eq!(got.as_deref(), Some("1.2.3"));
+
+        let got = fields.get("gax").map(String::to_owned);
+        assert_eq!(got.as_deref(), Some(build_info::PKG_VERSION));
+
+        let got = fields.get("grpc");
+        assert!(got.is_some(), "{fields:?}");
+
+        let got = fields.get("rest");
+        assert!(got.is_none(), "{fields:?}");
 
         let got = fields.get("gl-rust").map(String::to_owned);
         let want = build_info::RUSTC_VERSION;

--- a/src/generated/api/apikeys/v2/src/lib.rs
+++ b/src/generated/api/apikeys/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/api/servicecontrol/v1/src/lib.rs
+++ b/src/generated/api/servicecontrol/v1/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/api/servicecontrol/v2/src/lib.rs
+++ b/src/generated/api/servicecontrol/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/api/servicemanagement/v1/src/lib.rs
+++ b/src/generated/api/servicemanagement/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/api/serviceusage/v1/src/lib.rs
+++ b/src/generated/api/serviceusage/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/appengine/v1/src/lib.rs
+++ b/src/generated/appengine/v1/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/bigtable/admin/v2/src/lib.rs
+++ b/src/generated/bigtable/admin/v2/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/accessapproval/v1/src/lib.rs
+++ b/src/generated/cloud/accessapproval/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/advisorynotifications/v1/src/lib.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/aiplatform/v1/src/lib.rs
+++ b/src/generated/cloud/aiplatform/v1/src/lib.rs
@@ -165,7 +165,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/alloydb/v1/src/lib.rs
+++ b/src/generated/cloud/alloydb/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/apigateway/v1/src/lib.rs
+++ b/src/generated/cloud/apigateway/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/apigeeconnect/v1/src/lib.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/apihub/v1/src/lib.rs
+++ b/src/generated/cloud/apihub/v1/src/lib.rs
@@ -69,7 +69,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/apphub/v1/src/lib.rs
+++ b/src/generated/cloud/apphub/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/asset/v1/src/lib.rs
+++ b/src/generated/cloud/asset/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/assuredworkloads/v1/src/lib.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/backupdr/v1/src/lib.rs
+++ b/src/generated/cloud/backupdr/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/baremetalsolution/v2/src/lib.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/lib.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/bigquery/connection/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/bigquery/migration/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/bigquery/v2/src/lib.rs
+++ b/src/generated/cloud/bigquery/v2/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/billing/v1/src/lib.rs
+++ b/src/generated/cloud/billing/v1/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/binaryauthorization/v1/src/lib.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/certificatemanager/v1/src/lib.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/chronicle/v1/src/lib.rs
+++ b/src/generated/cloud/chronicle/v1/src/lib.rs
@@ -67,7 +67,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/clouddms/v1/src/lib.rs
+++ b/src/generated/cloud/clouddms/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/lib.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/confidentialcomputing/v1/src/lib.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/config/v1/src/lib.rs
+++ b/src/generated/cloud/config/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/connectors/v1/src/lib.rs
+++ b/src/generated/cloud/connectors/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/datacatalog/lineage/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/datacatalog/v1/src/lib.rs
+++ b/src/generated/cloud/datacatalog/v1/src/lib.rs
@@ -67,7 +67,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/datafusion/v1/src/lib.rs
+++ b/src/generated/cloud/datafusion/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/dataplex/v1/src/lib.rs
+++ b/src/generated/cloud/dataplex/v1/src/lib.rs
@@ -71,7 +71,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/dataproc/v1/src/lib.rs
+++ b/src/generated/cloud/dataproc/v1/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/datastream/v1/src/lib.rs
+++ b/src/generated/cloud/datastream/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/deploy/v1/src/lib.rs
+++ b/src/generated/cloud/deploy/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/developerconnect/v1/src/lib.rs
+++ b/src/generated/cloud/developerconnect/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/lib.rs
@@ -81,7 +81,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/dialogflow/v2/src/lib.rs
+++ b/src/generated/cloud/dialogflow/v2/src/lib.rs
@@ -83,7 +83,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/discoveryengine/v1/src/lib.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/lib.rs
@@ -80,7 +80,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/documentai/v1/src/lib.rs
+++ b/src/generated/cloud/documentai/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/domains/v1/src/lib.rs
+++ b/src/generated/cloud/domains/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/edgecontainer/v1/src/lib.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/edgenetwork/v1/src/lib.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/essentialcontacts/v1/src/lib.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/eventarc/v1/src/lib.rs
+++ b/src/generated/cloud/eventarc/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/filestore/v1/src/lib.rs
+++ b/src/generated/cloud/filestore/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/financialservices/v1/src/lib.rs
+++ b/src/generated/cloud/financialservices/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/functions/v2/src/lib.rs
+++ b/src/generated/cloud/functions/v2/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/gkebackup/v1/src/lib.rs
+++ b/src/generated/cloud/gkebackup/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/lib.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/gkehub/v1/src/lib.rs
+++ b/src/generated/cloud/gkehub/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/gkemulticloud/v1/src/lib.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/gsuiteaddons/v1/src/lib.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/iap/v1/src/lib.rs
+++ b/src/generated/cloud/iap/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/ids/v1/src/lib.rs
+++ b/src/generated/cloud/ids/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/kms/inventory/v1/src/lib.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/kms/v1/src/lib.rs
+++ b/src/generated/cloud/kms/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/language/v2/src/lib.rs
+++ b/src/generated/cloud/language/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/licensemanager/v1/src/lib.rs
+++ b/src/generated/cloud/licensemanager/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/location/src/lib.rs
+++ b/src/generated/cloud/location/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/lustre/v1/src/lib.rs
+++ b/src/generated/cloud/lustre/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/managedidentities/v1/src/lib.rs
+++ b/src/generated/cloud/managedidentities/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/memcache/v1/src/lib.rs
+++ b/src/generated/cloud/memcache/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/memorystore/v1/src/lib.rs
+++ b/src/generated/cloud/memorystore/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/metastore/v1/src/lib.rs
+++ b/src/generated/cloud/metastore/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/migrationcenter/v1/src/lib.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/modelarmor/v1/src/lib.rs
+++ b/src/generated/cloud/modelarmor/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/netapp/v1/src/lib.rs
+++ b/src/generated/cloud/netapp/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/networkconnectivity/v1/src/lib.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/lib.rs
@@ -67,7 +67,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/networkmanagement/v1/src/lib.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/networksecurity/v1/src/lib.rs
+++ b/src/generated/cloud/networksecurity/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/networkservices/v1/src/lib.rs
+++ b/src/generated/cloud/networkservices/v1/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/notebooks/v2/src/lib.rs
+++ b/src/generated/cloud/notebooks/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/optimization/v1/src/lib.rs
+++ b/src/generated/cloud/optimization/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/oracledatabase/v1/src/lib.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/lib.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/orgpolicy/v2/src/lib.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/osconfig/v1/src/lib.rs
+++ b/src/generated/cloud/osconfig/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/oslogin/v1/src/lib.rs
+++ b/src/generated/cloud/oslogin/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/parallelstore/v1/src/lib.rs
+++ b/src/generated/cloud/parallelstore/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/parametermanager/v1/src/lib.rs
+++ b/src/generated/cloud/parametermanager/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/policysimulator/v1/src/lib.rs
+++ b/src/generated/cloud/policysimulator/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/lib.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/policytroubleshooter/v1/src/lib.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/lib.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/lib.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/recommender/v1/src/lib.rs
+++ b/src/generated/cloud/recommender/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/redis/cluster/v1/src/lib.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/redis/v1/src/lib.rs
+++ b/src/generated/cloud/redis/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/resourcemanager/v3/src/lib.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/lib.rs
@@ -69,7 +69,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/retail/v2/src/lib.rs
+++ b/src/generated/cloud/retail/v2/src/lib.rs
@@ -75,7 +75,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/run/v2/src/lib.rs
+++ b/src/generated/cloud/run/v2/src/lib.rs
@@ -70,7 +70,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/scheduler/v1/src/lib.rs
+++ b/src/generated/cloud/scheduler/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/secretmanager/v1/src/lib.rs
+++ b/src/generated/cloud/secretmanager/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/securesourcemanager/v1/src/lib.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/security/privateca/v1/src/lib.rs
+++ b/src/generated/cloud/security/privateca/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/security/publicca/v1/src/lib.rs
+++ b/src/generated/cloud/security/publicca/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/securitycenter/v2/src/lib.rs
+++ b/src/generated/cloud/securitycenter/v2/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/securityposture/v1/src/lib.rs
+++ b/src/generated/cloud/securityposture/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/servicedirectory/v1/src/lib.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/servicehealth/v1/src/lib.rs
+++ b/src/generated/cloud/servicehealth/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/shell/v1/src/lib.rs
+++ b/src/generated/cloud/shell/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/speech/v2/src/lib.rs
+++ b/src/generated/cloud/speech/v2/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/sql/v1/src/lib.rs
+++ b/src/generated/cloud/sql/v1/src/lib.rs
@@ -73,7 +73,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/storagebatchoperations/v1/src/lib.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/storageinsights/v1/src/lib.rs
+++ b/src/generated/cloud/storageinsights/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/support/v2/src/lib.rs
+++ b/src/generated/cloud/support/v2/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/talent/v4/src/lib.rs
+++ b/src/generated/cloud/talent/v4/src/lib.rs
@@ -69,7 +69,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/tasks/v2/src/lib.rs
+++ b/src/generated/cloud/tasks/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/telcoautomation/v1/src/lib.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/texttospeech/v1/src/lib.rs
+++ b/src/generated/cloud/texttospeech/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/timeseriesinsights/v1/src/lib.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/tpu/v2/src/lib.rs
+++ b/src/generated/cloud/tpu/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/translate/v3/src/lib.rs
+++ b/src/generated/cloud/translate/v3/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/video/livestream/v1/src/lib.rs
+++ b/src/generated/cloud/video/livestream/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/video/stitcher/v1/src/lib.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/video/transcoder/v1/src/lib.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/videointelligence/v1/src/lib.rs
+++ b/src/generated/cloud/videointelligence/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/vision/v1/src/lib.rs
+++ b/src/generated/cloud/vision/v1/src/lib.rs
@@ -66,7 +66,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/vmmigration/v1/src/lib.rs
+++ b/src/generated/cloud/vmmigration/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/vmwareengine/v1/src/lib.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/vpcaccess/v1/src/lib.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/webrisk/v1/src/lib.rs
+++ b/src/generated/cloud/webrisk/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/websecurityscanner/v1/src/lib.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/workflows/executions/v1/src/lib.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/workflows/v1/src/lib.rs
+++ b/src/generated/cloud/workflows/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/cloud/workstations/v1/src/lib.rs
+++ b/src/generated/cloud/workstations/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/container/v1/src/lib.rs
+++ b/src/generated/container/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/datastore/admin/v1/src/lib.rs
+++ b/src/generated/datastore/admin/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/devtools/artifactregistry/v1/src/lib.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/devtools/cloudbuild/v1/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/devtools/cloudbuild/v2/src/lib.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/devtools/cloudprofiler/v2/src/lib.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/devtools/cloudtrace/v2/src/lib.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/devtools/containeranalysis/v1/src/lib.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/firestore/admin/v1/src/lib.rs
+++ b/src/generated/firestore/admin/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/grafeas/v1/src/lib.rs
+++ b/src/generated/grafeas/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/iam/admin/v1/src/lib.rs
+++ b/src/generated/iam/admin/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/iam/credentials/v1/src/lib.rs
+++ b/src/generated/iam/credentials/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/iam/v1/src/lib.rs
+++ b/src/generated/iam/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/iam/v2/src/lib.rs
+++ b/src/generated/iam/v2/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/iam/v3/src/lib.rs
+++ b/src/generated/iam/v3/src/lib.rs
@@ -64,7 +64,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/identity/accesscontextmanager/v1/src/lib.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/logging/v2/src/lib.rs
+++ b/src/generated/logging/v2/src/lib.rs
@@ -67,7 +67,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/longrunning/src/lib.rs
+++ b/src/generated/longrunning/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/monitoring/dashboard/v1/src/lib.rs
+++ b/src/generated/monitoring/dashboard/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/monitoring/metricsscope/v1/src/lib.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/monitoring/v3/src/lib.rs
+++ b/src/generated/monitoring/v3/src/lib.rs
@@ -72,7 +72,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/openapi-validation/src/lib.rs
+++ b/src/generated/openapi-validation/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/privacy/dlp/v2/src/lib.rs
+++ b/src/generated/privacy/dlp/v2/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/showcase/src/lib.rs
+++ b/src/generated/showcase/src/lib.rs
@@ -68,7 +68,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/spanner/admin/database/v1/src/lib.rs
+++ b/src/generated/spanner/admin/database/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/spanner/admin/instance/v1/src/lib.rs
+++ b/src/generated/spanner/admin/instance/v1/src/lib.rs
@@ -65,7 +65,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/generated/storagetransfer/v1/src/lib.rs
+++ b/src/generated/storagetransfer/v1/src/lib.rs
@@ -63,7 +63,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.rest_header_value()
         };
     }
 }

--- a/src/storage-control/src/generated/gapic/transport.rs
+++ b/src/storage-control/src/generated/gapic/transport.rs
@@ -30,7 +30,7 @@ mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.grpc_header_value()
         };
     }
 }

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -30,7 +30,7 @@ mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GAPIC,
             };
-            ac.header_value()
+            ac.grpc_header_value()
         };
     }
 }

--- a/src/storage/src/client.rs
+++ b/src/storage/src/client.rs
@@ -291,7 +291,7 @@ pub(crate) mod info {
                 version:       VERSION,
                 library_type:  gaxi::api_header::GCCL,
             };
-            ac.header_value()
+            ac.grpc_header_value()
         };
     }
 }


### PR DESCRIPTION
The `rest/{vvv}` field is required for showcase and part of the client
library specification.

Fixes #2087
