### PR TITLE
fix(wkt): deserialize floats from ints

### DIFF
--- a/src/wkt/tests/message_with_f32.rs
+++ b/src/wkt/tests/message_with_f32.rs
@@ -57,6 +57,17 @@ mod test {
         Ok(())
     }
 
+    #[test_case(-1, -1.0)]
+    #[test_case(-2, -2.0)]
+    #[test_case(3, 3.0)]
+    #[test_case(4, 4.0)]
+    fn test_singular_as_int(input: i32, want: f32) -> Result {
+        let input = json!({"singular": input});
+        let got = serde_json::from_value::<MessageWithF32>(input)?;
+        assert_eq!(got.singular, want);
+        Ok(())
+    }
+
     #[test_case(9876.5, 9876.5)]
     #[test_case(f32::INFINITY, "Infinity")]
     #[test_case(f32::NEG_INFINITY, "-Infinity")]

--- a/src/wkt/tests/message_with_f64.rs
+++ b/src/wkt/tests/message_with_f64.rs
@@ -57,6 +57,17 @@ mod test {
         Ok(())
     }
 
+    #[test_case(-1, -1.0)]
+    #[test_case(-2, -2.0)]
+    #[test_case(3, 3.0)]
+    #[test_case(4, 4.0)]
+    fn test_singular_as_int(input: i64, want: f64) -> Result {
+        let input = json!({"singular": input});
+        let got = serde_json::from_value::<MessageWithF64>(input)?;
+        assert_eq!(got.singular, want);
+        Ok(())
+    }
+
     #[test_case(9876.5, 9876.5)]
     #[test_case(f64::INFINITY, "Infinity")]
     #[test_case(f64::NEG_INFINITY, "-Infinity")]


### PR DESCRIPTION
Sometimes floating point values appear as integers on the wire. The service may
send `1` when the value is `1.0`, and the service is doing the right thing in
this case.