### PR TITLE
fix(auth)!: Make Token struct pub(crate) since it is not exposed in a public surface

### DIFF
--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -19,7 +19,7 @@ use tokio::time::Instant;
 
 /// Represents an auth token.
 #[derive(Clone, PartialEq)]
-pub struct Token {
+pub(crate) struct Token {
     /// The actual token string.
     ///
     /// This is the value used in `Authorization:` header.


### PR DESCRIPTION
Fixes #2073 .

Since `token()` method that used to expose the `Token` struct has been removed as part of #2072, we are free to mark the `Token` struct as `pub(crate)`.