### PR TITLE
cleanup!: remove error-prone setters for `oneof`

### DIFF
--- a/generator/internal/rust/templates/common/message.mustache
+++ b/generator/internal/rust/templates/common/message.mustache
@@ -120,56 +120,6 @@ impl {{Codec.Name}} {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [{{Group.Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.FieldName}}]
-    /// to hold a `{{Codec.BranchName}}`.
-    ///
-    /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
-    /// mutually exclusive.
-    {{#Deprecated}}
-    #[deprecated]
-    {{/Deprecated}}
-    {{#Singular}}
-    pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
-        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
-            {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                v.into()
-            )
-        );
-        self
-    }
-    {{/Singular}}
-    {{#Repeated}}
-    pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = V>,
-        V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
-    {
-        use std::iter::Iterator;
-        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
-            {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                v.into_iter().map(|i| i.into()).collect()
-            )
-        );
-        self
-    }
-    {{/Repeated}}
-    {{#Map}}
-    pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
-    where
-        T: std::iter::IntoIterator<Item = (K, V)>,
-        K: std::convert::Into<{{{Codec.KeyType}}}>,
-        V: std::convert::Into<{{{Codec.ValueType}}}>,
-    {
-        use std::iter::Iterator;
-        self.{{Group.Codec.FieldName}} = std::option::Option::Some(
-            {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
-            )
-        );
-        self
-    }
-    {{/Map}}
     {{/Fields}}
     {{/OneOfs}}
 }

--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -284,54 +284,6 @@ pub mod {{Codec.ModuleName}} {
             self.0.request.{{Codec.FieldName}} = v.into();
             self
         }
-        {{#Fields}}
-
-        /// Sets the value of [{{Group.Codec.FieldName}}][{{Codec.FQMessageName}}::{{Group.Codec.FieldName}}]
-        /// to hold a `{{Codec.BranchName}}`.
-        ///
-        /// Note that all the setters affecting `{{Group.Codec.FieldName}}` are
-        /// mutually exclusive.
-        {{#Deprecated}}
-        #[deprecated]
-        {{/Deprecated}}
-        {{#Singular}}
-        pub fn set_{{Codec.SetterName}}<T: std::convert::Into<{{{Codec.FieldType}}}>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_{{Codec.SetterName}}(v);
-            self
-        }
-        {{/Singular}}
-        {{#Repeated}}
-        pub fn set_{{Codec.SetterName}}<T, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = V>,
-            V: std::convert::Into<{{{Codec.PrimitiveFieldType}}}>
-        {
-            use std::iter::Iterator;
-            self.{{Group.Codec.FieldName}} = std::option::Option::Some(
-                {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                    v.into_iter().map(|i| i.into()).collect()
-                )
-            );
-            self
-        }
-        {{/Repeated}}
-        {{#Map}}
-        pub fn set_{{Codec.SetterName}}<T, K, V>(mut self, v: T) -> Self
-        where
-            T: std::iter::IntoIterator<Item = (K, V)>,
-            K: std::convert::Into<{{{Codec.KeyType}}}>,
-            V: std::convert::Into<{{{Codec.ValueType}}}>,
-        {
-            use std::iter::Iterator;
-            self.{{Group.Codec.FieldName}} = std::option::Option::Some(
-                {{Group.Codec.QualifiedName}}::{{Codec.BranchName}}(
-                    v.into_iter().map(|(k, v)| (k.into(), v.into())).collect()
-                )
-            );
-            self
-        }
-        {{/Map}}
-        {{/Fields}}
         {{/InputType.OneOfs}}
     }
 

--- a/guide/samples/src/gemini.rs
+++ b/guide/samples/src/gemini.rs
@@ -32,7 +32,8 @@ pub async fn text_prompt(project_id: &str) -> crate::Result<()> {
     let response = client
         .generate_content().set_model(&model)
         .set_contents([vertexai::model::Content::new().set_role("user").set_parts([
-            vertexai::model::Part::new().set_text("What's a good name for a flower shop that specializes in selling bouquets of dried flowers?"),
+            vertexai::model::Part::new().set_data(
+                vertexai::model::part::Data::Text("What's a good name for a flower shop that specializes in selling bouquets of dried flowers?".into())),
         ])])
         .send()
         .await;
@@ -66,14 +67,17 @@ pub async fn prompt_and_image(project_id: &str) -> crate::Result<()> {
         .set_contents(
             [vertexai::model::Content::new().set_role("user").set_parts([
                 // ANCHOR: prompt-and-image-image-part
-                vertexai::model::Part::new().set_file_data(
+                vertexai::model::Part::new().set_data(vertexai::model::part::Data::FileData(
                     vertexai::model::FileData::new()
                         .set_mime_type("image/jpeg")
-                        .set_file_uri("gs://generativeai-downloads/images/scones.jpg"),
-                ),
+                        .set_file_uri("gs://generativeai-downloads/images/scones.jpg")
+                        .into(),
+                )),
                 // ANCHOR_END: prompt-and-image-image-part
                 // ANCHOR: prompt-and-image-prompt-part
-                vertexai::model::Part::new().set_text("Describe this picture."),
+                vertexai::model::Part::new().set_data(vertexai::model::part::Data::Text(
+                    "Describe this picture.".into(),
+                )),
                 // ANCHOR_END: prompt-and-image-prompt-part
             ])],
         )

--- a/guide/samples/src/lro.rs
+++ b/guide/samples/src/lro.rs
@@ -20,6 +20,8 @@ use google_cloud_speech_v2 as speech;
 // ANCHOR: start
 pub async fn start(project_id: &str) -> crate::Result<()> {
     // ANCHOR: client
+    use speech::model::*;
+
     let client = speech::client::Speech::builder().build().await?;
     // ANCHOR_END: client
 
@@ -31,24 +33,30 @@ pub async fn start(project_id: &str) -> crate::Result<()> {
         ))
         // ANCHOR_END: request-builder
         // ANCHOR: audio-file
-        .set_files([speech::model::BatchRecognizeFileMetadata::new()
-            .set_uri("gs://cloud-samples-data/speech/hello.wav")])
+        .set_files([BatchRecognizeFileMetadata::new().set_audio_source(
+            batch_recognize_file_metadata::AudioSource::Uri(
+                "gs://cloud-samples-data/speech/hello.wav".into(),
+            ),
+        )])
         // ANCHOR_END: audio-file
         // ANCHOR: transcript-output
-        .set_recognition_output_config(
-            speech::model::RecognitionOutputConfig::new()
-                .set_inline_response_config(speech::model::InlineOutputConfig::new()),
-        )
+        .set_recognition_output_config(RecognitionOutputConfig::new().set_output(
+            recognition_output_config::Output::InlineResponseConfig(
+                InlineOutputConfig::new().into(),
+            ),
+        ))
         // ANCHOR_END: transcript-output
         // ANCHOR: configuration
         .set_processing_strategy(
             speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
         )
         .set_config(
-            speech::model::RecognitionConfig::new()
+            RecognitionConfig::new()
                 .set_language_codes(["en-US"])
                 .set_model("short")
-                .set_auto_decoding_config(speech::model::AutoDetectDecodingConfig::new()),
+                .set_decoding_config(recognition_config::DecodingConfig::AutoDecodingConfig(
+                    AutoDetectDecodingConfig::new().into(),
+                )),
         )
         // ANCHOR_END: configuration
         // ANCHOR: send
@@ -70,6 +78,7 @@ pub async fn start(project_id: &str) -> crate::Result<()> {
 pub async fn automatic(project_id: &str) -> crate::Result<()> {
     // ANCHOR: automatic-use
     use speech::Poller;
+    use speech::model::*;
     // ANCHOR_END: automatic-use
     // ANCHOR: automatic-prepare
     let client = speech::client::Speech::builder().build().await?;
@@ -79,20 +88,24 @@ pub async fn automatic(project_id: &str) -> crate::Result<()> {
         .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
-        .set_files([speech::model::BatchRecognizeFileMetadata::new()
-            .set_uri("gs://cloud-samples-data/speech/hello.wav")])
-        .set_recognition_output_config(
-            speech::model::RecognitionOutputConfig::new()
-                .set_inline_response_config(speech::model::InlineOutputConfig::new()),
-        )
-        .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
-        )
+        .set_files([BatchRecognizeFileMetadata::new().set_audio_source(
+            batch_recognize_file_metadata::AudioSource::Uri(
+                "gs://cloud-samples-data/speech/hello.wav".into(),
+            ),
+        )])
+        .set_recognition_output_config(RecognitionOutputConfig::new().set_output(
+            recognition_output_config::Output::InlineResponseConfig(
+                InlineOutputConfig::new().into(),
+            ),
+        ))
+        .set_processing_strategy(batch_recognize_request::ProcessingStrategy::DynamicBatching)
         .set_config(
-            speech::model::RecognitionConfig::new()
+            RecognitionConfig::new()
                 .set_language_codes(["en-US"])
                 .set_model("short")
-                .set_auto_decoding_config(speech::model::AutoDetectDecodingConfig::new()),
+                .set_decoding_config(recognition_config::DecodingConfig::AutoDecodingConfig(
+                    AutoDetectDecodingConfig::new().into(),
+                )),
         )
         // ANCHOR_END: automatic-prepare
         // ANCHOR: automatic-print
@@ -113,6 +126,7 @@ pub async fn automatic(project_id: &str) -> crate::Result<()> {
 pub async fn polling(project_id: &str) -> crate::Result<()> {
     // ANCHOR: polling-use
     use speech::Poller;
+    use speech::model::*;
     // ANCHOR_END: polling-use
     // ANCHOR: polling-prepare
     let client = speech::client::Speech::builder().build().await?;
@@ -122,20 +136,24 @@ pub async fn polling(project_id: &str) -> crate::Result<()> {
         .set_recognizer(format!(
             "projects/{project_id}/locations/global/recognizers/_"
         ))
-        .set_files([speech::model::BatchRecognizeFileMetadata::new()
-            .set_uri("gs://cloud-samples-data/speech/hello.wav")])
-        .set_recognition_output_config(
-            speech::model::RecognitionOutputConfig::new()
-                .set_inline_response_config(speech::model::InlineOutputConfig::new()),
-        )
-        .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
-        )
+        .set_files([BatchRecognizeFileMetadata::new().set_audio_source(
+            batch_recognize_file_metadata::AudioSource::Uri(
+                "gs://cloud-samples-data/speech/hello.wav".into(),
+            ),
+        )])
+        .set_recognition_output_config(RecognitionOutputConfig::new().set_output(
+            recognition_output_config::Output::InlineResponseConfig(
+                InlineOutputConfig::new().into(),
+            ),
+        ))
+        .set_processing_strategy(batch_recognize_request::ProcessingStrategy::DynamicBatching)
         .set_config(
-            speech::model::RecognitionConfig::new()
+            RecognitionConfig::new()
                 .set_language_codes(["en-US"])
                 .set_model("short")
-                .set_auto_decoding_config(speech::model::AutoDetectDecodingConfig::new()),
+                .set_decoding_config(recognition_config::DecodingConfig::AutoDecodingConfig(
+                    AutoDetectDecodingConfig::new().into(),
+                )),
         )
         // ANCHOR_END: polling-prepare
         // ANCHOR: polling-poller

--- a/guide/samples/src/polling_policies.rs
+++ b/guide/samples/src/polling_policies.rs
@@ -24,6 +24,7 @@ pub async fn client_backoff(project_id: &str) -> crate::Result<()> {
     use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
     // ANCHOR_END: client-backoff-use
     use speech::Poller;
+    use speech::model::*;
     use std::time::Duration;
 
     // ANCHOR: client-backoff-client
@@ -46,20 +47,24 @@ pub async fn client_backoff(project_id: &str) -> crate::Result<()> {
         ))
         // ANCHOR_END: client-backoff-builder
         // ANCHOR: client-backoff-prepare
-        .set_files([speech::model::BatchRecognizeFileMetadata::new()
-            .set_uri("gs://cloud-samples-data/speech/hello.wav")])
-        .set_recognition_output_config(
-            speech::model::RecognitionOutputConfig::new()
-                .set_inline_response_config(speech::model::InlineOutputConfig::new()),
-        )
-        .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
-        )
+        .set_files([BatchRecognizeFileMetadata::new().set_audio_source(
+            batch_recognize_file_metadata::AudioSource::Uri(
+                "gs://cloud-samples-data/speech/hello.wav".into(),
+            ),
+        )])
+        .set_recognition_output_config(RecognitionOutputConfig::new().set_output(
+            recognition_output_config::Output::InlineResponseConfig(
+                InlineOutputConfig::new().into(),
+            ),
+        ))
+        .set_processing_strategy(batch_recognize_request::ProcessingStrategy::DynamicBatching)
         .set_config(
-            speech::model::RecognitionConfig::new()
+            RecognitionConfig::new()
                 .set_language_codes(["en-US"])
                 .set_model("short")
-                .set_auto_decoding_config(speech::model::AutoDetectDecodingConfig::new()),
+                .set_decoding_config(recognition_config::DecodingConfig::AutoDecodingConfig(
+                    AutoDetectDecodingConfig::new().into(),
+                )),
         )
         // ANCHOR_END: client-backoff-prepare
         // ANCHOR: client-backoff-print
@@ -84,6 +89,7 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
     use google_cloud_gax::options::RequestOptionsBuilder;
     // ANCHOR_END: rpc-backoff-builder-trait
     use speech::Poller;
+    use speech::model::*;
 
     // ANCHOR: rpc-backoff-client
     let client = speech::client::Speech::builder().build().await?;
@@ -105,20 +111,24 @@ pub async fn rpc_backoff(project_id: &str) -> crate::Result<()> {
         )
         // ANCHOR_END: rpc-backoff-rpc-polling-backoff
         // ANCHOR: rpc-backoff-prepare
-        .set_files([speech::model::BatchRecognizeFileMetadata::new()
-            .set_uri("gs://cloud-samples-data/speech/hello.wav")])
-        .set_recognition_output_config(
-            speech::model::RecognitionOutputConfig::new()
-                .set_inline_response_config(speech::model::InlineOutputConfig::new()),
-        )
-        .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
-        )
+        .set_files([BatchRecognizeFileMetadata::new().set_audio_source(
+            batch_recognize_file_metadata::AudioSource::Uri(
+                "gs://cloud-samples-data/speech/hello.wav".into(),
+            ),
+        )])
+        .set_recognition_output_config(RecognitionOutputConfig::new().set_output(
+            recognition_output_config::Output::InlineResponseConfig(
+                InlineOutputConfig::new().into(),
+            ),
+        ))
+        .set_processing_strategy(batch_recognize_request::ProcessingStrategy::DynamicBatching)
         .set_config(
-            speech::model::RecognitionConfig::new()
+            RecognitionConfig::new()
                 .set_language_codes(["en-US"])
                 .set_model("short")
-                .set_auto_decoding_config(speech::model::AutoDetectDecodingConfig::new()),
+                .set_decoding_config(recognition_config::DecodingConfig::AutoDecodingConfig(
+                    AutoDetectDecodingConfig::new().into(),
+                )),
         )
         // ANCHOR_END: rpc-backoff-prepare
         // ANCHOR: rpc-backoff-print
@@ -141,6 +151,7 @@ pub async fn client_errors(project_id: &str) -> crate::Result<()> {
     use std::time::Duration;
     // ANCHOR_END: client-errors-use
     use speech::Poller;
+    use speech::model::*;
 
     // ANCHOR: client-errors-client
     let client = speech::client::Speech::builder()
@@ -161,20 +172,24 @@ pub async fn client_errors(project_id: &str) -> crate::Result<()> {
         ))
         // ANCHOR_END: client-errors-builder
         // ANCHOR: client-errors-prepare
-        .set_files([speech::model::BatchRecognizeFileMetadata::new()
-            .set_uri("gs://cloud-samples-data/speech/hello.wav")])
-        .set_recognition_output_config(
-            speech::model::RecognitionOutputConfig::new()
-                .set_inline_response_config(speech::model::InlineOutputConfig::new()),
-        )
-        .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
-        )
+        .set_files([BatchRecognizeFileMetadata::new().set_audio_source(
+            batch_recognize_file_metadata::AudioSource::Uri(
+                "gs://cloud-samples-data/speech/hello.wav".into(),
+            ),
+        )])
+        .set_recognition_output_config(RecognitionOutputConfig::new().set_output(
+            recognition_output_config::Output::InlineResponseConfig(
+                InlineOutputConfig::new().into(),
+            ),
+        ))
+        .set_processing_strategy(batch_recognize_request::ProcessingStrategy::DynamicBatching)
         .set_config(
-            speech::model::RecognitionConfig::new()
+            RecognitionConfig::new()
                 .set_language_codes(["en-US"])
                 .set_model("short")
-                .set_auto_decoding_config(speech::model::AutoDetectDecodingConfig::new()),
+                .set_decoding_config(recognition_config::DecodingConfig::AutoDecodingConfig(
+                    AutoDetectDecodingConfig::new().into(),
+                )),
         )
         // ANCHOR_END: client-errors-prepare
         // ANCHOR: client-errors-print
@@ -200,6 +215,7 @@ pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
     use google_cloud_gax::options::RequestOptionsBuilder;
     // ANCHOR_END: rpc-errors-builder-trait
     use speech::Poller;
+    use speech::model::*;
 
     // ANCHOR: rpc-errors-client
     let client = speech::client::Speech::builder().build().await?;
@@ -220,20 +236,24 @@ pub async fn rpc_errors(project_id: &str) -> crate::Result<()> {
         )
         // ANCHOR_END: rpc-errors-rpc-polling-backoff
         // ANCHOR: rpc-errors-prepare
-        .set_files([speech::model::BatchRecognizeFileMetadata::new()
-            .set_uri("gs://cloud-samples-data/speech/hello.wav")])
-        .set_recognition_output_config(
-            speech::model::RecognitionOutputConfig::new()
-                .set_inline_response_config(speech::model::InlineOutputConfig::new()),
-        )
-        .set_processing_strategy(
-            speech::model::batch_recognize_request::ProcessingStrategy::DynamicBatching,
-        )
+        .set_files([BatchRecognizeFileMetadata::new().set_audio_source(
+            batch_recognize_file_metadata::AudioSource::Uri(
+                "gs://cloud-samples-data/speech/hello.wav".into(),
+            ),
+        )])
+        .set_recognition_output_config(RecognitionOutputConfig::new().set_output(
+            recognition_output_config::Output::InlineResponseConfig(
+                InlineOutputConfig::new().into(),
+            ),
+        ))
+        .set_processing_strategy(batch_recognize_request::ProcessingStrategy::DynamicBatching)
         .set_config(
-            speech::model::RecognitionConfig::new()
+            RecognitionConfig::new()
                 .set_language_codes(["en-US"])
                 .set_model("short")
-                .set_auto_decoding_config(speech::model::AutoDetectDecodingConfig::new()),
+                .set_decoding_config(recognition_config::DecodingConfig::AutoDecodingConfig(
+                    AutoDetectDecodingConfig::new().into(),
+                )),
         )
         // ANCHOR_END: rpc-errors-prepare
         // ANCHOR: rpc-errors-print

--- a/src/auth/integration-tests/src/lib.rs
+++ b/src/auth/integration-tests/src/lib.rs
@@ -18,7 +18,7 @@ use auth::credentials::{
 };
 use gax::error::Error;
 use language::client::LanguageService;
-use language::model::Document;
+use language::model::{Document, document::Source, document::Type};
 use scoped_env::ScopedEnv;
 use secretmanager::client::SecretManagerService;
 
@@ -114,8 +114,8 @@ pub async fn api_key() -> Result<()> {
 
     // Make a request using the API key.
     let d = Document::new()
-        .set_content("Hello, world!")
-        .set_type(language::model::document::Type::PlainText);
+        .set_source(Source::Content("Hello, world!".into()))
+        .set_type(Type::PlainText);
     client.analyze_sentiment().set_document(d).send().await?;
 
     Ok(())

--- a/src/firestore/src/convert.rs
+++ b/src/firestore/src/convert.rs
@@ -150,12 +150,14 @@ mod test {
 
     #[test]
     fn test_message_repeated() -> anyhow::Result<()> {
-        let sidekick =
-            model::value::ValueType::ArrayValue(Box::new(model::ArrayValue::new().set_values([
-                model::Value::new().set_string_value("abc"),
-                model::Value::new().set_integer_value(123),
-                model::Value::new().set_double_value(1234.5),
-            ])));
+        let sidekick = model::value::ValueType::ArrayValue(Box::new(
+            model::ArrayValue::new().set_values([
+                model::Value::new()
+                    .set_value_type(model::value::ValueType::StringValue("abc".into())),
+                model::Value::new().set_value_type(model::value::ValueType::IntegerValue(123)),
+                model::Value::new().set_value_type(model::value::ValueType::DoubleValue(1234.5)),
+            ]),
+        ));
         let proto = google::firestore::v1::value::ValueType::ArrayValue(
             google::firestore::v1::ArrayValue {
                 values: vec![
@@ -188,12 +190,24 @@ mod test {
     #[test]
     fn test_message_map() -> anyhow::Result<()> {
         use std::collections::HashMap;
-        let sidekick =
-            model::value::ValueType::MapValue(Box::new(model::MapValue::new().set_fields([
-                ("string", model::Value::new().set_string_value("abc")),
-                ("integer", model::Value::new().set_integer_value(123)),
-                ("double", model::Value::new().set_double_value(1234.5)),
-            ])));
+        let sidekick = model::value::ValueType::MapValue(Box::new(
+            model::MapValue::new().set_fields([
+                (
+                    "string",
+                    model::Value::new()
+                        .set_value_type(model::value::ValueType::StringValue("abc".into())),
+                ),
+                (
+                    "integer",
+                    model::Value::new().set_value_type(model::value::ValueType::IntegerValue(123)),
+                ),
+                (
+                    "double",
+                    model::Value::new()
+                        .set_value_type(model::value::ValueType::DoubleValue(1234.5)),
+                ),
+            ]),
+        ));
         let proto =
             google::firestore::v1::value::ValueType::MapValue(google::firestore::v1::MapValue {
                 fields: HashMap::from_iter([

--- a/src/firestore/src/generated/gapic/builder.rs
+++ b/src/firestore/src/generated/gapic/builder.rs
@@ -144,29 +144,6 @@ pub mod firestore {
             self.0.request.consistency_selector = v.into();
             self
         }
-
-        /// Sets the value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
-        /// to hold a `Transaction`.
-        ///
-        /// Note that all the setters affecting `consistency_selector` are
-        /// mutually exclusive.
-        pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_transaction(v);
-            self
-        }
-
-        /// Sets the value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
-        /// to hold a `ReadTime`.
-        ///
-        /// Note that all the setters affecting `consistency_selector` are
-        /// mutually exclusive.
-        pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_read_time(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -308,29 +285,6 @@ pub mod firestore {
             v: T,
         ) -> Self {
             self.0.request.consistency_selector = v.into();
-            self
-        }
-
-        /// Sets the value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
-        /// to hold a `Transaction`.
-        ///
-        /// Note that all the setters affecting `consistency_selector` are
-        /// mutually exclusive.
-        pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_transaction(v);
-            self
-        }
-
-        /// Sets the value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
-        /// to hold a `ReadTime`.
-        ///
-        /// Note that all the setters affecting `consistency_selector` are
-        /// mutually exclusive.
-        pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_read_time(v);
             self
         }
     }
@@ -840,21 +794,6 @@ pub mod firestore {
             self
         }
 
-        /// Sets the value of [query_type][crate::model::PartitionQueryRequest::query_type]
-        /// to hold a `StructuredQuery`.
-        ///
-        /// Note that all the setters affecting `query_type` are
-        /// mutually exclusive.
-        pub fn set_structured_query<
-            T: std::convert::Into<std::boxed::Box<crate::model::StructuredQuery>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_structured_query(v);
-            self
-        }
-
         /// Sets the value of [consistency_selector][crate::model::PartitionQueryRequest::consistency_selector].
         ///
         /// Note that all the setters affecting `consistency_selector` are
@@ -866,19 +805,6 @@ pub mod firestore {
             v: T,
         ) -> Self {
             self.0.request.consistency_selector = v.into();
-            self
-        }
-
-        /// Sets the value of [consistency_selector][crate::model::PartitionQueryRequest::consistency_selector]
-        /// to hold a `ReadTime`.
-        ///
-        /// Note that all the setters affecting `consistency_selector` are
-        /// mutually exclusive.
-        pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_read_time(v);
             self
         }
     }
@@ -970,19 +896,6 @@ pub mod firestore {
             v: T,
         ) -> Self {
             self.0.request.consistency_selector = v.into();
-            self
-        }
-
-        /// Sets the value of [consistency_selector][crate::model::ListCollectionIdsRequest::consistency_selector]
-        /// to hold a `ReadTime`.
-        ///
-        /// Note that all the setters affecting `consistency_selector` are
-        /// mutually exclusive.
-        pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_read_time(v);
             self
         }
     }

--- a/src/firestore/src/generated/gapic/model.rs
+++ b/src/firestore/src/generated/gapic/model.rs
@@ -278,17 +278,6 @@ impl Precondition {
         })
     }
 
-    /// Sets the value of [condition_type][crate::model::Precondition::condition_type]
-    /// to hold a `Exists`.
-    ///
-    /// Note that all the setters affecting `condition_type` are
-    /// mutually exclusive.
-    pub fn set_exists<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.condition_type =
-            std::option::Option::Some(crate::model::precondition::ConditionType::Exists(v.into()));
-        self
-    }
-
     /// The value of [condition_type][crate::model::Precondition::condition_type]
     /// if it holds a `UpdateTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -300,21 +289,6 @@ impl Precondition {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [condition_type][crate::model::Precondition::condition_type]
-    /// to hold a `UpdateTime`.
-    ///
-    /// Note that all the setters affecting `condition_type` are
-    /// mutually exclusive.
-    pub fn set_update_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition_type = std::option::Option::Some(
-            crate::model::precondition::ConditionType::UpdateTime(v.into()),
-        );
-        self
     }
 }
 
@@ -403,22 +377,6 @@ impl TransactionOptions {
         })
     }
 
-    /// Sets the value of [mode][crate::model::TransactionOptions::mode]
-    /// to hold a `ReadOnly`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_read_only<
-        T: std::convert::Into<std::boxed::Box<crate::model::transaction_options::ReadOnly>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode =
-            std::option::Option::Some(crate::model::transaction_options::Mode::ReadOnly(v.into()));
-        self
-    }
-
     /// The value of [mode][crate::model::TransactionOptions::mode]
     /// if it holds a `ReadWrite`, `None` if the field is not set or
     /// holds a different branch.
@@ -430,22 +388,6 @@ impl TransactionOptions {
             crate::model::transaction_options::Mode::ReadWrite(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [mode][crate::model::TransactionOptions::mode]
-    /// to hold a `ReadWrite`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_read_write<
-        T: std::convert::Into<std::boxed::Box<crate::model::transaction_options::ReadWrite>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode =
-            std::option::Option::Some(crate::model::transaction_options::Mode::ReadWrite(v.into()));
-        self
     }
 }
 
@@ -549,23 +491,6 @@ pub mod transaction_options {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [consistency_selector][crate::model::transaction_options::ReadOnly::consistency_selector]
-        /// to hold a `ReadTime`.
-        ///
-        /// Note that all the setters affecting `consistency_selector` are
-        /// mutually exclusive.
-        pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.consistency_selector = std::option::Option::Some(
-                crate::model::transaction_options::read_only::ConsistencySelector::ReadTime(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -787,17 +712,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `NullValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_null_value<T: std::convert::Into<wkt::NullValue>>(mut self, v: T) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::NullValue(v.into()));
-        self
-    }
-
     /// The value of [value_type][crate::model::Value::value_type]
     /// if it holds a `BooleanValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -807,17 +721,6 @@ impl Value {
             crate::model::value::ValueType::BooleanValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `BooleanValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_boolean_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::BooleanValue(v.into()));
-        self
     }
 
     /// The value of [value_type][crate::model::Value::value_type]
@@ -831,17 +734,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `IntegerValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_integer_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::IntegerValue(v.into()));
-        self
-    }
-
     /// The value of [value_type][crate::model::Value::value_type]
     /// if it holds a `DoubleValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -851,17 +743,6 @@ impl Value {
             crate::model::value::ValueType::DoubleValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::DoubleValue(v.into()));
-        self
     }
 
     /// The value of [value_type][crate::model::Value::value_type]
@@ -875,20 +756,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `TimestampValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_timestamp_value<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::TimestampValue(v.into()));
-        self
-    }
-
     /// The value of [value_type][crate::model::Value::value_type]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -898,17 +765,6 @@ impl Value {
             crate::model::value::ValueType::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::StringValue(v.into()));
-        self
     }
 
     /// The value of [value_type][crate::model::Value::value_type]
@@ -922,17 +778,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `BytesValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_bytes_value<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::BytesValue(v.into()));
-        self
-    }
-
     /// The value of [value_type][crate::model::Value::value_type]
     /// if it holds a `ReferenceValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -942,17 +787,6 @@ impl Value {
             crate::model::value::ValueType::ReferenceValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `ReferenceValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_reference_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::ReferenceValue(v.into()));
-        self
     }
 
     /// The value of [value_type][crate::model::Value::value_type]
@@ -966,20 +800,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `GeoPointValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_geo_point_value<T: std::convert::Into<std::boxed::Box<gtype::model::LatLng>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::GeoPointValue(v.into()));
-        self
-    }
-
     /// The value of [value_type][crate::model::Value::value_type]
     /// if it holds a `ArrayValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -991,20 +811,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `ArrayValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_array_value<T: std::convert::Into<std::boxed::Box<crate::model::ArrayValue>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::ArrayValue(v.into()));
-        self
-    }
-
     /// The value of [value_type][crate::model::Value::value_type]
     /// if it holds a `MapValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -1014,20 +820,6 @@ impl Value {
             crate::model::value::ValueType::MapValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value_type][crate::model::Value::value_type]
-    /// to hold a `MapValue`.
-    ///
-    /// Note that all the setters affecting `value_type` are
-    /// mutually exclusive.
-    pub fn set_map_value<T: std::convert::Into<std::boxed::Box<crate::model::MapValue>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value_type =
-            std::option::Option::Some(crate::model::value::ValueType::MapValue(v.into()));
-        self
     }
 }
 
@@ -1302,18 +1094,6 @@ impl GetDocumentRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::get_document_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -1325,21 +1105,6 @@ impl GetDocumentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::GetDocumentRequest::consistency_selector]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::get_document_request::ConsistencySelector::ReadTime(v.into()),
-        );
-        self
     }
 }
 
@@ -1550,18 +1315,6 @@ impl ListDocumentsRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::list_documents_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -1573,21 +1326,6 @@ impl ListDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::ListDocumentsRequest::consistency_selector]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::list_documents_request::ConsistencySelector::ReadTime(v.into()),
-        );
-        self
     }
 }
 
@@ -2028,18 +1766,6 @@ impl BatchGetDocumentsRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::batch_get_documents_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
     /// if it holds a `NewTransaction`, `None` if the field is not set or
     /// holds a different branch.
@@ -2055,25 +1781,6 @@ impl BatchGetDocumentsRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
-    /// to hold a `NewTransaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_new_transaction<
-        T: std::convert::Into<std::boxed::Box<crate::model::TransactionOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::batch_get_documents_request::ConsistencySelector::NewTransaction(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -2085,21 +1792,6 @@ impl BatchGetDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::BatchGetDocumentsRequest::consistency_selector]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::batch_get_documents_request::ConsistencySelector::ReadTime(v.into()),
-        );
-        self
     }
 }
 
@@ -2236,21 +1928,6 @@ impl BatchGetDocumentsResponse {
         })
     }
 
-    /// Sets the value of [result][crate::model::BatchGetDocumentsResponse::result]
-    /// to hold a `Found`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_found<T: std::convert::Into<std::boxed::Box<crate::model::Document>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::batch_get_documents_response::Result::Found(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::BatchGetDocumentsResponse::result]
     /// if it holds a `Missing`, `None` if the field is not set or
     /// holds a different branch.
@@ -2262,18 +1939,6 @@ impl BatchGetDocumentsResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::BatchGetDocumentsResponse::result]
-    /// to hold a `Missing`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_missing<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::batch_get_documents_response::Result::Missing(v.into()),
-        );
-        self
     }
 }
 
@@ -2654,23 +2319,6 @@ impl RunQueryRequest {
         })
     }
 
-    /// Sets the value of [query_type][crate::model::RunQueryRequest::query_type]
-    /// to hold a `StructuredQuery`.
-    ///
-    /// Note that all the setters affecting `query_type` are
-    /// mutually exclusive.
-    pub fn set_structured_query<
-        T: std::convert::Into<std::boxed::Box<crate::model::StructuredQuery>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.query_type = std::option::Option::Some(
-            crate::model::run_query_request::QueryType::StructuredQuery(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector].
     ///
     /// Note that all the setters affecting `consistency_selector` are mutually
@@ -2700,18 +2348,6 @@ impl RunQueryRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_query_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
     /// if it holds a `NewTransaction`, `None` if the field is not set or
     /// holds a different branch.
@@ -2727,23 +2363,6 @@ impl RunQueryRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
-    /// to hold a `NewTransaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_new_transaction<
-        T: std::convert::Into<std::boxed::Box<crate::model::TransactionOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_query_request::ConsistencySelector::NewTransaction(v.into()),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -2755,21 +2374,6 @@ impl RunQueryRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::RunQueryRequest::consistency_selector]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_query_request::ConsistencySelector::ReadTime(v.into()),
-        );
-        self
     }
 }
 
@@ -2977,18 +2581,6 @@ impl RunQueryResponse {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [continuation_selector][crate::model::RunQueryResponse::continuation_selector]
-    /// to hold a `Done`.
-    ///
-    /// Note that all the setters affecting `continuation_selector` are
-    /// mutually exclusive.
-    pub fn set_done<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.continuation_selector = std::option::Option::Some(
-            crate::model::run_query_response::ContinuationSelector::Done(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for RunQueryResponse {
@@ -3110,25 +2702,6 @@ impl RunAggregationQueryRequest {
         })
     }
 
-    /// Sets the value of [query_type][crate::model::RunAggregationQueryRequest::query_type]
-    /// to hold a `StructuredAggregationQuery`.
-    ///
-    /// Note that all the setters affecting `query_type` are
-    /// mutually exclusive.
-    pub fn set_structured_aggregation_query<
-        T: std::convert::Into<std::boxed::Box<crate::model::StructuredAggregationQuery>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.query_type = std::option::Option::Some(
-            crate::model::run_aggregation_query_request::QueryType::StructuredAggregationQuery(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector].
     ///
     /// Note that all the setters affecting `consistency_selector` are mutually
@@ -3160,18 +2733,6 @@ impl RunAggregationQueryRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
-    /// to hold a `Transaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_transaction<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_aggregation_query_request::ConsistencySelector::Transaction(v.into()),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
     /// if it holds a `NewTransaction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3187,25 +2748,6 @@ impl RunAggregationQueryRequest {
         })
     }
 
-    /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
-    /// to hold a `NewTransaction`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_new_transaction<
-        T: std::convert::Into<std::boxed::Box<crate::model::TransactionOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_aggregation_query_request::ConsistencySelector::NewTransaction(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -3217,21 +2759,6 @@ impl RunAggregationQueryRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::RunAggregationQueryRequest::consistency_selector]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::run_aggregation_query_request::ConsistencySelector::ReadTime(v.into()),
-        );
-        self
     }
 }
 
@@ -3527,23 +3054,6 @@ impl PartitionQueryRequest {
         })
     }
 
-    /// Sets the value of [query_type][crate::model::PartitionQueryRequest::query_type]
-    /// to hold a `StructuredQuery`.
-    ///
-    /// Note that all the setters affecting `query_type` are
-    /// mutually exclusive.
-    pub fn set_structured_query<
-        T: std::convert::Into<std::boxed::Box<crate::model::StructuredQuery>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.query_type = std::option::Option::Some(
-            crate::model::partition_query_request::QueryType::StructuredQuery(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [consistency_selector][crate::model::PartitionQueryRequest::consistency_selector].
     ///
     /// Note that all the setters affecting `consistency_selector` are mutually
@@ -3571,21 +3081,6 @@ impl PartitionQueryRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::PartitionQueryRequest::consistency_selector]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::partition_query_request::ConsistencySelector::ReadTime(v.into()),
-        );
-        self
     }
 }
 
@@ -3998,21 +3493,6 @@ impl ListenRequest {
         })
     }
 
-    /// Sets the value of [target_change][crate::model::ListenRequest::target_change]
-    /// to hold a `AddTarget`.
-    ///
-    /// Note that all the setters affecting `target_change` are
-    /// mutually exclusive.
-    pub fn set_add_target<T: std::convert::Into<std::boxed::Box<crate::model::Target>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_change = std::option::Option::Some(
-            crate::model::listen_request::TargetChange::AddTarget(v.into()),
-        );
-        self
-    }
-
     /// The value of [target_change][crate::model::ListenRequest::target_change]
     /// if it holds a `RemoveTarget`, `None` if the field is not set or
     /// holds a different branch.
@@ -4024,18 +3504,6 @@ impl ListenRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_change][crate::model::ListenRequest::target_change]
-    /// to hold a `RemoveTarget`.
-    ///
-    /// Note that all the setters affecting `target_change` are
-    /// mutually exclusive.
-    pub fn set_remove_target<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.target_change = std::option::Option::Some(
-            crate::model::listen_request::TargetChange::RemoveTarget(v.into()),
-        );
-        self
     }
 }
 
@@ -4124,21 +3592,6 @@ impl ListenResponse {
         })
     }
 
-    /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
-    /// to hold a `TargetChange`.
-    ///
-    /// Note that all the setters affecting `response_type` are
-    /// mutually exclusive.
-    pub fn set_target_change<T: std::convert::Into<std::boxed::Box<crate::model::TargetChange>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response_type = std::option::Option::Some(
-            crate::model::listen_response::ResponseType::TargetChange(v.into()),
-        );
-        self
-    }
-
     /// The value of [response_type][crate::model::ListenResponse::response_type]
     /// if it holds a `DocumentChange`, `None` if the field is not set or
     /// holds a different branch.
@@ -4152,23 +3605,6 @@ impl ListenResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
-    /// to hold a `DocumentChange`.
-    ///
-    /// Note that all the setters affecting `response_type` are
-    /// mutually exclusive.
-    pub fn set_document_change<
-        T: std::convert::Into<std::boxed::Box<crate::model::DocumentChange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response_type = std::option::Option::Some(
-            crate::model::listen_response::ResponseType::DocumentChange(v.into()),
-        );
-        self
     }
 
     /// The value of [response_type][crate::model::ListenResponse::response_type]
@@ -4186,23 +3622,6 @@ impl ListenResponse {
         })
     }
 
-    /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
-    /// to hold a `DocumentDelete`.
-    ///
-    /// Note that all the setters affecting `response_type` are
-    /// mutually exclusive.
-    pub fn set_document_delete<
-        T: std::convert::Into<std::boxed::Box<crate::model::DocumentDelete>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response_type = std::option::Option::Some(
-            crate::model::listen_response::ResponseType::DocumentDelete(v.into()),
-        );
-        self
-    }
-
     /// The value of [response_type][crate::model::ListenResponse::response_type]
     /// if it holds a `DocumentRemove`, `None` if the field is not set or
     /// holds a different branch.
@@ -4218,23 +3637,6 @@ impl ListenResponse {
         })
     }
 
-    /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
-    /// to hold a `DocumentRemove`.
-    ///
-    /// Note that all the setters affecting `response_type` are
-    /// mutually exclusive.
-    pub fn set_document_remove<
-        T: std::convert::Into<std::boxed::Box<crate::model::DocumentRemove>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response_type = std::option::Option::Some(
-            crate::model::listen_response::ResponseType::DocumentRemove(v.into()),
-        );
-        self
-    }
-
     /// The value of [response_type][crate::model::ListenResponse::response_type]
     /// if it holds a `Filter`, `None` if the field is not set or
     /// holds a different branch.
@@ -4244,21 +3646,6 @@ impl ListenResponse {
             crate::model::listen_response::ResponseType::Filter(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response_type][crate::model::ListenResponse::response_type]
-    /// to hold a `Filter`.
-    ///
-    /// Note that all the setters affecting `response_type` are
-    /// mutually exclusive.
-    pub fn set_filter<T: std::convert::Into<std::boxed::Box<crate::model::ExistenceFilter>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response_type = std::option::Option::Some(
-            crate::model::listen_response::ResponseType::Filter(v.into()),
-        );
-        self
     }
 }
 
@@ -4444,20 +3831,6 @@ impl Target {
         })
     }
 
-    /// Sets the value of [target_type][crate::model::Target::target_type]
-    /// to hold a `Query`.
-    ///
-    /// Note that all the setters affecting `target_type` are
-    /// mutually exclusive.
-    pub fn set_query<T: std::convert::Into<std::boxed::Box<crate::model::target::QueryTarget>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_type =
-            std::option::Option::Some(crate::model::target::TargetType::Query(v.into()));
-        self
-    }
-
     /// The value of [target_type][crate::model::Target::target_type]
     /// if it holds a `Documents`, `None` if the field is not set or
     /// holds a different branch.
@@ -4469,22 +3842,6 @@ impl Target {
             crate::model::target::TargetType::Documents(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_type][crate::model::Target::target_type]
-    /// to hold a `Documents`.
-    ///
-    /// Note that all the setters affecting `target_type` are
-    /// mutually exclusive.
-    pub fn set_documents<
-        T: std::convert::Into<std::boxed::Box<crate::model::target::DocumentsTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_type =
-            std::option::Option::Some(crate::model::target::TargetType::Documents(v.into()));
-        self
     }
 
     /// Sets the value of [resume_type][crate::model::Target::resume_type].
@@ -4512,17 +3869,6 @@ impl Target {
         })
     }
 
-    /// Sets the value of [resume_type][crate::model::Target::resume_type]
-    /// to hold a `ResumeToken`.
-    ///
-    /// Note that all the setters affecting `resume_type` are
-    /// mutually exclusive.
-    pub fn set_resume_token<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.resume_type =
-            std::option::Option::Some(crate::model::target::ResumeType::ResumeToken(v.into()));
-        self
-    }
-
     /// The value of [resume_type][crate::model::Target::resume_type]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -4532,20 +3878,6 @@ impl Target {
             crate::model::target::ResumeType::ReadTime(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resume_type][crate::model::Target::resume_type]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `resume_type` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resume_type =
-            std::option::Option::Some(crate::model::target::ResumeType::ReadTime(v.into()));
-        self
     }
 }
 
@@ -4661,23 +3993,6 @@ pub mod target {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [query_type][crate::model::target::QueryTarget::query_type]
-        /// to hold a `StructuredQuery`.
-        ///
-        /// Note that all the setters affecting `query_type` are
-        /// mutually exclusive.
-        pub fn set_structured_query<
-            T: std::convert::Into<std::boxed::Box<crate::model::StructuredQuery>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.query_type = std::option::Option::Some(
-                crate::model::target::query_target::QueryType::StructuredQuery(v.into()),
-            );
-            self
         }
     }
 
@@ -5130,21 +4445,6 @@ impl ListCollectionIdsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [consistency_selector][crate::model::ListCollectionIdsRequest::consistency_selector]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `consistency_selector` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.consistency_selector = std::option::Option::Some(
-            crate::model::list_collection_ids_request::ConsistencySelector::ReadTime(v.into()),
-        );
-        self
     }
 }
 
@@ -5707,23 +5007,6 @@ pub mod structured_query {
             })
         }
 
-        /// Sets the value of [filter_type][crate::model::structured_query::Filter::filter_type]
-        /// to hold a `CompositeFilter`.
-        ///
-        /// Note that all the setters affecting `filter_type` are
-        /// mutually exclusive.
-        pub fn set_composite_filter<
-            T: std::convert::Into<std::boxed::Box<crate::model::structured_query::CompositeFilter>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.filter_type = std::option::Option::Some(
-                crate::model::structured_query::filter::FilterType::CompositeFilter(v.into()),
-            );
-            self
-        }
-
         /// The value of [filter_type][crate::model::structured_query::Filter::filter_type]
         /// if it holds a `FieldFilter`, `None` if the field is not set or
         /// holds a different branch.
@@ -5740,23 +5023,6 @@ pub mod structured_query {
             })
         }
 
-        /// Sets the value of [filter_type][crate::model::structured_query::Filter::filter_type]
-        /// to hold a `FieldFilter`.
-        ///
-        /// Note that all the setters affecting `filter_type` are
-        /// mutually exclusive.
-        pub fn set_field_filter<
-            T: std::convert::Into<std::boxed::Box<crate::model::structured_query::FieldFilter>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.filter_type = std::option::Option::Some(
-                crate::model::structured_query::filter::FilterType::FieldFilter(v.into()),
-            );
-            self
-        }
-
         /// The value of [filter_type][crate::model::structured_query::Filter::filter_type]
         /// if it holds a `UnaryFilter`, `None` if the field is not set or
         /// holds a different branch.
@@ -5771,23 +5037,6 @@ pub mod structured_query {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [filter_type][crate::model::structured_query::Filter::filter_type]
-        /// to hold a `UnaryFilter`.
-        ///
-        /// Note that all the setters affecting `filter_type` are
-        /// mutually exclusive.
-        pub fn set_unary_filter<
-            T: std::convert::Into<std::boxed::Box<crate::model::structured_query::UnaryFilter>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.filter_type = std::option::Option::Some(
-                crate::model::structured_query::filter::FilterType::UnaryFilter(v.into()),
-            );
-            self
         }
     }
 
@@ -6407,23 +5656,6 @@ pub mod structured_query {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [operand_type][crate::model::structured_query::UnaryFilter::operand_type]
-        /// to hold a `Field`.
-        ///
-        /// Note that all the setters affecting `operand_type` are
-        /// mutually exclusive.
-        pub fn set_field<
-            T: std::convert::Into<std::boxed::Box<crate::model::structured_query::FieldReference>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.operand_type = std::option::Option::Some(
-                crate::model::structured_query::unary_filter::OperandType::Field(v.into()),
-            );
-            self
         }
     }
 
@@ -7237,23 +6469,6 @@ impl StructuredAggregationQuery {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [query_type][crate::model::StructuredAggregationQuery::query_type]
-    /// to hold a `StructuredQuery`.
-    ///
-    /// Note that all the setters affecting `query_type` are
-    /// mutually exclusive.
-    pub fn set_structured_query<
-        T: std::convert::Into<std::boxed::Box<crate::model::StructuredQuery>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.query_type = std::option::Option::Some(
-            crate::model::structured_aggregation_query::QueryType::StructuredQuery(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for StructuredAggregationQuery {
@@ -7368,25 +6583,6 @@ pub mod structured_aggregation_query {
             })
         }
 
-        /// Sets the value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
-        /// to hold a `Count`.
-        ///
-        /// Note that all the setters affecting `operator` are
-        /// mutually exclusive.
-        pub fn set_count<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::structured_aggregation_query::aggregation::Count>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.operator = std::option::Option::Some(
-                crate::model::structured_aggregation_query::aggregation::Operator::Count(v.into()),
-            );
-            self
-        }
-
         /// The value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
         /// if it holds a `Sum`, `None` if the field is not set or
         /// holds a different branch.
@@ -7404,25 +6600,6 @@ pub mod structured_aggregation_query {
             })
         }
 
-        /// Sets the value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
-        /// to hold a `Sum`.
-        ///
-        /// Note that all the setters affecting `operator` are
-        /// mutually exclusive.
-        pub fn set_sum<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::structured_aggregation_query::aggregation::Sum>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.operator = std::option::Option::Some(
-                crate::model::structured_aggregation_query::aggregation::Operator::Sum(v.into()),
-            );
-            self
-        }
-
         /// The value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
         /// if it holds a `Avg`, `None` if the field is not set or
         /// holds a different branch.
@@ -7438,25 +6615,6 @@ pub mod structured_aggregation_query {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [operator][crate::model::structured_aggregation_query::Aggregation::operator]
-        /// to hold a `Avg`.
-        ///
-        /// Note that all the setters affecting `operator` are
-        /// mutually exclusive.
-        pub fn set_avg<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::structured_aggregation_query::aggregation::Avg>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.operator = std::option::Option::Some(
-                crate::model::structured_aggregation_query::aggregation::Operator::Avg(v.into()),
-            );
-            self
         }
     }
 
@@ -8070,20 +7228,6 @@ impl Write {
         })
     }
 
-    /// Sets the value of [operation][crate::model::Write::operation]
-    /// to hold a `Update`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_update<T: std::convert::Into<std::boxed::Box<crate::model::Document>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation =
-            std::option::Option::Some(crate::model::write::Operation::Update(v.into()));
-        self
-    }
-
     /// The value of [operation][crate::model::Write::operation]
     /// if it holds a `Delete`, `None` if the field is not set or
     /// holds a different branch.
@@ -8093,17 +7237,6 @@ impl Write {
             crate::model::write::Operation::Delete(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [operation][crate::model::Write::operation]
-    /// to hold a `Delete`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_delete<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.operation =
-            std::option::Option::Some(crate::model::write::Operation::Delete(v.into()));
-        self
     }
 
     /// The value of [operation][crate::model::Write::operation]
@@ -8117,22 +7250,6 @@ impl Write {
             crate::model::write::Operation::Transform(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [operation][crate::model::Write::operation]
-    /// to hold a `Transform`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_transform<
-        T: std::convert::Into<std::boxed::Box<crate::model::DocumentTransform>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation =
-            std::option::Option::Some(crate::model::write::Operation::Transform(v.into()));
-        self
     }
 }
 
@@ -8302,25 +7419,6 @@ pub mod document_transform {
             })
         }
 
-        /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// to hold a `SetToServerValue`.
-        ///
-        /// Note that all the setters affecting `transform_type` are
-        /// mutually exclusive.
-        pub fn set_set_to_server_value<
-            T: std::convert::Into<crate::model::document_transform::field_transform::ServerValue>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.transform_type = std::option::Option::Some(
-                crate::model::document_transform::field_transform::TransformType::SetToServerValue(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
         /// if it holds a `Increment`, `None` if the field is not set or
         /// holds a different branch.
@@ -8332,23 +7430,6 @@ pub mod document_transform {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// to hold a `Increment`.
-        ///
-        /// Note that all the setters affecting `transform_type` are
-        /// mutually exclusive.
-        pub fn set_increment<T: std::convert::Into<std::boxed::Box<crate::model::Value>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.transform_type = std::option::Option::Some(
-                crate::model::document_transform::field_transform::TransformType::Increment(
-                    v.into(),
-                ),
-            );
-            self
         }
 
         /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
@@ -8364,21 +7445,6 @@ pub mod document_transform {
             })
         }
 
-        /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// to hold a `Maximum`.
-        ///
-        /// Note that all the setters affecting `transform_type` are
-        /// mutually exclusive.
-        pub fn set_maximum<T: std::convert::Into<std::boxed::Box<crate::model::Value>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.transform_type = std::option::Option::Some(
-                crate::model::document_transform::field_transform::TransformType::Maximum(v.into()),
-            );
-            self
-        }
-
         /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
         /// if it holds a `Minimum`, `None` if the field is not set or
         /// holds a different branch.
@@ -8390,21 +7456,6 @@ pub mod document_transform {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// to hold a `Minimum`.
-        ///
-        /// Note that all the setters affecting `transform_type` are
-        /// mutually exclusive.
-        pub fn set_minimum<T: std::convert::Into<std::boxed::Box<crate::model::Value>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.transform_type = std::option::Option::Some(
-                crate::model::document_transform::field_transform::TransformType::Minimum(v.into()),
-            );
-            self
         }
 
         /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
@@ -8420,25 +7471,6 @@ pub mod document_transform {
             })
         }
 
-        /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// to hold a `AppendMissingElements`.
-        ///
-        /// Note that all the setters affecting `transform_type` are
-        /// mutually exclusive.
-        pub fn set_append_missing_elements<
-            T: std::convert::Into<std::boxed::Box<crate::model::ArrayValue>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.transform_type = std::option::Option::Some(
-                crate::model::document_transform::field_transform::TransformType::AppendMissingElements(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
         /// if it holds a `RemoveAllFromArray`, `None` if the field is not set or
         /// holds a different branch.
@@ -8450,25 +7482,6 @@ pub mod document_transform {
                 crate::model::document_transform::field_transform::TransformType::RemoveAllFromArray(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [transform_type][crate::model::document_transform::FieldTransform::transform_type]
-        /// to hold a `RemoveAllFromArray`.
-        ///
-        /// Note that all the setters affecting `transform_type` are
-        /// mutually exclusive.
-        pub fn set_remove_all_from_array<
-            T: std::convert::Into<std::boxed::Box<crate::model::ArrayValue>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.transform_type = std::option::Option::Some(
-                crate::model::document_transform::field_transform::TransformType::RemoveAllFromArray(
-                    v.into()
-                )
-            );
-            self
         }
     }
 

--- a/src/generated/api/apikeys/v2/src/model.rs
+++ b/src/generated/api/apikeys/v2/src/model.rs
@@ -750,23 +750,6 @@ impl Restrictions {
         })
     }
 
-    /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]
-    /// to hold a `BrowserKeyRestrictions`.
-    ///
-    /// Note that all the setters affecting `client_restrictions` are
-    /// mutually exclusive.
-    pub fn set_browser_key_restrictions<
-        T: std::convert::Into<std::boxed::Box<crate::model::BrowserKeyRestrictions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.client_restrictions = std::option::Option::Some(
-            crate::model::restrictions::ClientRestrictions::BrowserKeyRestrictions(v.into()),
-        );
-        self
-    }
-
     /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
     /// if it holds a `ServerKeyRestrictions`, `None` if the field is not set or
     /// holds a different branch.
@@ -780,23 +763,6 @@ impl Restrictions {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]
-    /// to hold a `ServerKeyRestrictions`.
-    ///
-    /// Note that all the setters affecting `client_restrictions` are
-    /// mutually exclusive.
-    pub fn set_server_key_restrictions<
-        T: std::convert::Into<std::boxed::Box<crate::model::ServerKeyRestrictions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.client_restrictions = std::option::Option::Some(
-            crate::model::restrictions::ClientRestrictions::ServerKeyRestrictions(v.into()),
-        );
-        self
     }
 
     /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
@@ -814,23 +780,6 @@ impl Restrictions {
         })
     }
 
-    /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]
-    /// to hold a `AndroidKeyRestrictions`.
-    ///
-    /// Note that all the setters affecting `client_restrictions` are
-    /// mutually exclusive.
-    pub fn set_android_key_restrictions<
-        T: std::convert::Into<std::boxed::Box<crate::model::AndroidKeyRestrictions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.client_restrictions = std::option::Option::Some(
-            crate::model::restrictions::ClientRestrictions::AndroidKeyRestrictions(v.into()),
-        );
-        self
-    }
-
     /// The value of [client_restrictions][crate::model::Restrictions::client_restrictions]
     /// if it holds a `IosKeyRestrictions`, `None` if the field is not set or
     /// holds a different branch.
@@ -844,23 +793,6 @@ impl Restrictions {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [client_restrictions][crate::model::Restrictions::client_restrictions]
-    /// to hold a `IosKeyRestrictions`.
-    ///
-    /// Note that all the setters affecting `client_restrictions` are
-    /// mutually exclusive.
-    pub fn set_ios_key_restrictions<
-        T: std::convert::Into<std::boxed::Box<crate::model::IosKeyRestrictions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.client_restrictions = std::option::Option::Some(
-            crate::model::restrictions::ClientRestrictions::IosKeyRestrictions(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/api/servicecontrol/v1/src/model.rs
+++ b/src/generated/api/servicecontrol/v1/src/model.rs
@@ -568,23 +568,6 @@ impl Distribution {
         })
     }
 
-    /// Sets the value of [bucket_option][crate::model::Distribution::bucket_option]
-    /// to hold a `LinearBuckets`.
-    ///
-    /// Note that all the setters affecting `bucket_option` are
-    /// mutually exclusive.
-    pub fn set_linear_buckets<
-        T: std::convert::Into<std::boxed::Box<crate::model::distribution::LinearBuckets>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bucket_option = std::option::Option::Some(
-            crate::model::distribution::BucketOption::LinearBuckets(v.into()),
-        );
-        self
-    }
-
     /// The value of [bucket_option][crate::model::Distribution::bucket_option]
     /// if it holds a `ExponentialBuckets`, `None` if the field is not set or
     /// holds a different branch.
@@ -600,23 +583,6 @@ impl Distribution {
         })
     }
 
-    /// Sets the value of [bucket_option][crate::model::Distribution::bucket_option]
-    /// to hold a `ExponentialBuckets`.
-    ///
-    /// Note that all the setters affecting `bucket_option` are
-    /// mutually exclusive.
-    pub fn set_exponential_buckets<
-        T: std::convert::Into<std::boxed::Box<crate::model::distribution::ExponentialBuckets>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bucket_option = std::option::Option::Some(
-            crate::model::distribution::BucketOption::ExponentialBuckets(v.into()),
-        );
-        self
-    }
-
     /// The value of [bucket_option][crate::model::Distribution::bucket_option]
     /// if it holds a `ExplicitBuckets`, `None` if the field is not set or
     /// holds a different branch.
@@ -630,23 +596,6 @@ impl Distribution {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [bucket_option][crate::model::Distribution::bucket_option]
-    /// to hold a `ExplicitBuckets`.
-    ///
-    /// Note that all the setters affecting `bucket_option` are
-    /// mutually exclusive.
-    pub fn set_explicit_buckets<
-        T: std::convert::Into<std::boxed::Box<crate::model::distribution::ExplicitBuckets>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bucket_option = std::option::Option::Some(
-            crate::model::distribution::BucketOption::ExplicitBuckets(v.into()),
-        );
-        self
     }
 }
 
@@ -1243,20 +1192,6 @@ impl LogEntry {
         })
     }
 
-    /// Sets the value of [payload][crate::model::LogEntry::payload]
-    /// to hold a `ProtoPayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_proto_payload<T: std::convert::Into<std::boxed::Box<wkt::Any>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.payload =
-            std::option::Option::Some(crate::model::log_entry::Payload::ProtoPayload(v.into()));
-        self
-    }
-
     /// The value of [payload][crate::model::LogEntry::payload]
     /// if it holds a `TextPayload`, `None` if the field is not set or
     /// holds a different branch.
@@ -1268,17 +1203,6 @@ impl LogEntry {
         })
     }
 
-    /// Sets the value of [payload][crate::model::LogEntry::payload]
-    /// to hold a `TextPayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_text_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.payload =
-            std::option::Option::Some(crate::model::log_entry::Payload::TextPayload(v.into()));
-        self
-    }
-
     /// The value of [payload][crate::model::LogEntry::payload]
     /// if it holds a `StructPayload`, `None` if the field is not set or
     /// holds a different branch.
@@ -1288,20 +1212,6 @@ impl LogEntry {
             crate::model::log_entry::Payload::StructPayload(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [payload][crate::model::LogEntry::payload]
-    /// to hold a `StructPayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_struct_payload<T: std::convert::Into<std::boxed::Box<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.payload =
-            std::option::Option::Some(crate::model::log_entry::Payload::StructPayload(v.into()));
-        self
     }
 }
 
@@ -1564,17 +1474,6 @@ impl MetricValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::MetricValue::value]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::metric_value::Value::BoolValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::MetricValue::value]
     /// if it holds a `Int64Value`, `None` if the field is not set or
     /// holds a different branch.
@@ -1584,17 +1483,6 @@ impl MetricValue {
             crate::model::metric_value::Value::Int64Value(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::MetricValue::value]
-    /// to hold a `Int64Value`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::metric_value::Value::Int64Value(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::MetricValue::value]
@@ -1608,17 +1496,6 @@ impl MetricValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::MetricValue::value]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::metric_value::Value::DoubleValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::MetricValue::value]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -1628,17 +1505,6 @@ impl MetricValue {
             crate::model::metric_value::Value::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::MetricValue::value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::metric_value::Value::StringValue(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::MetricValue::value]
@@ -1652,23 +1518,6 @@ impl MetricValue {
             crate::model::metric_value::Value::DistributionValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::MetricValue::value]
-    /// to hold a `DistributionValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_distribution_value<
-        T: std::convert::Into<std::boxed::Box<crate::model::Distribution>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value = std::option::Option::Some(
-            crate::model::metric_value::Value::DistributionValue(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/api/servicemanagement/v1/src/model.rs
+++ b/src/generated/api/servicemanagement/v1/src/model.rs
@@ -1014,23 +1014,6 @@ impl Rollout {
         })
     }
 
-    /// Sets the value of [strategy][crate::model::Rollout::strategy]
-    /// to hold a `TrafficPercentStrategy`.
-    ///
-    /// Note that all the setters affecting `strategy` are
-    /// mutually exclusive.
-    pub fn set_traffic_percent_strategy<
-        T: std::convert::Into<std::boxed::Box<crate::model::rollout::TrafficPercentStrategy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.strategy = std::option::Option::Some(
-            crate::model::rollout::Strategy::TrafficPercentStrategy(v.into()),
-        );
-        self
-    }
-
     /// The value of [strategy][crate::model::Rollout::strategy]
     /// if it holds a `DeleteServiceStrategy`, `None` if the field is not set or
     /// holds a different branch.
@@ -1044,23 +1027,6 @@ impl Rollout {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [strategy][crate::model::Rollout::strategy]
-    /// to hold a `DeleteServiceStrategy`.
-    ///
-    /// Note that all the setters affecting `strategy` are
-    /// mutually exclusive.
-    pub fn set_delete_service_strategy<
-        T: std::convert::Into<std::boxed::Box<crate::model::rollout::DeleteServiceStrategy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.strategy = std::option::Option::Some(
-            crate::model::rollout::Strategy::DeleteServiceStrategy(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/api/types/src/model.rs
+++ b/src/generated/api/types/src/model.rs
@@ -241,16 +241,6 @@ impl JwtLocation {
         })
     }
 
-    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
-    /// to hold a `Header`.
-    ///
-    /// Note that all the setters affecting `r#in` are
-    /// mutually exclusive.
-    pub fn set_header<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Header(v.into()));
-        self
-    }
-
     /// The value of [r#in][crate::model::JwtLocation::r#in]
     /// if it holds a `Query`, `None` if the field is not set or
     /// holds a different branch.
@@ -262,16 +252,6 @@ impl JwtLocation {
         })
     }
 
-    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
-    /// to hold a `Query`.
-    ///
-    /// Note that all the setters affecting `r#in` are
-    /// mutually exclusive.
-    pub fn set_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Query(v.into()));
-        self
-    }
-
     /// The value of [r#in][crate::model::JwtLocation::r#in]
     /// if it holds a `Cookie`, `None` if the field is not set or
     /// holds a different branch.
@@ -281,16 +261,6 @@ impl JwtLocation {
             crate::model::jwt_location::In::Cookie(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#in][crate::model::JwtLocation::r#in]
-    /// to hold a `Cookie`.
-    ///
-    /// Note that all the setters affecting `r#in` are
-    /// mutually exclusive.
-    pub fn set_cookie<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#in = std::option::Option::Some(crate::model::jwt_location::In::Cookie(v.into()));
-        self
     }
 }
 
@@ -848,18 +818,6 @@ impl BackendRule {
         })
     }
 
-    /// Sets the value of [authentication][crate::model::BackendRule::authentication]
-    /// to hold a `JwtAudience`.
-    ///
-    /// Note that all the setters affecting `authentication` are
-    /// mutually exclusive.
-    pub fn set_jwt_audience<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication = std::option::Option::Some(
-            crate::model::backend_rule::Authentication::JwtAudience(v.into()),
-        );
-        self
-    }
-
     /// The value of [authentication][crate::model::BackendRule::authentication]
     /// if it holds a `DisableAuth`, `None` if the field is not set or
     /// holds a different branch.
@@ -871,18 +829,6 @@ impl BackendRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authentication][crate::model::BackendRule::authentication]
-    /// to hold a `DisableAuth`.
-    ///
-    /// Note that all the setters affecting `authentication` are
-    /// mutually exclusive.
-    pub fn set_disable_auth<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.authentication = std::option::Option::Some(
-            crate::model::backend_rule::Authentication::DisableAuth(v.into()),
-        );
-        self
     }
 }
 
@@ -3357,23 +3303,6 @@ pub mod distribution {
             })
         }
 
-        /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
-        /// to hold a `LinearBuckets`.
-        ///
-        /// Note that all the setters affecting `options` are
-        /// mutually exclusive.
-        pub fn set_linear_buckets<
-            T: std::convert::Into<std::boxed::Box<crate::model::distribution::bucket_options::Linear>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.options = std::option::Option::Some(
-                crate::model::distribution::bucket_options::Options::LinearBuckets(v.into()),
-            );
-            self
-        }
-
         /// The value of [options][crate::model::distribution::BucketOptions::options]
         /// if it holds a `ExponentialBuckets`, `None` if the field is not set or
         /// holds a different branch.
@@ -3391,25 +3320,6 @@ pub mod distribution {
             })
         }
 
-        /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
-        /// to hold a `ExponentialBuckets`.
-        ///
-        /// Note that all the setters affecting `options` are
-        /// mutually exclusive.
-        pub fn set_exponential_buckets<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::distribution::bucket_options::Exponential>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.options = std::option::Option::Some(
-                crate::model::distribution::bucket_options::Options::ExponentialBuckets(v.into()),
-            );
-            self
-        }
-
         /// The value of [options][crate::model::distribution::BucketOptions::options]
         /// if it holds a `ExplicitBuckets`, `None` if the field is not set or
         /// holds a different branch.
@@ -3425,25 +3335,6 @@ pub mod distribution {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [options][crate::model::distribution::BucketOptions::options]
-        /// to hold a `ExplicitBuckets`.
-        ///
-        /// Note that all the setters affecting `options` are
-        /// mutually exclusive.
-        pub fn set_explicit_buckets<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::distribution::bucket_options::Explicit>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.options = std::option::Option::Some(
-                crate::model::distribution::bucket_options::Options::ExplicitBuckets(v.into()),
-            );
-            self
         }
     }
 
@@ -4814,16 +4705,6 @@ impl HttpRule {
         })
     }
 
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Get`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_get<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Get(v.into()));
-        self
-    }
-
     /// The value of [pattern][crate::model::HttpRule::pattern]
     /// if it holds a `Put`, `None` if the field is not set or
     /// holds a different branch.
@@ -4833,16 +4714,6 @@ impl HttpRule {
             crate::model::http_rule::Pattern::Put(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Put`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_put<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Put(v.into()));
-        self
     }
 
     /// The value of [pattern][crate::model::HttpRule::pattern]
@@ -4856,16 +4727,6 @@ impl HttpRule {
         })
     }
 
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Post`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_post<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Post(v.into()));
-        self
-    }
-
     /// The value of [pattern][crate::model::HttpRule::pattern]
     /// if it holds a `Delete`, `None` if the field is not set or
     /// holds a different branch.
@@ -4875,17 +4736,6 @@ impl HttpRule {
             crate::model::http_rule::Pattern::Delete(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Delete`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_delete<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern =
-            std::option::Option::Some(crate::model::http_rule::Pattern::Delete(v.into()));
-        self
     }
 
     /// The value of [pattern][crate::model::HttpRule::pattern]
@@ -4899,16 +4749,6 @@ impl HttpRule {
         })
     }
 
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Patch`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_patch<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.pattern = std::option::Option::Some(crate::model::http_rule::Pattern::Patch(v.into()));
-        self
-    }
-
     /// The value of [pattern][crate::model::HttpRule::pattern]
     /// if it holds a `Custom`, `None` if the field is not set or
     /// holds a different branch.
@@ -4918,20 +4758,6 @@ impl HttpRule {
             crate::model::http_rule::Pattern::Custom(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [pattern][crate::model::HttpRule::pattern]
-    /// to hold a `Custom`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_custom<T: std::convert::Into<std::boxed::Box<crate::model::CustomHttpPattern>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pattern =
-            std::option::Option::Some(crate::model::http_rule::Pattern::Custom(v.into()));
-        self
     }
 }
 

--- a/src/generated/appengine/v1/src/model.rs
+++ b/src/generated/appengine/v1/src/model.rs
@@ -433,22 +433,6 @@ impl UrlMap {
         })
     }
 
-    /// Sets the value of [handler_type][crate::model::UrlMap::handler_type]
-    /// to hold a `StaticFiles`.
-    ///
-    /// Note that all the setters affecting `handler_type` are
-    /// mutually exclusive.
-    pub fn set_static_files<
-        T: std::convert::Into<std::boxed::Box<crate::model::StaticFilesHandler>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.handler_type =
-            std::option::Option::Some(crate::model::url_map::HandlerType::StaticFiles(v.into()));
-        self
-    }
-
     /// The value of [handler_type][crate::model::UrlMap::handler_type]
     /// if it holds a `Script`, `None` if the field is not set or
     /// holds a different branch.
@@ -458,20 +442,6 @@ impl UrlMap {
             crate::model::url_map::HandlerType::Script(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [handler_type][crate::model::UrlMap::handler_type]
-    /// to hold a `Script`.
-    ///
-    /// Note that all the setters affecting `handler_type` are
-    /// mutually exclusive.
-    pub fn set_script<T: std::convert::Into<std::boxed::Box<crate::model::ScriptHandler>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.handler_type =
-            std::option::Option::Some(crate::model::url_map::HandlerType::Script(v.into()));
-        self
     }
 
     /// The value of [handler_type][crate::model::UrlMap::handler_type]
@@ -485,22 +455,6 @@ impl UrlMap {
             crate::model::url_map::HandlerType::ApiEndpoint(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [handler_type][crate::model::UrlMap::handler_type]
-    /// to hold a `ApiEndpoint`.
-    ///
-    /// Note that all the setters affecting `handler_type` are
-    /// mutually exclusive.
-    pub fn set_api_endpoint<
-        T: std::convert::Into<std::boxed::Box<crate::model::ApiEndpointHandler>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.handler_type =
-            std::option::Option::Some(crate::model::url_map::HandlerType::ApiEndpoint(v.into()));
-        self
     }
 }
 
@@ -4051,22 +4005,6 @@ impl AuditData {
         })
     }
 
-    /// Sets the value of [method][crate::model::AuditData::method]
-    /// to hold a `UpdateService`.
-    ///
-    /// Note that all the setters affecting `method` are
-    /// mutually exclusive.
-    pub fn set_update_service<
-        T: std::convert::Into<std::boxed::Box<crate::model::UpdateServiceMethod>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method =
-            std::option::Option::Some(crate::model::audit_data::Method::UpdateService(v.into()));
-        self
-    }
-
     /// The value of [method][crate::model::AuditData::method]
     /// if it holds a `CreateVersion`, `None` if the field is not set or
     /// holds a different branch.
@@ -4078,22 +4016,6 @@ impl AuditData {
             crate::model::audit_data::Method::CreateVersion(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [method][crate::model::AuditData::method]
-    /// to hold a `CreateVersion`.
-    ///
-    /// Note that all the setters affecting `method` are
-    /// mutually exclusive.
-    pub fn set_create_version<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateVersionMethod>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method =
-            std::option::Option::Some(crate::model::audit_data::Method::CreateVersion(v.into()));
-        self
     }
 }
 
@@ -6458,23 +6380,6 @@ impl OperationMetadataV1 {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [method_metadata][crate::model::OperationMetadataV1::method_metadata]
-    /// to hold a `CreateVersionMetadata`.
-    ///
-    /// Note that all the setters affecting `method_metadata` are
-    /// mutually exclusive.
-    pub fn set_create_version_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateVersionMetadataV1>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method_metadata = std::option::Option::Some(
-            crate::model::operation_metadata_v_1::MethodMetadata::CreateVersionMetadata(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for OperationMetadataV1 {
@@ -7448,22 +7353,6 @@ impl Version {
         })
     }
 
-    /// Sets the value of [scaling][crate::model::Version::scaling]
-    /// to hold a `AutomaticScaling`.
-    ///
-    /// Note that all the setters affecting `scaling` are
-    /// mutually exclusive.
-    pub fn set_automatic_scaling<
-        T: std::convert::Into<std::boxed::Box<crate::model::AutomaticScaling>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scaling =
-            std::option::Option::Some(crate::model::version::Scaling::AutomaticScaling(v.into()));
-        self
-    }
-
     /// The value of [scaling][crate::model::Version::scaling]
     /// if it holds a `BasicScaling`, `None` if the field is not set or
     /// holds a different branch.
@@ -7477,20 +7366,6 @@ impl Version {
         })
     }
 
-    /// Sets the value of [scaling][crate::model::Version::scaling]
-    /// to hold a `BasicScaling`.
-    ///
-    /// Note that all the setters affecting `scaling` are
-    /// mutually exclusive.
-    pub fn set_basic_scaling<T: std::convert::Into<std::boxed::Box<crate::model::BasicScaling>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scaling =
-            std::option::Option::Some(crate::model::version::Scaling::BasicScaling(v.into()));
-        self
-    }
-
     /// The value of [scaling][crate::model::Version::scaling]
     /// if it holds a `ManualScaling`, `None` if the field is not set or
     /// holds a different branch.
@@ -7502,22 +7377,6 @@ impl Version {
             crate::model::version::Scaling::ManualScaling(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [scaling][crate::model::Version::scaling]
-    /// to hold a `ManualScaling`.
-    ///
-    /// Note that all the setters affecting `scaling` are
-    /// mutually exclusive.
-    pub fn set_manual_scaling<
-        T: std::convert::Into<std::boxed::Box<crate::model::ManualScaling>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scaling =
-            std::option::Option::Some(crate::model::version::Scaling::ManualScaling(v.into()));
-        self
     }
 }
 
@@ -8829,17 +8688,6 @@ impl Entrypoint {
             crate::model::entrypoint::Command::Shell(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [command][crate::model::Entrypoint::command]
-    /// to hold a `Shell`.
-    ///
-    /// Note that all the setters affecting `command` are
-    /// mutually exclusive.
-    pub fn set_shell<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.command =
-            std::option::Option::Some(crate::model::entrypoint::Command::Shell(v.into()));
-        self
     }
 }
 

--- a/src/generated/apps/script/gmail/src/model.rs
+++ b/src/generated/apps/script/gmail/src/model.rs
@@ -194,18 +194,6 @@ impl UniversalAction {
         })
     }
 
-    /// Sets the value of [action_type][crate::model::UniversalAction::action_type]
-    /// to hold a `OpenLink`.
-    ///
-    /// Note that all the setters affecting `action_type` are
-    /// mutually exclusive.
-    pub fn set_open_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.action_type = std::option::Option::Some(
-            crate::model::universal_action::ActionType::OpenLink(v.into()),
-        );
-        self
-    }
-
     /// The value of [action_type][crate::model::UniversalAction::action_type]
     /// if it holds a `RunFunction`, `None` if the field is not set or
     /// holds a different branch.
@@ -217,18 +205,6 @@ impl UniversalAction {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action_type][crate::model::UniversalAction::action_type]
-    /// to hold a `RunFunction`.
-    ///
-    /// Note that all the setters affecting `action_type` are
-    /// mutually exclusive.
-    pub fn set_run_function<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.action_type = std::option::Option::Some(
-            crate::model::universal_action::ActionType::RunFunction(v.into()),
-        );
-        self
     }
 }
 
@@ -513,23 +489,6 @@ impl ContextualTrigger {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [trigger][crate::model::ContextualTrigger::trigger]
-    /// to hold a `Unconditional`.
-    ///
-    /// Note that all the setters affecting `trigger` are
-    /// mutually exclusive.
-    pub fn set_unconditional<
-        T: std::convert::Into<std::boxed::Box<crate::model::UnconditionalTrigger>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.trigger = std::option::Option::Some(
-            crate::model::contextual_trigger::Trigger::Unconditional(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/apps/script/gtype/src/model.rs
+++ b/src/generated/apps/script/gtype/src/model.rs
@@ -405,18 +405,6 @@ impl UniversalActionExtensionPoint {
         })
     }
 
-    /// Sets the value of [action_type][crate::model::UniversalActionExtensionPoint::action_type]
-    /// to hold a `OpenLink`.
-    ///
-    /// Note that all the setters affecting `action_type` are
-    /// mutually exclusive.
-    pub fn set_open_link<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.action_type = std::option::Option::Some(
-            crate::model::universal_action_extension_point::ActionType::OpenLink(v.into()),
-        );
-        self
-    }
-
     /// The value of [action_type][crate::model::UniversalActionExtensionPoint::action_type]
     /// if it holds a `RunFunction`, `None` if the field is not set or
     /// holds a different branch.
@@ -428,18 +416,6 @@ impl UniversalActionExtensionPoint {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action_type][crate::model::UniversalActionExtensionPoint::action_type]
-    /// to hold a `RunFunction`.
-    ///
-    /// Note that all the setters affecting `action_type` are
-    /// mutually exclusive.
-    pub fn set_run_function<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.action_type = std::option::Option::Some(
-            crate::model::universal_action_extension_point::ActionType::RunFunction(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/bigtable/admin/v2/src/builder.rs
+++ b/src/generated/bigtable/admin/v2/src/builder.rs
@@ -1029,21 +1029,6 @@ pub mod bigtable_instance_admin {
             self.0.request.config = v.into();
             self
         }
-
-        /// Sets the value of [config][crate::model::Cluster::config]
-        /// to hold a `ClusterConfig`.
-        ///
-        /// Note that all the setters affecting `config` are
-        /// mutually exclusive.
-        pub fn set_cluster_config<
-            T: std::convert::Into<std::boxed::Box<crate::model::cluster::ClusterConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_cluster_config(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -4706,26 +4691,6 @@ pub mod bigtable_table_admin {
             self.0.request.target = v.into();
             self
         }
-
-        /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
-        /// to hold a `RowKeyPrefix`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_row_key_prefix<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_row_key_prefix(v);
-            self
-        }
-
-        /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
-        /// to hold a `DeleteAllDataFromTable`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_delete_all_data_from_table<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_delete_all_data_from_table(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -4876,36 +4841,6 @@ pub mod bigtable_table_admin {
             v: T,
         ) -> Self {
             self.0.request.mode = v.into();
-            self
-        }
-
-        /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
-        /// to hold a `StandardReadRemoteWrites`.
-        ///
-        /// Note that all the setters affecting `mode` are
-        /// mutually exclusive.
-        pub fn set_standard_read_remote_writes<
-            T: std::convert::Into<std::boxed::Box<crate::model::StandardReadRemoteWrites>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_standard_read_remote_writes(v);
-            self
-        }
-
-        /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
-        /// to hold a `DataBoostReadLocalWrites`.
-        ///
-        /// Note that all the setters affecting `mode` are
-        /// mutually exclusive.
-        pub fn set_data_boost_read_local_writes<
-            T: std::convert::Into<std::boxed::Box<crate::model::DataBoostReadLocalWrites>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_data_boost_read_local_writes(v);
             self
         }
     }
@@ -5818,16 +5753,6 @@ pub mod bigtable_table_admin {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::RestoreTableRequest::source]
-        /// to hold a `Backup`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_backup(v);
             self
         }
     }

--- a/src/generated/bigtable/admin/v2/src/model.rs
+++ b/src/generated/bigtable/admin/v2/src/model.rs
@@ -2674,18 +2674,6 @@ impl RestoreTableRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::RestoreTableRequest::source]
-    /// to hold a `Backup`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_table_request::Source::Backup(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for RestoreTableRequest {
@@ -2826,21 +2814,6 @@ impl RestoreTableMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_info][crate::model::RestoreTableMetadata::source_info]
-    /// to hold a `BackupInfo`.
-    ///
-    /// Note that all the setters affecting `source_info` are
-    /// mutually exclusive.
-    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_info = std::option::Option::Some(
-            crate::model::restore_table_metadata::SourceInfo::BackupInfo(v.into()),
-        );
-        self
     }
 }
 
@@ -3175,18 +3148,6 @@ impl DropRowRangeRequest {
         })
     }
 
-    /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
-    /// to hold a `RowKeyPrefix`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_row_key_prefix<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::drop_row_range_request::Target::RowKeyPrefix(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::DropRowRangeRequest::target]
     /// if it holds a `DeleteAllDataFromTable`, `None` if the field is not set or
     /// holds a different branch.
@@ -3198,18 +3159,6 @@ impl DropRowRangeRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::DropRowRangeRequest::target]
-    /// to hold a `DeleteAllDataFromTable`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_delete_all_data_from_table<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::drop_row_range_request::Target::DeleteAllDataFromTable(v.into()),
-        );
-        self
     }
 }
 
@@ -3841,21 +3790,6 @@ pub mod modify_column_families_request {
             })
         }
 
-        /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
-        /// to hold a `Create`.
-        ///
-        /// Note that all the setters affecting `r#mod` are
-        /// mutually exclusive.
-        pub fn set_create<T: std::convert::Into<std::boxed::Box<crate::model::ColumnFamily>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#mod = std::option::Option::Some(
-                crate::model::modify_column_families_request::modification::Mod::Create(v.into()),
-            );
-            self
-        }
-
         /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
         /// if it holds a `Update`, `None` if the field is not set or
         /// holds a different branch.
@@ -3869,21 +3803,6 @@ pub mod modify_column_families_request {
             })
         }
 
-        /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
-        /// to hold a `Update`.
-        ///
-        /// Note that all the setters affecting `r#mod` are
-        /// mutually exclusive.
-        pub fn set_update<T: std::convert::Into<std::boxed::Box<crate::model::ColumnFamily>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#mod = std::option::Option::Some(
-                crate::model::modify_column_families_request::modification::Mod::Update(v.into()),
-            );
-            self
-        }
-
         /// The value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
         /// if it holds a `Drop`, `None` if the field is not set or
         /// holds a different branch.
@@ -3895,18 +3814,6 @@ pub mod modify_column_families_request {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [r#mod][crate::model::modify_column_families_request::Modification::r#mod]
-        /// to hold a `Drop`.
-        ///
-        /// Note that all the setters affecting `r#mod` are
-        /// mutually exclusive.
-        pub fn set_drop<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.r#mod = std::option::Option::Some(
-                crate::model::modify_column_families_request::modification::Mod::Drop(v.into()),
-            );
-            self
         }
     }
 
@@ -4092,23 +3999,6 @@ impl CheckConsistencyRequest {
         })
     }
 
-    /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
-    /// to hold a `StandardReadRemoteWrites`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_standard_read_remote_writes<
-        T: std::convert::Into<std::boxed::Box<crate::model::StandardReadRemoteWrites>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode = std::option::Option::Some(
-            crate::model::check_consistency_request::Mode::StandardReadRemoteWrites(v.into()),
-        );
-        self
-    }
-
     /// The value of [mode][crate::model::CheckConsistencyRequest::mode]
     /// if it holds a `DataBoostReadLocalWrites`, `None` if the field is not set or
     /// holds a different branch.
@@ -4122,23 +4012,6 @@ impl CheckConsistencyRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [mode][crate::model::CheckConsistencyRequest::mode]
-    /// to hold a `DataBoostReadLocalWrites`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_data_boost_read_local_writes<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataBoostReadLocalWrites>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode = std::option::Option::Some(
-            crate::model::check_consistency_request::Mode::DataBoostReadLocalWrites(v.into()),
-        );
-        self
     }
 }
 
@@ -6555,22 +6428,6 @@ impl Cluster {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [config][crate::model::Cluster::config]
-    /// to hold a `ClusterConfig`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_cluster_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::cluster::ClusterConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config =
-            std::option::Option::Some(crate::model::cluster::Config::ClusterConfig(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Cluster {
@@ -7112,23 +6969,6 @@ impl AppProfile {
         })
     }
 
-    /// Sets the value of [routing_policy][crate::model::AppProfile::routing_policy]
-    /// to hold a `MultiClusterRoutingUseAny`.
-    ///
-    /// Note that all the setters affecting `routing_policy` are
-    /// mutually exclusive.
-    pub fn set_multi_cluster_routing_use_any<
-        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::MultiClusterRoutingUseAny>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.routing_policy = std::option::Option::Some(
-            crate::model::app_profile::RoutingPolicy::MultiClusterRoutingUseAny(v.into()),
-        );
-        self
-    }
-
     /// The value of [routing_policy][crate::model::AppProfile::routing_policy]
     /// if it holds a `SingleClusterRouting`, `None` if the field is not set or
     /// holds a different branch.
@@ -7143,23 +6983,6 @@ impl AppProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [routing_policy][crate::model::AppProfile::routing_policy]
-    /// to hold a `SingleClusterRouting`.
-    ///
-    /// Note that all the setters affecting `routing_policy` are
-    /// mutually exclusive.
-    pub fn set_single_cluster_routing<
-        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::SingleClusterRouting>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.routing_policy = std::option::Option::Some(
-            crate::model::app_profile::RoutingPolicy::SingleClusterRouting(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [isolation][crate::model::AppProfile::isolation].
@@ -7188,21 +7011,6 @@ impl AppProfile {
         })
     }
 
-    /// Sets the value of [isolation][crate::model::AppProfile::isolation]
-    /// to hold a `Priority`.
-    ///
-    /// Note that all the setters affecting `isolation` are
-    /// mutually exclusive.
-    #[deprecated]
-    pub fn set_priority<T: std::convert::Into<crate::model::app_profile::Priority>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.isolation =
-            std::option::Option::Some(crate::model::app_profile::Isolation::Priority(v.into()));
-        self
-    }
-
     /// The value of [isolation][crate::model::AppProfile::isolation]
     /// if it holds a `StandardIsolation`, `None` if the field is not set or
     /// holds a different branch.
@@ -7216,23 +7024,6 @@ impl AppProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [isolation][crate::model::AppProfile::isolation]
-    /// to hold a `StandardIsolation`.
-    ///
-    /// Note that all the setters affecting `isolation` are
-    /// mutually exclusive.
-    pub fn set_standard_isolation<
-        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::StandardIsolation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.isolation = std::option::Option::Some(
-            crate::model::app_profile::Isolation::StandardIsolation(v.into()),
-        );
-        self
     }
 
     /// The value of [isolation][crate::model::AppProfile::isolation]
@@ -7249,23 +7040,6 @@ impl AppProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [isolation][crate::model::AppProfile::isolation]
-    /// to hold a `DataBoostIsolationReadOnly`.
-    ///
-    /// Note that all the setters affecting `isolation` are
-    /// mutually exclusive.
-    pub fn set_data_boost_isolation_read_only<
-        T: std::convert::Into<std::boxed::Box<crate::model::app_profile::DataBoostIsolationReadOnly>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.isolation = std::option::Option::Some(
-            crate::model::app_profile::Isolation::DataBoostIsolationReadOnly(v.into()),
-        );
-        self
     }
 }
 
@@ -7360,29 +7134,6 @@ pub mod app_profile {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [affinity][crate::model::app_profile::MultiClusterRoutingUseAny::affinity]
-        /// to hold a `RowAffinity`.
-        ///
-        /// Note that all the setters affecting `affinity` are
-        /// mutually exclusive.
-        pub fn set_row_affinity<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::app_profile::multi_cluster_routing_use_any::RowAffinity,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.affinity = std::option::Option::Some(
-                crate::model::app_profile::multi_cluster_routing_use_any::Affinity::RowAffinity(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -8180,20 +7931,6 @@ impl RestoreInfo {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source_info][crate::model::RestoreInfo::source_info]
-    /// to hold a `BackupInfo`.
-    ///
-    /// Note that all the setters affecting `source_info` are
-    /// mutually exclusive.
-    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_info =
-            std::option::Option::Some(crate::model::restore_info::SourceInfo::BackupInfo(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for RestoreInfo {
@@ -8490,23 +8227,6 @@ impl Table {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [automated_backup_config][crate::model::Table::automated_backup_config]
-    /// to hold a `AutomatedBackupPolicy`.
-    ///
-    /// Note that all the setters affecting `automated_backup_config` are
-    /// mutually exclusive.
-    pub fn set_automated_backup_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::table::AutomatedBackupPolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.automated_backup_config = std::option::Option::Some(
-            crate::model::table::AutomatedBackupConfig::AutomatedBackupPolicy(v.into()),
-        );
-        self
     }
 }
 
@@ -9175,23 +8895,6 @@ impl AuthorizedView {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [authorized_view][crate::model::AuthorizedView::authorized_view]
-    /// to hold a `SubsetView`.
-    ///
-    /// Note that all the setters affecting `authorized_view` are
-    /// mutually exclusive.
-    pub fn set_subset_view<
-        T: std::convert::Into<std::boxed::Box<crate::model::authorized_view::SubsetView>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorized_view = std::option::Option::Some(
-            crate::model::authorized_view::AuthorizedView::SubsetView(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for AuthorizedView {
@@ -9577,17 +9280,6 @@ impl GcRule {
         })
     }
 
-    /// Sets the value of [rule][crate::model::GcRule::rule]
-    /// to hold a `MaxNumVersions`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_max_num_versions<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.rule =
-            std::option::Option::Some(crate::model::gc_rule::Rule::MaxNumVersions(v.into()));
-        self
-    }
-
     /// The value of [rule][crate::model::GcRule::rule]
     /// if it holds a `MaxAge`, `None` if the field is not set or
     /// holds a different branch.
@@ -9597,19 +9289,6 @@ impl GcRule {
             crate::model::gc_rule::Rule::MaxAge(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule][crate::model::GcRule::rule]
-    /// to hold a `MaxAge`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_max_age<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(crate::model::gc_rule::Rule::MaxAge(v.into()));
-        self
     }
 
     /// The value of [rule][crate::model::GcRule::rule]
@@ -9625,21 +9304,6 @@ impl GcRule {
         })
     }
 
-    /// Sets the value of [rule][crate::model::GcRule::rule]
-    /// to hold a `Intersection`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_intersection<
-        T: std::convert::Into<std::boxed::Box<crate::model::gc_rule::Intersection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(crate::model::gc_rule::Rule::Intersection(v.into()));
-        self
-    }
-
     /// The value of [rule][crate::model::GcRule::rule]
     /// if it holds a `Union`, `None` if the field is not set or
     /// holds a different branch.
@@ -9649,19 +9313,6 @@ impl GcRule {
             crate::model::gc_rule::Rule::Union(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule][crate::model::GcRule::rule]
-    /// to hold a `Union`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_union<T: std::convert::Into<std::boxed::Box<crate::model::gc_rule::Union>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(crate::model::gc_rule::Rule::Union(v.into()));
-        self
     }
 }
 
@@ -10847,19 +10498,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `BytesType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_bytes_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Bytes>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::BytesType(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `StringType`, `None` if the field is not set or
     /// holds a different branch.
@@ -10873,19 +10511,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `StringType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_string_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::String>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::StringType(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `Int64Type`, `None` if the field is not set or
     /// holds a different branch.
@@ -10895,19 +10520,6 @@ impl Type {
             crate::model::r#type::Kind::Int64Type(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `Int64Type`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_int64_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Int64>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::Int64Type(v.into()));
-        self
     }
 
     /// The value of [kind][crate::model::Type::kind]
@@ -10923,21 +10535,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `Float32Type`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_float32_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Float32>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::Float32Type(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `Float64Type`, `None` if the field is not set or
     /// holds a different branch.
@@ -10951,21 +10548,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `Float64Type`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_float64_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Float64>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::Float64Type(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `BoolType`, `None` if the field is not set or
     /// holds a different branch.
@@ -10975,19 +10557,6 @@ impl Type {
             crate::model::r#type::Kind::BoolType(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `BoolType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_bool_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Bool>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::BoolType(v.into()));
-        self
     }
 
     /// The value of [kind][crate::model::Type::kind]
@@ -11003,21 +10572,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `TimestampType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_timestamp_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Timestamp>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::TimestampType(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `DateType`, `None` if the field is not set or
     /// holds a different branch.
@@ -11027,19 +10581,6 @@ impl Type {
             crate::model::r#type::Kind::DateType(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `DateType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_date_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Date>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::DateType(v.into()));
-        self
     }
 
     /// The value of [kind][crate::model::Type::kind]
@@ -11055,21 +10596,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `AggregateType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_aggregate_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::r#type::Aggregate>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::AggregateType(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `StructType`, `None` if the field is not set or
     /// holds a different branch.
@@ -11083,19 +10609,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `StructType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_struct_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::StructType(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `ArrayType`, `None` if the field is not set or
     /// holds a different branch.
@@ -11107,19 +10620,6 @@ impl Type {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `ArrayType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_array_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Array>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::ArrayType(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Type::kind]
     /// if it holds a `MapType`, `None` if the field is not set or
     /// holds a different branch.
@@ -11129,19 +10629,6 @@ impl Type {
             crate::model::r#type::Kind::MapType(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::Type::kind]
-    /// to hold a `MapType`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_map_type<T: std::convert::Into<std::boxed::Box<crate::model::r#type::Map>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::r#type::Kind::MapType(v.into()));
-        self
     }
 }
 
@@ -11248,23 +10735,6 @@ pub mod r#type {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [encoding][crate::model::r#type::bytes::Encoding::encoding]
-            /// to hold a `Raw`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_raw<
-                T: std::convert::Into<std::boxed::Box<crate::model::r#type::bytes::encoding::Raw>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::bytes::encoding::Encoding::Raw(v.into()),
-                );
-                self
             }
         }
 
@@ -11413,26 +10883,6 @@ pub mod r#type {
                 })
             }
 
-            /// Sets the value of [encoding][crate::model::r#type::string::Encoding::encoding]
-            /// to hold a `Utf8Raw`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            #[deprecated]
-            pub fn set_utf8_raw<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::r#type::string::encoding::Utf8Raw>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::string::encoding::Encoding::Utf8Raw(v.into()),
-                );
-                self
-            }
-
             /// The value of [encoding][crate::model::r#type::string::Encoding::encoding]
             /// if it holds a `Utf8Bytes`, `None` if the field is not set or
             /// holds a different branch.
@@ -11448,25 +10898,6 @@ pub mod r#type {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [encoding][crate::model::r#type::string::Encoding::encoding]
-            /// to hold a `Utf8Bytes`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_utf8_bytes<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::r#type::string::encoding::Utf8Bytes>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::string::encoding::Encoding::Utf8Bytes(v.into()),
-                );
-                self
             }
         }
 
@@ -11649,25 +11080,6 @@ pub mod r#type {
                 })
             }
 
-            /// Sets the value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
-            /// to hold a `BigEndianBytes`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_big_endian_bytes<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::r#type::int_64::encoding::BigEndianBytes>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::int_64::encoding::Encoding::BigEndianBytes(v.into()),
-                );
-                self
-            }
-
             /// The value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
             /// if it holds a `OrderedCodeBytes`, `None` if the field is not set or
             /// holds a different branch.
@@ -11683,25 +11095,6 @@ pub mod r#type {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [encoding][crate::model::r#type::int_64::Encoding::encoding]
-            /// to hold a `OrderedCodeBytes`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_ordered_code_bytes<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::r#type::int_64::encoding::OrderedCodeBytes>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::int_64::encoding::Encoding::OrderedCodeBytes(v.into()),
-                );
-                self
             }
         }
 
@@ -11972,23 +11365,6 @@ pub mod r#type {
                     _ => std::option::Option::None,
                 })
             }
-
-            /// Sets the value of [encoding][crate::model::r#type::timestamp::Encoding::encoding]
-            /// to hold a `UnixMicrosInt64`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_unix_micros_int64<
-                T: std::convert::Into<std::boxed::Box<crate::model::r#type::int_64::Encoding>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::timestamp::encoding::Encoding::UnixMicrosInt64(v.into()),
-                );
-                self
-            }
         }
 
         impl wkt::message::Message for Encoding {
@@ -12206,25 +11582,6 @@ pub mod r#type {
                 })
             }
 
-            /// Sets the value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
-            /// to hold a `Singleton`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_singleton<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::r#type::r#struct::encoding::Singleton>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::r#struct::encoding::Encoding::Singleton(v.into()),
-                );
-                self
-            }
-
             /// The value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
             /// if it holds a `DelimitedBytes`, `None` if the field is not set or
             /// holds a different branch.
@@ -12242,25 +11599,6 @@ pub mod r#type {
                 })
             }
 
-            /// Sets the value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
-            /// to hold a `DelimitedBytes`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_delimited_bytes<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::r#type::r#struct::encoding::DelimitedBytes>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::r#struct::encoding::Encoding::DelimitedBytes(v.into()),
-                );
-                self
-            }
-
             /// The value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
             /// if it holds a `OrderedCodeBytes`, `None` if the field is not set or
             /// holds a different branch.
@@ -12276,25 +11614,6 @@ pub mod r#type {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [encoding][crate::model::r#type::r#struct::Encoding::encoding]
-            /// to hold a `OrderedCodeBytes`.
-            ///
-            /// Note that all the setters affecting `encoding` are
-            /// mutually exclusive.
-            pub fn set_ordered_code_bytes<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::r#type::r#struct::encoding::OrderedCodeBytes>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.encoding = std::option::Option::Some(
-                    crate::model::r#type::r#struct::encoding::Encoding::OrderedCodeBytes(v.into()),
-                );
-                self
             }
         }
 
@@ -12646,23 +11965,6 @@ pub mod r#type {
             })
         }
 
-        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
-        /// to hold a `Sum`.
-        ///
-        /// Note that all the setters affecting `aggregator` are
-        /// mutually exclusive.
-        pub fn set_sum<
-            T: std::convert::Into<std::boxed::Box<crate::model::r#type::aggregate::Sum>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.aggregator = std::option::Option::Some(
-                crate::model::r#type::aggregate::Aggregator::Sum(v.into()),
-            );
-            self
-        }
-
         /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
         /// if it holds a `HllppUniqueCount`, `None` if the field is not set or
         /// holds a different branch.
@@ -12680,27 +11982,6 @@ pub mod r#type {
             })
         }
 
-        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
-        /// to hold a `HllppUniqueCount`.
-        ///
-        /// Note that all the setters affecting `aggregator` are
-        /// mutually exclusive.
-        pub fn set_hllpp_unique_count<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::r#type::aggregate::HyperLogLogPlusPlusUniqueCount,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.aggregator = std::option::Option::Some(
-                crate::model::r#type::aggregate::Aggregator::HllppUniqueCount(v.into()),
-            );
-            self
-        }
-
         /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
         /// if it holds a `Max`, `None` if the field is not set or
         /// holds a different branch.
@@ -12714,23 +11995,6 @@ pub mod r#type {
             })
         }
 
-        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
-        /// to hold a `Max`.
-        ///
-        /// Note that all the setters affecting `aggregator` are
-        /// mutually exclusive.
-        pub fn set_max<
-            T: std::convert::Into<std::boxed::Box<crate::model::r#type::aggregate::Max>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.aggregator = std::option::Option::Some(
-                crate::model::r#type::aggregate::Aggregator::Max(v.into()),
-            );
-            self
-        }
-
         /// The value of [aggregator][crate::model::r#type::Aggregate::aggregator]
         /// if it holds a `Min`, `None` if the field is not set or
         /// holds a different branch.
@@ -12742,23 +12006,6 @@ pub mod r#type {
                 crate::model::r#type::aggregate::Aggregator::Min(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [aggregator][crate::model::r#type::Aggregate::aggregator]
-        /// to hold a `Min`.
-        ///
-        /// Note that all the setters affecting `aggregator` are
-        /// mutually exclusive.
-        pub fn set_min<
-            T: std::convert::Into<std::boxed::Box<crate::model::r#type::aggregate::Min>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.aggregator = std::option::Option::Some(
-                crate::model::r#type::aggregate::Aggregator::Min(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/accessapproval/v1/src/model.rs
+++ b/src/generated/cloud/accessapproval/v1/src/model.rs
@@ -387,21 +387,6 @@ impl SignatureInfo {
         })
     }
 
-    /// Sets the value of [verification_info][crate::model::SignatureInfo::verification_info]
-    /// to hold a `GooglePublicKeyPem`.
-    ///
-    /// Note that all the setters affecting `verification_info` are
-    /// mutually exclusive.
-    pub fn set_google_public_key_pem<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.verification_info = std::option::Option::Some(
-            crate::model::signature_info::VerificationInfo::GooglePublicKeyPem(v.into()),
-        );
-        self
-    }
-
     /// The value of [verification_info][crate::model::SignatureInfo::verification_info]
     /// if it holds a `CustomerKmsKeyVersion`, `None` if the field is not set or
     /// holds a different branch.
@@ -413,21 +398,6 @@ impl SignatureInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [verification_info][crate::model::SignatureInfo::verification_info]
-    /// to hold a `CustomerKmsKeyVersion`.
-    ///
-    /// Note that all the setters affecting `verification_info` are
-    /// mutually exclusive.
-    pub fn set_customer_kms_key_version<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.verification_info = std::option::Option::Some(
-            crate::model::signature_info::VerificationInfo::CustomerKmsKeyVersion(v.into()),
-        );
-        self
     }
 }
 
@@ -769,20 +739,6 @@ impl ApprovalRequest {
         })
     }
 
-    /// Sets the value of [decision][crate::model::ApprovalRequest::decision]
-    /// to hold a `Approve`.
-    ///
-    /// Note that all the setters affecting `decision` are
-    /// mutually exclusive.
-    pub fn set_approve<T: std::convert::Into<std::boxed::Box<crate::model::ApproveDecision>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.decision =
-            std::option::Option::Some(crate::model::approval_request::Decision::Approve(v.into()));
-        self
-    }
-
     /// The value of [decision][crate::model::ApprovalRequest::decision]
     /// if it holds a `Dismiss`, `None` if the field is not set or
     /// holds a different branch.
@@ -792,20 +748,6 @@ impl ApprovalRequest {
             crate::model::approval_request::Decision::Dismiss(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [decision][crate::model::ApprovalRequest::decision]
-    /// to hold a `Dismiss`.
-    ///
-    /// Note that all the setters affecting `decision` are
-    /// mutually exclusive.
-    pub fn set_dismiss<T: std::convert::Into<std::boxed::Box<crate::model::DismissDecision>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.decision =
-            std::option::Option::Some(crate::model::approval_request::Decision::Dismiss(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/advisorynotifications/v1/src/model.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/model.rs
@@ -376,19 +376,6 @@ impl Attachment {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [data][crate::model::Attachment::data]
-    /// to hold a `Csv`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_csv<T: std::convert::Into<std::boxed::Box<crate::model::Csv>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(crate::model::attachment::Data::Csv(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Attachment {

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -1680,36 +1680,6 @@ pub mod dataset_service {
             self.0.request.order = v.into();
             self
         }
-
-        /// Sets the value of [order][crate::model::SearchDataItemsRequest::order]
-        /// to hold a `OrderByDataItem`.
-        ///
-        /// Note that all the setters affecting `order` are
-        /// mutually exclusive.
-        pub fn set_order_by_data_item<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_order_by_data_item(v);
-            self
-        }
-
-        /// Sets the value of [order][crate::model::SearchDataItemsRequest::order]
-        /// to hold a `OrderByAnnotation`.
-        ///
-        /// Note that all the setters affecting `order` are
-        /// mutually exclusive.
-        pub fn set_order_by_annotation<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::search_data_items_request::OrderByAnnotation>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_order_by_annotation(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -6323,380 +6293,6 @@ pub mod evaluation_service {
             v: T,
         ) -> Self {
             self.0.request.metric_inputs = v.into();
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `ExactMatchInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_exact_match_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::ExactMatchInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_exact_match_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `BleuInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_bleu_input<T: std::convert::Into<std::boxed::Box<crate::model::BleuInput>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_bleu_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `RougeInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_rouge_input<T: std::convert::Into<std::boxed::Box<crate::model::RougeInput>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_rouge_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `FluencyInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_fluency_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::FluencyInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_fluency_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `CoherenceInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_coherence_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::CoherenceInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_coherence_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `SafetyInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_safety_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::SafetyInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_safety_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `GroundednessInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_groundedness_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::GroundednessInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_groundedness_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `FulfillmentInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_fulfillment_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::FulfillmentInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_fulfillment_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `SummarizationQualityInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_summarization_quality_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::SummarizationQualityInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_summarization_quality_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `PairwiseSummarizationQualityInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_pairwise_summarization_quality_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::PairwiseSummarizationQualityInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_pairwise_summarization_quality_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `SummarizationHelpfulnessInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_summarization_helpfulness_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::SummarizationHelpfulnessInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_summarization_helpfulness_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `SummarizationVerbosityInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_summarization_verbosity_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::SummarizationVerbosityInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_summarization_verbosity_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `QuestionAnsweringQualityInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_question_answering_quality_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::QuestionAnsweringQualityInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_question_answering_quality_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `PairwiseQuestionAnsweringQualityInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_pairwise_question_answering_quality_input<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::PairwiseQuestionAnsweringQualityInput>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self
-                .0
-                .request
-                .set_pairwise_question_answering_quality_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `QuestionAnsweringRelevanceInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_question_answering_relevance_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::QuestionAnsweringRelevanceInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_question_answering_relevance_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `QuestionAnsweringHelpfulnessInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_question_answering_helpfulness_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::QuestionAnsweringHelpfulnessInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_question_answering_helpfulness_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `QuestionAnsweringCorrectnessInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_question_answering_correctness_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::QuestionAnsweringCorrectnessInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_question_answering_correctness_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `PointwiseMetricInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_pointwise_metric_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::PointwiseMetricInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_pointwise_metric_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `PairwiseMetricInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_pairwise_metric_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::PairwiseMetricInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_pairwise_metric_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `ToolCallValidInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_tool_call_valid_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::ToolCallValidInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_tool_call_valid_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `ToolNameMatchInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_tool_name_match_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::ToolNameMatchInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_tool_name_match_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `ToolParameterKeyMatchInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_tool_parameter_key_match_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::ToolParameterKeyMatchInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_tool_parameter_key_match_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `ToolParameterKvMatchInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_tool_parameter_kv_match_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::ToolParameterKVMatchInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_tool_parameter_kv_match_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `CometInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_comet_input<T: std::convert::Into<std::boxed::Box<crate::model::CometInput>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_comet_input(v);
-            self
-        }
-
-        /// Sets the value of [metric_inputs][crate::model::EvaluateInstancesRequest::metric_inputs]
-        /// to hold a `MetricxInput`.
-        ///
-        /// Note that all the setters affecting `metric_inputs` are
-        /// mutually exclusive.
-        pub fn set_metricx_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::MetricxInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_metricx_input(v);
             self
         }
     }
@@ -15506,47 +15102,6 @@ pub mod featurestore_service {
             self
         }
 
-        /// Sets the value of [source][crate::model::ImportFeatureValuesRequest::source]
-        /// to hold a `AvroSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_avro_source<T: std::convert::Into<std::boxed::Box<crate::model::AvroSource>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_avro_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportFeatureValuesRequest::source]
-        /// to hold a `BigquerySource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_bigquery_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_bigquery_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportFeatureValuesRequest::source]
-        /// to hold a `CsvSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_csv_source<T: std::convert::Into<std::boxed::Box<crate::model::CsvSource>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_csv_source(v);
-            self
-        }
-
         /// Sets the value of [feature_time_source][crate::model::ImportFeatureValuesRequest::feature_time_source].
         ///
         /// Note that all the setters affecting `feature_time_source` are
@@ -15558,32 +15113,6 @@ pub mod featurestore_service {
             v: T,
         ) -> Self {
             self.0.request.feature_time_source = v.into();
-            self
-        }
-
-        /// Sets the value of [feature_time_source][crate::model::ImportFeatureValuesRequest::feature_time_source]
-        /// to hold a `FeatureTimeField`.
-        ///
-        /// Note that all the setters affecting `feature_time_source` are
-        /// mutually exclusive.
-        pub fn set_feature_time_field<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_feature_time_field(v);
-            self
-        }
-
-        /// Sets the value of [feature_time_source][crate::model::ImportFeatureValuesRequest::feature_time_source]
-        /// to hold a `FeatureTime`.
-        ///
-        /// Note that all the setters affecting `feature_time_source` are
-        /// mutually exclusive.
-        pub fn set_feature_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_feature_time(v);
             self
         }
     }
@@ -15757,36 +15286,6 @@ pub mod featurestore_service {
             self.0.request.read_option = v.into();
             self
         }
-
-        /// Sets the value of [read_option][crate::model::BatchReadFeatureValuesRequest::read_option]
-        /// to hold a `CsvReadInstances`.
-        ///
-        /// Note that all the setters affecting `read_option` are
-        /// mutually exclusive.
-        pub fn set_csv_read_instances<
-            T: std::convert::Into<std::boxed::Box<crate::model::CsvSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_csv_read_instances(v);
-            self
-        }
-
-        /// Sets the value of [read_option][crate::model::BatchReadFeatureValuesRequest::read_option]
-        /// to hold a `BigqueryReadInstances`.
-        ///
-        /// Note that all the setters affecting `read_option` are
-        /// mutually exclusive.
-        pub fn set_bigquery_read_instances<
-            T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_bigquery_read_instances(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -15943,40 +15442,6 @@ pub mod featurestore_service {
             self.0.request.mode = v.into();
             self
         }
-
-        /// Sets the value of [mode][crate::model::ExportFeatureValuesRequest::mode]
-        /// to hold a `SnapshotExport`.
-        ///
-        /// Note that all the setters affecting `mode` are
-        /// mutually exclusive.
-        pub fn set_snapshot_export<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::export_feature_values_request::SnapshotExport>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_snapshot_export(v);
-            self
-        }
-
-        /// Sets the value of [mode][crate::model::ExportFeatureValuesRequest::mode]
-        /// to hold a `FullExport`.
-        ///
-        /// Note that all the setters affecting `mode` are
-        /// mutually exclusive.
-        pub fn set_full_export<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::export_feature_values_request::FullExport>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_full_export(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -16098,42 +15563,6 @@ pub mod featurestore_service {
             v: T,
         ) -> Self {
             self.0.request.delete_option = v.into();
-            self
-        }
-
-        /// Sets the value of [delete_option][crate::model::DeleteFeatureValuesRequest::delete_option]
-        /// to hold a `SelectEntity`.
-        ///
-        /// Note that all the setters affecting `delete_option` are
-        /// mutually exclusive.
-        pub fn set_select_entity<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::delete_feature_values_request::SelectEntity>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_select_entity(v);
-            self
-        }
-
-        /// Sets the value of [delete_option][crate::model::DeleteFeatureValuesRequest::delete_option]
-        /// to hold a `SelectTimeRangeAndFeature`.
-        ///
-        /// Note that all the setters affecting `delete_option` are
-        /// mutually exclusive.
-        pub fn set_select_time_range_and_feature<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::delete_feature_values_request::SelectTimeRangeAndFeature,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_select_time_range_and_feature(v);
             self
         }
     }
@@ -35713,29 +35142,6 @@ pub mod model_service {
             self.0.request.destination_model = v.into();
             self
         }
-
-        /// Sets the value of [destination_model][crate::model::CopyModelRequest::destination_model]
-        /// to hold a `ModelId`.
-        ///
-        /// Note that all the setters affecting `destination_model` are
-        /// mutually exclusive.
-        pub fn set_model_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_model_id(v);
-            self
-        }
-
-        /// Sets the value of [destination_model][crate::model::CopyModelRequest::destination_model]
-        /// to hold a `ParentModel`.
-        ///
-        /// Note that all the setters affecting `destination_model` are
-        /// mutually exclusive.
-        pub fn set_parent_model<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_parent_model(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -54917,23 +54323,6 @@ pub mod vertex_rag_service {
             self.0.request.data_source = v.into();
             self
         }
-
-        /// Sets the value of [data_source][crate::model::RetrieveContextsRequest::data_source]
-        /// to hold a `VertexRagStore`.
-        ///
-        /// Note that all the setters affecting `data_source` are
-        /// mutually exclusive.
-        pub fn set_vertex_rag_store<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::retrieve_contexts_request::VertexRagStore>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_vertex_rag_store(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -55030,21 +54419,6 @@ pub mod vertex_rag_service {
             v: T,
         ) -> Self {
             self.0.request.data_source = v.into();
-            self
-        }
-
-        /// Sets the value of [data_source][crate::model::AugmentPromptRequest::data_source]
-        /// to hold a `VertexRagStore`.
-        ///
-        /// Note that all the setters affecting `data_source` are
-        /// mutually exclusive.
-        pub fn set_vertex_rag_store<
-            T: std::convert::Into<std::boxed::Box<crate::model::VertexRagStore>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_vertex_rag_store(v);
             self
         }
     }

--- a/src/generated/cloud/alloydb/v1/src/builder.rs
+++ b/src/generated/cloud/alloydb/v1/src/builder.rs
@@ -194,21 +194,6 @@ pub mod alloy_dbcsql_admin {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::RestoreFromCloudSQLRequest::source]
-        /// to hold a `CloudsqlBackupRunSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_cloudsql_backup_run_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::CloudSQLBackupRunSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_cloudsql_backup_run_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -1305,21 +1290,6 @@ pub mod alloy_db_admin {
             self
         }
 
-        /// Sets the value of [destination][crate::model::ExportClusterRequest::destination]
-        /// to hold a `GcsDestination`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_destination<
-            T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_destination(v);
-            self
-        }
-
         /// Sets the value of [export_options][crate::model::ExportClusterRequest::export_options].
         ///
         /// Note that all the setters affecting `export_options` are
@@ -1331,40 +1301,6 @@ pub mod alloy_db_admin {
             v: T,
         ) -> Self {
             self.0.request.export_options = v.into();
-            self
-        }
-
-        /// Sets the value of [export_options][crate::model::ExportClusterRequest::export_options]
-        /// to hold a `CsvExportOptions`.
-        ///
-        /// Note that all the setters affecting `export_options` are
-        /// mutually exclusive.
-        pub fn set_csv_export_options<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::export_cluster_request::CsvExportOptions>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_csv_export_options(v);
-            self
-        }
-
-        /// Sets the value of [export_options][crate::model::ExportClusterRequest::export_options]
-        /// to hold a `SqlExportOptions`.
-        ///
-        /// Note that all the setters affecting `export_options` are
-        /// mutually exclusive.
-        pub fn set_sql_export_options<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::export_cluster_request::SqlExportOptions>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_sql_export_options(v);
             self
         }
     }
@@ -1503,40 +1439,6 @@ pub mod alloy_db_admin {
             v: T,
         ) -> Self {
             self.0.request.import_options = v.into();
-            self
-        }
-
-        /// Sets the value of [import_options][crate::model::ImportClusterRequest::import_options]
-        /// to hold a `SqlImportOptions`.
-        ///
-        /// Note that all the setters affecting `import_options` are
-        /// mutually exclusive.
-        pub fn set_sql_import_options<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::import_cluster_request::SqlImportOptions>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_sql_import_options(v);
-            self
-        }
-
-        /// Sets the value of [import_options][crate::model::ImportClusterRequest::import_options]
-        /// to hold a `CsvImportOptions`.
-        ///
-        /// Note that all the setters affecting `import_options` are
-        /// mutually exclusive.
-        pub fn set_csv_import_options<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::import_cluster_request::CsvImportOptions>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_csv_import_options(v);
             self
         }
     }
@@ -2173,36 +2075,6 @@ pub mod alloy_db_admin {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::RestoreClusterRequest::source]
-        /// to hold a `BackupSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_backup_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::BackupSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_backup_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::RestoreClusterRequest::source]
-        /// to hold a `ContinuousBackupSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_continuous_backup_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::ContinuousBackupSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_continuous_backup_source(v);
             self
         }
     }
@@ -3627,16 +3499,6 @@ pub mod alloy_db_admin {
             v: T,
         ) -> Self {
             self.0.request.user_credential = v.into();
-            self
-        }
-
-        /// Sets the value of [user_credential][crate::model::ExecuteSqlRequest::user_credential]
-        /// to hold a `Password`.
-        ///
-        /// Note that all the setters affecting `user_credential` are
-        /// mutually exclusive.
-        pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_password(v);
             self
         }
     }

--- a/src/generated/cloud/alloydb/v1/src/model.rs
+++ b/src/generated/cloud/alloydb/v1/src/model.rs
@@ -172,23 +172,6 @@ impl RestoreFromCloudSQLRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::RestoreFromCloudSQLRequest::source]
-    /// to hold a `CloudsqlBackupRunSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_cloudsql_backup_run_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSQLBackupRunSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_from_cloud_sql_request::Source::CloudsqlBackupRunSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for RestoreFromCloudSQLRequest {
@@ -1345,23 +1328,6 @@ impl AutomatedBackupPolicy {
         })
     }
 
-    /// Sets the value of [schedule][crate::model::AutomatedBackupPolicy::schedule]
-    /// to hold a `WeeklySchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_weekly_schedule<
-        T: std::convert::Into<std::boxed::Box<crate::model::automated_backup_policy::WeeklySchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::automated_backup_policy::Schedule::WeeklySchedule(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [retention][crate::model::AutomatedBackupPolicy::retention].
     ///
     /// Note that all the setters affecting `retention` are mutually
@@ -1393,25 +1359,6 @@ impl AutomatedBackupPolicy {
         })
     }
 
-    /// Sets the value of [retention][crate::model::AutomatedBackupPolicy::retention]
-    /// to hold a `TimeBasedRetention`.
-    ///
-    /// Note that all the setters affecting `retention` are
-    /// mutually exclusive.
-    pub fn set_time_based_retention<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::automated_backup_policy::TimeBasedRetention>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.retention = std::option::Option::Some(
-            crate::model::automated_backup_policy::Retention::TimeBasedRetention(v.into()),
-        );
-        self
-    }
-
     /// The value of [retention][crate::model::AutomatedBackupPolicy::retention]
     /// if it holds a `QuantityBasedRetention`, `None` if the field is not set or
     /// holds a different branch.
@@ -1427,25 +1374,6 @@ impl AutomatedBackupPolicy {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [retention][crate::model::AutomatedBackupPolicy::retention]
-    /// to hold a `QuantityBasedRetention`.
-    ///
-    /// Note that all the setters affecting `retention` are
-    /// mutually exclusive.
-    pub fn set_quantity_based_retention<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::automated_backup_policy::QuantityBasedRetention>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.retention = std::option::Option::Some(
-            crate::model::automated_backup_policy::Retention::QuantityBasedRetention(v.into()),
-        );
-        self
     }
 }
 
@@ -2508,20 +2436,6 @@ impl Cluster {
         })
     }
 
-    /// Sets the value of [source][crate::model::Cluster::source]
-    /// to hold a `BackupSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_backup_source<T: std::convert::Into<std::boxed::Box<crate::model::BackupSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::cluster::Source::BackupSource(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Cluster::source]
     /// if it holds a `MigrationSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -2533,22 +2447,6 @@ impl Cluster {
             crate::model::cluster::Source::MigrationSource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Cluster::source]
-    /// to hold a `MigrationSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_migration_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::MigrationSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::cluster::Source::MigrationSource(v.into()));
-        self
     }
 
     /// The value of [source][crate::model::Cluster::source]
@@ -2564,23 +2462,6 @@ impl Cluster {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Cluster::source]
-    /// to hold a `CloudsqlBackupRunSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_cloudsql_backup_run_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSQLBackupRunSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::cluster::Source::CloudsqlBackupRunSource(v.into()),
-        );
-        self
     }
 }
 
@@ -5739,25 +5620,6 @@ impl SupportedDatabaseFlag {
         })
     }
 
-    /// Sets the value of [restrictions][crate::model::SupportedDatabaseFlag::restrictions]
-    /// to hold a `StringRestrictions`.
-    ///
-    /// Note that all the setters affecting `restrictions` are
-    /// mutually exclusive.
-    pub fn set_string_restrictions<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::supported_database_flag::StringRestrictions>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.restrictions = std::option::Option::Some(
-            crate::model::supported_database_flag::Restrictions::StringRestrictions(v.into()),
-        );
-        self
-    }
-
     /// The value of [restrictions][crate::model::SupportedDatabaseFlag::restrictions]
     /// if it holds a `IntegerRestrictions`, `None` if the field is not set or
     /// holds a different branch.
@@ -5773,25 +5635,6 @@ impl SupportedDatabaseFlag {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [restrictions][crate::model::SupportedDatabaseFlag::restrictions]
-    /// to hold a `IntegerRestrictions`.
-    ///
-    /// Note that all the setters affecting `restrictions` are
-    /// mutually exclusive.
-    pub fn set_integer_restrictions<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::supported_database_flag::IntegerRestrictions>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.restrictions = std::option::Option::Some(
-            crate::model::supported_database_flag::Restrictions::IntegerRestrictions(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [recommended_value][crate::model::SupportedDatabaseFlag::recommended_value].
@@ -5823,23 +5666,6 @@ impl SupportedDatabaseFlag {
         })
     }
 
-    /// Sets the value of [recommended_value][crate::model::SupportedDatabaseFlag::recommended_value]
-    /// to hold a `RecommendedStringValue`.
-    ///
-    /// Note that all the setters affecting `recommended_value` are
-    /// mutually exclusive.
-    pub fn set_recommended_string_value<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recommended_value = std::option::Option::Some(
-            crate::model::supported_database_flag::RecommendedValue::RecommendedStringValue(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [recommended_value][crate::model::SupportedDatabaseFlag::recommended_value]
     /// if it holds a `RecommendedIntegerValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -5853,25 +5679,6 @@ impl SupportedDatabaseFlag {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [recommended_value][crate::model::SupportedDatabaseFlag::recommended_value]
-    /// to hold a `RecommendedIntegerValue`.
-    ///
-    /// Note that all the setters affecting `recommended_value` are
-    /// mutually exclusive.
-    pub fn set_recommended_integer_value<
-        T: std::convert::Into<std::boxed::Box<wkt::Int64Value>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recommended_value = std::option::Option::Some(
-            crate::model::supported_database_flag::RecommendedValue::RecommendedIntegerValue(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -7143,23 +6950,6 @@ impl ExportClusterRequest {
         })
     }
 
-    /// Sets the value of [destination][crate::model::ExportClusterRequest::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_cluster_request::Destination::GcsDestination(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [export_options][crate::model::ExportClusterRequest::export_options].
     ///
     /// Note that all the setters affecting `export_options` are mutually
@@ -7192,23 +6982,6 @@ impl ExportClusterRequest {
         })
     }
 
-    /// Sets the value of [export_options][crate::model::ExportClusterRequest::export_options]
-    /// to hold a `CsvExportOptions`.
-    ///
-    /// Note that all the setters affecting `export_options` are
-    /// mutually exclusive.
-    pub fn set_csv_export_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::export_cluster_request::CsvExportOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.export_options = std::option::Option::Some(
-            crate::model::export_cluster_request::ExportOptions::CsvExportOptions(v.into()),
-        );
-        self
-    }
-
     /// The value of [export_options][crate::model::ExportClusterRequest::export_options]
     /// if it holds a `SqlExportOptions`, `None` if the field is not set or
     /// holds a different branch.
@@ -7223,23 +6996,6 @@ impl ExportClusterRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [export_options][crate::model::ExportClusterRequest::export_options]
-    /// to hold a `SqlExportOptions`.
-    ///
-    /// Note that all the setters affecting `export_options` are
-    /// mutually exclusive.
-    pub fn set_sql_export_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::export_cluster_request::SqlExportOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.export_options = std::option::Option::Some(
-            crate::model::export_cluster_request::ExportOptions::SqlExportOptions(v.into()),
-        );
-        self
     }
 }
 
@@ -7485,23 +7241,6 @@ impl ExportClusterResponse {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ExportClusterResponse::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_cluster_response::Destination::GcsDestination(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExportClusterResponse {
@@ -7625,23 +7364,6 @@ impl ImportClusterRequest {
         })
     }
 
-    /// Sets the value of [import_options][crate::model::ImportClusterRequest::import_options]
-    /// to hold a `SqlImportOptions`.
-    ///
-    /// Note that all the setters affecting `import_options` are
-    /// mutually exclusive.
-    pub fn set_sql_import_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::import_cluster_request::SqlImportOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_options = std::option::Option::Some(
-            crate::model::import_cluster_request::ImportOptions::SqlImportOptions(v.into()),
-        );
-        self
-    }
-
     /// The value of [import_options][crate::model::ImportClusterRequest::import_options]
     /// if it holds a `CsvImportOptions`, `None` if the field is not set or
     /// holds a different branch.
@@ -7656,23 +7378,6 @@ impl ImportClusterRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [import_options][crate::model::ImportClusterRequest::import_options]
-    /// to hold a `CsvImportOptions`.
-    ///
-    /// Note that all the setters affecting `import_options` are
-    /// mutually exclusive.
-    pub fn set_csv_import_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::import_cluster_request::CsvImportOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_options = std::option::Option::Some(
-            crate::model::import_cluster_request::ImportOptions::CsvImportOptions(v.into()),
-        );
-        self
     }
 }
 
@@ -8917,21 +8622,6 @@ impl RestoreClusterRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::RestoreClusterRequest::source]
-    /// to hold a `BackupSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_backup_source<T: std::convert::Into<std::boxed::Box<crate::model::BackupSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_cluster_request::Source::BackupSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::RestoreClusterRequest::source]
     /// if it holds a `ContinuousBackupSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -8945,23 +8635,6 @@ impl RestoreClusterRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::RestoreClusterRequest::source]
-    /// to hold a `ContinuousBackupSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_continuous_backup_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ContinuousBackupSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_cluster_request::Source::ContinuousBackupSource(v.into()),
-        );
-        self
     }
 }
 
@@ -10468,18 +10141,6 @@ impl ExecuteSqlRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [user_credential][crate::model::ExecuteSqlRequest::user_credential]
-    /// to hold a `Password`.
-    ///
-    /// Note that all the setters affecting `user_credential` are
-    /// mutually exclusive.
-    pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.user_credential = std::option::Option::Some(
-            crate::model::execute_sql_request::UserCredential::Password(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExecuteSqlRequest {
@@ -11692,25 +11353,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request_specific][crate::model::OperationMetadata::request_specific]
-    /// to hold a `BatchCreateInstancesMetadata`.
-    ///
-    /// Note that all the setters affecting `request_specific` are
-    /// mutually exclusive.
-    pub fn set_batch_create_instances_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::BatchCreateInstancesMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request_specific = std::option::Option::Some(
-            crate::model::operation_metadata::RequestSpecific::BatchCreateInstancesMetadata(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [request_specific][crate::model::OperationMetadata::request_specific]
     /// if it holds a `UpgradeClusterStatus`, `None` if the field is not set or
     /// holds a different branch.
@@ -11724,23 +11366,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request_specific][crate::model::OperationMetadata::request_specific]
-    /// to hold a `UpgradeClusterStatus`.
-    ///
-    /// Note that all the setters affecting `request_specific` are
-    /// mutually exclusive.
-    pub fn set_upgrade_cluster_status<
-        T: std::convert::Into<std::boxed::Box<crate::model::UpgradeClusterStatus>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request_specific = std::option::Option::Some(
-            crate::model::operation_metadata::RequestSpecific::UpgradeClusterStatus(v.into()),
-        );
-        self
     }
 }
 
@@ -11934,29 +11559,6 @@ pub mod upgrade_cluster_status {
                 crate::model::upgrade_cluster_status::stage_status::StageSpecificStatus::ReadPoolInstancesUpgrade(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [stage_specific_status][crate::model::upgrade_cluster_status::StageStatus::stage_specific_status]
-        /// to hold a `ReadPoolInstancesUpgrade`.
-        ///
-        /// Note that all the setters affecting `stage_specific_status` are
-        /// mutually exclusive.
-        pub fn set_read_pool_instances_upgrade<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::upgrade_cluster_status::ReadPoolInstancesUpgradeStageStatus,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.stage_specific_status = std::option::Option::Some(
-                crate::model::upgrade_cluster_status::stage_status::StageSpecificStatus::ReadPoolInstancesUpgrade(
-                    v.into()
-                )
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/apigeeconnect/v1/src/model.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/model.rs
@@ -382,19 +382,6 @@ impl Payload {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Payload::kind]
-    /// to hold a `HttpRequest`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_http_request<T: std::convert::Into<std::boxed::Box<crate::model::HttpRequest>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::payload::Kind::HttpRequest(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Payload::kind]
     /// if it holds a `StreamInfo`, `None` if the field is not set or
     /// holds a different branch.
@@ -406,19 +393,6 @@ impl Payload {
         })
     }
 
-    /// Sets the value of [kind][crate::model::Payload::kind]
-    /// to hold a `StreamInfo`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_stream_info<T: std::convert::Into<std::boxed::Box<crate::model::StreamInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::payload::Kind::StreamInfo(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::Payload::kind]
     /// if it holds a `Action`, `None` if the field is not set or
     /// holds a different branch.
@@ -428,16 +402,6 @@ impl Payload {
             crate::model::payload::Kind::Action(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::Payload::kind]
-    /// to hold a `Action`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_action<T: std::convert::Into<crate::model::Action>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::payload::Kind::Action(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/apihub/v1/src/model.rs
+++ b/src/generated/cloud/apihub/v1/src/model.rs
@@ -2439,20 +2439,6 @@ impl ApiHubResource {
         })
     }
 
-    /// Sets the value of [resource][crate::model::ApiHubResource::resource]
-    /// to hold a `Api`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_api<T: std::convert::Into<std::boxed::Box<crate::model::Api>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource =
-            std::option::Option::Some(crate::model::api_hub_resource::Resource::Api(v.into()));
-        self
-    }
-
     /// The value of [resource][crate::model::ApiHubResource::resource]
     /// if it holds a `Operation`, `None` if the field is not set or
     /// holds a different branch.
@@ -2462,21 +2448,6 @@ impl ApiHubResource {
             crate::model::api_hub_resource::Resource::Operation(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource][crate::model::ApiHubResource::resource]
-    /// to hold a `Operation`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_operation<T: std::convert::Into<std::boxed::Box<crate::model::ApiOperation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(
-            crate::model::api_hub_resource::Resource::Operation(v.into()),
-        );
-        self
     }
 
     /// The value of [resource][crate::model::ApiHubResource::resource]
@@ -2490,21 +2461,6 @@ impl ApiHubResource {
         })
     }
 
-    /// Sets the value of [resource][crate::model::ApiHubResource::resource]
-    /// to hold a `Deployment`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_deployment<T: std::convert::Into<std::boxed::Box<crate::model::Deployment>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(
-            crate::model::api_hub_resource::Resource::Deployment(v.into()),
-        );
-        self
-    }
-
     /// The value of [resource][crate::model::ApiHubResource::resource]
     /// if it holds a `Spec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2514,20 +2470,6 @@ impl ApiHubResource {
             crate::model::api_hub_resource::Resource::Spec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource][crate::model::ApiHubResource::resource]
-    /// to hold a `Spec`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_spec<T: std::convert::Into<std::boxed::Box<crate::model::Spec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource =
-            std::option::Option::Some(crate::model::api_hub_resource::Resource::Spec(v.into()));
-        self
     }
 
     /// The value of [resource][crate::model::ApiHubResource::resource]
@@ -2541,21 +2483,6 @@ impl ApiHubResource {
         })
     }
 
-    /// Sets the value of [resource][crate::model::ApiHubResource::resource]
-    /// to hold a `Definition`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_definition<T: std::convert::Into<std::boxed::Box<crate::model::Definition>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(
-            crate::model::api_hub_resource::Resource::Definition(v.into()),
-        );
-        self
-    }
-
     /// The value of [resource][crate::model::ApiHubResource::resource]
     /// if it holds a `Version`, `None` if the field is not set or
     /// holds a different branch.
@@ -2565,20 +2492,6 @@ impl ApiHubResource {
             crate::model::api_hub_resource::Resource::Version(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource][crate::model::ApiHubResource::resource]
-    /// to hold a `Version`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_version<T: std::convert::Into<std::boxed::Box<crate::model::Version>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource =
-            std::option::Option::Some(crate::model::api_hub_resource::Resource::Version(v.into()));
-        self
     }
 }
 
@@ -4781,19 +4694,6 @@ impl Definition {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [value][crate::model::Definition::value]
-    /// to hold a `Schema`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_schema<T: std::convert::Into<std::boxed::Box<crate::model::Schema>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value = std::option::Option::Some(crate::model::definition::Value::Schema(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Definition {
@@ -5744,23 +5644,6 @@ impl SpecDetails {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [details][crate::model::SpecDetails::details]
-    /// to hold a `OpenApiSpecDetails`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_open_api_spec_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::OpenApiSpecDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::spec_details::Details::OpenApiSpecDetails(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for SpecDetails {
@@ -6082,23 +5965,6 @@ impl OperationDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [operation][crate::model::OperationDetails::operation]
-    /// to hold a `HttpOperation`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_http_operation<
-        T: std::convert::Into<std::boxed::Box<crate::model::HttpOperation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation = std::option::Option::Some(
-            crate::model::operation_details::Operation::HttpOperation(v.into()),
-        );
-        self
     }
 }
 
@@ -6573,22 +6439,6 @@ impl AttributeValues {
         })
     }
 
-    /// Sets the value of [value][crate::model::AttributeValues::value]
-    /// to hold a `EnumValues`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_enum_values<
-        T: std::convert::Into<std::boxed::Box<crate::model::attribute_values::EnumAttributeValues>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::attribute_values::Value::EnumValues(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::AttributeValues::value]
     /// if it holds a `StringValues`, `None` if the field is not set or
     /// holds a different branch.
@@ -6603,23 +6453,6 @@ impl AttributeValues {
         })
     }
 
-    /// Sets the value of [value][crate::model::AttributeValues::value]
-    /// to hold a `StringValues`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_values<
-        T: std::convert::Into<std::boxed::Box<crate::model::attribute_values::StringAttributeValues>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value = std::option::Option::Some(
-            crate::model::attribute_values::Value::StringValues(v.into()),
-        );
-        self
-    }
-
     /// The value of [value][crate::model::AttributeValues::value]
     /// if it holds a `JsonValues`, `None` if the field is not set or
     /// holds a different branch.
@@ -6632,22 +6465,6 @@ impl AttributeValues {
             crate::model::attribute_values::Value::JsonValues(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::AttributeValues::value]
-    /// to hold a `JsonValues`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_json_values<
-        T: std::convert::Into<std::boxed::Box<crate::model::attribute_values::StringAttributeValues>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::attribute_values::Value::JsonValues(v.into()));
-        self
     }
 }
 
@@ -7243,21 +7060,6 @@ impl DependencyEntityReference {
         })
     }
 
-    /// Sets the value of [identifier][crate::model::DependencyEntityReference::identifier]
-    /// to hold a `OperationResourceName`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_operation_resource_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier = std::option::Option::Some(
-            crate::model::dependency_entity_reference::Identifier::OperationResourceName(v.into()),
-        );
-        self
-    }
-
     /// The value of [identifier][crate::model::DependencyEntityReference::identifier]
     /// if it holds a `ExternalApiResourceName`, `None` if the field is not set or
     /// holds a different branch.
@@ -7269,23 +7071,6 @@ impl DependencyEntityReference {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [identifier][crate::model::DependencyEntityReference::identifier]
-    /// to hold a `ExternalApiResourceName`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_external_api_resource_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier = std::option::Option::Some(
-            crate::model::dependency_entity_reference::Identifier::ExternalApiResourceName(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/asset/v1/src/builder.rs
+++ b/src/generated/cloud/asset/v1/src/builder.rs
@@ -1452,29 +1452,6 @@ pub mod asset_service {
             self
         }
 
-        /// Sets the value of [query][crate::model::QueryAssetsRequest::query]
-        /// to hold a `Statement`.
-        ///
-        /// Note that all the setters affecting `query` are
-        /// mutually exclusive.
-        pub fn set_statement<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_statement(v);
-            self
-        }
-
-        /// Sets the value of [query][crate::model::QueryAssetsRequest::query]
-        /// to hold a `JobReference`.
-        ///
-        /// Note that all the setters affecting `query` are
-        /// mutually exclusive.
-        pub fn set_job_reference<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_job_reference(v);
-            self
-        }
-
         /// Sets the value of [time][crate::model::QueryAssetsRequest::time].
         ///
         /// Note that all the setters affecting `time` are
@@ -1484,34 +1461,6 @@ pub mod asset_service {
             v: T,
         ) -> Self {
             self.0.request.time = v.into();
-            self
-        }
-
-        /// Sets the value of [time][crate::model::QueryAssetsRequest::time]
-        /// to hold a `ReadTimeWindow`.
-        ///
-        /// Note that all the setters affecting `time` are
-        /// mutually exclusive.
-        pub fn set_read_time_window<
-            T: std::convert::Into<std::boxed::Box<crate::model::TimeWindow>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_read_time_window(v);
-            self
-        }
-
-        /// Sets the value of [time][crate::model::QueryAssetsRequest::time]
-        /// to hold a `ReadTime`.
-        ///
-        /// Note that all the setters affecting `time` are
-        /// mutually exclusive.
-        pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_read_time(v);
             self
         }
     }

--- a/src/generated/cloud/asset/v1/src/model.rs
+++ b/src/generated/cloud/asset/v1/src/model.rs
@@ -1016,23 +1016,6 @@ impl OutputConfig {
         })
     }
 
-    /// Sets the value of [destination][crate::model::OutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::output_config::Destination::GcsDestination(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::OutputConfig::destination]
     /// if it holds a `BigqueryDestination`, `None` if the field is not set or
     /// holds a different branch.
@@ -1046,23 +1029,6 @@ impl OutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::OutputConfig::destination]
-    /// to hold a `BigqueryDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_bigquery_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::output_config::Destination::BigqueryDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -1135,20 +1101,6 @@ impl OutputResult {
             crate::model::output_result::Result::GcsResult(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::OutputResult::result]
-    /// to hold a `GcsResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_gcs_result<T: std::convert::Into<std::boxed::Box<crate::model::GcsOutputResult>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::output_result::Result::GcsResult(v.into()));
-        self
     }
 }
 
@@ -1256,17 +1208,6 @@ impl GcsDestination {
         })
     }
 
-    /// Sets the value of [object_uri][crate::model::GcsDestination::object_uri]
-    /// to hold a `Uri`.
-    ///
-    /// Note that all the setters affecting `object_uri` are
-    /// mutually exclusive.
-    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.object_uri =
-            std::option::Option::Some(crate::model::gcs_destination::ObjectUri::Uri(v.into()));
-        self
-    }
-
     /// The value of [object_uri][crate::model::GcsDestination::object_uri]
     /// if it holds a `UriPrefix`, `None` if the field is not set or
     /// holds a different branch.
@@ -1276,18 +1217,6 @@ impl GcsDestination {
             crate::model::gcs_destination::ObjectUri::UriPrefix(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [object_uri][crate::model::GcsDestination::object_uri]
-    /// to hold a `UriPrefix`.
-    ///
-    /// Note that all the setters affecting `object_uri` are
-    /// mutually exclusive.
-    pub fn set_uri_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.object_uri = std::option::Option::Some(
-            crate::model::gcs_destination::ObjectUri::UriPrefix(v.into()),
-        );
-        self
     }
 }
 
@@ -1724,23 +1653,6 @@ impl FeedOutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::FeedOutputConfig::destination]
-    /// to hold a `PubsubDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_pubsub_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::PubsubDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::feed_output_config::Destination::PubsubDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -2991,23 +2903,6 @@ pub mod iam_policy_analysis_query {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [time_context][crate::model::iam_policy_analysis_query::ConditionContext::time_context]
-        /// to hold a `AccessTime`.
-        ///
-        /// Note that all the setters affecting `time_context` are
-        /// mutually exclusive.
-        pub fn set_access_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.time_context = std::option::Option::Some(
-                crate::model::iam_policy_analysis_query::condition_context::TimeContext::AccessTime(
-                    v.into(),
-                ),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for ConditionContext {
@@ -3350,25 +3245,6 @@ impl IamPolicyAnalysisOutputConfig {
         })
     }
 
-    /// Sets the value of [destination][crate::model::IamPolicyAnalysisOutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::iam_policy_analysis_output_config::GcsDestination>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::iam_policy_analysis_output_config::Destination::GcsDestination(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::IamPolicyAnalysisOutputConfig::destination]
     /// if it holds a `BigqueryDestination`, `None` if the field is not set or
     /// holds a different branch.
@@ -3384,29 +3260,6 @@ impl IamPolicyAnalysisOutputConfig {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::IamPolicyAnalysisOutputConfig::destination]
-    /// to hold a `BigqueryDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_bigquery_destination<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::iam_policy_analysis_output_config::BigQueryDestination,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::iam_policy_analysis_output_config::Destination::BigqueryDestination(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -3999,25 +3852,6 @@ pub mod saved_query {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [query_content][crate::model::saved_query::QueryContent::query_content]
-        /// to hold a `IamPolicyAnalysisQuery`.
-        ///
-        /// Note that all the setters affecting `query_content` are
-        /// mutually exclusive.
-        pub fn set_iam_policy_analysis_query<
-            T: std::convert::Into<std::boxed::Box<crate::model::IamPolicyAnalysisQuery>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.query_content = std::option::Option::Some(
-                crate::model::saved_query::query_content::QueryContent::IamPolicyAnalysisQuery(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -4686,22 +4520,6 @@ impl MoveAnalysis {
         })
     }
 
-    /// Sets the value of [result][crate::model::MoveAnalysis::result]
-    /// to hold a `Analysis`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_analysis<
-        T: std::convert::Into<std::boxed::Box<crate::model::MoveAnalysisResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::move_analysis::Result::Analysis(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::MoveAnalysis::result]
     /// if it holds a `Error`, `None` if the field is not set or
     /// holds a different branch.
@@ -4711,20 +4529,6 @@ impl MoveAnalysis {
             crate::model::move_analysis::Result::Error(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::MoveAnalysis::result]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::move_analysis::Result::Error(v.into()));
-        self
     }
 }
 
@@ -5097,18 +4901,6 @@ impl QueryAssetsRequest {
         })
     }
 
-    /// Sets the value of [query][crate::model::QueryAssetsRequest::query]
-    /// to hold a `Statement`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_statement<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::query_assets_request::Query::Statement(v.into()),
-        );
-        self
-    }
-
     /// The value of [query][crate::model::QueryAssetsRequest::query]
     /// if it holds a `JobReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -5120,18 +4912,6 @@ impl QueryAssetsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::QueryAssetsRequest::query]
-    /// to hold a `JobReference`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_job_reference<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::query_assets_request::Query::JobReference(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [time][crate::model::QueryAssetsRequest::time].
@@ -5163,23 +4943,6 @@ impl QueryAssetsRequest {
         })
     }
 
-    /// Sets the value of [time][crate::model::QueryAssetsRequest::time]
-    /// to hold a `ReadTimeWindow`.
-    ///
-    /// Note that all the setters affecting `time` are
-    /// mutually exclusive.
-    pub fn set_read_time_window<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimeWindow>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time = std::option::Option::Some(
-            crate::model::query_assets_request::Time::ReadTimeWindow(v.into()),
-        );
-        self
-    }
-
     /// The value of [time][crate::model::QueryAssetsRequest::time]
     /// if it holds a `ReadTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -5189,20 +4952,6 @@ impl QueryAssetsRequest {
             crate::model::query_assets_request::Time::ReadTime(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [time][crate::model::QueryAssetsRequest::time]
-    /// to hold a `ReadTime`.
-    ///
-    /// Note that all the setters affecting `time` are
-    /// mutually exclusive.
-    pub fn set_read_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time =
-            std::option::Option::Some(crate::model::query_assets_request::Time::ReadTime(v.into()));
-        self
     }
 }
 
@@ -5323,21 +5072,6 @@ impl QueryAssetsResponse {
         })
     }
 
-    /// Sets the value of [response][crate::model::QueryAssetsResponse::response]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response = std::option::Option::Some(
-            crate::model::query_assets_response::Response::Error(v.into()),
-        );
-        self
-    }
-
     /// The value of [response][crate::model::QueryAssetsResponse::response]
     /// if it holds a `QueryResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -5349,21 +5083,6 @@ impl QueryAssetsResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response][crate::model::QueryAssetsResponse::response]
-    /// to hold a `QueryResult`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_query_result<T: std::convert::Into<std::boxed::Box<crate::model::QueryResult>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response = std::option::Option::Some(
-            crate::model::query_assets_response::Response::QueryResult(v.into()),
-        );
-        self
     }
 
     /// The value of [response][crate::model::QueryAssetsResponse::response]
@@ -5379,23 +5098,6 @@ impl QueryAssetsResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response][crate::model::QueryAssetsResponse::response]
-    /// to hold a `OutputConfig`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_output_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::QueryAssetsOutputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response = std::option::Option::Some(
-            crate::model::query_assets_response::Response::OutputConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -6100,25 +5802,6 @@ pub mod analyzer_org_policy {
             })
         }
 
-        /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
-        /// to hold a `Values`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_values<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::analyzer_org_policy::rule::StringValues>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::analyzer_org_policy::rule::Kind::Values(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
         /// if it holds a `AllowAll`, `None` if the field is not set or
         /// holds a different branch.
@@ -6130,18 +5813,6 @@ pub mod analyzer_org_policy {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
-        /// to hold a `AllowAll`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_allow_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::analyzer_org_policy::rule::Kind::AllowAll(v.into()),
-            );
-            self
         }
 
         /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
@@ -6157,18 +5828,6 @@ pub mod analyzer_org_policy {
             })
         }
 
-        /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
-        /// to hold a `DenyAll`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_deny_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::analyzer_org_policy::rule::Kind::DenyAll(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::analyzer_org_policy::Rule::kind]
         /// if it holds a `Enforce`, `None` if the field is not set or
         /// holds a different branch.
@@ -6180,18 +5839,6 @@ pub mod analyzer_org_policy {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::analyzer_org_policy::Rule::kind]
-        /// to hold a `Enforce`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_enforce<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::analyzer_org_policy::rule::Kind::Enforce(v.into()),
-            );
-            self
         }
     }
 
@@ -6332,27 +5979,6 @@ impl AnalyzerOrgPolicyConstraint {
         })
     }
 
-    /// Sets the value of [constraint_definition][crate::model::AnalyzerOrgPolicyConstraint::constraint_definition]
-    /// to hold a `GoogleDefinedConstraint`.
-    ///
-    /// Note that all the setters affecting `constraint_definition` are
-    /// mutually exclusive.
-    pub fn set_google_defined_constraint<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::analyzer_org_policy_constraint::Constraint>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.constraint_definition = std::option::Option::Some(
-            crate::model::analyzer_org_policy_constraint::ConstraintDefinition::GoogleDefinedConstraint(
-                v.into()
-            )
-        );
-        self
-    }
-
     /// The value of [constraint_definition][crate::model::AnalyzerOrgPolicyConstraint::constraint_definition]
     /// if it holds a `CustomConstraint`, `None` if the field is not set or
     /// holds a different branch.
@@ -6366,27 +5992,6 @@ impl AnalyzerOrgPolicyConstraint {
             crate::model::analyzer_org_policy_constraint::ConstraintDefinition::CustomConstraint(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [constraint_definition][crate::model::AnalyzerOrgPolicyConstraint::constraint_definition]
-    /// to hold a `CustomConstraint`.
-    ///
-    /// Note that all the setters affecting `constraint_definition` are
-    /// mutually exclusive.
-    pub fn set_custom_constraint<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::analyzer_org_policy_constraint::CustomConstraint>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.constraint_definition = std::option::Option::Some(
-            crate::model::analyzer_org_policy_constraint::ConstraintDefinition::CustomConstraint(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -6514,29 +6119,6 @@ pub mod analyzer_org_policy_constraint {
             })
         }
 
-        /// Sets the value of [constraint_type][crate::model::analyzer_org_policy_constraint::Constraint::constraint_type]
-        /// to hold a `ListConstraint`.
-        ///
-        /// Note that all the setters affecting `constraint_type` are
-        /// mutually exclusive.
-        pub fn set_list_constraint<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::analyzer_org_policy_constraint::constraint::ListConstraint,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.constraint_type = std::option::Option::Some(
-                crate::model::analyzer_org_policy_constraint::constraint::ConstraintType::ListConstraint(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [constraint_type][crate::model::analyzer_org_policy_constraint::Constraint::constraint_type]
         /// if it holds a `BooleanConstraint`, `None` if the field is not set or
         /// holds a different branch.
@@ -6552,29 +6134,6 @@ pub mod analyzer_org_policy_constraint {
                 crate::model::analyzer_org_policy_constraint::constraint::ConstraintType::BooleanConstraint(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [constraint_type][crate::model::analyzer_org_policy_constraint::Constraint::constraint_type]
-        /// to hold a `BooleanConstraint`.
-        ///
-        /// Note that all the setters affecting `constraint_type` are
-        /// mutually exclusive.
-        pub fn set_boolean_constraint<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::analyzer_org_policy_constraint::constraint::BooleanConstraint,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.constraint_type = std::option::Option::Some(
-                crate::model::analyzer_org_policy_constraint::constraint::ConstraintType::BooleanConstraint(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -8467,29 +8026,6 @@ pub mod analyze_org_policy_governed_assets_response {
             })
         }
 
-        /// Sets the value of [governed_asset][crate::model::analyze_org_policy_governed_assets_response::GovernedAsset::governed_asset]
-        /// to hold a `GovernedResource`.
-        ///
-        /// Note that all the setters affecting `governed_asset` are
-        /// mutually exclusive.
-        pub fn set_governed_resource<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::analyze_org_policy_governed_assets_response::GovernedResource,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.governed_asset = std::option::Option::Some(
-                crate::model::analyze_org_policy_governed_assets_response::governed_asset::GovernedAsset::GovernedResource(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [governed_asset][crate::model::analyze_org_policy_governed_assets_response::GovernedAsset::governed_asset]
         /// if it holds a `GovernedIamPolicy`, `None` if the field is not set or
         /// holds a different branch.
@@ -8505,20 +8041,6 @@ pub mod analyze_org_policy_governed_assets_response {
                 crate::model::analyze_org_policy_governed_assets_response::governed_asset::GovernedAsset::GovernedIamPolicy(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [governed_asset][crate::model::analyze_org_policy_governed_assets_response::GovernedAsset::governed_asset]
-        /// to hold a `GovernedIamPolicy`.
-        ///
-        /// Note that all the setters affecting `governed_asset` are
-        /// mutually exclusive.
-        pub fn set_governed_iam_policy<T: std::convert::Into<std::boxed::Box<crate::model::analyze_org_policy_governed_assets_response::GovernedIamPolicy>>>(mut self, v: T) -> Self{
-            self.governed_asset = std::option::Option::Some(
-                crate::model::analyze_org_policy_governed_assets_response::governed_asset::GovernedAsset::GovernedIamPolicy(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -8896,23 +8418,6 @@ impl AssetEnrichment {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [enrichment_data][crate::model::AssetEnrichment::enrichment_data]
-    /// to hold a `ResourceOwners`.
-    ///
-    /// Note that all the setters affecting `enrichment_data` are
-    /// mutually exclusive.
-    pub fn set_resource_owners<
-        T: std::convert::Into<std::boxed::Box<crate::model::ResourceOwners>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enrichment_data = std::option::Option::Some(
-            crate::model::asset_enrichment::EnrichmentData::ResourceOwners(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for AssetEnrichment {
@@ -9166,23 +8671,6 @@ impl Asset {
         })
     }
 
-    /// Sets the value of [access_context_policy][crate::model::Asset::access_context_policy]
-    /// to hold a `AccessPolicy`.
-    ///
-    /// Note that all the setters affecting `access_context_policy` are
-    /// mutually exclusive.
-    pub fn set_access_policy<
-        T: std::convert::Into<std::boxed::Box<accesscontextmanager_v1::model::AccessPolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.access_context_policy = std::option::Option::Some(
-            crate::model::asset::AccessContextPolicy::AccessPolicy(v.into()),
-        );
-        self
-    }
-
     /// The value of [access_context_policy][crate::model::Asset::access_context_policy]
     /// if it holds a `AccessLevel`, `None` if the field is not set or
     /// holds a different branch.
@@ -9196,23 +8684,6 @@ impl Asset {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [access_context_policy][crate::model::Asset::access_context_policy]
-    /// to hold a `AccessLevel`.
-    ///
-    /// Note that all the setters affecting `access_context_policy` are
-    /// mutually exclusive.
-    pub fn set_access_level<
-        T: std::convert::Into<std::boxed::Box<accesscontextmanager_v1::model::AccessLevel>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.access_context_policy = std::option::Option::Some(
-            crate::model::asset::AccessContextPolicy::AccessLevel(v.into()),
-        );
-        self
     }
 
     /// The value of [access_context_policy][crate::model::Asset::access_context_policy]
@@ -9229,23 +8700,6 @@ impl Asset {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [access_context_policy][crate::model::Asset::access_context_policy]
-    /// to hold a `ServicePerimeter`.
-    ///
-    /// Note that all the setters affecting `access_context_policy` are
-    /// mutually exclusive.
-    pub fn set_service_perimeter<
-        T: std::convert::Into<std::boxed::Box<accesscontextmanager_v1::model::ServicePerimeter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.access_context_policy = std::option::Option::Some(
-            crate::model::asset::AccessContextPolicy::ServicePerimeter(v.into()),
-        );
-        self
     }
 }
 
@@ -11382,18 +10836,6 @@ pub mod iam_policy_analysis_result {
             })
         }
 
-        /// Sets the value of [oneof_access][crate::model::iam_policy_analysis_result::Access::oneof_access]
-        /// to hold a `Role`.
-        ///
-        /// Note that all the setters affecting `oneof_access` are
-        /// mutually exclusive.
-        pub fn set_role<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.oneof_access = std::option::Option::Some(
-                crate::model::iam_policy_analysis_result::access::OneofAccess::Role(v.into()),
-            );
-            self
-        }
-
         /// The value of [oneof_access][crate::model::iam_policy_analysis_result::Access::oneof_access]
         /// if it holds a `Permission`, `None` if the field is not set or
         /// holds a different branch.
@@ -11405,18 +10847,6 @@ pub mod iam_policy_analysis_result {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [oneof_access][crate::model::iam_policy_analysis_result::Access::oneof_access]
-        /// to hold a `Permission`.
-        ///
-        /// Note that all the setters affecting `oneof_access` are
-        /// mutually exclusive.
-        pub fn set_permission<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.oneof_access = std::option::Option::Some(
-                crate::model::iam_policy_analysis_result::access::OneofAccess::Permission(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/backupdr/v1/src/builder.rs
+++ b/src/generated/cloud/backupdr/v1/src/builder.rs
@@ -2035,21 +2035,6 @@ pub mod backup_dr {
             self
         }
 
-        /// Sets the value of [target_environment][crate::model::RestoreBackupRequest::target_environment]
-        /// to hold a `ComputeInstanceTargetEnvironment`.
-        ///
-        /// Note that all the setters affecting `target_environment` are
-        /// mutually exclusive.
-        pub fn set_compute_instance_target_environment<
-            T: std::convert::Into<std::boxed::Box<crate::model::ComputeInstanceTargetEnvironment>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_compute_instance_target_environment(v);
-            self
-        }
-
         /// Sets the value of [instance_properties][crate::model::RestoreBackupRequest::instance_properties].
         ///
         /// Note that all the setters affecting `instance_properties` are
@@ -2061,21 +2046,6 @@ pub mod backup_dr {
             v: T,
         ) -> Self {
             self.0.request.instance_properties = v.into();
-            self
-        }
-
-        /// Sets the value of [instance_properties][crate::model::RestoreBackupRequest::instance_properties]
-        /// to hold a `ComputeInstanceRestoreProperties`.
-        ///
-        /// Note that all the setters affecting `instance_properties` are
-        /// mutually exclusive.
-        pub fn set_compute_instance_restore_properties<
-            T: std::convert::Into<std::boxed::Box<crate::model::ComputeInstanceRestoreProperties>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_compute_instance_restore_properties(v);
             self
         }
     }

--- a/src/generated/cloud/backupdr/v1/src/model.rs
+++ b/src/generated/cloud/backupdr/v1/src/model.rs
@@ -1891,23 +1891,6 @@ impl BackupRule {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [backup_schedule_oneof][crate::model::BackupRule::backup_schedule_oneof]
-    /// to hold a `StandardSchedule`.
-    ///
-    /// Note that all the setters affecting `backup_schedule_oneof` are
-    /// mutually exclusive.
-    pub fn set_standard_schedule<
-        T: std::convert::Into<std::boxed::Box<crate::model::StandardSchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_schedule_oneof = std::option::Option::Some(
-            crate::model::backup_rule::BackupScheduleOneof::StandardSchedule(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BackupRule {
@@ -4506,23 +4489,6 @@ impl DataSource {
         })
     }
 
-    /// Sets the value of [source_resource][crate::model::DataSource::source_resource]
-    /// to hold a `DataSourceGcpResource`.
-    ///
-    /// Note that all the setters affecting `source_resource` are
-    /// mutually exclusive.
-    pub fn set_data_source_gcp_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataSourceGcpResource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_resource = std::option::Option::Some(
-            crate::model::data_source::SourceResource::DataSourceGcpResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_resource][crate::model::DataSource::source_resource]
     /// if it holds a `DataSourceBackupApplianceApplication`, `None` if the field is not set or
     /// holds a different branch.
@@ -4537,25 +4503,6 @@ impl DataSource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_resource][crate::model::DataSource::source_resource]
-    /// to hold a `DataSourceBackupApplianceApplication`.
-    ///
-    /// Note that all the setters affecting `source_resource` are
-    /// mutually exclusive.
-    pub fn set_data_source_backup_appliance_application<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataSourceBackupApplianceApplication>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_resource = std::option::Option::Some(
-            crate::model::data_source::SourceResource::DataSourceBackupApplianceApplication(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -4827,23 +4774,6 @@ impl BackupConfigInfo {
         })
     }
 
-    /// Sets the value of [backup_config][crate::model::BackupConfigInfo::backup_config]
-    /// to hold a `GcpBackupConfig`.
-    ///
-    /// Note that all the setters affecting `backup_config` are
-    /// mutually exclusive.
-    pub fn set_gcp_backup_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcpBackupConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_config = std::option::Option::Some(
-            crate::model::backup_config_info::BackupConfig::GcpBackupConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [backup_config][crate::model::BackupConfigInfo::backup_config]
     /// if it holds a `BackupApplianceBackupConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -4857,23 +4787,6 @@ impl BackupConfigInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [backup_config][crate::model::BackupConfigInfo::backup_config]
-    /// to hold a `BackupApplianceBackupConfig`.
-    ///
-    /// Note that all the setters affecting `backup_config` are
-    /// mutually exclusive.
-    pub fn set_backup_appliance_backup_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::BackupApplianceBackupConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_config = std::option::Option::Some(
-            crate::model::backup_config_info::BackupConfig::BackupApplianceBackupConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -5312,25 +5225,6 @@ impl DataSourceGcpResource {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [gcp_resource_properties][crate::model::DataSourceGcpResource::gcp_resource_properties]
-    /// to hold a `ComputeInstanceDatasourceProperties`.
-    ///
-    /// Note that all the setters affecting `gcp_resource_properties` are
-    /// mutually exclusive.
-    pub fn set_compute_instance_datasource_properties<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeInstanceDataSourceProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.gcp_resource_properties = std::option::Option::Some(
-            crate::model::data_source_gcp_resource::GcpResourceProperties::ComputeInstanceDatasourceProperties(
-                v.into()
-            )
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DataSourceGcpResource {
@@ -5580,18 +5474,6 @@ impl BackupApplianceLockInfo {
         })
     }
 
-    /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
-    /// to hold a `JobName`.
-    ///
-    /// Note that all the setters affecting `lock_source` are
-    /// mutually exclusive.
-    pub fn set_job_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.lock_source = std::option::Option::Some(
-            crate::model::backup_appliance_lock_info::LockSource::JobName(v.into()),
-        );
-        self
-    }
-
     /// The value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
     /// if it holds a `BackupImage`, `None` if the field is not set or
     /// holds a different branch.
@@ -5605,18 +5487,6 @@ impl BackupApplianceLockInfo {
         })
     }
 
-    /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
-    /// to hold a `BackupImage`.
-    ///
-    /// Note that all the setters affecting `lock_source` are
-    /// mutually exclusive.
-    pub fn set_backup_image<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.lock_source = std::option::Option::Some(
-            crate::model::backup_appliance_lock_info::LockSource::BackupImage(v.into()),
-        );
-        self
-    }
-
     /// The value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
     /// if it holds a `SlaId`, `None` if the field is not set or
     /// holds a different branch.
@@ -5628,18 +5498,6 @@ impl BackupApplianceLockInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [lock_source][crate::model::BackupApplianceLockInfo::lock_source]
-    /// to hold a `SlaId`.
-    ///
-    /// Note that all the setters affecting `lock_source` are
-    /// mutually exclusive.
-    pub fn set_sla_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.lock_source = std::option::Option::Some(
-            crate::model::backup_appliance_lock_info::LockSource::SlaId(v.into()),
-        );
-        self
     }
 }
 
@@ -5732,23 +5590,6 @@ impl BackupLock {
         })
     }
 
-    /// Sets the value of [client_lock_info][crate::model::BackupLock::client_lock_info]
-    /// to hold a `BackupApplianceLockInfo`.
-    ///
-    /// Note that all the setters affecting `client_lock_info` are
-    /// mutually exclusive.
-    pub fn set_backup_appliance_lock_info<
-        T: std::convert::Into<std::boxed::Box<crate::model::BackupApplianceLockInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.client_lock_info = std::option::Option::Some(
-            crate::model::backup_lock::ClientLockInfo::BackupApplianceLockInfo(v.into()),
-        );
-        self
-    }
-
     /// The value of [client_lock_info][crate::model::BackupLock::client_lock_info]
     /// if it holds a `ServiceLockInfo`, `None` if the field is not set or
     /// holds a different branch.
@@ -5762,23 +5603,6 @@ impl BackupLock {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [client_lock_info][crate::model::BackupLock::client_lock_info]
-    /// to hold a `ServiceLockInfo`.
-    ///
-    /// Note that all the setters affecting `client_lock_info` are
-    /// mutually exclusive.
-    pub fn set_service_lock_info<
-        T: std::convert::Into<std::boxed::Box<crate::model::ServiceLockInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.client_lock_info = std::option::Option::Some(
-            crate::model::backup_lock::ClientLockInfo::ServiceLockInfo(v.into()),
-        );
-        self
     }
 }
 
@@ -6049,23 +5873,6 @@ impl Backup {
         })
     }
 
-    /// Sets the value of [backup_properties][crate::model::Backup::backup_properties]
-    /// to hold a `ComputeInstanceBackupProperties`.
-    ///
-    /// Note that all the setters affecting `backup_properties` are
-    /// mutually exclusive.
-    pub fn set_compute_instance_backup_properties<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeInstanceBackupProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_properties = std::option::Option::Some(
-            crate::model::backup::BackupProperties::ComputeInstanceBackupProperties(v.into()),
-        );
-        self
-    }
-
     /// The value of [backup_properties][crate::model::Backup::backup_properties]
     /// if it holds a `BackupApplianceBackupProperties`, `None` if the field is not set or
     /// holds a different branch.
@@ -6079,23 +5886,6 @@ impl Backup {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [backup_properties][crate::model::Backup::backup_properties]
-    /// to hold a `BackupApplianceBackupProperties`.
-    ///
-    /// Note that all the setters affecting `backup_properties` are
-    /// mutually exclusive.
-    pub fn set_backup_appliance_backup_properties<
-        T: std::convert::Into<std::boxed::Box<crate::model::BackupApplianceBackupProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_properties = std::option::Option::Some(
-            crate::model::backup::BackupProperties::BackupApplianceBackupProperties(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [plan_info][crate::model::Backup::plan_info].
@@ -6123,22 +5913,6 @@ impl Backup {
             crate::model::backup::PlanInfo::GcpBackupPlanInfo(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [plan_info][crate::model::Backup::plan_info]
-    /// to hold a `GcpBackupPlanInfo`.
-    ///
-    /// Note that all the setters affecting `plan_info` are
-    /// mutually exclusive.
-    pub fn set_gcp_backup_plan_info<
-        T: std::convert::Into<std::boxed::Box<crate::model::backup::GCPBackupPlanInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.plan_info =
-            std::option::Option::Some(crate::model::backup::PlanInfo::GcpBackupPlanInfo(v.into()));
-        self
     }
 }
 
@@ -7890,25 +7664,6 @@ impl RestoreBackupRequest {
         })
     }
 
-    /// Sets the value of [target_environment][crate::model::RestoreBackupRequest::target_environment]
-    /// to hold a `ComputeInstanceTargetEnvironment`.
-    ///
-    /// Note that all the setters affecting `target_environment` are
-    /// mutually exclusive.
-    pub fn set_compute_instance_target_environment<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeInstanceTargetEnvironment>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_environment = std::option::Option::Some(
-            crate::model::restore_backup_request::TargetEnvironment::ComputeInstanceTargetEnvironment(
-                v.into()
-            )
-        );
-        self
-    }
-
     /// Sets the value of [instance_properties][crate::model::RestoreBackupRequest::instance_properties].
     ///
     /// Note that all the setters affecting `instance_properties` are mutually
@@ -7936,25 +7691,6 @@ impl RestoreBackupRequest {
             crate::model::restore_backup_request::InstanceProperties::ComputeInstanceRestoreProperties(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [instance_properties][crate::model::RestoreBackupRequest::instance_properties]
-    /// to hold a `ComputeInstanceRestoreProperties`.
-    ///
-    /// Note that all the setters affecting `instance_properties` are
-    /// mutually exclusive.
-    pub fn set_compute_instance_restore_properties<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeInstanceRestoreProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.instance_properties = std::option::Option::Some(
-            crate::model::restore_backup_request::InstanceProperties::ComputeInstanceRestoreProperties(
-                v.into()
-            )
-        );
-        self
     }
 }
 
@@ -8076,21 +7812,6 @@ impl TargetResource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_resource_info][crate::model::TargetResource::target_resource_info]
-    /// to hold a `GcpResource`.
-    ///
-    /// Note that all the setters affecting `target_resource_info` are
-    /// mutually exclusive.
-    pub fn set_gcp_resource<T: std::convert::Into<std::boxed::Box<crate::model::GcpResource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_resource_info = std::option::Option::Some(
-            crate::model::target_resource::TargetResourceInfo::GcpResource(v.into()),
-        );
-        self
     }
 }
 
@@ -9434,17 +9155,6 @@ impl CustomerEncryptionKey {
         })
     }
 
-    /// Sets the value of [key][crate::model::CustomerEncryptionKey::key]
-    /// to hold a `RawKey`.
-    ///
-    /// Note that all the setters affecting `key` are
-    /// mutually exclusive.
-    pub fn set_raw_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.key =
-            std::option::Option::Some(crate::model::customer_encryption_key::Key::RawKey(v.into()));
-        self
-    }
-
     /// The value of [key][crate::model::CustomerEncryptionKey::key]
     /// if it holds a `RsaEncryptedKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -9458,21 +9168,6 @@ impl CustomerEncryptionKey {
         })
     }
 
-    /// Sets the value of [key][crate::model::CustomerEncryptionKey::key]
-    /// to hold a `RsaEncryptedKey`.
-    ///
-    /// Note that all the setters affecting `key` are
-    /// mutually exclusive.
-    pub fn set_rsa_encrypted_key<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.key = std::option::Option::Some(
-            crate::model::customer_encryption_key::Key::RsaEncryptedKey(v.into()),
-        );
-        self
-    }
-
     /// The value of [key][crate::model::CustomerEncryptionKey::key]
     /// if it holds a `KmsKeyName`, `None` if the field is not set or
     /// holds a different branch.
@@ -9484,18 +9179,6 @@ impl CustomerEncryptionKey {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [key][crate::model::CustomerEncryptionKey::key]
-    /// to hold a `KmsKeyName`.
-    ///
-    /// Note that all the setters affecting `key` are
-    /// mutually exclusive.
-    pub fn set_kms_key_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.key = std::option::Option::Some(
-            crate::model::customer_encryption_key::Key::KmsKeyName(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/baremetalsolution/v2/src/model.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/model.rs
@@ -5488,23 +5488,6 @@ impl ProvisioningQuota {
         })
     }
 
-    /// Sets the value of [quota][crate::model::ProvisioningQuota::quota]
-    /// to hold a `InstanceQuota`.
-    ///
-    /// Note that all the setters affecting `quota` are
-    /// mutually exclusive.
-    pub fn set_instance_quota<
-        T: std::convert::Into<std::boxed::Box<crate::model::InstanceQuota>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.quota = std::option::Option::Some(
-            crate::model::provisioning_quota::Quota::InstanceQuota(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [availability][crate::model::ProvisioningQuota::availability].
     ///
     /// Note that all the setters affecting `availability` are mutually
@@ -5532,18 +5515,6 @@ impl ProvisioningQuota {
         })
     }
 
-    /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
-    /// to hold a `ServerCount`.
-    ///
-    /// Note that all the setters affecting `availability` are
-    /// mutually exclusive.
-    pub fn set_server_count<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.availability = std::option::Option::Some(
-            crate::model::provisioning_quota::Availability::ServerCount(v.into()),
-        );
-        self
-    }
-
     /// The value of [availability][crate::model::ProvisioningQuota::availability]
     /// if it holds a `NetworkBandwidth`, `None` if the field is not set or
     /// holds a different branch.
@@ -5557,18 +5528,6 @@ impl ProvisioningQuota {
         })
     }
 
-    /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
-    /// to hold a `NetworkBandwidth`.
-    ///
-    /// Note that all the setters affecting `availability` are
-    /// mutually exclusive.
-    pub fn set_network_bandwidth<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.availability = std::option::Option::Some(
-            crate::model::provisioning_quota::Availability::NetworkBandwidth(v.into()),
-        );
-        self
-    }
-
     /// The value of [availability][crate::model::ProvisioningQuota::availability]
     /// if it holds a `StorageGib`, `None` if the field is not set or
     /// holds a different branch.
@@ -5580,18 +5539,6 @@ impl ProvisioningQuota {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [availability][crate::model::ProvisioningQuota::availability]
-    /// to hold a `StorageGib`.
-    ///
-    /// Note that all the setters affecting `availability` are
-    /// mutually exclusive.
-    pub fn set_storage_gib<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.availability = std::option::Option::Some(
-            crate::model::provisioning_quota::Availability::StorageGib(v.into()),
-        );
-        self
     }
 }
 
@@ -6596,18 +6543,6 @@ pub mod volume_config {
             })
         }
 
-        /// Sets the value of [client][crate::model::volume_config::NfsExport::client]
-        /// to hold a `MachineId`.
-        ///
-        /// Note that all the setters affecting `client` are
-        /// mutually exclusive.
-        pub fn set_machine_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.client = std::option::Option::Some(
-                crate::model::volume_config::nfs_export::Client::MachineId(v.into()),
-            );
-            self
-        }
-
         /// The value of [client][crate::model::volume_config::NfsExport::client]
         /// if it holds a `Cidr`, `None` if the field is not set or
         /// holds a different branch.
@@ -6619,18 +6554,6 @@ pub mod volume_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [client][crate::model::volume_config::NfsExport::client]
-        /// to hold a `Cidr`.
-        ///
-        /// Note that all the setters affecting `client` are
-        /// mutually exclusive.
-        pub fn set_cidr<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.client = std::option::Option::Some(
-                crate::model::volume_config::nfs_export::Client::Cidr(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/model.rs
@@ -162,25 +162,6 @@ impl NotificationConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [config][crate::model::NotificationConfig::config]
-    /// to hold a `PubsubNotification`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_pubsub_notification<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::notification_config::CloudPubSubNotificationConfig>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(
-            crate::model::notification_config::Config::PubsubNotification(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for NotificationConfig {
@@ -1008,25 +989,6 @@ pub mod app_connector {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [r#type][crate::model::app_connector::PrincipalInfo::r#type]
-        /// to hold a `ServiceAccount`.
-        ///
-        /// Note that all the setters affecting `r#type` are
-        /// mutually exclusive.
-        pub fn set_service_account<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::app_connector::principal_info::ServiceAccount>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#type = std::option::Option::Some(
-                crate::model::app_connector::principal_info::Type::ServiceAccount(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/model.rs
@@ -208,25 +208,6 @@ pub mod client_connector_service {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [ingress_config][crate::model::client_connector_service::Ingress::ingress_config]
-        /// to hold a `Config`.
-        ///
-        /// Note that all the setters affecting `ingress_config` are
-        /// mutually exclusive.
-        pub fn set_config<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::client_connector_service::ingress::Config>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.ingress_config = std::option::Option::Some(
-                crate::model::client_connector_service::ingress::IngressConfig::Config(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for Ingress {
@@ -548,27 +529,6 @@ pub mod client_connector_service {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [destination_type][crate::model::client_connector_service::Egress::destination_type]
-        /// to hold a `PeeredVpc`.
-        ///
-        /// Note that all the setters affecting `destination_type` are
-        /// mutually exclusive.
-        pub fn set_peered_vpc<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::client_connector_service::egress::PeeredVpc>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.destination_type = std::option::Option::Some(
-                crate::model::client_connector_service::egress::DestinationType::PeeredVpc(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
@@ -1029,36 +1029,6 @@ pub mod analytics_hub_service {
             self.0.request.destination = v.into();
             self
         }
-
-        /// Sets the value of [destination][crate::model::SubscribeListingRequest::destination]
-        /// to hold a `DestinationDataset`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_destination_dataset<
-            T: std::convert::Into<std::boxed::Box<crate::model::DestinationDataset>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_destination_dataset(v);
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::SubscribeListingRequest::destination]
-        /// to hold a `DestinationPubsubSubscription`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_destination_pubsub_subscription<
-            T: std::convert::Into<std::boxed::Box<crate::model::DestinationPubSubSubscription>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_destination_pubsub_subscription(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/model.rs
@@ -241,25 +241,6 @@ impl SharingEnvironmentConfig {
         })
     }
 
-    /// Sets the value of [environment][crate::model::SharingEnvironmentConfig::environment]
-    /// to hold a `DefaultExchangeConfig`.
-    ///
-    /// Note that all the setters affecting `environment` are
-    /// mutually exclusive.
-    pub fn set_default_exchange_config<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::sharing_environment_config::DefaultExchangeConfig>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.environment = std::option::Option::Some(
-            crate::model::sharing_environment_config::Environment::DefaultExchangeConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [environment][crate::model::SharingEnvironmentConfig::environment]
     /// if it holds a `DcrExchangeConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -275,25 +256,6 @@ impl SharingEnvironmentConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [environment][crate::model::SharingEnvironmentConfig::environment]
-    /// to hold a `DcrExchangeConfig`.
-    ///
-    /// Note that all the setters affecting `environment` are
-    /// mutually exclusive.
-    pub fn set_dcr_exchange_config<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::sharing_environment_config::DcrExchangeConfig>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.environment = std::option::Option::Some(
-            crate::model::sharing_environment_config::Environment::DcrExchangeConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -943,22 +905,6 @@ impl Listing {
         })
     }
 
-    /// Sets the value of [source][crate::model::Listing::source]
-    /// to hold a `BigqueryDataset`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_bigquery_dataset<
-        T: std::convert::Into<std::boxed::Box<crate::model::listing::BigQueryDatasetSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::listing::Source::BigqueryDataset(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Listing::source]
     /// if it holds a `PubsubTopic`, `None` if the field is not set or
     /// holds a different branch.
@@ -970,22 +916,6 @@ impl Listing {
             crate::model::listing::Source::PubsubTopic(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Listing::source]
-    /// to hold a `PubsubTopic`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_pubsub_topic<
-        T: std::convert::Into<std::boxed::Box<crate::model::listing::PubSubTopicSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::listing::Source::PubsubTopic(v.into()));
-        self
     }
 }
 
@@ -1126,20 +1056,6 @@ pub mod listing {
                 })
             }
 
-            /// Sets the value of [resource][crate::model::listing::big_query_dataset_source::SelectedResource::resource]
-            /// to hold a `Table`.
-            ///
-            /// Note that all the setters affecting `resource` are
-            /// mutually exclusive.
-            pub fn set_table<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.resource = std::option::Option::Some(
-                    crate::model::listing::big_query_dataset_source::selected_resource::Resource::Table(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [resource][crate::model::listing::big_query_dataset_source::SelectedResource::resource]
             /// if it holds a `Routine`, `None` if the field is not set or
             /// holds a different branch.
@@ -1149,20 +1065,6 @@ pub mod listing {
                     crate::model::listing::big_query_dataset_source::selected_resource::Resource::Routine(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [resource][crate::model::listing::big_query_dataset_source::SelectedResource::resource]
-            /// to hold a `Routine`.
-            ///
-            /// Note that all the setters affecting `resource` are
-            /// mutually exclusive.
-            pub fn set_routine<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.resource = std::option::Option::Some(
-                    crate::model::listing::big_query_dataset_source::selected_resource::Resource::Routine(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -2221,17 +2123,6 @@ impl Subscription {
         })
     }
 
-    /// Sets the value of [resource_name][crate::model::Subscription::resource_name]
-    /// to hold a `Listing`.
-    ///
-    /// Note that all the setters affecting `resource_name` are
-    /// mutually exclusive.
-    pub fn set_listing<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.resource_name =
-            std::option::Option::Some(crate::model::subscription::ResourceName::Listing(v.into()));
-        self
-    }
-
     /// The value of [resource_name][crate::model::Subscription::resource_name]
     /// if it holds a `DataExchange`, `None` if the field is not set or
     /// holds a different branch.
@@ -2243,18 +2134,6 @@ impl Subscription {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource_name][crate::model::Subscription::resource_name]
-    /// to hold a `DataExchange`.
-    ///
-    /// Note that all the setters affecting `resource_name` are
-    /// mutually exclusive.
-    pub fn set_data_exchange<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.resource_name = std::option::Option::Some(
-            crate::model::subscription::ResourceName::DataExchange(v.into()),
-        );
-        self
     }
 }
 
@@ -2326,21 +2205,6 @@ pub mod subscription {
             })
         }
 
-        /// Sets the value of [reference][crate::model::subscription::LinkedResource::reference]
-        /// to hold a `LinkedDataset`.
-        ///
-        /// Note that all the setters affecting `reference` are
-        /// mutually exclusive.
-        pub fn set_linked_dataset<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.reference = std::option::Option::Some(
-                crate::model::subscription::linked_resource::Reference::LinkedDataset(v.into()),
-            );
-            self
-        }
-
         /// The value of [reference][crate::model::subscription::LinkedResource::reference]
         /// if it holds a `LinkedPubsubSubscription`, `None` if the field is not set or
         /// holds a different branch.
@@ -2350,23 +2214,6 @@ pub mod subscription {
                 crate::model::subscription::linked_resource::Reference::LinkedPubsubSubscription(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [reference][crate::model::subscription::LinkedResource::reference]
-        /// to hold a `LinkedPubsubSubscription`.
-        ///
-        /// Note that all the setters affecting `reference` are
-        /// mutually exclusive.
-        pub fn set_linked_pubsub_subscription<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.reference = std::option::Option::Some(
-                crate::model::subscription::linked_resource::Reference::LinkedPubsubSubscription(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -3410,23 +3257,6 @@ impl SubscribeListingRequest {
         })
     }
 
-    /// Sets the value of [destination][crate::model::SubscribeListingRequest::destination]
-    /// to hold a `DestinationDataset`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_dataset<
-        T: std::convert::Into<std::boxed::Box<crate::model::DestinationDataset>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::subscribe_listing_request::Destination::DestinationDataset(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::SubscribeListingRequest::destination]
     /// if it holds a `DestinationPubsubSubscription`, `None` if the field is not set or
     /// holds a different branch.
@@ -3440,25 +3270,6 @@ impl SubscribeListingRequest {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::SubscribeListingRequest::destination]
-    /// to hold a `DestinationPubsubSubscription`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_pubsub_subscription<
-        T: std::convert::Into<std::boxed::Box<crate::model::DestinationPubSubSubscription>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::subscribe_listing_request::Destination::DestinationPubsubSubscription(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -4797,23 +4608,6 @@ impl PushConfig {
         })
     }
 
-    /// Sets the value of [authentication_method][crate::model::PushConfig::authentication_method]
-    /// to hold a `OidcToken`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_oidc_token<
-        T: std::convert::Into<std::boxed::Box<crate::model::push_config::OidcToken>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::push_config::AuthenticationMethod::OidcToken(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [wrapper][crate::model::PushConfig::wrapper].
     ///
     /// Note that all the setters affecting `wrapper` are mutually
@@ -4841,22 +4635,6 @@ impl PushConfig {
         })
     }
 
-    /// Sets the value of [wrapper][crate::model::PushConfig::wrapper]
-    /// to hold a `PubsubWrapper`.
-    ///
-    /// Note that all the setters affecting `wrapper` are
-    /// mutually exclusive.
-    pub fn set_pubsub_wrapper<
-        T: std::convert::Into<std::boxed::Box<crate::model::push_config::PubsubWrapper>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.wrapper =
-            std::option::Option::Some(crate::model::push_config::Wrapper::PubsubWrapper(v.into()));
-        self
-    }
-
     /// The value of [wrapper][crate::model::PushConfig::wrapper]
     /// if it holds a `NoWrapper`, `None` if the field is not set or
     /// holds a different branch.
@@ -4868,22 +4646,6 @@ impl PushConfig {
             crate::model::push_config::Wrapper::NoWrapper(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [wrapper][crate::model::PushConfig::wrapper]
-    /// to hold a `NoWrapper`.
-    ///
-    /// Note that all the setters affecting `wrapper` are
-    /// mutually exclusive.
-    pub fn set_no_wrapper<
-        T: std::convert::Into<std::boxed::Box<crate::model::push_config::NoWrapper>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.wrapper =
-            std::option::Option::Some(crate::model::push_config::Wrapper::NoWrapper(v.into()));
-        self
     }
 }
 
@@ -5310,23 +5072,6 @@ impl CloudStorageConfig {
         })
     }
 
-    /// Sets the value of [output_format][crate::model::CloudStorageConfig::output_format]
-    /// to hold a `TextConfig`.
-    ///
-    /// Note that all the setters affecting `output_format` are
-    /// mutually exclusive.
-    pub fn set_text_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::cloud_storage_config::TextConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_format = std::option::Option::Some(
-            crate::model::cloud_storage_config::OutputFormat::TextConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [output_format][crate::model::CloudStorageConfig::output_format]
     /// if it holds a `AvroConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -5340,23 +5085,6 @@ impl CloudStorageConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [output_format][crate::model::CloudStorageConfig::output_format]
-    /// to hold a `AvroConfig`.
-    ///
-    /// Note that all the setters affecting `output_format` are
-    /// mutually exclusive.
-    pub fn set_avro_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::cloud_storage_config::AvroConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_format = std::option::Option::Some(
-            crate::model::cloud_storage_config::OutputFormat::AvroConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -5529,23 +5257,6 @@ impl MessageTransform {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transform][crate::model::MessageTransform::transform]
-    /// to hold a `JavascriptUdf`.
-    ///
-    /// Note that all the setters affecting `transform` are
-    /// mutually exclusive.
-    pub fn set_javascript_udf<
-        T: std::convert::Into<std::boxed::Box<crate::model::JavaScriptUDF>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transform = std::option::Option::Some(
-            crate::model::message_transform::Transform::JavascriptUdf(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/bigquery/connection/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/model.rs
@@ -451,22 +451,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `CloudSql`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties =
-            std::option::Option::Some(crate::model::connection::Properties::CloudSql(v.into()));
-        self
-    }
-
     /// The value of [properties][crate::model::Connection::properties]
     /// if it holds a `Aws`, `None` if the field is not set or
     /// holds a different branch.
@@ -478,20 +462,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `Aws`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_aws<T: std::convert::Into<std::boxed::Box<crate::model::AwsProperties>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties =
-            std::option::Option::Some(crate::model::connection::Properties::Aws(v.into()));
-        self
-    }
-
     /// The value of [properties][crate::model::Connection::properties]
     /// if it holds a `Azure`, `None` if the field is not set or
     /// holds a different branch.
@@ -501,20 +471,6 @@ impl Connection {
             crate::model::connection::Properties::Azure(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `Azure`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_azure<T: std::convert::Into<std::boxed::Box<crate::model::AzureProperties>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties =
-            std::option::Option::Some(crate::model::connection::Properties::Azure(v.into()));
-        self
     }
 
     /// The value of [properties][crate::model::Connection::properties]
@@ -530,22 +486,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `CloudSpanner`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_cloud_spanner<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSpannerProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties =
-            std::option::Option::Some(crate::model::connection::Properties::CloudSpanner(v.into()));
-        self
-    }
-
     /// The value of [properties][crate::model::Connection::properties]
     /// if it holds a `CloudResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -559,23 +499,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `CloudResource`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_cloud_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudResourceProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties = std::option::Option::Some(
-            crate::model::connection::Properties::CloudResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [properties][crate::model::Connection::properties]
     /// if it holds a `Spark`, `None` if the field is not set or
     /// holds a different branch.
@@ -585,20 +508,6 @@ impl Connection {
             crate::model::connection::Properties::Spark(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `Spark`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_spark<T: std::convert::Into<std::boxed::Box<crate::model::SparkProperties>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties =
-            std::option::Option::Some(crate::model::connection::Properties::Spark(v.into()));
-        self
     }
 
     /// The value of [properties][crate::model::Connection::properties]
@@ -614,23 +523,6 @@ impl Connection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `SalesforceDataCloud`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_salesforce_data_cloud<
-        T: std::convert::Into<std::boxed::Box<crate::model::SalesforceDataCloudProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties = std::option::Option::Some(
-            crate::model::connection::Properties::SalesforceDataCloud(v.into()),
-        );
-        self
     }
 }
 
@@ -1093,24 +985,6 @@ impl AwsProperties {
         })
     }
 
-    /// Sets the value of [authentication_method][crate::model::AwsProperties::authentication_method]
-    /// to hold a `CrossAccountRole`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    #[deprecated]
-    pub fn set_cross_account_role<
-        T: std::convert::Into<std::boxed::Box<crate::model::AwsCrossAccountRole>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::aws_properties::AuthenticationMethod::CrossAccountRole(v.into()),
-        );
-        self
-    }
-
     /// The value of [authentication_method][crate::model::AwsProperties::authentication_method]
     /// if it holds a `AccessRole`, `None` if the field is not set or
     /// holds a different branch.
@@ -1124,21 +998,6 @@ impl AwsProperties {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authentication_method][crate::model::AwsProperties::authentication_method]
-    /// to hold a `AccessRole`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_access_role<T: std::convert::Into<std::boxed::Box<crate::model::AwsAccessRole>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::aws_properties::AuthenticationMethod::AccessRole(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/model.rs
@@ -466,18 +466,6 @@ impl DataPolicy {
         })
     }
 
-    /// Sets the value of [matching_label][crate::model::DataPolicy::matching_label]
-    /// to hold a `PolicyTag`.
-    ///
-    /// Note that all the setters affecting `matching_label` are
-    /// mutually exclusive.
-    pub fn set_policy_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.matching_label = std::option::Option::Some(
-            crate::model::data_policy::MatchingLabel::PolicyTag(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [policy][crate::model::DataPolicy::policy].
     ///
     /// Note that all the setters affecting `policy` are mutually
@@ -503,23 +491,6 @@ impl DataPolicy {
             crate::model::data_policy::Policy::DataMaskingPolicy(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [policy][crate::model::DataPolicy::policy]
-    /// to hold a `DataMaskingPolicy`.
-    ///
-    /// Note that all the setters affecting `policy` are
-    /// mutually exclusive.
-    pub fn set_data_masking_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataMaskingPolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.policy = std::option::Option::Some(
-            crate::model::data_policy::Policy::DataMaskingPolicy(v.into()),
-        );
-        self
     }
 }
 
@@ -742,23 +713,6 @@ impl DataMaskingPolicy {
         })
     }
 
-    /// Sets the value of [masking_expression][crate::model::DataMaskingPolicy::masking_expression]
-    /// to hold a `PredefinedExpression`.
-    ///
-    /// Note that all the setters affecting `masking_expression` are
-    /// mutually exclusive.
-    pub fn set_predefined_expression<
-        T: std::convert::Into<crate::model::data_masking_policy::PredefinedExpression>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.masking_expression = std::option::Option::Some(
-            crate::model::data_masking_policy::MaskingExpression::PredefinedExpression(v.into()),
-        );
-        self
-    }
-
     /// The value of [masking_expression][crate::model::DataMaskingPolicy::masking_expression]
     /// if it holds a `Routine`, `None` if the field is not set or
     /// holds a different branch.
@@ -770,18 +724,6 @@ impl DataMaskingPolicy {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [masking_expression][crate::model::DataMaskingPolicy::masking_expression]
-    /// to hold a `Routine`.
-    ///
-    /// Note that all the setters affecting `masking_expression` are
-    /// mutually exclusive.
-    pub fn set_routine<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.masking_expression = std::option::Option::Some(
-            crate::model::data_masking_policy::MaskingExpression::Routine(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
@@ -827,36 +827,6 @@ pub mod data_transfer_service {
             self.0.request.time = v.into();
             self
         }
-
-        /// Sets the value of [time][crate::model::StartManualTransferRunsRequest::time]
-        /// to hold a `RequestedTimeRange`.
-        ///
-        /// Note that all the setters affecting `time` are
-        /// mutually exclusive.
-        pub fn set_requested_time_range<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::start_manual_transfer_runs_request::TimeRange>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_requested_time_range(v);
-            self
-        }
-
-        /// Sets the value of [time][crate::model::StartManualTransferRunsRequest::time]
-        /// to hold a `RequestedRunTime`.
-        ///
-        /// Note that all the setters affecting `time` are
-        /// mutually exclusive.
-        pub fn set_requested_run_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_requested_run_time(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/model.rs
@@ -2307,25 +2307,6 @@ impl StartManualTransferRunsRequest {
         })
     }
 
-    /// Sets the value of [time][crate::model::StartManualTransferRunsRequest::time]
-    /// to hold a `RequestedTimeRange`.
-    ///
-    /// Note that all the setters affecting `time` are
-    /// mutually exclusive.
-    pub fn set_requested_time_range<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::start_manual_transfer_runs_request::TimeRange>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time = std::option::Option::Some(
-            crate::model::start_manual_transfer_runs_request::Time::RequestedTimeRange(v.into()),
-        );
-        self
-    }
-
     /// The value of [time][crate::model::StartManualTransferRunsRequest::time]
     /// if it holds a `RequestedRunTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -2337,21 +2318,6 @@ impl StartManualTransferRunsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [time][crate::model::StartManualTransferRunsRequest::time]
-    /// to hold a `RequestedRunTime`.
-    ///
-    /// Note that all the setters affecting `time` are
-    /// mutually exclusive.
-    pub fn set_requested_run_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time = std::option::Option::Some(
-            crate::model::start_manual_transfer_runs_request::Time::RequestedRunTime(v.into()),
-        );
-        self
     }
 }
 
@@ -2732,23 +2698,6 @@ impl ScheduleOptionsV2 {
         })
     }
 
-    /// Sets the value of [schedule][crate::model::ScheduleOptionsV2::schedule]
-    /// to hold a `TimeBasedSchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_time_based_schedule<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimeBasedSchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::schedule_options_v_2::Schedule::TimeBasedSchedule(v.into()),
-        );
-        self
-    }
-
     /// The value of [schedule][crate::model::ScheduleOptionsV2::schedule]
     /// if it holds a `ManualSchedule`, `None` if the field is not set or
     /// holds a different branch.
@@ -2764,23 +2713,6 @@ impl ScheduleOptionsV2 {
         })
     }
 
-    /// Sets the value of [schedule][crate::model::ScheduleOptionsV2::schedule]
-    /// to hold a `ManualSchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_manual_schedule<
-        T: std::convert::Into<std::boxed::Box<crate::model::ManualSchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::schedule_options_v_2::Schedule::ManualSchedule(v.into()),
-        );
-        self
-    }
-
     /// The value of [schedule][crate::model::ScheduleOptionsV2::schedule]
     /// if it holds a `EventDrivenSchedule`, `None` if the field is not set or
     /// holds a different branch.
@@ -2794,23 +2726,6 @@ impl ScheduleOptionsV2 {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schedule][crate::model::ScheduleOptionsV2::schedule]
-    /// to hold a `EventDrivenSchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_event_driven_schedule<
-        T: std::convert::Into<std::boxed::Box<crate::model::EventDrivenSchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::schedule_options_v_2::Schedule::EventDrivenSchedule(v.into()),
-        );
-        self
     }
 }
 
@@ -3336,21 +3251,6 @@ impl TransferConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::TransferConfig::destination]
-    /// to hold a `DestinationDatasetId`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_dataset_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::transfer_config::Destination::DestinationDatasetId(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for TransferConfig {
@@ -3643,21 +3543,6 @@ impl TransferRun {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::TransferRun::destination]
-    /// to hold a `DestinationDatasetId`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_dataset_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::transfer_run::Destination::DestinationDatasetId(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/bigquery/migration/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/model.rs
@@ -502,23 +502,6 @@ impl MigrationTask {
         })
     }
 
-    /// Sets the value of [task_details][crate::model::MigrationTask::task_details]
-    /// to hold a `TranslationConfigDetails`.
-    ///
-    /// Note that all the setters affecting `task_details` are
-    /// mutually exclusive.
-    pub fn set_translation_config_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::TranslationConfigDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task_details = std::option::Option::Some(
-            crate::model::migration_task::TaskDetails::TranslationConfigDetails(v.into()),
-        );
-        self
-    }
-
     /// The value of [task_details][crate::model::MigrationTask::task_details]
     /// if it holds a `TranslationDetails`, `None` if the field is not set or
     /// holds a different branch.
@@ -532,23 +515,6 @@ impl MigrationTask {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [task_details][crate::model::MigrationTask::task_details]
-    /// to hold a `TranslationDetails`.
-    ///
-    /// Note that all the setters affecting `task_details` are
-    /// mutually exclusive.
-    pub fn set_translation_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::TranslationDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task_details = std::option::Option::Some(
-            crate::model::migration_task::TaskDetails::TranslationDetails(v.into()),
-        );
-        self
     }
 }
 
@@ -1112,23 +1078,6 @@ impl MigrationTaskResult {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [details][crate::model::MigrationTaskResult::details]
-    /// to hold a `TranslationTaskResult`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_translation_task_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::TranslationTaskResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::migration_task_result::Details::TranslationTaskResult(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for MigrationTaskResult {
@@ -1599,17 +1548,6 @@ impl TypedValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::BoolValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::TypedValue::value]
     /// if it holds a `Int64Value`, `None` if the field is not set or
     /// holds a different branch.
@@ -1619,17 +1557,6 @@ impl TypedValue {
             crate::model::typed_value::Value::Int64Value(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `Int64Value`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::Int64Value(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::TypedValue::value]
@@ -1643,17 +1570,6 @@ impl TypedValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::DoubleValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::TypedValue::value]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -1663,17 +1579,6 @@ impl TypedValue {
             crate::model::typed_value::Value::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::StringValue(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::TypedValue::value]
@@ -1687,23 +1592,6 @@ impl TypedValue {
             crate::model::typed_value::Value::DistributionValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `DistributionValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_distribution_value<
-        T: std::convert::Into<std::boxed::Box<api::model::Distribution>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value = std::option::Option::Some(
-            crate::model::typed_value::Value::DistributionValue(v.into()),
-        );
-        self
     }
 }
 
@@ -2351,18 +2239,6 @@ impl TranslationConfigDetails {
         })
     }
 
-    /// Sets the value of [source_location][crate::model::TranslationConfigDetails::source_location]
-    /// to hold a `GcsSourcePath`.
-    ///
-    /// Note that all the setters affecting `source_location` are
-    /// mutually exclusive.
-    pub fn set_gcs_source_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source_location = std::option::Option::Some(
-            crate::model::translation_config_details::SourceLocation::GcsSourcePath(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [target_location][crate::model::TranslationConfigDetails::target_location].
     ///
     /// Note that all the setters affecting `target_location` are mutually
@@ -2390,18 +2266,6 @@ impl TranslationConfigDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_location][crate::model::TranslationConfigDetails::target_location]
-    /// to hold a `GcsTargetPath`.
-    ///
-    /// Note that all the setters affecting `target_location` are
-    /// mutually exclusive.
-    pub fn set_gcs_target_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target_location = std::option::Option::Some(
-            crate::model::translation_config_details::TargetLocation::GcsTargetPath(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [output_name_mapping][crate::model::TranslationConfigDetails::output_name_mapping].
@@ -2433,23 +2297,6 @@ impl TranslationConfigDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [output_name_mapping][crate::model::TranslationConfigDetails::output_name_mapping]
-    /// to hold a `NameMappingList`.
-    ///
-    /// Note that all the setters affecting `output_name_mapping` are
-    /// mutually exclusive.
-    pub fn set_name_mapping_list<
-        T: std::convert::Into<std::boxed::Box<crate::model::ObjectNameMappingList>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_name_mapping = std::option::Option::Some(
-            crate::model::translation_config_details::OutputNameMapping::NameMappingList(v.into()),
-        );
-        self
     }
 }
 
@@ -2542,23 +2389,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `BigqueryDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_bigquery_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::BigqueryDialect(v.into()),
-        );
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `HiveqlDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2570,22 +2400,6 @@ impl Dialect {
             crate::model::dialect::DialectValue::HiveqlDialect(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `HiveqlDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_hiveql_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::HiveQLDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value =
-            std::option::Option::Some(crate::model::dialect::DialectValue::HiveqlDialect(v.into()));
-        self
     }
 
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2601,23 +2415,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `RedshiftDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_redshift_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::RedshiftDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::RedshiftDialect(v.into()),
-        );
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `TeradataDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2629,23 +2426,6 @@ impl Dialect {
             crate::model::dialect::DialectValue::TeradataDialect(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `TeradataDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_teradata_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::TeradataDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::TeradataDialect(v.into()),
-        );
-        self
     }
 
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2661,22 +2441,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `OracleDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_oracle_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::OracleDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value =
-            std::option::Option::Some(crate::model::dialect::DialectValue::OracleDialect(v.into()));
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `SparksqlDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2688,23 +2452,6 @@ impl Dialect {
             crate::model::dialect::DialectValue::SparksqlDialect(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `SparksqlDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_sparksql_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::SparkSQLDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::SparksqlDialect(v.into()),
-        );
-        self
     }
 
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2722,23 +2469,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `SnowflakeDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_snowflake_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::SnowflakeDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::SnowflakeDialect(v.into()),
-        );
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `NetezzaDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2750,23 +2480,6 @@ impl Dialect {
             crate::model::dialect::DialectValue::NetezzaDialect(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `NetezzaDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_netezza_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::NetezzaDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::NetezzaDialect(v.into()),
-        );
-        self
     }
 
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2784,23 +2497,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `AzureSynapseDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_azure_synapse_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::AzureSynapseDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::AzureSynapseDialect(v.into()),
-        );
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `VerticaDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2812,23 +2508,6 @@ impl Dialect {
             crate::model::dialect::DialectValue::VerticaDialect(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `VerticaDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_vertica_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::VerticaDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::VerticaDialect(v.into()),
-        );
-        self
     }
 
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2846,23 +2525,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `SqlServerDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_sql_server_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::SQLServerDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::SqlServerDialect(v.into()),
-        );
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `PostgresqlDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2878,23 +2540,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `PostgresqlDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_postgresql_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostgresqlDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::PostgresqlDialect(v.into()),
-        );
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `PrestoDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2906,22 +2551,6 @@ impl Dialect {
             crate::model::dialect::DialectValue::PrestoDialect(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `PrestoDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_presto_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::PrestoDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value =
-            std::option::Option::Some(crate::model::dialect::DialectValue::PrestoDialect(v.into()));
-        self
     }
 
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2937,20 +2566,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `MysqlDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_mysql_dialect<T: std::convert::Into<std::boxed::Box<crate::model::MySQLDialect>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value =
-            std::option::Option::Some(crate::model::dialect::DialectValue::MysqlDialect(v.into()));
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `Db2Dialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -2960,20 +2575,6 @@ impl Dialect {
             crate::model::dialect::DialectValue::Db2Dialect(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `Db2Dialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_db2_dialect<T: std::convert::Into<std::boxed::Box<crate::model::DB2Dialect>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value =
-            std::option::Option::Some(crate::model::dialect::DialectValue::Db2Dialect(v.into()));
-        self
     }
 
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
@@ -2989,22 +2590,6 @@ impl Dialect {
         })
     }
 
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `SqliteDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_sqlite_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::SQLiteDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value =
-            std::option::Option::Some(crate::model::dialect::DialectValue::SqliteDialect(v.into()));
-        self
-    }
-
     /// The value of [dialect_value][crate::model::Dialect::dialect_value]
     /// if it holds a `GreenplumDialect`, `None` if the field is not set or
     /// holds a different branch.
@@ -3018,23 +2603,6 @@ impl Dialect {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dialect_value][crate::model::Dialect::dialect_value]
-    /// to hold a `GreenplumDialect`.
-    ///
-    /// Note that all the setters affecting `dialect_value` are
-    /// mutually exclusive.
-    pub fn set_greenplum_dialect<
-        T: std::convert::Into<std::boxed::Box<crate::model::GreenplumDialect>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dialect_value = std::option::Option::Some(
-            crate::model::dialect::DialectValue::GreenplumDialect(v.into()),
-        );
-        self
     }
 }
 
@@ -4293,17 +3861,6 @@ impl SourceSpec {
         })
     }
 
-    /// Sets the value of [source][crate::model::SourceSpec::source]
-    /// to hold a `BaseUri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_base_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::source_spec::Source::BaseUri(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::SourceSpec::source]
     /// if it holds a `Literal`, `None` if the field is not set or
     /// holds a different branch.
@@ -4313,20 +3870,6 @@ impl SourceSpec {
             crate::model::source_spec::Source::Literal(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::SourceSpec::source]
-    /// to hold a `Literal`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_literal<T: std::convert::Into<std::boxed::Box<crate::model::Literal>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::source_spec::Source::Literal(v.into()));
-        self
     }
 }
 
@@ -4442,17 +3985,6 @@ impl Literal {
         })
     }
 
-    /// Sets the value of [literal_data][crate::model::Literal::literal_data]
-    /// to hold a `LiteralString`.
-    ///
-    /// Note that all the setters affecting `literal_data` are
-    /// mutually exclusive.
-    pub fn set_literal_string<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.literal_data =
-            std::option::Option::Some(crate::model::literal::LiteralData::LiteralString(v.into()));
-        self
-    }
-
     /// The value of [literal_data][crate::model::Literal::literal_data]
     /// if it holds a `LiteralBytes`, `None` if the field is not set or
     /// holds a different branch.
@@ -4462,17 +3994,6 @@ impl Literal {
             crate::model::literal::LiteralData::LiteralBytes(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [literal_data][crate::model::Literal::literal_data]
-    /// to hold a `LiteralBytes`.
-    ///
-    /// Note that all the setters affecting `literal_data` are
-    /// mutually exclusive.
-    pub fn set_literal_bytes<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.literal_data =
-            std::option::Option::Some(crate::model::literal::LiteralData::LiteralBytes(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/bigquery/v2/src/model.rs
+++ b/src/generated/cloud/bigquery/v2/src/model.rs
@@ -4861,18 +4861,6 @@ impl RemoteModelInfo {
         })
     }
 
-    /// Sets the value of [remote_service][crate::model::RemoteModelInfo::remote_service]
-    /// to hold a `Endpoint`.
-    ///
-    /// Note that all the setters affecting `remote_service` are
-    /// mutually exclusive.
-    pub fn set_endpoint<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.remote_service = std::option::Option::Some(
-            crate::model::remote_model_info::RemoteService::Endpoint(v.into()),
-        );
-        self
-    }
-
     /// The value of [remote_service][crate::model::RemoteModelInfo::remote_service]
     /// if it holds a `RemoteServiceType`, `None` if the field is not set or
     /// holds a different branch.
@@ -4886,23 +4874,6 @@ impl RemoteModelInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [remote_service][crate::model::RemoteModelInfo::remote_service]
-    /// to hold a `RemoteServiceType`.
-    ///
-    /// Note that all the setters affecting `remote_service` are
-    /// mutually exclusive.
-    pub fn set_remote_service_type<
-        T: std::convert::Into<crate::model::remote_model_info::RemoteServiceType>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_service = std::option::Option::Some(
-            crate::model::remote_model_info::RemoteService::RemoteServiceType(v.into()),
-        );
-        self
     }
 }
 
@@ -7488,25 +7459,6 @@ pub mod model {
                     })
                 }
 
-                /// Sets the value of [value][crate::model::model::clustering_metrics::cluster::FeatureValue::value]
-                /// to hold a `NumericalValue`.
-                ///
-                /// Note that all the setters affecting `value` are
-                /// mutually exclusive.
-                pub fn set_numerical_value<
-                    T: std::convert::Into<std::boxed::Box<wkt::DoubleValue>>,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.value = std::option::Option::Some(
-                        crate::model::model::clustering_metrics::cluster::feature_value::Value::NumericalValue(
-                            v.into()
-                        )
-                    );
-                    self
-                }
-
                 /// The value of [value][crate::model::model::clustering_metrics::cluster::FeatureValue::value]
                 /// if it holds a `CategoricalValue`, `None` if the field is not set or
                 /// holds a different branch.
@@ -7516,20 +7468,6 @@ pub mod model {
                         crate::model::model::clustering_metrics::cluster::feature_value::Value::CategoricalValue(v) => std::option::Option::Some(v),
                         _ => std::option::Option::None,
                     })
-                }
-
-                /// Sets the value of [value][crate::model::model::clustering_metrics::cluster::FeatureValue::value]
-                /// to hold a `CategoricalValue`.
-                ///
-                /// Note that all the setters affecting `value` are
-                /// mutually exclusive.
-                pub fn set_categorical_value<T: std::convert::Into<std::boxed::Box<crate::model::model::clustering_metrics::cluster::feature_value::CategoricalValue>>>(mut self, v: T) -> Self{
-                    self.value = std::option::Option::Some(
-                        crate::model::model::clustering_metrics::cluster::feature_value::Value::CategoricalValue(
-                            v.into()
-                        )
-                    );
-                    self
                 }
             }
 
@@ -8057,23 +7995,6 @@ pub mod model {
             })
         }
 
-        /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// to hold a `RegressionMetrics`.
-        ///
-        /// Note that all the setters affecting `metrics` are
-        /// mutually exclusive.
-        pub fn set_regression_metrics<
-            T: std::convert::Into<std::boxed::Box<crate::model::model::RegressionMetrics>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = std::option::Option::Some(
-                crate::model::model::evaluation_metrics::Metrics::RegressionMetrics(v.into()),
-            );
-            self
-        }
-
         /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
         /// if it holds a `BinaryClassificationMetrics`, `None` if the field is not set or
         /// holds a different branch.
@@ -8088,25 +8009,6 @@ pub mod model {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// to hold a `BinaryClassificationMetrics`.
-        ///
-        /// Note that all the setters affecting `metrics` are
-        /// mutually exclusive.
-        pub fn set_binary_classification_metrics<
-            T: std::convert::Into<std::boxed::Box<crate::model::model::BinaryClassificationMetrics>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = std::option::Option::Some(
-                crate::model::model::evaluation_metrics::Metrics::BinaryClassificationMetrics(
-                    v.into(),
-                ),
-            );
-            self
         }
 
         /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
@@ -8124,27 +8026,6 @@ pub mod model {
             })
         }
 
-        /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// to hold a `MultiClassClassificationMetrics`.
-        ///
-        /// Note that all the setters affecting `metrics` are
-        /// mutually exclusive.
-        pub fn set_multi_class_classification_metrics<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::model::MultiClassClassificationMetrics>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = std::option::Option::Some(
-                crate::model::model::evaluation_metrics::Metrics::MultiClassClassificationMetrics(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
         /// if it holds a `ClusteringMetrics`, `None` if the field is not set or
         /// holds a different branch.
@@ -8160,23 +8041,6 @@ pub mod model {
             })
         }
 
-        /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// to hold a `ClusteringMetrics`.
-        ///
-        /// Note that all the setters affecting `metrics` are
-        /// mutually exclusive.
-        pub fn set_clustering_metrics<
-            T: std::convert::Into<std::boxed::Box<crate::model::model::ClusteringMetrics>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = std::option::Option::Some(
-                crate::model::model::evaluation_metrics::Metrics::ClusteringMetrics(v.into()),
-            );
-            self
-        }
-
         /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
         /// if it holds a `RankingMetrics`, `None` if the field is not set or
         /// holds a different branch.
@@ -8190,23 +8054,6 @@ pub mod model {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// to hold a `RankingMetrics`.
-        ///
-        /// Note that all the setters affecting `metrics` are
-        /// mutually exclusive.
-        pub fn set_ranking_metrics<
-            T: std::convert::Into<std::boxed::Box<crate::model::model::RankingMetrics>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = std::option::Option::Some(
-                crate::model::model::evaluation_metrics::Metrics::RankingMetrics(v.into()),
-            );
-            self
         }
 
         /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
@@ -8225,23 +8072,6 @@ pub mod model {
             })
         }
 
-        /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// to hold a `ArimaForecastingMetrics`.
-        ///
-        /// Note that all the setters affecting `metrics` are
-        /// mutually exclusive.
-        pub fn set_arima_forecasting_metrics<
-            T: std::convert::Into<std::boxed::Box<crate::model::model::ArimaForecastingMetrics>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = std::option::Option::Some(
-                crate::model::model::evaluation_metrics::Metrics::ArimaForecastingMetrics(v.into()),
-            );
-            self
-        }
-
         /// The value of [metrics][crate::model::model::EvaluationMetrics::metrics]
         /// if it holds a `DimensionalityReductionMetrics`, `None` if the field is not set or
         /// holds a different branch.
@@ -8255,27 +8085,6 @@ pub mod model {
                 crate::model::model::evaluation_metrics::Metrics::DimensionalityReductionMetrics(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [metrics][crate::model::model::EvaluationMetrics::metrics]
-        /// to hold a `DimensionalityReductionMetrics`.
-        ///
-        /// Note that all the setters affecting `metrics` are
-        /// mutually exclusive.
-        pub fn set_dimensionality_reduction_metrics<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::model::DimensionalityReductionMetrics>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.metrics = std::option::Option::Some(
-                crate::model::model::evaluation_metrics::Metrics::DimensionalityReductionMetrics(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -11331,25 +11140,6 @@ pub mod model {
             })
         }
 
-        /// Sets the value of [search_space][crate::model::model::DoubleHparamSearchSpace::search_space]
-        /// to hold a `Range`.
-        ///
-        /// Note that all the setters affecting `search_space` are
-        /// mutually exclusive.
-        pub fn set_range<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::model::double_hparam_search_space::DoubleRange>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.search_space = std::option::Option::Some(
-                crate::model::model::double_hparam_search_space::SearchSpace::Range(v.into()),
-            );
-            self
-        }
-
         /// The value of [search_space][crate::model::model::DoubleHparamSearchSpace::search_space]
         /// if it holds a `Candidates`, `None` if the field is not set or
         /// holds a different branch.
@@ -11365,27 +11155,6 @@ pub mod model {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [search_space][crate::model::model::DoubleHparamSearchSpace::search_space]
-        /// to hold a `Candidates`.
-        ///
-        /// Note that all the setters affecting `search_space` are
-        /// mutually exclusive.
-        pub fn set_candidates<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::model::double_hparam_search_space::DoubleCandidates,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.search_space = std::option::Option::Some(
-                crate::model::model::double_hparam_search_space::SearchSpace::Candidates(v.into()),
-            );
-            self
         }
     }
 
@@ -11556,25 +11325,6 @@ pub mod model {
             })
         }
 
-        /// Sets the value of [search_space][crate::model::model::IntHparamSearchSpace::search_space]
-        /// to hold a `Range`.
-        ///
-        /// Note that all the setters affecting `search_space` are
-        /// mutually exclusive.
-        pub fn set_range<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::model::int_hparam_search_space::IntRange>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.search_space = std::option::Option::Some(
-                crate::model::model::int_hparam_search_space::SearchSpace::Range(v.into()),
-            );
-            self
-        }
-
         /// The value of [search_space][crate::model::model::IntHparamSearchSpace::search_space]
         /// if it holds a `Candidates`, `None` if the field is not set or
         /// holds a different branch.
@@ -11590,25 +11340,6 @@ pub mod model {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [search_space][crate::model::model::IntHparamSearchSpace::search_space]
-        /// to hold a `Candidates`.
-        ///
-        /// Note that all the setters affecting `search_space` are
-        /// mutually exclusive.
-        pub fn set_candidates<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::model::int_hparam_search_space::IntCandidates>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.search_space = std::option::Option::Some(
-                crate::model::model::int_hparam_search_space::SearchSpace::Candidates(v.into()),
-            );
-            self
         }
     }
 
@@ -15505,23 +15236,6 @@ impl PrivacyPolicy {
         })
     }
 
-    /// Sets the value of [privacy_policy][crate::model::PrivacyPolicy::privacy_policy]
-    /// to hold a `AggregationThresholdPolicy`.
-    ///
-    /// Note that all the setters affecting `privacy_policy` are
-    /// mutually exclusive.
-    pub fn set_aggregation_threshold_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::AggregationThresholdPolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.privacy_policy = std::option::Option::Some(
-            crate::model::privacy_policy::PrivacyPolicy::AggregationThresholdPolicy(v.into()),
-        );
-        self
-    }
-
     /// The value of [privacy_policy][crate::model::PrivacyPolicy::privacy_policy]
     /// if it holds a `DifferentialPrivacyPolicy`, `None` if the field is not set or
     /// holds a different branch.
@@ -15535,23 +15249,6 @@ impl PrivacyPolicy {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [privacy_policy][crate::model::PrivacyPolicy::privacy_policy]
-    /// to hold a `DifferentialPrivacyPolicy`.
-    ///
-    /// Note that all the setters affecting `privacy_policy` are
-    /// mutually exclusive.
-    pub fn set_differential_privacy_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::DifferentialPrivacyPolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.privacy_policy = std::option::Option::Some(
-            crate::model::privacy_policy::PrivacyPolicy::DifferentialPrivacyPolicy(v.into()),
-        );
-        self
     }
 }
 
@@ -19221,23 +18918,6 @@ impl StandardSqlDataType {
         })
     }
 
-    /// Sets the value of [sub_type][crate::model::StandardSqlDataType::sub_type]
-    /// to hold a `ArrayElementType`.
-    ///
-    /// Note that all the setters affecting `sub_type` are
-    /// mutually exclusive.
-    pub fn set_array_element_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::StandardSqlDataType>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sub_type = std::option::Option::Some(
-            crate::model::standard_sql_data_type::SubType::ArrayElementType(v.into()),
-        );
-        self
-    }
-
     /// The value of [sub_type][crate::model::StandardSqlDataType::sub_type]
     /// if it holds a `StructType`, `None` if the field is not set or
     /// holds a different branch.
@@ -19253,23 +18933,6 @@ impl StandardSqlDataType {
         })
     }
 
-    /// Sets the value of [sub_type][crate::model::StandardSqlDataType::sub_type]
-    /// to hold a `StructType`.
-    ///
-    /// Note that all the setters affecting `sub_type` are
-    /// mutually exclusive.
-    pub fn set_struct_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::StandardSqlStructType>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sub_type = std::option::Option::Some(
-            crate::model::standard_sql_data_type::SubType::StructType(v.into()),
-        );
-        self
-    }
-
     /// The value of [sub_type][crate::model::StandardSqlDataType::sub_type]
     /// if it holds a `RangeElementType`, `None` if the field is not set or
     /// holds a different branch.
@@ -19283,23 +18946,6 @@ impl StandardSqlDataType {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [sub_type][crate::model::StandardSqlDataType::sub_type]
-    /// to hold a `RangeElementType`.
-    ///
-    /// Note that all the setters affecting `sub_type` are
-    /// mutually exclusive.
-    pub fn set_range_element_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::StandardSqlDataType>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sub_type = std::option::Option::Some(
-            crate::model::standard_sql_data_type::SubType::RangeElementType(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/binaryauthorization/v1/src/model.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/model.rs
@@ -851,23 +851,6 @@ impl Attestor {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [attestor_type][crate::model::Attestor::attestor_type]
-    /// to hold a `UserOwnedGrafeasNote`.
-    ///
-    /// Note that all the setters affecting `attestor_type` are
-    /// mutually exclusive.
-    pub fn set_user_owned_grafeas_note<
-        T: std::convert::Into<std::boxed::Box<crate::model::UserOwnedGrafeasNote>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.attestor_type = std::option::Option::Some(
-            crate::model::attestor::AttestorType::UserOwnedGrafeasNote(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for Attestor {
@@ -1337,21 +1320,6 @@ impl AttestorPublicKey {
         })
     }
 
-    /// Sets the value of [public_key][crate::model::AttestorPublicKey::public_key]
-    /// to hold a `AsciiArmoredPgpPublicKey`.
-    ///
-    /// Note that all the setters affecting `public_key` are
-    /// mutually exclusive.
-    pub fn set_ascii_armored_pgp_public_key<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.public_key = std::option::Option::Some(
-            crate::model::attestor_public_key::PublicKey::AsciiArmoredPgpPublicKey(v.into()),
-        );
-        self
-    }
-
     /// The value of [public_key][crate::model::AttestorPublicKey::public_key]
     /// if it holds a `PkixPublicKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -1365,23 +1333,6 @@ impl AttestorPublicKey {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [public_key][crate::model::AttestorPublicKey::public_key]
-    /// to hold a `PkixPublicKey`.
-    ///
-    /// Note that all the setters affecting `public_key` are
-    /// mutually exclusive.
-    pub fn set_pkix_public_key<
-        T: std::convert::Into<std::boxed::Box<crate::model::PkixPublicKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.public_key = std::option::Option::Some(
-            crate::model::attestor_public_key::PublicKey::PkixPublicKey(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/certificatemanager/v1/src/model.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/model.rs
@@ -508,20 +508,6 @@ pub mod certificate_issuance_config {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [kind][crate::model::certificate_issuance_config::CertificateAuthorityConfig::kind]
-        /// to hold a `CertificateAuthorityServiceConfig`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_certificate_authority_service_config<T: std::convert::Into<std::boxed::Box<crate::model::certificate_issuance_config::certificate_authority_config::CertificateAuthorityServiceConfig>>>(mut self, v: T) -> Self{
-            self.kind = std::option::Option::Some(
-                crate::model::certificate_issuance_config::certificate_authority_config::Kind::CertificateAuthorityServiceConfig(
-                    v.into()
-                )
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for CertificateAuthorityConfig {
@@ -2314,22 +2300,6 @@ impl Certificate {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Certificate::r#type]
-    /// to hold a `SelfManaged`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_self_managed<
-        T: std::convert::Into<std::boxed::Box<crate::model::certificate::SelfManagedCertificate>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::certificate::Type::SelfManaged(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Certificate::r#type]
     /// if it holds a `Managed`, `None` if the field is not set or
     /// holds a different branch.
@@ -2341,21 +2311,6 @@ impl Certificate {
             crate::model::certificate::Type::Managed(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Certificate::r#type]
-    /// to hold a `Managed`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_managed<
-        T: std::convert::Into<std::boxed::Box<crate::model::certificate::ManagedCertificate>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::certificate::Type::Managed(v.into()));
-        self
     }
 }
 
@@ -3585,21 +3540,6 @@ pub mod certificate_map {
             })
         }
 
-        /// Sets the value of [target_proxy][crate::model::certificate_map::GclbTarget::target_proxy]
-        /// to hold a `TargetHttpsProxy`.
-        ///
-        /// Note that all the setters affecting `target_proxy` are
-        /// mutually exclusive.
-        pub fn set_target_https_proxy<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.target_proxy = std::option::Option::Some(
-                crate::model::certificate_map::gclb_target::TargetProxy::TargetHttpsProxy(v.into()),
-            );
-            self
-        }
-
         /// The value of [target_proxy][crate::model::certificate_map::GclbTarget::target_proxy]
         /// if it holds a `TargetSslProxy`, `None` if the field is not set or
         /// holds a different branch.
@@ -3611,21 +3551,6 @@ pub mod certificate_map {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [target_proxy][crate::model::certificate_map::GclbTarget::target_proxy]
-        /// to hold a `TargetSslProxy`.
-        ///
-        /// Note that all the setters affecting `target_proxy` are
-        /// mutually exclusive.
-        pub fn set_target_ssl_proxy<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.target_proxy = std::option::Option::Some(
-                crate::model::certificate_map::gclb_target::TargetProxy::TargetSslProxy(v.into()),
-            );
-            self
         }
     }
 
@@ -3841,18 +3766,6 @@ impl CertificateMapEntry {
         })
     }
 
-    /// Sets the value of [r#match][crate::model::CertificateMapEntry::r#match]
-    /// to hold a `Hostname`.
-    ///
-    /// Note that all the setters affecting `r#match` are
-    /// mutually exclusive.
-    pub fn set_hostname<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#match = std::option::Option::Some(
-            crate::model::certificate_map_entry::Match::Hostname(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#match][crate::model::CertificateMapEntry::r#match]
     /// if it holds a `Matcher`, `None` if the field is not set or
     /// holds a different branch.
@@ -3862,21 +3775,6 @@ impl CertificateMapEntry {
             crate::model::certificate_map_entry::Match::Matcher(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#match][crate::model::CertificateMapEntry::r#match]
-    /// to hold a `Matcher`.
-    ///
-    /// Note that all the setters affecting `r#match` are
-    /// mutually exclusive.
-    pub fn set_matcher<T: std::convert::Into<crate::model::certificate_map_entry::Matcher>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#match = std::option::Option::Some(
-            crate::model::certificate_map_entry::Match::Matcher(v.into()),
-        );
-        self
     }
 }
 
@@ -4873,21 +4771,6 @@ pub mod trust_config {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [kind][crate::model::trust_config::TrustAnchor::kind]
-        /// to hold a `PemCertificate`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_pem_certificate<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::trust_config::trust_anchor::Kind::PemCertificate(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for TrustAnchor {
@@ -4958,21 +4841,6 @@ pub mod trust_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::trust_config::IntermediateCA::kind]
-        /// to hold a `PemCertificate`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_pem_certificate<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::trust_config::intermediate_ca::Kind::PemCertificate(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/chronicle/v1/src/model.rs
+++ b/src/generated/cloud/chronicle/v1/src/model.rs
@@ -816,18 +816,6 @@ impl DataAccessLabel {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [definition][crate::model::DataAccessLabel::definition]
-    /// to hold a `UdmQuery`.
-    ///
-    /// Note that all the setters affecting `definition` are
-    /// mutually exclusive.
-    pub fn set_udm_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.definition = std::option::Option::Some(
-            crate::model::data_access_label::Definition::UdmQuery(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DataAccessLabel {
@@ -1072,21 +1060,6 @@ impl DataAccessLabelReference {
         })
     }
 
-    /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
-    /// to hold a `DataAccessLabel`.
-    ///
-    /// Note that all the setters affecting `label` are
-    /// mutually exclusive.
-    pub fn set_data_access_label<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.label = std::option::Option::Some(
-            crate::model::data_access_label_reference::Label::DataAccessLabel(v.into()),
-        );
-        self
-    }
-
     /// The value of [label][crate::model::DataAccessLabelReference::label]
     /// if it holds a `LogType`, `None` if the field is not set or
     /// holds a different branch.
@@ -1098,18 +1071,6 @@ impl DataAccessLabelReference {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
-    /// to hold a `LogType`.
-    ///
-    /// Note that all the setters affecting `label` are
-    /// mutually exclusive.
-    pub fn set_log_type<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.label = std::option::Option::Some(
-            crate::model::data_access_label_reference::Label::LogType(v.into()),
-        );
-        self
     }
 
     /// The value of [label][crate::model::DataAccessLabelReference::label]
@@ -1125,18 +1086,6 @@ impl DataAccessLabelReference {
         })
     }
 
-    /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
-    /// to hold a `AssetNamespace`.
-    ///
-    /// Note that all the setters affecting `label` are
-    /// mutually exclusive.
-    pub fn set_asset_namespace<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.label = std::option::Option::Some(
-            crate::model::data_access_label_reference::Label::AssetNamespace(v.into()),
-        );
-        self
-    }
-
     /// The value of [label][crate::model::DataAccessLabelReference::label]
     /// if it holds a `IngestionLabel`, `None` if the field is not set or
     /// holds a different branch.
@@ -1150,23 +1099,6 @@ impl DataAccessLabelReference {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [label][crate::model::DataAccessLabelReference::label]
-    /// to hold a `IngestionLabel`.
-    ///
-    /// Note that all the setters affecting `label` are
-    /// mutually exclusive.
-    pub fn set_ingestion_label<
-        T: std::convert::Into<std::boxed::Box<crate::model::IngestionLabel>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.label = std::option::Option::Some(
-            crate::model::data_access_label_reference::Label::IngestionLabel(v.into()),
-        );
-        self
     }
 }
 
@@ -1450,25 +1382,6 @@ pub mod watchlist {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [mechanism][crate::model::watchlist::EntityPopulationMechanism::mechanism]
-        /// to hold a `Manual`.
-        ///
-        /// Note that all the setters affecting `mechanism` are
-        /// mutually exclusive.
-        pub fn set_manual<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::watchlist::entity_population_mechanism::Manual>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.mechanism = std::option::Option::Some(
-                crate::model::watchlist::entity_population_mechanism::Mechanism::Manual(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/clouddms/v1/src/builder.rs
+++ b/src/generated/cloud/clouddms/v1/src/builder.rs
@@ -1358,36 +1358,6 @@ pub mod data_migration_service {
             self.0.request.vm_config = v.into();
             self
         }
-
-        /// Sets the value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
-        /// to hold a `VmCreationConfig`.
-        ///
-        /// Note that all the setters affecting `vm_config` are
-        /// mutually exclusive.
-        pub fn set_vm_creation_config<
-            T: std::convert::Into<std::boxed::Box<crate::model::VmCreationConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_vm_creation_config(v);
-            self
-        }
-
-        /// Sets the value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
-        /// to hold a `VmSelectionConfig`.
-        ///
-        /// Note that all the setters affecting `vm_config` are
-        /// mutually exclusive.
-        pub fn set_vm_selection_config<
-            T: std::convert::Into<std::boxed::Box<crate::model::VmSelectionConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_vm_selection_config(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -3544,32 +3514,6 @@ pub mod data_migration_service {
             self.0.request.seed_from = v.into();
             self
         }
-
-        /// Sets the value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
-        /// to hold a `SourceConnectionProfile`.
-        ///
-        /// Note that all the setters affecting `seed_from` are
-        /// mutually exclusive.
-        pub fn set_source_connection_profile<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_source_connection_profile(v);
-            self
-        }
-
-        /// Sets the value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
-        /// to hold a `DestinationConnectionProfile`.
-        ///
-        /// Note that all the setters affecting `seed_from` are
-        /// mutually exclusive.
-        pub fn set_destination_connection_profile<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_destination_connection_profile(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -4197,19 +4141,6 @@ pub mod data_migration_service {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ApplyConversionWorkspaceRequest::destination]
-        /// to hold a `ConnectionProfile`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_connection_profile<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_connection_profile(v);
             self
         }
     }

--- a/src/generated/cloud/clouddms/v1/src/model.rs
+++ b/src/generated/cloud/clouddms/v1/src/model.rs
@@ -762,23 +762,6 @@ impl GenerateSshScriptRequest {
         })
     }
 
-    /// Sets the value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
-    /// to hold a `VmCreationConfig`.
-    ///
-    /// Note that all the setters affecting `vm_config` are
-    /// mutually exclusive.
-    pub fn set_vm_creation_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::VmCreationConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vm_config = std::option::Option::Some(
-            crate::model::generate_ssh_script_request::VmConfig::VmCreationConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
     /// if it holds a `VmSelectionConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -792,23 +775,6 @@ impl GenerateSshScriptRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [vm_config][crate::model::GenerateSshScriptRequest::vm_config]
-    /// to hold a `VmSelectionConfig`.
-    ///
-    /// Note that all the setters affecting `vm_config` are
-    /// mutually exclusive.
-    pub fn set_vm_selection_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::VmSelectionConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vm_config = std::option::Option::Some(
-            crate::model::generate_ssh_script_request::VmConfig::VmSelectionConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -2498,23 +2464,6 @@ impl ApplyConversionWorkspaceRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ApplyConversionWorkspaceRequest::destination]
-    /// to hold a `ConnectionProfile`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_connection_profile<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::apply_conversion_workspace_request::Destination::ConnectionProfile(
-                v.into(),
-            ),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ApplyConversionWorkspaceRequest {
@@ -2772,23 +2721,6 @@ impl SeedConversionWorkspaceRequest {
         })
     }
 
-    /// Sets the value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
-    /// to hold a `SourceConnectionProfile`.
-    ///
-    /// Note that all the setters affecting `seed_from` are
-    /// mutually exclusive.
-    pub fn set_source_connection_profile<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.seed_from = std::option::Option::Some(
-            crate::model::seed_conversion_workspace_request::SeedFrom::SourceConnectionProfile(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
     /// if it holds a `DestinationConnectionProfile`, `None` if the field is not set or
     /// holds a different branch.
@@ -2798,23 +2730,6 @@ impl SeedConversionWorkspaceRequest {
             crate::model::seed_conversion_workspace_request::SeedFrom::DestinationConnectionProfile(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [seed_from][crate::model::SeedConversionWorkspaceRequest::seed_from]
-    /// to hold a `DestinationConnectionProfile`.
-    ///
-    /// Note that all the setters affecting `seed_from` are
-    /// mutually exclusive.
-    pub fn set_destination_connection_profile<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.seed_from = std::option::Option::Some(
-            crate::model::seed_conversion_workspace_request::SeedFrom::DestinationConnectionProfile(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -4250,25 +4165,6 @@ impl PostgreSqlConnectionProfile {
         })
     }
 
-    /// Sets the value of [connectivity][crate::model::PostgreSqlConnectionProfile::connectivity]
-    /// to hold a `StaticIpConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_static_ip_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::StaticIpConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::postgre_sql_connection_profile::Connectivity::StaticIpConnectivity(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [connectivity][crate::model::PostgreSqlConnectionProfile::connectivity]
     /// if it holds a `PrivateServiceConnectConnectivity`, `None` if the field is not set or
     /// holds a different branch.
@@ -4281,25 +4177,6 @@ impl PostgreSqlConnectionProfile {
             crate::model::postgre_sql_connection_profile::Connectivity::PrivateServiceConnectConnectivity(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connectivity][crate::model::PostgreSqlConnectionProfile::connectivity]
-    /// to hold a `PrivateServiceConnectConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_private_service_connect_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::PrivateServiceConnectConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::postgre_sql_connection_profile::Connectivity::PrivateServiceConnectConnectivity(
-                v.into()
-            )
-        );
-        self
     }
 }
 
@@ -4464,25 +4341,6 @@ impl OracleConnectionProfile {
         })
     }
 
-    /// Sets the value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
-    /// to hold a `StaticServiceIpConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_static_service_ip_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::StaticServiceIpConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::oracle_connection_profile::Connectivity::StaticServiceIpConnectivity(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
     /// if it holds a `ForwardSshConnectivity`, `None` if the field is not set or
     /// holds a different branch.
@@ -4498,23 +4356,6 @@ impl OracleConnectionProfile {
         })
     }
 
-    /// Sets the value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
-    /// to hold a `ForwardSshConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_forward_ssh_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::ForwardSshTunnelConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::oracle_connection_profile::Connectivity::ForwardSshConnectivity(v.into()),
-        );
-        self
-    }
-
     /// The value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
     /// if it holds a `PrivateConnectivity`, `None` if the field is not set or
     /// holds a different branch.
@@ -4528,23 +4369,6 @@ impl OracleConnectionProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connectivity][crate::model::OracleConnectionProfile::connectivity]
-    /// to hold a `PrivateConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_private_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::PrivateConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::oracle_connection_profile::Connectivity::PrivateConnectivity(v.into()),
-        );
-        self
     }
 }
 
@@ -4771,21 +4595,6 @@ impl SqlAclEntry {
         })
     }
 
-    /// Sets the value of [expiration][crate::model::SqlAclEntry::expiration]
-    /// to hold a `ExpireTime`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.expiration = std::option::Option::Some(
-            crate::model::sql_acl_entry::Expiration::ExpireTime(v.into()),
-        );
-        self
-    }
-
     /// The value of [expiration][crate::model::SqlAclEntry::expiration]
     /// if it holds a `Ttl`, `None` if the field is not set or
     /// holds a different branch.
@@ -4795,17 +4604,6 @@ impl SqlAclEntry {
             crate::model::sql_acl_entry::Expiration::Ttl(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [expiration][crate::model::SqlAclEntry::expiration]
-    /// to hold a `Ttl`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
-        self.expiration =
-            std::option::Option::Some(crate::model::sql_acl_entry::Expiration::Ttl(v.into()));
-        self
     }
 }
 
@@ -6537,18 +6335,6 @@ impl ForwardSshTunnelConnectivity {
         })
     }
 
-    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
-    /// to hold a `Password`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::Password(v.into()),
-        );
-        self
-    }
-
     /// The value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
     /// if it holds a `PrivateKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -6560,20 +6346,6 @@ impl ForwardSshTunnelConnectivity {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
-    /// to hold a `PrivateKey`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_private_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::PrivateKey(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -7042,23 +6814,6 @@ impl MigrationJob {
         })
     }
 
-    /// Sets the value of [connectivity][crate::model::MigrationJob::connectivity]
-    /// to hold a `ReverseSshConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_reverse_ssh_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReverseSshConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::migration_job::Connectivity::ReverseSshConnectivity(v.into()),
-        );
-        self
-    }
-
     /// The value of [connectivity][crate::model::MigrationJob::connectivity]
     /// if it holds a `VpcPeeringConnectivity`, `None` if the field is not set or
     /// holds a different branch.
@@ -7074,23 +6829,6 @@ impl MigrationJob {
         })
     }
 
-    /// Sets the value of [connectivity][crate::model::MigrationJob::connectivity]
-    /// to hold a `VpcPeeringConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_vpc_peering_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::VpcPeeringConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::migration_job::Connectivity::VpcPeeringConnectivity(v.into()),
-        );
-        self
-    }
-
     /// The value of [connectivity][crate::model::MigrationJob::connectivity]
     /// if it holds a `StaticIpConnectivity`, `None` if the field is not set or
     /// holds a different branch.
@@ -7104,23 +6842,6 @@ impl MigrationJob {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connectivity][crate::model::MigrationJob::connectivity]
-    /// to hold a `StaticIpConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_static_ip_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::StaticIpConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::migration_job::Connectivity::StaticIpConnectivity(v.into()),
-        );
-        self
     }
 }
 
@@ -8127,23 +7848,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// to hold a `Mysql`.
-    ///
-    /// Note that all the setters affecting `connection_profile` are
-    /// mutually exclusive.
-    pub fn set_mysql<
-        T: std::convert::Into<std::boxed::Box<crate::model::MySqlConnectionProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_profile = std::option::Option::Some(
-            crate::model::connection_profile::ConnectionProfile::Mysql(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
     /// if it holds a `Postgresql`, `None` if the field is not set or
     /// holds a different branch.
@@ -8157,23 +7861,6 @@ impl ConnectionProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// to hold a `Postgresql`.
-    ///
-    /// Note that all the setters affecting `connection_profile` are
-    /// mutually exclusive.
-    pub fn set_postgresql<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostgreSqlConnectionProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_profile = std::option::Option::Some(
-            crate::model::connection_profile::ConnectionProfile::Postgresql(v.into()),
-        );
-        self
     }
 
     /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
@@ -8191,23 +7878,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// to hold a `Oracle`.
-    ///
-    /// Note that all the setters affecting `connection_profile` are
-    /// mutually exclusive.
-    pub fn set_oracle<
-        T: std::convert::Into<std::boxed::Box<crate::model::OracleConnectionProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_profile = std::option::Option::Some(
-            crate::model::connection_profile::ConnectionProfile::Oracle(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
     /// if it holds a `Cloudsql`, `None` if the field is not set or
     /// holds a different branch.
@@ -8223,23 +7893,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// to hold a `Cloudsql`.
-    ///
-    /// Note that all the setters affecting `connection_profile` are
-    /// mutually exclusive.
-    pub fn set_cloudsql<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlConnectionProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_profile = std::option::Option::Some(
-            crate::model::connection_profile::ConnectionProfile::Cloudsql(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
     /// if it holds a `Alloydb`, `None` if the field is not set or
     /// holds a different branch.
@@ -8253,23 +7906,6 @@ impl ConnectionProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connection_profile][crate::model::ConnectionProfile::connection_profile]
-    /// to hold a `Alloydb`.
-    ///
-    /// Note that all the setters affecting `connection_profile` are
-    /// mutually exclusive.
-    pub fn set_alloydb<
-        T: std::convert::Into<std::boxed::Box<crate::model::AlloyDbConnectionProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_profile = std::option::Option::Some(
-            crate::model::connection_profile::ConnectionProfile::Alloydb(v.into()),
-        );
-        self
     }
 }
 
@@ -9027,23 +8663,6 @@ impl PrivateConnection {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [connectivity][crate::model::PrivateConnection::connectivity]
-    /// to hold a `VpcPeeringConfig`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_vpc_peering_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::VpcPeeringConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::private_connection::Connectivity::VpcPeeringConfig(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for PrivateConnection {
@@ -9603,23 +9222,6 @@ impl BackgroundJobLogEntry {
         })
     }
 
-    /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
-    /// to hold a `SeedJobDetails`.
-    ///
-    /// Note that all the setters affecting `job_details` are
-    /// mutually exclusive.
-    pub fn set_seed_job_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::background_job_log_entry::SeedJobDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_details = std::option::Option::Some(
-            crate::model::background_job_log_entry::JobDetails::SeedJobDetails(v.into()),
-        );
-        self
-    }
-
     /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
     /// if it holds a `ImportRulesJobDetails`, `None` if the field is not set or
     /// holds a different branch.
@@ -9635,25 +9237,6 @@ impl BackgroundJobLogEntry {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
-    /// to hold a `ImportRulesJobDetails`.
-    ///
-    /// Note that all the setters affecting `job_details` are
-    /// mutually exclusive.
-    pub fn set_import_rules_job_details<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::background_job_log_entry::ImportRulesJobDetails>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_details = std::option::Option::Some(
-            crate::model::background_job_log_entry::JobDetails::ImportRulesJobDetails(v.into()),
-        );
-        self
     }
 
     /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
@@ -9673,25 +9256,6 @@ impl BackgroundJobLogEntry {
         })
     }
 
-    /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
-    /// to hold a `ConvertJobDetails`.
-    ///
-    /// Note that all the setters affecting `job_details` are
-    /// mutually exclusive.
-    pub fn set_convert_job_details<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::background_job_log_entry::ConvertJobDetails>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_details = std::option::Option::Some(
-            crate::model::background_job_log_entry::JobDetails::ConvertJobDetails(v.into()),
-        );
-        self
-    }
-
     /// The value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
     /// if it holds a `ApplyJobDetails`, `None` if the field is not set or
     /// holds a different branch.
@@ -9707,25 +9271,6 @@ impl BackgroundJobLogEntry {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_details][crate::model::BackgroundJobLogEntry::job_details]
-    /// to hold a `ApplyJobDetails`.
-    ///
-    /// Note that all the setters affecting `job_details` are
-    /// mutually exclusive.
-    pub fn set_apply_job_details<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::background_job_log_entry::ApplyJobDetails>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_details = std::option::Option::Some(
-            crate::model::background_job_log_entry::JobDetails::ApplyJobDetails(v.into()),
-        );
-        self
     }
 }
 
@@ -10298,23 +9843,6 @@ impl MappingRule {
         })
     }
 
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `SingleEntityRename`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_single_entity_rename<
-        T: std::convert::Into<std::boxed::Box<crate::model::SingleEntityRename>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::SingleEntityRename(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::MappingRule::details]
     /// if it holds a `MultiEntityRename`, `None` if the field is not set or
     /// holds a different branch.
@@ -10330,23 +9858,6 @@ impl MappingRule {
         })
     }
 
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `MultiEntityRename`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_multi_entity_rename<
-        T: std::convert::Into<std::boxed::Box<crate::model::MultiEntityRename>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::MultiEntityRename(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::MappingRule::details]
     /// if it holds a `EntityMove`, `None` if the field is not set or
     /// holds a different branch.
@@ -10356,20 +9867,6 @@ impl MappingRule {
             crate::model::mapping_rule::Details::EntityMove(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `EntityMove`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_entity_move<T: std::convert::Into<std::boxed::Box<crate::model::EntityMove>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::mapping_rule::Details::EntityMove(v.into()));
-        self
     }
 
     /// The value of [details][crate::model::MappingRule::details]
@@ -10387,23 +9884,6 @@ impl MappingRule {
         })
     }
 
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `SingleColumnChange`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_single_column_change<
-        T: std::convert::Into<std::boxed::Box<crate::model::SingleColumnChange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::SingleColumnChange(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::MappingRule::details]
     /// if it holds a `MultiColumnDataTypeChange`, `None` if the field is not set or
     /// holds a different branch.
@@ -10417,23 +9897,6 @@ impl MappingRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `MultiColumnDataTypeChange`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_multi_column_data_type_change<
-        T: std::convert::Into<std::boxed::Box<crate::model::MultiColumnDatatypeChange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::MultiColumnDataTypeChange(v.into()),
-        );
-        self
     }
 
     /// The value of [details][crate::model::MappingRule::details]
@@ -10451,23 +9914,6 @@ impl MappingRule {
         })
     }
 
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `ConditionalColumnSetValue`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_conditional_column_set_value<
-        T: std::convert::Into<std::boxed::Box<crate::model::ConditionalColumnSetValue>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::ConditionalColumnSetValue(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::MappingRule::details]
     /// if it holds a `ConvertRowidColumn`, `None` if the field is not set or
     /// holds a different branch.
@@ -10481,23 +9927,6 @@ impl MappingRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `ConvertRowidColumn`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_convert_rowid_column<
-        T: std::convert::Into<std::boxed::Box<crate::model::ConvertRowIdToColumn>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::ConvertRowidColumn(v.into()),
-        );
-        self
     }
 
     /// The value of [details][crate::model::MappingRule::details]
@@ -10515,23 +9944,6 @@ impl MappingRule {
         })
     }
 
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `SetTablePrimaryKey`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_set_table_primary_key<
-        T: std::convert::Into<std::boxed::Box<crate::model::SetTablePrimaryKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::SetTablePrimaryKey(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::MappingRule::details]
     /// if it holds a `SinglePackageChange`, `None` if the field is not set or
     /// holds a different branch.
@@ -10547,23 +9959,6 @@ impl MappingRule {
         })
     }
 
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `SinglePackageChange`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_single_package_change<
-        T: std::convert::Into<std::boxed::Box<crate::model::SinglePackageChange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::SinglePackageChange(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::MappingRule::details]
     /// if it holds a `SourceSqlChange`, `None` if the field is not set or
     /// holds a different branch.
@@ -10575,23 +9970,6 @@ impl MappingRule {
             crate::model::mapping_rule::Details::SourceSqlChange(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `SourceSqlChange`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_source_sql_change<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceSqlChange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::SourceSqlChange(v.into()),
-        );
-        self
     }
 
     /// The value of [details][crate::model::MappingRule::details]
@@ -10607,23 +9985,6 @@ impl MappingRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::MappingRule::details]
-    /// to hold a `FilterTableColumns`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_filter_table_columns<
-        T: std::convert::Into<std::boxed::Box<crate::model::FilterTableColumns>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::mapping_rule::Details::FilterTableColumns(v.into()),
-        );
-        self
     }
 }
 
@@ -11294,23 +10655,6 @@ impl MultiColumnDatatypeChange {
         })
     }
 
-    /// Sets the value of [source_filter][crate::model::MultiColumnDatatypeChange::source_filter]
-    /// to hold a `SourceTextFilter`.
-    ///
-    /// Note that all the setters affecting `source_filter` are
-    /// mutually exclusive.
-    pub fn set_source_text_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceTextFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_filter = std::option::Option::Some(
-            crate::model::multi_column_datatype_change::SourceFilter::SourceTextFilter(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_filter][crate::model::MultiColumnDatatypeChange::source_filter]
     /// if it holds a `SourceNumericFilter`, `None` if the field is not set or
     /// holds a different branch.
@@ -11324,23 +10668,6 @@ impl MultiColumnDatatypeChange {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_filter][crate::model::MultiColumnDatatypeChange::source_filter]
-    /// to hold a `SourceNumericFilter`.
-    ///
-    /// Note that all the setters affecting `source_filter` are
-    /// mutually exclusive.
-    pub fn set_source_numeric_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceNumericFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_filter = std::option::Option::Some(
-            crate::model::multi_column_datatype_change::SourceFilter::SourceNumericFilter(v.into()),
-        );
-        self
     }
 }
 
@@ -11577,23 +10904,6 @@ impl ConditionalColumnSetValue {
         })
     }
 
-    /// Sets the value of [source_filter][crate::model::ConditionalColumnSetValue::source_filter]
-    /// to hold a `SourceTextFilter`.
-    ///
-    /// Note that all the setters affecting `source_filter` are
-    /// mutually exclusive.
-    pub fn set_source_text_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceTextFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_filter = std::option::Option::Some(
-            crate::model::conditional_column_set_value::SourceFilter::SourceTextFilter(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_filter][crate::model::ConditionalColumnSetValue::source_filter]
     /// if it holds a `SourceNumericFilter`, `None` if the field is not set or
     /// holds a different branch.
@@ -11607,23 +10917,6 @@ impl ConditionalColumnSetValue {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_filter][crate::model::ConditionalColumnSetValue::source_filter]
-    /// to hold a `SourceNumericFilter`.
-    ///
-    /// Note that all the setters affecting `source_filter` are
-    /// mutually exclusive.
-    pub fn set_source_numeric_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceNumericFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_filter = std::option::Option::Some(
-            crate::model::conditional_column_set_value::SourceFilter::SourceNumericFilter(v.into()),
-        );
-        self
     }
 }
 
@@ -11699,17 +10992,6 @@ impl ValueTransformation {
         })
     }
 
-    /// Sets the value of [filter][crate::model::ValueTransformation::filter]
-    /// to hold a `IsNull`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_is_null<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(mut self, v: T) -> Self {
-        self.filter =
-            std::option::Option::Some(crate::model::value_transformation::Filter::IsNull(v.into()));
-        self
-    }
-
     /// The value of [filter][crate::model::ValueTransformation::filter]
     /// if it holds a `ValueList`, `None` if the field is not set or
     /// holds a different branch.
@@ -11723,21 +11005,6 @@ impl ValueTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::ValueTransformation::filter]
-    /// to hold a `ValueList`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_value_list<T: std::convert::Into<std::boxed::Box<crate::model::ValueListFilter>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::value_transformation::Filter::ValueList(v.into()),
-        );
-        self
     }
 
     /// The value of [filter][crate::model::ValueTransformation::filter]
@@ -11755,23 +11022,6 @@ impl ValueTransformation {
         })
     }
 
-    /// Sets the value of [filter][crate::model::ValueTransformation::filter]
-    /// to hold a `IntComparison`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_int_comparison<
-        T: std::convert::Into<std::boxed::Box<crate::model::IntComparisonFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::value_transformation::Filter::IntComparison(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::ValueTransformation::filter]
     /// if it holds a `DoubleComparison`, `None` if the field is not set or
     /// holds a different branch.
@@ -11785,23 +11035,6 @@ impl ValueTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::ValueTransformation::filter]
-    /// to hold a `DoubleComparison`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_double_comparison<
-        T: std::convert::Into<std::boxed::Box<crate::model::DoubleComparisonFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::value_transformation::Filter::DoubleComparison(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [action][crate::model::ValueTransformation::action].
@@ -11831,21 +11064,6 @@ impl ValueTransformation {
         })
     }
 
-    /// Sets the value of [action][crate::model::ValueTransformation::action]
-    /// to hold a `AssignNull`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_assign_null<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::value_transformation::Action::AssignNull(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::ValueTransformation::action]
     /// if it holds a `AssignSpecificValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -11861,23 +11079,6 @@ impl ValueTransformation {
         })
     }
 
-    /// Sets the value of [action][crate::model::ValueTransformation::action]
-    /// to hold a `AssignSpecificValue`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_assign_specific_value<
-        T: std::convert::Into<std::boxed::Box<crate::model::AssignSpecificValue>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::value_transformation::Action::AssignSpecificValue(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::ValueTransformation::action]
     /// if it holds a `AssignMinValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -11889,21 +11090,6 @@ impl ValueTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::ValueTransformation::action]
-    /// to hold a `AssignMinValue`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_assign_min_value<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::value_transformation::Action::AssignMinValue(v.into()),
-        );
-        self
     }
 
     /// The value of [action][crate::model::ValueTransformation::action]
@@ -11919,21 +11105,6 @@ impl ValueTransformation {
         })
     }
 
-    /// Sets the value of [action][crate::model::ValueTransformation::action]
-    /// to hold a `AssignMaxValue`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_assign_max_value<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::value_transformation::Action::AssignMaxValue(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::ValueTransformation::action]
     /// if it holds a `RoundScale`, `None` if the field is not set or
     /// holds a different branch.
@@ -11947,21 +11118,6 @@ impl ValueTransformation {
         })
     }
 
-    /// Sets the value of [action][crate::model::ValueTransformation::action]
-    /// to hold a `RoundScale`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_round_scale<T: std::convert::Into<std::boxed::Box<crate::model::RoundToScale>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::value_transformation::Action::RoundScale(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::ValueTransformation::action]
     /// if it holds a `ApplyHash`, `None` if the field is not set or
     /// holds a different branch.
@@ -11973,21 +11129,6 @@ impl ValueTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::ValueTransformation::action]
-    /// to hold a `ApplyHash`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_apply_hash<T: std::convert::Into<std::boxed::Box<crate::model::ApplyHash>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::value_transformation::Action::ApplyHash(v.into()),
-        );
-        self
     }
 }
 
@@ -12513,21 +11654,6 @@ impl ApplyHash {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [hash_function][crate::model::ApplyHash::hash_function]
-    /// to hold a `UuidFromBytes`.
-    ///
-    /// Note that all the setters affecting `hash_function` are
-    /// mutually exclusive.
-    pub fn set_uuid_from_bytes<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.hash_function = std::option::Option::Some(
-            crate::model::apply_hash::HashFunction::UuidFromBytes(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ApplyHash {
@@ -12729,23 +11855,6 @@ impl DatabaseEntity {
         })
     }
 
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `Database`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_database<
-        T: std::convert::Into<std::boxed::Box<crate::model::DatabaseInstanceEntity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body = std::option::Option::Some(
-            crate::model::database_entity::EntityBody::Database(v.into()),
-        );
-        self
-    }
-
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// if it holds a `Schema`, `None` if the field is not set or
     /// holds a different branch.
@@ -12755,20 +11864,6 @@ impl DatabaseEntity {
             crate::model::database_entity::EntityBody::Schema(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `Schema`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_schema<T: std::convert::Into<std::boxed::Box<crate::model::SchemaEntity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body =
-            std::option::Option::Some(crate::model::database_entity::EntityBody::Schema(v.into()));
-        self
     }
 
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -12782,20 +11877,6 @@ impl DatabaseEntity {
         })
     }
 
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `Table`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_table<T: std::convert::Into<std::boxed::Box<crate::model::TableEntity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body =
-            std::option::Option::Some(crate::model::database_entity::EntityBody::Table(v.into()));
-        self
-    }
-
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// if it holds a `View`, `None` if the field is not set or
     /// holds a different branch.
@@ -12807,20 +11888,6 @@ impl DatabaseEntity {
         })
     }
 
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `View`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_view<T: std::convert::Into<std::boxed::Box<crate::model::ViewEntity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body =
-            std::option::Option::Some(crate::model::database_entity::EntityBody::View(v.into()));
-        self
-    }
-
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// if it holds a `Sequence`, `None` if the field is not set or
     /// holds a different branch.
@@ -12830,21 +11897,6 @@ impl DatabaseEntity {
             crate::model::database_entity::EntityBody::Sequence(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `Sequence`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_sequence<T: std::convert::Into<std::boxed::Box<crate::model::SequenceEntity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body = std::option::Option::Some(
-            crate::model::database_entity::EntityBody::Sequence(v.into()),
-        );
-        self
     }
 
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -12862,23 +11914,6 @@ impl DatabaseEntity {
         })
     }
 
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `StoredProcedure`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_stored_procedure<
-        T: std::convert::Into<std::boxed::Box<crate::model::StoredProcedureEntity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body = std::option::Option::Some(
-            crate::model::database_entity::EntityBody::StoredProcedure(v.into()),
-        );
-        self
-    }
-
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// if it holds a `DatabaseFunction`, `None` if the field is not set or
     /// holds a different branch.
@@ -12894,23 +11929,6 @@ impl DatabaseEntity {
         })
     }
 
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `DatabaseFunction`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_database_function<
-        T: std::convert::Into<std::boxed::Box<crate::model::FunctionEntity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body = std::option::Option::Some(
-            crate::model::database_entity::EntityBody::DatabaseFunction(v.into()),
-        );
-        self
-    }
-
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// if it holds a `Synonym`, `None` if the field is not set or
     /// holds a different branch.
@@ -12920,20 +11938,6 @@ impl DatabaseEntity {
             crate::model::database_entity::EntityBody::Synonym(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `Synonym`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_synonym<T: std::convert::Into<std::boxed::Box<crate::model::SynonymEntity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body =
-            std::option::Option::Some(crate::model::database_entity::EntityBody::Synonym(v.into()));
-        self
     }
 
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -12951,23 +11955,6 @@ impl DatabaseEntity {
         })
     }
 
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `DatabasePackage`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_database_package<
-        T: std::convert::Into<std::boxed::Box<crate::model::PackageEntity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body = std::option::Option::Some(
-            crate::model::database_entity::EntityBody::DatabasePackage(v.into()),
-        );
-        self
-    }
-
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
     /// if it holds a `Udt`, `None` if the field is not set or
     /// holds a different branch.
@@ -12977,20 +11964,6 @@ impl DatabaseEntity {
             crate::model::database_entity::EntityBody::Udt(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `Udt`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_udt<T: std::convert::Into<std::boxed::Box<crate::model::UDTEntity>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body =
-            std::option::Option::Some(crate::model::database_entity::EntityBody::Udt(v.into()));
-        self
     }
 
     /// The value of [entity_body][crate::model::DatabaseEntity::entity_body]
@@ -13006,23 +11979,6 @@ impl DatabaseEntity {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entity_body][crate::model::DatabaseEntity::entity_body]
-    /// to hold a `MaterializedView`.
-    ///
-    /// Note that all the setters affecting `entity_body` are
-    /// mutually exclusive.
-    pub fn set_materialized_view<
-        T: std::convert::Into<std::boxed::Box<crate::model::MaterializedViewEntity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_body = std::option::Option::Some(
-            crate::model::database_entity::EntityBody::MaterializedView(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/model.rs
@@ -82,25 +82,6 @@ impl AssignmentProtocol {
         })
     }
 
-    /// Sets the value of [assignment_type][crate::model::AssignmentProtocol::assignment_type]
-    /// to hold a `ManualAssignmentType`.
-    ///
-    /// Note that all the setters affecting `assignment_type` are
-    /// mutually exclusive.
-    pub fn set_manual_assignment_type<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::assignment_protocol::ManualAssignmentType>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.assignment_type = std::option::Option::Some(
-            crate::model::assignment_protocol::AssignmentType::ManualAssignmentType(v.into()),
-        );
-        self
-    }
-
     /// The value of [assignment_type][crate::model::AssignmentProtocol::assignment_type]
     /// if it holds a `AutoAssignmentType`, `None` if the field is not set or
     /// holds a different branch.
@@ -115,23 +96,6 @@ impl AssignmentProtocol {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [assignment_type][crate::model::AssignmentProtocol::assignment_type]
-    /// to hold a `AutoAssignmentType`.
-    ///
-    /// Note that all the setters affecting `assignment_type` are
-    /// mutually exclusive.
-    pub fn set_auto_assignment_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::assignment_protocol::AutoAssignmentType>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.assignment_type = std::option::Option::Some(
-            crate::model::assignment_protocol::AssignmentType::AutoAssignmentType(v.into()),
-        );
-        self
     }
 }
 
@@ -1230,18 +1194,6 @@ pub mod parameter {
             })
         }
 
-        /// Sets the value of [kind][crate::model::parameter::Value::kind]
-        /// to hold a `Int64Value`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::parameter::value::Kind::Int64Value(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::parameter::Value::kind]
         /// if it holds a `StringValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -1255,21 +1207,6 @@ pub mod parameter {
             })
         }
 
-        /// Sets the value of [kind][crate::model::parameter::Value::kind]
-        /// to hold a `StringValue`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_string_value<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::parameter::value::Kind::StringValue(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::parameter::Value::kind]
         /// if it holds a `DoubleValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -1281,18 +1218,6 @@ pub mod parameter {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::parameter::Value::kind]
-        /// to hold a `DoubleValue`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::parameter::value::Kind::DoubleValue(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
@@ -257,36 +257,6 @@ pub mod confidential_computing {
             self.0.request.tee_attestation = v.into();
             self
         }
-
-        /// Sets the value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
-        /// to hold a `TdCcel`.
-        ///
-        /// Note that all the setters affecting `tee_attestation` are
-        /// mutually exclusive.
-        pub fn set_td_ccel<
-            T: std::convert::Into<std::boxed::Box<crate::model::TdxCcelAttestation>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_td_ccel(v);
-            self
-        }
-
-        /// Sets the value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
-        /// to hold a `SevSnpAttestation`.
-        ///
-        /// Note that all the setters affecting `tee_attestation` are
-        /// mutually exclusive.
-        pub fn set_sev_snp_attestation<
-            T: std::convert::Into<std::boxed::Box<crate::model::SevSnpAttestation>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_sev_snp_attestation(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/confidentialcomputing/v1/src/model.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/model.rs
@@ -298,21 +298,6 @@ impl VerifyAttestationRequest {
         })
     }
 
-    /// Sets the value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
-    /// to hold a `TdCcel`.
-    ///
-    /// Note that all the setters affecting `tee_attestation` are
-    /// mutually exclusive.
-    pub fn set_td_ccel<T: std::convert::Into<std::boxed::Box<crate::model::TdxCcelAttestation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tee_attestation = std::option::Option::Some(
-            crate::model::verify_attestation_request::TeeAttestation::TdCcel(v.into()),
-        );
-        self
-    }
-
     /// The value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
     /// if it holds a `SevSnpAttestation`, `None` if the field is not set or
     /// holds a different branch.
@@ -326,23 +311,6 @@ impl VerifyAttestationRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [tee_attestation][crate::model::VerifyAttestationRequest::tee_attestation]
-    /// to hold a `SevSnpAttestation`.
-    ///
-    /// Note that all the setters affecting `tee_attestation` are
-    /// mutually exclusive.
-    pub fn set_sev_snp_attestation<
-        T: std::convert::Into<std::boxed::Box<crate::model::SevSnpAttestation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tee_attestation = std::option::Option::Some(
-            crate::model::verify_attestation_request::TeeAttestation::SevSnpAttestation(v.into()),
-        );
-        self
     }
 }
 
@@ -666,23 +634,6 @@ impl TokenOptions {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [token_type_options][crate::model::TokenOptions::token_type_options]
-    /// to hold a `AwsPrincipalTagsOptions`.
-    ///
-    /// Note that all the setters affecting `token_type_options` are
-    /// mutually exclusive.
-    pub fn set_aws_principal_tags_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::token_options::AwsPrincipalTagsOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.token_type_options = std::option::Option::Some(
-            crate::model::token_options::TokenTypeOptions::AwsPrincipalTagsOptions(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/config/v1/src/model.rs
+++ b/src/generated/cloud/config/v1/src/model.rs
@@ -394,23 +394,6 @@ impl Deployment {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [blueprint][crate::model::Deployment::blueprint]
-    /// to hold a `TerraformBlueprint`.
-    ///
-    /// Note that all the setters affecting `blueprint` are
-    /// mutually exclusive.
-    pub fn set_terraform_blueprint<
-        T: std::convert::Into<std::boxed::Box<crate::model::TerraformBlueprint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.blueprint = std::option::Option::Some(
-            crate::model::deployment::Blueprint::TerraformBlueprint(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for Deployment {
@@ -994,18 +977,6 @@ impl TerraformBlueprint {
         })
     }
 
-    /// Sets the value of [source][crate::model::TerraformBlueprint::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::terraform_blueprint::Source::GcsSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::TerraformBlueprint::source]
     /// if it holds a `GitSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -1015,21 +986,6 @@ impl TerraformBlueprint {
             crate::model::terraform_blueprint::Source::GitSource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::TerraformBlueprint::source]
-    /// to hold a `GitSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_git_source<T: std::convert::Into<std::boxed::Box<crate::model::GitSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::terraform_blueprint::Source::GitSource(v.into()),
-        );
-        self
     }
 }
 
@@ -2135,23 +2091,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [resource_metadata][crate::model::OperationMetadata::resource_metadata]
-    /// to hold a `DeploymentMetadata`.
-    ///
-    /// Note that all the setters affecting `resource_metadata` are
-    /// mutually exclusive.
-    pub fn set_deployment_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeploymentOperationMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource_metadata = std::option::Option::Some(
-            crate::model::operation_metadata::ResourceMetadata::DeploymentMetadata(v.into()),
-        );
-        self
-    }
-
     /// The value of [resource_metadata][crate::model::OperationMetadata::resource_metadata]
     /// if it holds a `PreviewMetadata`, `None` if the field is not set or
     /// holds a different branch.
@@ -2165,23 +2104,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource_metadata][crate::model::OperationMetadata::resource_metadata]
-    /// to hold a `PreviewMetadata`.
-    ///
-    /// Note that all the setters affecting `resource_metadata` are
-    /// mutually exclusive.
-    pub fn set_preview_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::PreviewOperationMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource_metadata = std::option::Option::Some(
-            crate::model::operation_metadata::ResourceMetadata::PreviewMetadata(v.into()),
-        );
-        self
     }
 }
 
@@ -2499,23 +2421,6 @@ impl Revision {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [blueprint][crate::model::Revision::blueprint]
-    /// to hold a `TerraformBlueprint`.
-    ///
-    /// Note that all the setters affecting `blueprint` are
-    /// mutually exclusive.
-    pub fn set_terraform_blueprint<
-        T: std::convert::Into<std::boxed::Box<crate::model::TerraformBlueprint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.blueprint = std::option::Option::Some(
-            crate::model::revision::Blueprint::TerraformBlueprint(v.into()),
-        );
-        self
     }
 }
 
@@ -4804,23 +4709,6 @@ impl Preview {
             crate::model::preview::Blueprint::TerraformBlueprint(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [blueprint][crate::model::Preview::blueprint]
-    /// to hold a `TerraformBlueprint`.
-    ///
-    /// Note that all the setters affecting `blueprint` are
-    /// mutually exclusive.
-    pub fn set_terraform_blueprint<
-        T: std::convert::Into<std::boxed::Box<crate::model::TerraformBlueprint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.blueprint = std::option::Option::Some(
-            crate::model::preview::Blueprint::TerraformBlueprint(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/connectors/v1/src/model.rs
+++ b/src/generated/cloud/connectors/v1/src/model.rs
@@ -102,22 +102,6 @@ impl AuthConfig {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
-    /// to hold a `UserPassword`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_user_password<
-        T: std::convert::Into<std::boxed::Box<crate::model::auth_config::UserPassword>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::auth_config::Type::UserPassword(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::AuthConfig::r#type]
     /// if it holds a `Oauth2JwtBearer`, `None` if the field is not set or
     /// holds a different branch.
@@ -129,22 +113,6 @@ impl AuthConfig {
             crate::model::auth_config::Type::Oauth2JwtBearer(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
-    /// to hold a `Oauth2JwtBearer`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_oauth2_jwt_bearer<
-        T: std::convert::Into<std::boxed::Box<crate::model::auth_config::Oauth2JwtBearer>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::auth_config::Type::Oauth2JwtBearer(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::AuthConfig::r#type]
@@ -163,23 +131,6 @@ impl AuthConfig {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
-    /// to hold a `Oauth2ClientCredentials`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_oauth2_client_credentials<
-        T: std::convert::Into<std::boxed::Box<crate::model::auth_config::Oauth2ClientCredentials>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::auth_config::Type::Oauth2ClientCredentials(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::AuthConfig::r#type]
     /// if it holds a `SshPublicKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -191,22 +142,6 @@ impl AuthConfig {
             crate::model::auth_config::Type::SshPublicKey(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::AuthConfig::r#type]
-    /// to hold a `SshPublicKey`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_ssh_public_key<
-        T: std::convert::Into<std::boxed::Box<crate::model::auth_config::SshPublicKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::auth_config::Type::SshPublicKey(v.into()));
-        self
     }
 }
 
@@ -1281,17 +1216,6 @@ impl ConfigVariable {
         })
     }
 
-    /// Sets the value of [value][crate::model::ConfigVariable::value]
-    /// to hold a `IntValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::config_variable::Value::IntValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::ConfigVariable::value]
     /// if it holds a `BoolValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -1301,17 +1225,6 @@ impl ConfigVariable {
             crate::model::config_variable::Value::BoolValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::ConfigVariable::value]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::config_variable::Value::BoolValue(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::ConfigVariable::value]
@@ -1325,17 +1238,6 @@ impl ConfigVariable {
         })
     }
 
-    /// Sets the value of [value][crate::model::ConfigVariable::value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::config_variable::Value::StringValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::ConfigVariable::value]
     /// if it holds a `SecretValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -1345,20 +1247,6 @@ impl ConfigVariable {
             crate::model::config_variable::Value::SecretValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::ConfigVariable::value]
-    /// to hold a `SecretValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_secret_value<T: std::convert::Into<std::boxed::Box<crate::model::Secret>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::config_variable::Value::SecretValue(v.into()));
-        self
     }
 }
 
@@ -4585,18 +4473,6 @@ impl EgressControlConfig {
         })
     }
 
-    /// Sets the value of [oneof_backends][crate::model::EgressControlConfig::oneof_backends]
-    /// to hold a `Backends`.
-    ///
-    /// Note that all the setters affecting `oneof_backends` are
-    /// mutually exclusive.
-    pub fn set_backends<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.oneof_backends = std::option::Option::Some(
-            crate::model::egress_control_config::OneofBackends::Backends(v.into()),
-        );
-        self
-    }
-
     /// The value of [oneof_backends][crate::model::EgressControlConfig::oneof_backends]
     /// if it holds a `ExtractionRules`, `None` if the field is not set or
     /// holds a different branch.
@@ -4610,23 +4486,6 @@ impl EgressControlConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [oneof_backends][crate::model::EgressControlConfig::oneof_backends]
-    /// to hold a `ExtractionRules`.
-    ///
-    /// Note that all the setters affecting `oneof_backends` are
-    /// mutually exclusive.
-    pub fn set_extraction_rules<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExtractionRules>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.oneof_backends = std::option::Option::Some(
-            crate::model::egress_control_config::OneofBackends::ExtractionRules(v.into()),
-        );
-        self
     }
 }
 
@@ -5021,21 +4880,6 @@ impl Destination {
         })
     }
 
-    /// Sets the value of [destination][crate::model::Destination::destination]
-    /// to hold a `ServiceAttachment`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_service_attachment<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::destination::Destination::ServiceAttachment(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::Destination::destination]
     /// if it holds a `Host`, `None` if the field is not set or
     /// holds a different branch.
@@ -5045,17 +4889,6 @@ impl Destination {
             crate::model::destination::Destination::Host(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::Destination::destination]
-    /// to hold a `Host`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_host<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination =
-            std::option::Option::Some(crate::model::destination::Destination::Host(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
@@ -1395,23 +1395,6 @@ pub mod contact_center_insights {
             self
         }
 
-        /// Sets the value of [source][crate::model::IngestConversationsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::ingest_conversations_request::GcsSource>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
-
         /// Sets the value of [object_config][crate::model::IngestConversationsRequest::object_config].
         ///
         /// Note that all the setters affecting `object_config` are
@@ -1423,25 +1406,6 @@ pub mod contact_center_insights {
             v: T,
         ) -> Self {
             self.0.request.object_config = v.into();
-            self
-        }
-
-        /// Sets the value of [object_config][crate::model::IngestConversationsRequest::object_config]
-        /// to hold a `TranscriptObjectConfig`.
-        ///
-        /// Note that all the setters affecting `object_config` are
-        /// mutually exclusive.
-        pub fn set_transcript_object_config<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::ingest_conversations_request::TranscriptObjectConfig,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_transcript_object_config(v);
             self
         }
     }
@@ -1588,25 +1552,6 @@ pub mod contact_center_insights {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportInsightsDataRequest::destination]
-        /// to hold a `BigQueryDestination`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_big_query_destination<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::export_insights_data_request::BigQueryDestination,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_big_query_destination(v);
             self
         }
     }
@@ -2376,23 +2321,6 @@ pub mod contact_center_insights {
             self.0.request.destination = v.into();
             self
         }
-
-        /// Sets the value of [destination][crate::model::ExportIssueModelRequest::destination]
-        /// to hold a `GcsDestination`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_destination<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::export_issue_model_request::GcsDestination>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_destination(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -2518,23 +2446,6 @@ pub mod contact_center_insights {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportIssueModelRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::import_issue_model_request::GcsSource>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
             self
         }
     }
@@ -6577,23 +6488,6 @@ pub mod contact_center_insights {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::BulkUploadFeedbackLabelsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::bulk_upload_feedback_labels_request::GcsSource>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -6757,25 +6651,6 @@ pub mod contact_center_insights {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::BulkDownloadFeedbackLabelsRequest::destination]
-        /// to hold a `GcsDestination`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_destination<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::bulk_download_feedback_labels_request::GcsDestination,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_destination(v);
             self
         }
     }

--- a/src/generated/cloud/contactcenterinsights/v1/src/model.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/model.rs
@@ -1100,23 +1100,6 @@ impl IngestConversationsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::IngestConversationsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ingest_conversations_request::GcsSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::ingest_conversations_request::Source::GcsSource(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [object_config][crate::model::IngestConversationsRequest::object_config].
     ///
     /// Note that all the setters affecting `object_config` are mutually
@@ -1148,27 +1131,6 @@ impl IngestConversationsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [object_config][crate::model::IngestConversationsRequest::object_config]
-    /// to hold a `TranscriptObjectConfig`.
-    ///
-    /// Note that all the setters affecting `object_config` are
-    /// mutually exclusive.
-    pub fn set_transcript_object_config<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::ingest_conversations_request::TranscriptObjectConfig>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.object_config = std::option::Option::Some(
-            crate::model::ingest_conversations_request::ObjectConfig::TranscriptObjectConfig(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -2448,25 +2410,6 @@ impl ExportInsightsDataRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ExportInsightsDataRequest::destination]
-    /// to hold a `BigQueryDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_big_query_destination<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::export_insights_data_request::BigQueryDestination>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_insights_data_request::Destination::BigQueryDestination(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExportInsightsDataRequest {
@@ -3431,25 +3374,6 @@ impl ExportIssueModelRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ExportIssueModelRequest::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::export_issue_model_request::GcsDestination>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_issue_model_request::Destination::GcsDestination(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExportIssueModelRequest {
@@ -3658,23 +3582,6 @@ impl ImportIssueModelRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportIssueModelRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::import_issue_model_request::GcsSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_issue_model_request::Source::GcsSource(v.into()),
-        );
-        self
     }
 }
 
@@ -5241,23 +5148,6 @@ impl Dimension {
         })
     }
 
-    /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
-    /// to hold a `IssueDimensionMetadata`.
-    ///
-    /// Note that all the setters affecting `dimension_metadata` are
-    /// mutually exclusive.
-    pub fn set_issue_dimension_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::dimension::IssueDimensionMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dimension_metadata = std::option::Option::Some(
-            crate::model::dimension::DimensionMetadata::IssueDimensionMetadata(v.into()),
-        );
-        self
-    }
-
     /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
     /// if it holds a `AgentDimensionMetadata`, `None` if the field is not set or
     /// holds a different branch.
@@ -5272,23 +5162,6 @@ impl Dimension {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
-    /// to hold a `AgentDimensionMetadata`.
-    ///
-    /// Note that all the setters affecting `dimension_metadata` are
-    /// mutually exclusive.
-    pub fn set_agent_dimension_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::dimension::AgentDimensionMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dimension_metadata = std::option::Option::Some(
-            crate::model::dimension::DimensionMetadata::AgentDimensionMetadata(v.into()),
-        );
-        self
     }
 
     /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
@@ -5307,23 +5180,6 @@ impl Dimension {
         })
     }
 
-    /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
-    /// to hold a `QaQuestionDimensionMetadata`.
-    ///
-    /// Note that all the setters affecting `dimension_metadata` are
-    /// mutually exclusive.
-    pub fn set_qa_question_dimension_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::dimension::QaQuestionDimensionMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dimension_metadata = std::option::Option::Some(
-            crate::model::dimension::DimensionMetadata::QaQuestionDimensionMetadata(v.into()),
-        );
-        self
-    }
-
     /// The value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
     /// if it holds a `QaQuestionAnswerDimensionMetadata`, `None` if the field is not set or
     /// holds a different branch.
@@ -5339,25 +5195,6 @@ impl Dimension {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dimension_metadata][crate::model::Dimension::dimension_metadata]
-    /// to hold a `QaQuestionAnswerDimensionMetadata`.
-    ///
-    /// Note that all the setters affecting `dimension_metadata` are
-    /// mutually exclusive.
-    pub fn set_qa_question_answer_dimension_metadata<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::dimension::QaQuestionAnswerDimensionMetadata>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dimension_metadata = std::option::Option::Some(
-            crate::model::dimension::DimensionMetadata::QaQuestionAnswerDimensionMetadata(v.into()),
-        );
-        self
     }
 }
 
@@ -6333,20 +6170,6 @@ pub mod query_metrics_response {
                     crate::model::query_metrics_response::slice::data_point::Measure::ConversationMeasure(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [measure][crate::model::query_metrics_response::slice::DataPoint::measure]
-            /// to hold a `ConversationMeasure`.
-            ///
-            /// Note that all the setters affecting `measure` are
-            /// mutually exclusive.
-            pub fn set_conversation_measure<T: std::convert::Into<std::boxed::Box<crate::model::query_metrics_response::slice::data_point::ConversationMeasure>>>(mut self, v: T) -> Self{
-                self.measure = std::option::Option::Some(
-                    crate::model::query_metrics_response::slice::data_point::Measure::ConversationMeasure(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -8495,25 +8318,6 @@ impl BulkUploadFeedbackLabelsRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::BulkUploadFeedbackLabelsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::bulk_upload_feedback_labels_request::GcsSource>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::bulk_upload_feedback_labels_request::Source::GcsSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BulkUploadFeedbackLabelsRequest {
@@ -9052,29 +8856,6 @@ impl BulkDownloadFeedbackLabelsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::BulkDownloadFeedbackLabelsRequest::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::bulk_download_feedback_labels_request::GcsDestination,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::bulk_download_feedback_labels_request::Destination::GcsDestination(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -9977,22 +9758,6 @@ impl Conversation {
         })
     }
 
-    /// Sets the value of [metadata][crate::model::Conversation::metadata]
-    /// to hold a `CallMetadata`.
-    ///
-    /// Note that all the setters affecting `metadata` are
-    /// mutually exclusive.
-    pub fn set_call_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::conversation::CallMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata =
-            std::option::Option::Some(crate::model::conversation::Metadata::CallMetadata(v.into()));
-        self
-    }
-
     /// Sets the value of [expiration][crate::model::Conversation::expiration].
     ///
     /// Note that all the setters affecting `expiration` are mutually
@@ -10018,20 +9783,6 @@ impl Conversation {
         })
     }
 
-    /// Sets the value of [expiration][crate::model::Conversation::expiration]
-    /// to hold a `ExpireTime`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.expiration =
-            std::option::Option::Some(crate::model::conversation::Expiration::ExpireTime(v.into()));
-        self
-    }
-
     /// The value of [expiration][crate::model::Conversation::expiration]
     /// if it holds a `Ttl`, `None` if the field is not set or
     /// holds a different branch.
@@ -10041,17 +9792,6 @@ impl Conversation {
             crate::model::conversation::Expiration::Ttl(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [expiration][crate::model::Conversation::expiration]
-    /// to hold a `Ttl`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
-        self.expiration =
-            std::option::Option::Some(crate::model::conversation::Expiration::Ttl(v.into()));
-        self
     }
 }
 
@@ -10878,21 +10618,6 @@ impl ConversationDataSource {
         })
     }
 
-    /// Sets the value of [source][crate::model::ConversationDataSource::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::conversation_data_source::Source::GcsSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ConversationDataSource::source]
     /// if it holds a `DialogflowSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -10906,23 +10631,6 @@ impl ConversationDataSource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ConversationDataSource::source]
-    /// to hold a `DialogflowSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_dialogflow_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::DialogflowSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::conversation_data_source::Source::DialogflowSource(v.into()),
-        );
-        self
     }
 }
 
@@ -11102,23 +10810,6 @@ impl AnalysisResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [metadata][crate::model::AnalysisResult::metadata]
-    /// to hold a `CallAnalysisMetadata`.
-    ///
-    /// Note that all the setters affecting `metadata` are
-    /// mutually exclusive.
-    pub fn set_call_analysis_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::analysis_result::CallAnalysisMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = std::option::Option::Some(
-            crate::model::analysis_result::Metadata::CallAnalysisMetadata(v.into()),
-        );
-        self
     }
 }
 
@@ -11433,17 +11124,6 @@ impl FeedbackLabel {
         })
     }
 
-    /// Sets the value of [label_type][crate::model::FeedbackLabel::label_type]
-    /// to hold a `Label`.
-    ///
-    /// Note that all the setters affecting `label_type` are
-    /// mutually exclusive.
-    pub fn set_label<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.label_type =
-            std::option::Option::Some(crate::model::feedback_label::LabelType::Label(v.into()));
-        self
-    }
-
     /// The value of [label_type][crate::model::FeedbackLabel::label_type]
     /// if it holds a `QaAnswerLabel`, `None` if the field is not set or
     /// holds a different branch.
@@ -11457,23 +11137,6 @@ impl FeedbackLabel {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [label_type][crate::model::FeedbackLabel::label_type]
-    /// to hold a `QaAnswerLabel`.
-    ///
-    /// Note that all the setters affecting `label_type` are
-    /// mutually exclusive.
-    pub fn set_qa_answer_label<
-        T: std::convert::Into<std::boxed::Box<crate::model::qa_answer::AnswerValue>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.label_type = std::option::Option::Some(
-            crate::model::feedback_label::LabelType::QaAnswerLabel(v.into()),
-        );
-        self
     }
 }
 
@@ -11738,23 +11401,6 @@ impl CallAnnotation {
         })
     }
 
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `InterruptionData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_interruption_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::InterruptionData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::call_annotation::Data::InterruptionData(v.into()),
-        );
-        self
-    }
-
     /// The value of [data][crate::model::CallAnnotation::data]
     /// if it holds a `SentimentData`, `None` if the field is not set or
     /// holds a different branch.
@@ -11768,22 +11414,6 @@ impl CallAnnotation {
         })
     }
 
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `SentimentData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_sentiment_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::SentimentData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data =
-            std::option::Option::Some(crate::model::call_annotation::Data::SentimentData(v.into()));
-        self
-    }
-
     /// The value of [data][crate::model::CallAnnotation::data]
     /// if it holds a `SilenceData`, `None` if the field is not set or
     /// holds a different branch.
@@ -11795,20 +11425,6 @@ impl CallAnnotation {
         })
     }
 
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `SilenceData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_silence_data<T: std::convert::Into<std::boxed::Box<crate::model::SilenceData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data =
-            std::option::Option::Some(crate::model::call_annotation::Data::SilenceData(v.into()));
-        self
-    }
-
     /// The value of [data][crate::model::CallAnnotation::data]
     /// if it holds a `HoldData`, `None` if the field is not set or
     /// holds a different branch.
@@ -11818,20 +11434,6 @@ impl CallAnnotation {
             crate::model::call_annotation::Data::HoldData(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `HoldData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_hold_data<T: std::convert::Into<std::boxed::Box<crate::model::HoldData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data =
-            std::option::Option::Some(crate::model::call_annotation::Data::HoldData(v.into()));
-        self
     }
 
     /// The value of [data][crate::model::CallAnnotation::data]
@@ -11849,23 +11451,6 @@ impl CallAnnotation {
         })
     }
 
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `EntityMentionData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_entity_mention_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::EntityMentionData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::call_annotation::Data::EntityMentionData(v.into()),
-        );
-        self
-    }
-
     /// The value of [data][crate::model::CallAnnotation::data]
     /// if it holds a `IntentMatchData`, `None` if the field is not set or
     /// holds a different branch.
@@ -11877,23 +11462,6 @@ impl CallAnnotation {
             crate::model::call_annotation::Data::IntentMatchData(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `IntentMatchData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_intent_match_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::IntentMatchData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::call_annotation::Data::IntentMatchData(v.into()),
-        );
-        self
     }
 
     /// The value of [data][crate::model::CallAnnotation::data]
@@ -11909,23 +11477,6 @@ impl CallAnnotation {
         })
     }
 
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `PhraseMatchData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_phrase_match_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::PhraseMatchData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::call_annotation::Data::PhraseMatchData(v.into()),
-        );
-        self
-    }
-
     /// The value of [data][crate::model::CallAnnotation::data]
     /// if it holds a `IssueMatchData`, `None` if the field is not set or
     /// holds a different branch.
@@ -11937,23 +11488,6 @@ impl CallAnnotation {
             crate::model::call_annotation::Data::IssueMatchData(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::CallAnnotation::data]
-    /// to hold a `IssueMatchData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_issue_match_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::IssueMatchData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(crate::model::call_annotation::Data::IssueMatchData(
-            v.into(),
-        ));
-        self
     }
 }
 
@@ -12050,18 +11584,6 @@ impl AnnotationBoundary {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [detailed_boundary][crate::model::AnnotationBoundary::detailed_boundary]
-    /// to hold a `WordIndex`.
-    ///
-    /// Note that all the setters affecting `detailed_boundary` are
-    /// mutually exclusive.
-    pub fn set_word_index<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.detailed_boundary = std::option::Option::Some(
-            crate::model::annotation_boundary::DetailedBoundary::WordIndex(v.into()),
-        );
-        self
     }
 }
 
@@ -14268,23 +13790,6 @@ impl PhraseMatchRuleConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [config][crate::model::PhraseMatchRuleConfig::config]
-    /// to hold a `ExactMatchConfig`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_exact_match_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExactMatchConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(
-            crate::model::phrase_match_rule_config::Config::ExactMatchConfig(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for PhraseMatchRuleConfig {
@@ -15010,23 +14515,6 @@ impl RuntimeAnnotation {
         })
     }
 
-    /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
-    /// to hold a `ArticleSuggestion`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_article_suggestion<
-        T: std::convert::Into<std::boxed::Box<crate::model::ArticleSuggestionData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::runtime_annotation::Data::ArticleSuggestion(v.into()),
-        );
-        self
-    }
-
     /// The value of [data][crate::model::RuntimeAnnotation::data]
     /// if it holds a `FaqAnswer`, `None` if the field is not set or
     /// holds a different branch.
@@ -15036,20 +14524,6 @@ impl RuntimeAnnotation {
             crate::model::runtime_annotation::Data::FaqAnswer(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
-    /// to hold a `FaqAnswer`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_faq_answer<T: std::convert::Into<std::boxed::Box<crate::model::FaqAnswerData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data =
-            std::option::Option::Some(crate::model::runtime_annotation::Data::FaqAnswer(v.into()));
-        self
     }
 
     /// The value of [data][crate::model::RuntimeAnnotation::data]
@@ -15063,20 +14537,6 @@ impl RuntimeAnnotation {
             crate::model::runtime_annotation::Data::SmartReply(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
-    /// to hold a `SmartReply`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_smart_reply<T: std::convert::Into<std::boxed::Box<crate::model::SmartReplyData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data =
-            std::option::Option::Some(crate::model::runtime_annotation::Data::SmartReply(v.into()));
-        self
     }
 
     /// The value of [data][crate::model::RuntimeAnnotation::data]
@@ -15094,23 +14554,6 @@ impl RuntimeAnnotation {
         })
     }
 
-    /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
-    /// to hold a `SmartComposeSuggestion`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_smart_compose_suggestion<
-        T: std::convert::Into<std::boxed::Box<crate::model::SmartComposeSuggestionData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::runtime_annotation::Data::SmartComposeSuggestion(v.into()),
-        );
-        self
-    }
-
     /// The value of [data][crate::model::RuntimeAnnotation::data]
     /// if it holds a `DialogflowInteraction`, `None` if the field is not set or
     /// holds a different branch.
@@ -15124,23 +14567,6 @@ impl RuntimeAnnotation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
-    /// to hold a `DialogflowInteraction`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_dialogflow_interaction<
-        T: std::convert::Into<std::boxed::Box<crate::model::DialogflowInteractionData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::runtime_annotation::Data::DialogflowInteraction(v.into()),
-        );
-        self
     }
 
     /// The value of [data][crate::model::RuntimeAnnotation::data]
@@ -15157,23 +14583,6 @@ impl RuntimeAnnotation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::RuntimeAnnotation::data]
-    /// to hold a `ConversationSummarizationSuggestion`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_conversation_summarization_suggestion<
-        T: std::convert::Into<std::boxed::Box<crate::model::ConversationSummarizationSuggestionData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(
-            crate::model::runtime_annotation::Data::ConversationSummarizationSuggestion(v.into()),
-        );
-        self
     }
 }
 
@@ -16198,23 +15607,6 @@ impl ConversationParticipant {
         })
     }
 
-    /// Sets the value of [participant][crate::model::ConversationParticipant::participant]
-    /// to hold a `DialogflowParticipantName`.
-    ///
-    /// Note that all the setters affecting `participant` are
-    /// mutually exclusive.
-    pub fn set_dialogflow_participant_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.participant = std::option::Option::Some(
-            crate::model::conversation_participant::Participant::DialogflowParticipantName(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [participant][crate::model::ConversationParticipant::participant]
     /// if it holds a `UserId`, `None` if the field is not set or
     /// holds a different branch.
@@ -16226,18 +15618,6 @@ impl ConversationParticipant {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [participant][crate::model::ConversationParticipant::participant]
-    /// to hold a `UserId`.
-    ///
-    /// Note that all the setters affecting `participant` are
-    /// mutually exclusive.
-    pub fn set_user_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.participant = std::option::Option::Some(
-            crate::model::conversation_participant::Participant::UserId(v.into()),
-        );
-        self
     }
 }
 
@@ -16731,23 +16111,6 @@ pub mod annotator_selector {
             })
         }
 
-        /// Sets the value of [model_source][crate::model::annotator_selector::SummarizationConfig::model_source]
-        /// to hold a `ConversationProfile`.
-        ///
-        /// Note that all the setters affecting `model_source` are
-        /// mutually exclusive.
-        pub fn set_conversation_profile<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.model_source = std::option::Option::Some(
-                crate::model::annotator_selector::summarization_config::ModelSource::ConversationProfile(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [model_source][crate::model::annotator_selector::SummarizationConfig::model_source]
         /// if it holds a `SummarizationModel`, `None` if the field is not set or
         /// holds a different branch.
@@ -16761,27 +16124,6 @@ pub mod annotator_selector {
                 crate::model::annotator_selector::summarization_config::ModelSource::SummarizationModel(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [model_source][crate::model::annotator_selector::SummarizationConfig::model_source]
-        /// to hold a `SummarizationModel`.
-        ///
-        /// Note that all the setters affecting `model_source` are
-        /// mutually exclusive.
-        pub fn set_summarization_model<
-            T: std::convert::Into<
-                    crate::model::annotator_selector::summarization_config::SummarizationModel,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.model_source = std::option::Option::Some(
-                crate::model::annotator_selector::summarization_config::ModelSource::SummarizationModel(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -17003,27 +16345,6 @@ pub mod annotator_selector {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [scorecard_source][crate::model::annotator_selector::QaConfig::scorecard_source]
-        /// to hold a `ScorecardList`.
-        ///
-        /// Note that all the setters affecting `scorecard_source` are
-        /// mutually exclusive.
-        pub fn set_scorecard_list<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::annotator_selector::qa_config::ScorecardList>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.scorecard_source = std::option::Option::Some(
-                crate::model::annotator_selector::qa_config::ScorecardSource::ScorecardList(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -17334,18 +16655,6 @@ pub mod qa_question {
             })
         }
 
-        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
-        /// to hold a `StrValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_str_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_question::answer_choice::Value::StrValue(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::qa_question::AnswerChoice::value]
         /// if it holds a `NumValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -17357,18 +16666,6 @@ pub mod qa_question {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
-        /// to hold a `NumValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_num_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_question::answer_choice::Value::NumValue(v.into()),
-            );
-            self
         }
 
         /// The value of [value][crate::model::qa_question::AnswerChoice::value]
@@ -17384,18 +16681,6 @@ pub mod qa_question {
             })
         }
 
-        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
-        /// to hold a `BoolValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_question::answer_choice::Value::BoolValue(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::qa_question::AnswerChoice::value]
         /// if it holds a `NaValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -17407,18 +16692,6 @@ pub mod qa_question {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::qa_question::AnswerChoice::value]
-        /// to hold a `NaValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_na_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_question::answer_choice::Value::NaValue(v.into()),
-            );
-            self
         }
     }
 
@@ -18101,18 +17374,6 @@ pub mod qa_answer {
             })
         }
 
-        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
-        /// to hold a `StrValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_str_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_answer::answer_value::Value::StrValue(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::qa_answer::AnswerValue::value]
         /// if it holds a `NumValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -18124,18 +17385,6 @@ pub mod qa_answer {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
-        /// to hold a `NumValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_num_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_answer::answer_value::Value::NumValue(v.into()),
-            );
-            self
         }
 
         /// The value of [value][crate::model::qa_answer::AnswerValue::value]
@@ -18151,18 +17400,6 @@ pub mod qa_answer {
             })
         }
 
-        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
-        /// to hold a `BoolValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_answer::answer_value::Value::BoolValue(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::qa_answer::AnswerValue::value]
         /// if it holds a `NaValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -18174,18 +17411,6 @@ pub mod qa_answer {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::qa_answer::AnswerValue::value]
-        /// to hold a `NaValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_na_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::qa_answer::answer_value::Value::NaValue(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
@@ -1398,32 +1398,6 @@ pub mod lineage {
             self.0.request.criteria = v.into();
             self
         }
-
-        /// Sets the value of [criteria][crate::model::SearchLinksRequest::criteria]
-        /// to hold a `Source`.
-        ///
-        /// Note that all the setters affecting `criteria` are
-        /// mutually exclusive.
-        pub fn set_source<T: std::convert::Into<std::boxed::Box<crate::model::EntityReference>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_source(v);
-            self
-        }
-
-        /// Sets the value of [criteria][crate::model::SearchLinksRequest::criteria]
-        /// to hold a `Target`.
-        ///
-        /// Note that all the setters affecting `criteria` are
-        /// mutually exclusive.
-        pub fn set_target<T: std::convert::Into<std::boxed::Box<crate::model::EntityReference>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_target(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/model.rs
@@ -2032,21 +2032,6 @@ impl SearchLinksRequest {
         })
     }
 
-    /// Sets the value of [criteria][crate::model::SearchLinksRequest::criteria]
-    /// to hold a `Source`.
-    ///
-    /// Note that all the setters affecting `criteria` are
-    /// mutually exclusive.
-    pub fn set_source<T: std::convert::Into<std::boxed::Box<crate::model::EntityReference>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.criteria = std::option::Option::Some(
-            crate::model::search_links_request::Criteria::Source(v.into()),
-        );
-        self
-    }
-
     /// The value of [criteria][crate::model::SearchLinksRequest::criteria]
     /// if it holds a `Target`, `None` if the field is not set or
     /// holds a different branch.
@@ -2056,21 +2041,6 @@ impl SearchLinksRequest {
             crate::model::search_links_request::Criteria::Target(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [criteria][crate::model::SearchLinksRequest::criteria]
-    /// to hold a `Target`.
-    ///
-    /// Note that all the setters affecting `criteria` are
-    /// mutually exclusive.
-    pub fn set_target<T: std::convert::Into<std::boxed::Box<crate::model::EntityReference>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.criteria = std::option::Option::Some(
-            crate::model::search_links_request::Criteria::Target(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/datacatalog/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builder.rs
@@ -941,45 +941,6 @@ pub mod data_catalog {
             self.0.request.target_name = v.into();
             self
         }
-
-        /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-        /// to hold a `LinkedResource`.
-        ///
-        /// Note that all the setters affecting `target_name` are
-        /// mutually exclusive.
-        pub fn set_linked_resource<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_linked_resource(v);
-            self
-        }
-
-        /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-        /// to hold a `SqlResource`.
-        ///
-        /// Note that all the setters affecting `target_name` are
-        /// mutually exclusive.
-        pub fn set_sql_resource<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_sql_resource(v);
-            self
-        }
-
-        /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-        /// to hold a `FullyQualifiedName`.
-        ///
-        /// Note that all the setters affecting `target_name` are
-        /// mutually exclusive.
-        pub fn set_fully_qualified_name<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_fully_qualified_name(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -2844,19 +2805,6 @@ pub mod data_catalog {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ImportEntriesRequest::source]
-        /// to hold a `GcsBucketPath`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_bucket_path<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_bucket_path(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -2931,36 +2879,6 @@ pub mod data_catalog {
             v: T,
         ) -> Self {
             self.0.request.configuration = v.into();
-            self
-        }
-
-        /// Sets the value of [configuration][crate::model::SetConfigRequest::configuration]
-        /// to hold a `TagTemplateMigration`.
-        ///
-        /// Note that all the setters affecting `configuration` are
-        /// mutually exclusive.
-        pub fn set_tag_template_migration<
-            T: std::convert::Into<crate::model::TagTemplateMigration>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_tag_template_migration(v);
-            self
-        }
-
-        /// Sets the value of [configuration][crate::model::SetConfigRequest::configuration]
-        /// to hold a `CatalogUiExperience`.
-        ///
-        /// Note that all the setters affecting `configuration` are
-        /// mutually exclusive.
-        pub fn set_catalog_ui_experience<
-            T: std::convert::Into<crate::model::CatalogUIExperience>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_catalog_ui_experience(v);
             self
         }
     }
@@ -4929,36 +4847,6 @@ pub mod policy_tag_manager_serialization {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ImportTaxonomiesRequest::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::InlineSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportTaxonomiesRequest::source]
-        /// to hold a `CrossRegionalSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_cross_regional_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::CrossRegionalSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_cross_regional_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -5049,16 +4937,6 @@ pub mod policy_tag_manager_serialization {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportTaxonomiesRequest::destination]
-        /// to hold a `SerializedTaxonomies`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_serialized_taxonomies<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_serialized_taxonomies(v);
             self
         }
     }

--- a/src/generated/cloud/datacatalog/v1/src/model.rs
+++ b/src/generated/cloud/datacatalog/v1/src/model.rs
@@ -108,23 +108,6 @@ impl BigQueryConnectionSpec {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [connection_spec][crate::model::BigQueryConnectionSpec::connection_spec]
-    /// to hold a `CloudSql`.
-    ///
-    /// Note that all the setters affecting `connection_spec` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlBigQueryConnectionSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_spec = std::option::Option::Some(
-            crate::model::big_query_connection_spec::ConnectionSpec::CloudSql(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BigQueryConnectionSpec {
@@ -629,23 +612,6 @@ impl DataSource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [properties][crate::model::DataSource::properties]
-    /// to hold a `StorageProperties`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_storage_properties<
-        T: std::convert::Into<std::boxed::Box<crate::model::StorageProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties = std::option::Option::Some(
-            crate::model::data_source::Properties::StorageProperties(v.into()),
-        );
-        self
     }
 }
 
@@ -1863,18 +1829,6 @@ impl LookupEntryRequest {
         })
     }
 
-    /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-    /// to hold a `LinkedResource`.
-    ///
-    /// Note that all the setters affecting `target_name` are
-    /// mutually exclusive.
-    pub fn set_linked_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target_name = std::option::Option::Some(
-            crate::model::lookup_entry_request::TargetName::LinkedResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [target_name][crate::model::LookupEntryRequest::target_name]
     /// if it holds a `SqlResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -1888,18 +1842,6 @@ impl LookupEntryRequest {
         })
     }
 
-    /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-    /// to hold a `SqlResource`.
-    ///
-    /// Note that all the setters affecting `target_name` are
-    /// mutually exclusive.
-    pub fn set_sql_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target_name = std::option::Option::Some(
-            crate::model::lookup_entry_request::TargetName::SqlResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [target_name][crate::model::LookupEntryRequest::target_name]
     /// if it holds a `FullyQualifiedName`, `None` if the field is not set or
     /// holds a different branch.
@@ -1911,21 +1853,6 @@ impl LookupEntryRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_name][crate::model::LookupEntryRequest::target_name]
-    /// to hold a `FullyQualifiedName`.
-    ///
-    /// Note that all the setters affecting `target_name` are
-    /// mutually exclusive.
-    pub fn set_fully_qualified_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_name = std::option::Option::Some(
-            crate::model::lookup_entry_request::TargetName::FullyQualifiedName(v.into()),
-        );
-        self
     }
 }
 
@@ -2269,16 +2196,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [entry_type][crate::model::Entry::entry_type]
-    /// to hold a `Type`.
-    ///
-    /// Note that all the setters affecting `entry_type` are
-    /// mutually exclusive.
-    pub fn set_type<T: std::convert::Into<crate::model::EntryType>>(mut self, v: T) -> Self {
-        self.entry_type = std::option::Option::Some(crate::model::entry::EntryType::Type(v.into()));
-        self
-    }
-
     /// The value of [entry_type][crate::model::Entry::entry_type]
     /// if it holds a `UserSpecifiedType`, `None` if the field is not set or
     /// holds a different branch.
@@ -2288,20 +2205,6 @@ impl Entry {
             crate::model::entry::EntryType::UserSpecifiedType(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entry_type][crate::model::Entry::entry_type]
-    /// to hold a `UserSpecifiedType`.
-    ///
-    /// Note that all the setters affecting `entry_type` are
-    /// mutually exclusive.
-    pub fn set_user_specified_type<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entry_type =
-            std::option::Option::Some(crate::model::entry::EntryType::UserSpecifiedType(v.into()));
-        self
     }
 
     /// Sets the value of [system][crate::model::Entry::system].
@@ -2327,20 +2230,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [system][crate::model::Entry::system]
-    /// to hold a `IntegratedSystem`.
-    ///
-    /// Note that all the setters affecting `system` are
-    /// mutually exclusive.
-    pub fn set_integrated_system<T: std::convert::Into<crate::model::IntegratedSystem>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system =
-            std::option::Option::Some(crate::model::entry::System::IntegratedSystem(v.into()));
-        self
-    }
-
     /// The value of [system][crate::model::Entry::system]
     /// if it holds a `UserSpecifiedSystem`, `None` if the field is not set or
     /// holds a different branch.
@@ -2350,20 +2239,6 @@ impl Entry {
             crate::model::entry::System::UserSpecifiedSystem(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [system][crate::model::Entry::system]
-    /// to hold a `UserSpecifiedSystem`.
-    ///
-    /// Note that all the setters affecting `system` are
-    /// mutually exclusive.
-    pub fn set_user_specified_system<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system =
-            std::option::Option::Some(crate::model::entry::System::UserSpecifiedSystem(v.into()));
-        self
     }
 
     /// Sets the value of [system_spec][crate::model::Entry::system_spec].
@@ -2395,23 +2270,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [system_spec][crate::model::Entry::system_spec]
-    /// to hold a `SqlDatabaseSystemSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_sql_database_system_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlDatabaseSystemSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec = std::option::Option::Some(
-            crate::model::entry::SystemSpec::SqlDatabaseSystemSpec(v.into()),
-        );
-        self
-    }
-
     /// The value of [system_spec][crate::model::Entry::system_spec]
     /// if it holds a `LookerSystemSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2423,22 +2281,6 @@ impl Entry {
             crate::model::entry::SystemSpec::LookerSystemSpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [system_spec][crate::model::Entry::system_spec]
-    /// to hold a `LookerSystemSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_looker_system_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::LookerSystemSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec =
-            std::option::Option::Some(crate::model::entry::SystemSpec::LookerSystemSpec(v.into()));
-        self
     }
 
     /// The value of [system_spec][crate::model::Entry::system_spec]
@@ -2454,23 +2296,6 @@ impl Entry {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [system_spec][crate::model::Entry::system_spec]
-    /// to hold a `CloudBigtableSystemSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_cloud_bigtable_system_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudBigtableSystemSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec = std::option::Option::Some(
-            crate::model::entry::SystemSpec::CloudBigtableSystemSpec(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [type_spec][crate::model::Entry::type_spec].
@@ -2500,22 +2325,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [type_spec][crate::model::Entry::type_spec]
-    /// to hold a `GcsFilesetSpec`.
-    ///
-    /// Note that all the setters affecting `type_spec` are
-    /// mutually exclusive.
-    pub fn set_gcs_fileset_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsFilesetSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_spec =
-            std::option::Option::Some(crate::model::entry::TypeSpec::GcsFilesetSpec(v.into()));
-        self
-    }
-
     /// The value of [type_spec][crate::model::Entry::type_spec]
     /// if it holds a `BigqueryTableSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2527,22 +2336,6 @@ impl Entry {
             crate::model::entry::TypeSpec::BigqueryTableSpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_spec][crate::model::Entry::type_spec]
-    /// to hold a `BigqueryTableSpec`.
-    ///
-    /// Note that all the setters affecting `type_spec` are
-    /// mutually exclusive.
-    pub fn set_bigquery_table_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryTableSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_spec =
-            std::option::Option::Some(crate::model::entry::TypeSpec::BigqueryTableSpec(v.into()));
-        self
     }
 
     /// The value of [type_spec][crate::model::Entry::type_spec]
@@ -2558,23 +2351,6 @@ impl Entry {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_spec][crate::model::Entry::type_spec]
-    /// to hold a `BigqueryDateShardedSpec`.
-    ///
-    /// Note that all the setters affecting `type_spec` are
-    /// mutually exclusive.
-    pub fn set_bigquery_date_sharded_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryDateShardedSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_spec = std::option::Option::Some(
-            crate::model::entry::TypeSpec::BigqueryDateShardedSpec(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [spec][crate::model::Entry::spec].
@@ -2602,22 +2378,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `DatabaseTableSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_database_table_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DatabaseTableSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::entry::Spec::DatabaseTableSpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::Entry::spec]
     /// if it holds a `DataSourceConnectionSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2631,23 +2391,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `DataSourceConnectionSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_data_source_connection_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataSourceConnectionSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec = std::option::Option::Some(crate::model::entry::Spec::DataSourceConnectionSpec(
-            v.into(),
-        ));
-        self
-    }
-
     /// The value of [spec][crate::model::Entry::spec]
     /// if it holds a `RoutineSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2657,19 +2400,6 @@ impl Entry {
             crate::model::entry::Spec::RoutineSpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `RoutineSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_routine_spec<T: std::convert::Into<std::boxed::Box<crate::model::RoutineSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec = std::option::Option::Some(crate::model::entry::Spec::RoutineSpec(v.into()));
-        self
     }
 
     /// The value of [spec][crate::model::Entry::spec]
@@ -2683,19 +2413,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `DatasetSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_dataset_spec<T: std::convert::Into<std::boxed::Box<crate::model::DatasetSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec = std::option::Option::Some(crate::model::entry::Spec::DatasetSpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::Entry::spec]
     /// if it holds a `FilesetSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2705,19 +2422,6 @@ impl Entry {
             crate::model::entry::Spec::FilesetSpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `FilesetSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_fileset_spec<T: std::convert::Into<std::boxed::Box<crate::model::FilesetSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec = std::option::Option::Some(crate::model::entry::Spec::FilesetSpec(v.into()));
-        self
     }
 
     /// The value of [spec][crate::model::Entry::spec]
@@ -2731,19 +2435,6 @@ impl Entry {
         })
     }
 
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `ServiceSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_service_spec<T: std::convert::Into<std::boxed::Box<crate::model::ServiceSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec = std::option::Option::Some(crate::model::entry::Spec::ServiceSpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::Entry::spec]
     /// if it holds a `ModelSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2753,19 +2444,6 @@ impl Entry {
             crate::model::entry::Spec::ModelSpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `ModelSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_model_spec<T: std::convert::Into<std::boxed::Box<crate::model::ModelSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec = std::option::Option::Some(crate::model::entry::Spec::ModelSpec(v.into()));
-        self
     }
 
     /// The value of [spec][crate::model::Entry::spec]
@@ -2779,22 +2457,6 @@ impl Entry {
             crate::model::entry::Spec::FeatureOnlineStoreSpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [spec][crate::model::Entry::spec]
-    /// to hold a `FeatureOnlineStoreSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_feature_online_store_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::FeatureOnlineStoreSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::entry::Spec::FeatureOnlineStoreSpec(v.into()));
-        self
     }
 }
 
@@ -3069,20 +2731,6 @@ pub mod database_table_spec {
             })
         }
 
-        /// Sets the value of [source_definition][crate::model::database_table_spec::DatabaseViewSpec::source_definition]
-        /// to hold a `BaseTable`.
-        ///
-        /// Note that all the setters affecting `source_definition` are
-        /// mutually exclusive.
-        pub fn set_base_table<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source_definition = std::option::Option::Some(
-                crate::model::database_table_spec::database_view_spec::SourceDefinition::BaseTable(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [source_definition][crate::model::database_table_spec::DatabaseViewSpec::source_definition]
         /// if it holds a `SqlQuery`, `None` if the field is not set or
         /// holds a different branch.
@@ -3092,20 +2740,6 @@ pub mod database_table_spec {
                 crate::model::database_table_spec::database_view_spec::SourceDefinition::SqlQuery(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source_definition][crate::model::database_table_spec::DatabaseViewSpec::source_definition]
-        /// to hold a `SqlQuery`.
-        ///
-        /// Note that all the setters affecting `source_definition` are
-        /// mutually exclusive.
-        pub fn set_sql_query<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source_definition = std::option::Option::Some(
-                crate::model::database_table_spec::database_view_spec::SourceDefinition::SqlQuery(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -3590,23 +3224,6 @@ impl RoutineSpec {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [system_spec][crate::model::RoutineSpec::system_spec]
-    /// to hold a `BigqueryRoutineSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_bigquery_routine_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryRoutineSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec = std::option::Option::Some(
-            crate::model::routine_spec::SystemSpec::BigqueryRoutineSpec(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for RoutineSpec {
@@ -4016,23 +3633,6 @@ impl DatasetSpec {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [system_spec][crate::model::DatasetSpec::system_spec]
-    /// to hold a `VertexDatasetSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_vertex_dataset_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::VertexDatasetSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec = std::option::Option::Some(
-            crate::model::dataset_spec::SystemSpec::VertexDatasetSpec(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DatasetSpec {
@@ -4426,23 +4026,6 @@ impl ServiceSpec {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [system_spec][crate::model::ServiceSpec::system_spec]
-    /// to hold a `CloudBigtableInstanceSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_cloud_bigtable_instance_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudBigtableInstanceSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec = std::option::Option::Some(
-            crate::model::service_spec::SystemSpec::CloudBigtableInstanceSpec(v.into()),
-        );
-        self
     }
 }
 
@@ -5089,23 +4672,6 @@ impl ModelSpec {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [system_spec][crate::model::ModelSpec::system_spec]
-    /// to hold a `VertexModelSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_vertex_model_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::VertexModelSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec = std::option::Option::Some(
-            crate::model::model_spec::SystemSpec::VertexModelSpec(v.into()),
-        );
-        self
     }
 }
 
@@ -7026,18 +6592,6 @@ impl ImportEntriesRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::ImportEntriesRequest::source]
-    /// to hold a `GcsBucketPath`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_bucket_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_entries_request::Source::GcsBucketPath(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ImportEntriesRequest {
@@ -7486,21 +7040,6 @@ impl SetConfigRequest {
         })
     }
 
-    /// Sets the value of [configuration][crate::model::SetConfigRequest::configuration]
-    /// to hold a `TagTemplateMigration`.
-    ///
-    /// Note that all the setters affecting `configuration` are
-    /// mutually exclusive.
-    pub fn set_tag_template_migration<T: std::convert::Into<crate::model::TagTemplateMigration>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.configuration = std::option::Option::Some(
-            crate::model::set_config_request::Configuration::TagTemplateMigration(v.into()),
-        );
-        self
-    }
-
     /// The value of [configuration][crate::model::SetConfigRequest::configuration]
     /// if it holds a `CatalogUiExperience`, `None` if the field is not set or
     /// holds a different branch.
@@ -7512,21 +7051,6 @@ impl SetConfigRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [configuration][crate::model::SetConfigRequest::configuration]
-    /// to hold a `CatalogUiExperience`.
-    ///
-    /// Note that all the setters affecting `configuration` are
-    /// mutually exclusive.
-    pub fn set_catalog_ui_experience<T: std::convert::Into<crate::model::CatalogUIExperience>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.configuration = std::option::Option::Some(
-            crate::model::set_config_request::Configuration::CatalogUiExperience(v.into()),
-        );
-        self
     }
 }
 
@@ -8069,20 +7593,6 @@ impl TaggedEntry {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [entry][crate::model::TaggedEntry::entry]
-    /// to hold a `V1Entry`.
-    ///
-    /// Note that all the setters affecting `entry` are
-    /// mutually exclusive.
-    pub fn set_v1_entry<T: std::convert::Into<std::boxed::Box<crate::model::Entry>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entry =
-            std::option::Option::Some(crate::model::tagged_entry::Entry::V1Entry(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for TaggedEntry {
@@ -8146,19 +7656,6 @@ impl DumpItem {
             crate::model::dump_item::Item::TaggedEntry(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [item][crate::model::DumpItem::item]
-    /// to hold a `TaggedEntry`.
-    ///
-    /// Note that all the setters affecting `item` are
-    /// mutually exclusive.
-    pub fn set_tagged_entry<T: std::convert::Into<std::boxed::Box<crate::model::TaggedEntry>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.item = std::option::Option::Some(crate::model::dump_item::Item::TaggedEntry(v.into()));
-        self
     }
 }
 
@@ -8369,22 +7866,6 @@ impl PhysicalSchema {
         })
     }
 
-    /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
-    /// to hold a `Avro`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_avro<
-        T: std::convert::Into<std::boxed::Box<crate::model::physical_schema::AvroSchema>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schema =
-            std::option::Option::Some(crate::model::physical_schema::Schema::Avro(v.into()));
-        self
-    }
-
     /// The value of [schema][crate::model::PhysicalSchema::schema]
     /// if it holds a `Thrift`, `None` if the field is not set or
     /// holds a different branch.
@@ -8396,22 +7877,6 @@ impl PhysicalSchema {
             crate::model::physical_schema::Schema::Thrift(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
-    /// to hold a `Thrift`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_thrift<
-        T: std::convert::Into<std::boxed::Box<crate::model::physical_schema::ThriftSchema>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schema =
-            std::option::Option::Some(crate::model::physical_schema::Schema::Thrift(v.into()));
-        self
     }
 
     /// The value of [schema][crate::model::PhysicalSchema::schema]
@@ -8427,22 +7892,6 @@ impl PhysicalSchema {
         })
     }
 
-    /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
-    /// to hold a `Protobuf`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_protobuf<
-        T: std::convert::Into<std::boxed::Box<crate::model::physical_schema::ProtobufSchema>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schema =
-            std::option::Option::Some(crate::model::physical_schema::Schema::Protobuf(v.into()));
-        self
-    }
-
     /// The value of [schema][crate::model::PhysicalSchema::schema]
     /// if it holds a `Parquet`, `None` if the field is not set or
     /// holds a different branch.
@@ -8454,22 +7903,6 @@ impl PhysicalSchema {
             crate::model::physical_schema::Schema::Parquet(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
-    /// to hold a `Parquet`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_parquet<
-        T: std::convert::Into<std::boxed::Box<crate::model::physical_schema::ParquetSchema>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schema =
-            std::option::Option::Some(crate::model::physical_schema::Schema::Parquet(v.into()));
-        self
     }
 
     /// The value of [schema][crate::model::PhysicalSchema::schema]
@@ -8485,22 +7918,6 @@ impl PhysicalSchema {
         })
     }
 
-    /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
-    /// to hold a `Orc`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_orc<
-        T: std::convert::Into<std::boxed::Box<crate::model::physical_schema::OrcSchema>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schema =
-            std::option::Option::Some(crate::model::physical_schema::Schema::Orc(v.into()));
-        self
-    }
-
     /// The value of [schema][crate::model::PhysicalSchema::schema]
     /// if it holds a `Csv`, `None` if the field is not set or
     /// holds a different branch.
@@ -8512,22 +7929,6 @@ impl PhysicalSchema {
             crate::model::physical_schema::Schema::Csv(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schema][crate::model::PhysicalSchema::schema]
-    /// to hold a `Csv`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_csv<
-        T: std::convert::Into<std::boxed::Box<crate::model::physical_schema::CsvSchema>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schema =
-            std::option::Option::Some(crate::model::physical_schema::Schema::Csv(v.into()));
-        self
     }
 }
 
@@ -10027,21 +9428,6 @@ impl ImportTaxonomiesRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportTaxonomiesRequest::source]
-    /// to hold a `InlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_source<T: std::convert::Into<std::boxed::Box<crate::model::InlineSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_taxonomies_request::Source::InlineSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportTaxonomiesRequest::source]
     /// if it holds a `CrossRegionalSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -10055,23 +9441,6 @@ impl ImportTaxonomiesRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportTaxonomiesRequest::source]
-    /// to hold a `CrossRegionalSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_cross_regional_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::CrossRegionalSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_taxonomies_request::Source::CrossRegionalSource(v.into()),
-        );
-        self
     }
 }
 
@@ -10284,18 +9653,6 @@ impl ExportTaxonomiesRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportTaxonomiesRequest::destination]
-    /// to hold a `SerializedTaxonomies`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_serialized_taxonomies<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_taxonomies_request::Destination::SerializedTaxonomies(v.into()),
-        );
-        self
     }
 }
 
@@ -10584,23 +9941,6 @@ impl ColumnSchema {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [system_spec][crate::model::ColumnSchema::system_spec]
-    /// to hold a `LookerColumnSpec`.
-    ///
-    /// Note that all the setters affecting `system_spec` are
-    /// mutually exclusive.
-    pub fn set_looker_column_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::column_schema::LookerColumnSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system_spec = std::option::Option::Some(
-            crate::model::column_schema::SystemSpec::LookerColumnSpec(v.into()),
-        );
-        self
     }
 }
 
@@ -11188,21 +10528,6 @@ impl SearchCatalogResult {
         })
     }
 
-    /// Sets the value of [system][crate::model::SearchCatalogResult::system]
-    /// to hold a `IntegratedSystem`.
-    ///
-    /// Note that all the setters affecting `system` are
-    /// mutually exclusive.
-    pub fn set_integrated_system<T: std::convert::Into<crate::model::IntegratedSystem>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system = std::option::Option::Some(
-            crate::model::search_catalog_result::System::IntegratedSystem(v.into()),
-        );
-        self
-    }
-
     /// The value of [system][crate::model::SearchCatalogResult::system]
     /// if it holds a `UserSpecifiedSystem`, `None` if the field is not set or
     /// holds a different branch.
@@ -11214,21 +10539,6 @@ impl SearchCatalogResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [system][crate::model::SearchCatalogResult::system]
-    /// to hold a `UserSpecifiedSystem`.
-    ///
-    /// Note that all the setters affecting `system` are
-    /// mutually exclusive.
-    pub fn set_user_specified_system<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.system = std::option::Option::Some(
-            crate::model::search_catalog_result::System::UserSpecifiedSystem(v.into()),
-        );
-        self
     }
 }
 
@@ -11316,21 +10626,6 @@ impl BigQueryTableSpec {
         })
     }
 
-    /// Sets the value of [type_spec][crate::model::BigQueryTableSpec::type_spec]
-    /// to hold a `ViewSpec`.
-    ///
-    /// Note that all the setters affecting `type_spec` are
-    /// mutually exclusive.
-    pub fn set_view_spec<T: std::convert::Into<std::boxed::Box<crate::model::ViewSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_spec = std::option::Option::Some(
-            crate::model::big_query_table_spec::TypeSpec::ViewSpec(v.into()),
-        );
-        self
-    }
-
     /// The value of [type_spec][crate::model::BigQueryTableSpec::type_spec]
     /// if it holds a `TableSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -11342,21 +10637,6 @@ impl BigQueryTableSpec {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_spec][crate::model::BigQueryTableSpec::type_spec]
-    /// to hold a `TableSpec`.
-    ///
-    /// Note that all the setters affecting `type_spec` are
-    /// mutually exclusive.
-    pub fn set_table_spec<T: std::convert::Into<std::boxed::Box<crate::model::TableSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_spec = std::option::Option::Some(
-            crate::model::big_query_table_spec::TypeSpec::TableSpec(v.into()),
-        );
-        self
     }
 }
 
@@ -11660,16 +10940,6 @@ impl Tag {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [scope][crate::model::Tag::scope]
-    /// to hold a `Column`.
-    ///
-    /// Note that all the setters affecting `scope` are
-    /// mutually exclusive.
-    pub fn set_column<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.scope = std::option::Option::Some(crate::model::tag::Scope::Column(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Tag {
@@ -11777,16 +11047,6 @@ impl TagField {
         })
     }
 
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::DoubleValue(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::TagField::kind]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -11796,16 +11056,6 @@ impl TagField {
             crate::model::tag_field::Kind::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::StringValue(v.into()));
-        self
     }
 
     /// The value of [kind][crate::model::TagField::kind]
@@ -11819,16 +11069,6 @@ impl TagField {
         })
     }
 
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::BoolValue(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::TagField::kind]
     /// if it holds a `TimestampValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -11838,20 +11078,6 @@ impl TagField {
             crate::model::tag_field::Kind::TimestampValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `TimestampValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_timestamp_value<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind =
-            std::option::Option::Some(crate::model::tag_field::Kind::TimestampValue(v.into()));
-        self
     }
 
     /// The value of [kind][crate::model::TagField::kind]
@@ -11867,21 +11093,6 @@ impl TagField {
         })
     }
 
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `EnumValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_enum_value<
-        T: std::convert::Into<std::boxed::Box<crate::model::tag_field::EnumValue>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::tag_field::Kind::EnumValue(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::TagField::kind]
     /// if it holds a `RichtextValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -11891,17 +11102,6 @@ impl TagField {
             crate::model::tag_field::Kind::RichtextValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::TagField::kind]
-    /// to hold a `RichtextValue`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_richtext_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.kind =
-            std::option::Option::Some(crate::model::tag_field::Kind::RichtextValue(v.into()));
-        self
     }
 }
 
@@ -12388,20 +11588,6 @@ impl FieldType {
         })
     }
 
-    /// Sets the value of [type_decl][crate::model::FieldType::type_decl]
-    /// to hold a `PrimitiveType`.
-    ///
-    /// Note that all the setters affecting `type_decl` are
-    /// mutually exclusive.
-    pub fn set_primitive_type<T: std::convert::Into<crate::model::field_type::PrimitiveType>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_decl =
-            std::option::Option::Some(crate::model::field_type::TypeDecl::PrimitiveType(v.into()));
-        self
-    }
-
     /// The value of [type_decl][crate::model::FieldType::type_decl]
     /// if it holds a `EnumType`, `None` if the field is not set or
     /// holds a different branch.
@@ -12413,22 +11599,6 @@ impl FieldType {
             crate::model::field_type::TypeDecl::EnumType(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_decl][crate::model::FieldType::type_decl]
-    /// to hold a `EnumType`.
-    ///
-    /// Note that all the setters affecting `type_decl` are
-    /// mutually exclusive.
-    pub fn set_enum_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::field_type::EnumType>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_decl =
-            std::option::Option::Some(crate::model::field_type::TypeDecl::EnumType(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/dataplex/v1/src/model.rs
+++ b/src/generated/cloud/dataplex/v1/src/model.rs
@@ -274,27 +274,6 @@ pub mod environment {
             })
         }
 
-        /// Sets the value of [resources][crate::model::environment::InfrastructureSpec::resources]
-        /// to hold a `Compute`.
-        ///
-        /// Note that all the setters affecting `resources` are
-        /// mutually exclusive.
-        pub fn set_compute<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::environment::infrastructure_spec::ComputeResources,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.resources = std::option::Option::Some(
-                crate::model::environment::infrastructure_spec::Resources::Compute(v.into()),
-            );
-            self
-        }
-
         /// Sets the value of [runtime][crate::model::environment::InfrastructureSpec::runtime].
         ///
         /// Note that all the setters affecting `runtime` are mutually
@@ -326,25 +305,6 @@ pub mod environment {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [runtime][crate::model::environment::InfrastructureSpec::runtime]
-        /// to hold a `OsImage`.
-        ///
-        /// Note that all the setters affecting `runtime` are
-        /// mutually exclusive.
-        pub fn set_os_image<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::environment::infrastructure_spec::OsImageRuntime>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.runtime = std::option::Option::Some(
-                crate::model::environment::infrastructure_spec::Runtime::OsImage(v.into()),
-            );
-            self
         }
     }
 
@@ -786,16 +746,6 @@ impl Content {
         })
     }
 
-    /// Sets the value of [data][crate::model::Content::data]
-    /// to hold a `DataText`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_data_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data = std::option::Option::Some(crate::model::content::Data::DataText(v.into()));
-        self
-    }
-
     /// Sets the value of [content][crate::model::Content::content].
     ///
     /// Note that all the setters affecting `content` are mutually
@@ -823,22 +773,6 @@ impl Content {
         })
     }
 
-    /// Sets the value of [content][crate::model::Content::content]
-    /// to hold a `SqlScript`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_sql_script<
-        T: std::convert::Into<std::boxed::Box<crate::model::content::SqlScript>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::content::Content::SqlScript(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Content::content]
     /// if it holds a `Notebook`, `None` if the field is not set or
     /// holds a different branch.
@@ -850,20 +784,6 @@ impl Content {
             crate::model::content::Content::Notebook(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Content::content]
-    /// to hold a `Notebook`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_notebook<T: std::convert::Into<std::boxed::Box<crate::model::content::Notebook>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::content::Content::Notebook(v.into()));
-        self
     }
 }
 
@@ -5286,22 +5206,6 @@ impl MetadataJob {
         })
     }
 
-    /// Sets the value of [spec][crate::model::MetadataJob::spec]
-    /// to hold a `ImportSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_import_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::metadata_job::ImportJobSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::metadata_job::Spec::ImportSpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::MetadataJob::spec]
     /// if it holds a `ExportSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -5313,22 +5217,6 @@ impl MetadataJob {
             crate::model::metadata_job::Spec::ExportSpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [spec][crate::model::MetadataJob::spec]
-    /// to hold a `ExportSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_export_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::metadata_job::ExportJobSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::metadata_job::Spec::ExportSpec(v.into()));
-        self
     }
 
     /// Sets the value of [result][crate::model::MetadataJob::result].
@@ -5358,22 +5246,6 @@ impl MetadataJob {
         })
     }
 
-    /// Sets the value of [result][crate::model::MetadataJob::result]
-    /// to hold a `ImportResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_import_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::metadata_job::ImportJobResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::metadata_job::Result::ImportResult(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::MetadataJob::result]
     /// if it holds a `ExportResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -5385,22 +5257,6 @@ impl MetadataJob {
             crate::model::metadata_job::Result::ExportResult(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::MetadataJob::result]
-    /// to hold a `ExportResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_export_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::metadata_job::ExportJobResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::metadata_job::Result::ExportResult(v.into()));
-        self
     }
 }
 
@@ -8050,23 +7906,6 @@ impl DataDiscoverySpec {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [resource_config][crate::model::DataDiscoverySpec::resource_config]
-    /// to hold a `StorageConfig`.
-    ///
-    /// Note that all the setters affecting `resource_config` are
-    /// mutually exclusive.
-    pub fn set_storage_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_discovery_spec::StorageConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource_config = std::option::Option::Some(
-            crate::model::data_discovery_spec::ResourceConfig::StorageConfig(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DataDiscoverySpec {
@@ -9323,20 +9162,6 @@ pub mod data_profile_result {
                     })
                 }
 
-                /// Sets the value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
-                /// to hold a `StringProfile`.
-                ///
-                /// Note that all the setters affecting `field_info` are
-                /// mutually exclusive.
-                pub fn set_string_profile<T: std::convert::Into<std::boxed::Box<crate::model::data_profile_result::profile::field::profile_info::StringFieldInfo>>>(mut self, v: T) -> Self{
-                    self.field_info = std::option::Option::Some(
-                        crate::model::data_profile_result::profile::field::profile_info::FieldInfo::StringProfile(
-                            v.into()
-                        )
-                    );
-                    self
-                }
-
                 /// The value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
                 /// if it holds a `IntegerProfile`, `None` if the field is not set or
                 /// holds a different branch.
@@ -9348,20 +9173,6 @@ pub mod data_profile_result {
                     })
                 }
 
-                /// Sets the value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
-                /// to hold a `IntegerProfile`.
-                ///
-                /// Note that all the setters affecting `field_info` are
-                /// mutually exclusive.
-                pub fn set_integer_profile<T: std::convert::Into<std::boxed::Box<crate::model::data_profile_result::profile::field::profile_info::IntegerFieldInfo>>>(mut self, v: T) -> Self{
-                    self.field_info = std::option::Option::Some(
-                        crate::model::data_profile_result::profile::field::profile_info::FieldInfo::IntegerProfile(
-                            v.into()
-                        )
-                    );
-                    self
-                }
-
                 /// The value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
                 /// if it holds a `DoubleProfile`, `None` if the field is not set or
                 /// holds a different branch.
@@ -9371,20 +9182,6 @@ pub mod data_profile_result {
                         crate::model::data_profile_result::profile::field::profile_info::FieldInfo::DoubleProfile(v) => std::option::Option::Some(v),
                         _ => std::option::Option::None,
                     })
-                }
-
-                /// Sets the value of [field_info][crate::model::data_profile_result::profile::field::ProfileInfo::field_info]
-                /// to hold a `DoubleProfile`.
-                ///
-                /// Note that all the setters affecting `field_info` are
-                /// mutually exclusive.
-                pub fn set_double_profile<T: std::convert::Into<std::boxed::Box<crate::model::data_profile_result::profile::field::profile_info::DoubleFieldInfo>>>(mut self, v: T) -> Self{
-                    self.field_info = std::option::Option::Some(
-                        crate::model::data_profile_result::profile::field::profile_info::FieldInfo::DoubleProfile(
-                            v.into()
-                        )
-                    );
-                    self
                 }
             }
 
@@ -11138,23 +10935,6 @@ impl DataQualityRule {
         })
     }
 
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `RangeExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_range_expectation<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_quality_rule::RangeExpectation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::RangeExpectation(v.into()),
-        );
-        self
-    }
-
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// if it holds a `NonNullExpectation`, `None` if the field is not set or
     /// holds a different branch.
@@ -11169,23 +10949,6 @@ impl DataQualityRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `NonNullExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_non_null_expectation<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_quality_rule::NonNullExpectation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::NonNullExpectation(v.into()),
-        );
-        self
     }
 
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
@@ -11204,23 +10967,6 @@ impl DataQualityRule {
         })
     }
 
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `SetExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_set_expectation<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_quality_rule::SetExpectation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::SetExpectation(v.into()),
-        );
-        self
-    }
-
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// if it holds a `RegexExpectation`, `None` if the field is not set or
     /// holds a different branch.
@@ -11237,23 +10983,6 @@ impl DataQualityRule {
         })
     }
 
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `RegexExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_regex_expectation<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_quality_rule::RegexExpectation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::RegexExpectation(v.into()),
-        );
-        self
-    }
-
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// if it holds a `UniquenessExpectation`, `None` if the field is not set or
     /// holds a different branch.
@@ -11268,23 +10997,6 @@ impl DataQualityRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `UniquenessExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_uniqueness_expectation<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_quality_rule::UniquenessExpectation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::UniquenessExpectation(v.into()),
-        );
-        self
     }
 
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
@@ -11304,25 +11016,6 @@ impl DataQualityRule {
         })
     }
 
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `StatisticRangeExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_statistic_range_expectation<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::data_quality_rule::StatisticRangeExpectation>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::StatisticRangeExpectation(v.into()),
-        );
-        self
-    }
-
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// if it holds a `RowConditionExpectation`, `None` if the field is not set or
     /// holds a different branch.
@@ -11338,25 +11031,6 @@ impl DataQualityRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `RowConditionExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_row_condition_expectation<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::data_quality_rule::RowConditionExpectation>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::RowConditionExpectation(v.into()),
-        );
-        self
     }
 
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
@@ -11376,25 +11050,6 @@ impl DataQualityRule {
         })
     }
 
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `TableConditionExpectation`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_table_condition_expectation<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::data_quality_rule::TableConditionExpectation>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::TableConditionExpectation(v.into()),
-        );
-        self
-    }
-
     /// The value of [rule_type][crate::model::DataQualityRule::rule_type]
     /// if it holds a `SqlAssertion`, `None` if the field is not set or
     /// holds a different branch.
@@ -11408,23 +11063,6 @@ impl DataQualityRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule_type][crate::model::DataQualityRule::rule_type]
-    /// to hold a `SqlAssertion`.
-    ///
-    /// Note that all the setters affecting `rule_type` are
-    /// mutually exclusive.
-    pub fn set_sql_assertion<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_quality_rule::SqlAssertion>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type = std::option::Option::Some(
-            crate::model::data_quality_rule::RuleType::SqlAssertion(v.into()),
-        );
-        self
     }
 }
 
@@ -12593,18 +12231,6 @@ impl DataAttributeBinding {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource_reference][crate::model::DataAttributeBinding::resource_reference]
-    /// to hold a `Resource`.
-    ///
-    /// Note that all the setters affecting `resource_reference` are
-    /// mutually exclusive.
-    pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.resource_reference = std::option::Option::Some(
-            crate::model::data_attribute_binding::ResourceReference::Resource(v.into()),
-        );
-        self
     }
 }
 
@@ -15039,22 +14665,6 @@ impl DataScan {
         })
     }
 
-    /// Sets the value of [spec][crate::model::DataScan::spec]
-    /// to hold a `DataQualitySpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_data_quality_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataQualitySpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::data_scan::Spec::DataQualitySpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::DataScan::spec]
     /// if it holds a `DataProfileSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -15068,22 +14678,6 @@ impl DataScan {
         })
     }
 
-    /// Sets the value of [spec][crate::model::DataScan::spec]
-    /// to hold a `DataProfileSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_data_profile_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataProfileSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::data_scan::Spec::DataProfileSpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::DataScan::spec]
     /// if it holds a `DataDiscoverySpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -15095,22 +14689,6 @@ impl DataScan {
             crate::model::data_scan::Spec::DataDiscoverySpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [spec][crate::model::DataScan::spec]
-    /// to hold a `DataDiscoverySpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_data_discovery_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataDiscoverySpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::data_scan::Spec::DataDiscoverySpec(v.into()));
-        self
     }
 
     /// Sets the value of [result][crate::model::DataScan::result].
@@ -15140,22 +14718,6 @@ impl DataScan {
         })
     }
 
-    /// Sets the value of [result][crate::model::DataScan::result]
-    /// to hold a `DataQualityResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_quality_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataQualityResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::data_scan::Result::DataQualityResult(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::DataScan::result]
     /// if it holds a `DataProfileResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -15169,22 +14731,6 @@ impl DataScan {
         })
     }
 
-    /// Sets the value of [result][crate::model::DataScan::result]
-    /// to hold a `DataProfileResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_profile_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataProfileResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::data_scan::Result::DataProfileResult(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::DataScan::result]
     /// if it holds a `DataDiscoveryResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -15196,23 +14742,6 @@ impl DataScan {
             crate::model::data_scan::Result::DataDiscoveryResult(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::DataScan::result]
-    /// to hold a `DataDiscoveryResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_discovery_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataDiscoveryResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::data_scan::Result::DataDiscoveryResult(v.into()),
-        );
-        self
     }
 }
 
@@ -15293,18 +14822,6 @@ pub mod data_scan {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [incremental][crate::model::data_scan::ExecutionSpec::incremental]
-        /// to hold a `Field`.
-        ///
-        /// Note that all the setters affecting `incremental` are
-        /// mutually exclusive.
-        pub fn set_field<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.incremental = std::option::Option::Some(
-                crate::model::data_scan::execution_spec::Incremental::Field(v.into()),
-            );
-            self
         }
     }
 
@@ -15581,22 +15098,6 @@ impl DataScanJob {
         })
     }
 
-    /// Sets the value of [spec][crate::model::DataScanJob::spec]
-    /// to hold a `DataQualitySpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_data_quality_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataQualitySpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::data_scan_job::Spec::DataQualitySpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::DataScanJob::spec]
     /// if it holds a `DataProfileSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -15610,22 +15111,6 @@ impl DataScanJob {
         })
     }
 
-    /// Sets the value of [spec][crate::model::DataScanJob::spec]
-    /// to hold a `DataProfileSpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_data_profile_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataProfileSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec =
-            std::option::Option::Some(crate::model::data_scan_job::Spec::DataProfileSpec(v.into()));
-        self
-    }
-
     /// The value of [spec][crate::model::DataScanJob::spec]
     /// if it holds a `DataDiscoverySpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -15637,23 +15122,6 @@ impl DataScanJob {
             crate::model::data_scan_job::Spec::DataDiscoverySpec(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [spec][crate::model::DataScanJob::spec]
-    /// to hold a `DataDiscoverySpec`.
-    ///
-    /// Note that all the setters affecting `spec` are
-    /// mutually exclusive.
-    pub fn set_data_discovery_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataDiscoverySpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.spec = std::option::Option::Some(
-            crate::model::data_scan_job::Spec::DataDiscoverySpec(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [result][crate::model::DataScanJob::result].
@@ -15685,23 +15153,6 @@ impl DataScanJob {
         })
     }
 
-    /// Sets the value of [result][crate::model::DataScanJob::result]
-    /// to hold a `DataQualityResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_quality_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataQualityResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::data_scan_job::Result::DataQualityResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::DataScanJob::result]
     /// if it holds a `DataProfileResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -15717,23 +15168,6 @@ impl DataScanJob {
         })
     }
 
-    /// Sets the value of [result][crate::model::DataScanJob::result]
-    /// to hold a `DataProfileResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_profile_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataProfileResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::data_scan_job::Result::DataProfileResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::DataScanJob::result]
     /// if it holds a `DataDiscoveryResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -15747,23 +15181,6 @@ impl DataScanJob {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::DataScanJob::result]
-    /// to hold a `DataDiscoveryResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_discovery_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataDiscoveryResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::data_scan_job::Result::DataDiscoveryResult(v.into()),
-        );
-        self
     }
 }
 
@@ -16086,22 +15503,6 @@ impl DiscoveryEvent {
         })
     }
 
-    /// Sets the value of [details][crate::model::DiscoveryEvent::details]
-    /// to hold a `Config`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::discovery_event::ConfigDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::discovery_event::Details::Config(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::DiscoveryEvent::details]
     /// if it holds a `Entity`, `None` if the field is not set or
     /// holds a different branch.
@@ -16113,22 +15514,6 @@ impl DiscoveryEvent {
             crate::model::discovery_event::Details::Entity(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::DiscoveryEvent::details]
-    /// to hold a `Entity`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_entity<
-        T: std::convert::Into<std::boxed::Box<crate::model::discovery_event::EntityDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::discovery_event::Details::Entity(v.into()));
-        self
     }
 
     /// The value of [details][crate::model::DiscoveryEvent::details]
@@ -16145,22 +15530,6 @@ impl DiscoveryEvent {
         })
     }
 
-    /// Sets the value of [details][crate::model::DiscoveryEvent::details]
-    /// to hold a `Partition`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_partition<
-        T: std::convert::Into<std::boxed::Box<crate::model::discovery_event::PartitionDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::discovery_event::Details::Partition(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::DiscoveryEvent::details]
     /// if it holds a `Action`, `None` if the field is not set or
     /// holds a different branch.
@@ -16174,22 +15543,6 @@ impl DiscoveryEvent {
         })
     }
 
-    /// Sets the value of [details][crate::model::DiscoveryEvent::details]
-    /// to hold a `Action`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::discovery_event::ActionDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::discovery_event::Details::Action(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::DiscoveryEvent::details]
     /// if it holds a `Table`, `None` if the field is not set or
     /// holds a different branch.
@@ -16201,22 +15554,6 @@ impl DiscoveryEvent {
             crate::model::discovery_event::Details::Table(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::DiscoveryEvent::details]
-    /// to hold a `Table`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_table<
-        T: std::convert::Into<std::boxed::Box<crate::model::discovery_event::TableDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::discovery_event::Details::Table(v.into()));
-        self
     }
 }
 
@@ -17768,22 +17105,6 @@ impl SessionEvent {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [detail][crate::model::SessionEvent::detail]
-    /// to hold a `Query`.
-    ///
-    /// Note that all the setters affecting `detail` are
-    /// mutually exclusive.
-    pub fn set_query<
-        T: std::convert::Into<std::boxed::Box<crate::model::session_event::QueryDetail>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.detail =
-            std::option::Option::Some(crate::model::session_event::Detail::Query(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for SessionEvent {
@@ -18892,22 +18213,6 @@ impl DataScanEvent {
         })
     }
 
-    /// Sets the value of [result][crate::model::DataScanEvent::result]
-    /// to hold a `DataProfile`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_scan_event::DataProfileResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::data_scan_event::Result::DataProfile(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::DataScanEvent::result]
     /// if it holds a `DataQuality`, `None` if the field is not set or
     /// holds a different branch.
@@ -18920,22 +18225,6 @@ impl DataScanEvent {
             crate::model::data_scan_event::Result::DataQuality(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::DataScanEvent::result]
-    /// to hold a `DataQuality`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_data_quality<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_scan_event::DataQualityResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::data_scan_event::Result::DataQuality(v.into()));
-        self
     }
 
     /// Sets the value of [applied_configs][crate::model::DataScanEvent::applied_configs].
@@ -18969,25 +18258,6 @@ impl DataScanEvent {
         })
     }
 
-    /// Sets the value of [applied_configs][crate::model::DataScanEvent::applied_configs]
-    /// to hold a `DataProfileConfigs`.
-    ///
-    /// Note that all the setters affecting `applied_configs` are
-    /// mutually exclusive.
-    pub fn set_data_profile_configs<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::data_scan_event::DataProfileAppliedConfigs>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.applied_configs = std::option::Option::Some(
-            crate::model::data_scan_event::AppliedConfigs::DataProfileConfigs(v.into()),
-        );
-        self
-    }
-
     /// The value of [applied_configs][crate::model::DataScanEvent::applied_configs]
     /// if it holds a `DataQualityConfigs`, `None` if the field is not set or
     /// holds a different branch.
@@ -19003,25 +18273,6 @@ impl DataScanEvent {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [applied_configs][crate::model::DataScanEvent::applied_configs]
-    /// to hold a `DataQualityConfigs`.
-    ///
-    /// Note that all the setters affecting `applied_configs` are
-    /// mutually exclusive.
-    pub fn set_data_quality_configs<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::data_scan_event::DataQualityAppliedConfigs>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.applied_configs = std::option::Option::Some(
-            crate::model::data_scan_event::AppliedConfigs::DataQualityConfigs(v.into()),
-        );
-        self
     }
 }
 
@@ -23502,22 +22753,6 @@ impl StorageFormat {
         })
     }
 
-    /// Sets the value of [options][crate::model::StorageFormat::options]
-    /// to hold a `Csv`.
-    ///
-    /// Note that all the setters affecting `options` are
-    /// mutually exclusive.
-    pub fn set_csv<
-        T: std::convert::Into<std::boxed::Box<crate::model::storage_format::CsvOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options =
-            std::option::Option::Some(crate::model::storage_format::Options::Csv(v.into()));
-        self
-    }
-
     /// The value of [options][crate::model::StorageFormat::options]
     /// if it holds a `Json`, `None` if the field is not set or
     /// holds a different branch.
@@ -23531,22 +22766,6 @@ impl StorageFormat {
         })
     }
 
-    /// Sets the value of [options][crate::model::StorageFormat::options]
-    /// to hold a `Json`.
-    ///
-    /// Note that all the setters affecting `options` are
-    /// mutually exclusive.
-    pub fn set_json<
-        T: std::convert::Into<std::boxed::Box<crate::model::storage_format::JsonOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options =
-            std::option::Option::Some(crate::model::storage_format::Options::Json(v.into()));
-        self
-    }
-
     /// The value of [options][crate::model::StorageFormat::options]
     /// if it holds a `Iceberg`, `None` if the field is not set or
     /// holds a different branch.
@@ -23558,22 +22777,6 @@ impl StorageFormat {
             crate::model::storage_format::Options::Iceberg(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [options][crate::model::StorageFormat::options]
-    /// to hold a `Iceberg`.
-    ///
-    /// Note that all the setters affecting `options` are
-    /// mutually exclusive.
-    pub fn set_iceberg<
-        T: std::convert::Into<std::boxed::Box<crate::model::storage_format::IcebergOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options =
-            std::option::Option::Some(crate::model::storage_format::Options::Iceberg(v.into()));
-        self
     }
 }
 
@@ -24291,21 +23494,6 @@ impl Trigger {
         })
     }
 
-    /// Sets the value of [mode][crate::model::Trigger::mode]
-    /// to hold a `OnDemand`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_on_demand<
-        T: std::convert::Into<std::boxed::Box<crate::model::trigger::OnDemand>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode = std::option::Option::Some(crate::model::trigger::Mode::OnDemand(v.into()));
-        self
-    }
-
     /// The value of [mode][crate::model::Trigger::mode]
     /// if it holds a `Schedule`, `None` if the field is not set or
     /// holds a different branch.
@@ -24317,19 +23505,6 @@ impl Trigger {
             crate::model::trigger::Mode::Schedule(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [mode][crate::model::Trigger::mode]
-    /// to hold a `Schedule`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_schedule<T: std::convert::Into<std::boxed::Box<crate::model::trigger::Schedule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode = std::option::Option::Some(crate::model::trigger::Mode::Schedule(v.into()));
-        self
     }
 }
 
@@ -24469,17 +23644,6 @@ impl DataSource {
         })
     }
 
-    /// Sets the value of [source][crate::model::DataSource::source]
-    /// to hold a `Entity`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_entity<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::data_source::Source::Entity(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::DataSource::source]
     /// if it holds a `Resource`, `None` if the field is not set or
     /// holds a different branch.
@@ -24489,17 +23653,6 @@ impl DataSource {
             crate::model::data_source::Source::Resource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::DataSource::source]
-    /// to hold a `Resource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::data_source::Source::Resource(v.into()));
-        self
     }
 }
 
@@ -24579,23 +23732,6 @@ impl ScannedData {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_range][crate::model::ScannedData::data_range]
-    /// to hold a `IncrementalField`.
-    ///
-    /// Note that all the setters affecting `data_range` are
-    /// mutually exclusive.
-    pub fn set_incremental_field<
-        T: std::convert::Into<std::boxed::Box<crate::model::scanned_data::IncrementalField>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_range = std::option::Option::Some(
-            crate::model::scanned_data::DataRange::IncrementalField(v.into()),
-        );
-        self
     }
 }
 
@@ -25655,18 +24791,6 @@ pub mod zone {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [trigger][crate::model::zone::DiscoverySpec::trigger]
-        /// to hold a `Schedule`.
-        ///
-        /// Note that all the setters affecting `trigger` are
-        /// mutually exclusive.
-        pub fn set_schedule<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.trigger = std::option::Option::Some(
-                crate::model::zone::discovery_spec::Trigger::Schedule(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for DiscoverySpec {
@@ -26101,22 +25225,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `InvalidDataFormat`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_invalid_data_format<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::InvalidDataFormat>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::action::Details::InvalidDataFormat(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Action::details]
     /// if it holds a `IncompatibleDataSchema`, `None` if the field is not set or
     /// holds a different branch.
@@ -26132,23 +25240,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `IncompatibleDataSchema`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_incompatible_data_schema<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::IncompatibleDataSchema>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::action::Details::IncompatibleDataSchema(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::Action::details]
     /// if it holds a `InvalidDataPartition`, `None` if the field is not set or
     /// holds a different branch.
@@ -26160,23 +25251,6 @@ impl Action {
             crate::model::action::Details::InvalidDataPartition(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `InvalidDataPartition`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_invalid_data_partition<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::InvalidDataPartition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::action::Details::InvalidDataPartition(v.into()),
-        );
-        self
     }
 
     /// The value of [details][crate::model::Action::details]
@@ -26192,22 +25266,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `MissingData`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_missing_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::MissingData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::action::Details::MissingData(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Action::details]
     /// if it holds a `MissingResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -26221,22 +25279,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `MissingResource`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_missing_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::MissingResource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::action::Details::MissingResource(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Action::details]
     /// if it holds a `UnauthorizedResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -26248,23 +25290,6 @@ impl Action {
             crate::model::action::Details::UnauthorizedResource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `UnauthorizedResource`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_unauthorized_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::UnauthorizedResource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::action::Details::UnauthorizedResource(v.into()),
-        );
-        self
     }
 
     /// The value of [details][crate::model::Action::details]
@@ -26283,23 +25308,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `FailedSecurityPolicyApply`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_failed_security_policy_apply<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::FailedSecurityPolicyApply>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::action::Details::FailedSecurityPolicyApply(v.into()),
-        );
-        self
-    }
-
     /// The value of [details][crate::model::Action::details]
     /// if it holds a `InvalidDataOrganization`, `None` if the field is not set or
     /// holds a different branch.
@@ -26313,23 +25321,6 @@ impl Action {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Action::details]
-    /// to hold a `InvalidDataOrganization`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_invalid_data_organization<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::InvalidDataOrganization>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::action::Details::InvalidDataOrganization(v.into()),
-        );
-        self
     }
 }
 
@@ -27640,18 +26631,6 @@ pub mod asset {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [trigger][crate::model::asset::DiscoverySpec::trigger]
-        /// to hold a `Schedule`.
-        ///
-        /// Note that all the setters affecting `trigger` are
-        /// mutually exclusive.
-        pub fn set_schedule<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.trigger = std::option::Option::Some(
-                crate::model::asset::discovery_spec::Trigger::Schedule(v.into()),
-            );
-            self
         }
     }
 
@@ -31478,21 +30457,6 @@ impl Task {
         })
     }
 
-    /// Sets the value of [config][crate::model::Task::config]
-    /// to hold a `Spark`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_spark<
-        T: std::convert::Into<std::boxed::Box<crate::model::task::SparkTaskConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(crate::model::task::Config::Spark(v.into()));
-        self
-    }
-
     /// The value of [config][crate::model::Task::config]
     /// if it holds a `Notebook`, `None` if the field is not set or
     /// holds a different branch.
@@ -31504,21 +30468,6 @@ impl Task {
             crate::model::task::Config::Notebook(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [config][crate::model::Task::config]
-    /// to hold a `Notebook`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_notebook<
-        T: std::convert::Into<std::boxed::Box<crate::model::task::NotebookTaskConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(crate::model::task::Config::Notebook(v.into()));
-        self
     }
 }
 
@@ -31593,25 +30542,6 @@ pub mod task {
             })
         }
 
-        /// Sets the value of [resources][crate::model::task::InfrastructureSpec::resources]
-        /// to hold a `Batch`.
-        ///
-        /// Note that all the setters affecting `resources` are
-        /// mutually exclusive.
-        pub fn set_batch<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::task::infrastructure_spec::BatchComputeResources>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.resources = std::option::Option::Some(
-                crate::model::task::infrastructure_spec::Resources::Batch(v.into()),
-            );
-            self
-        }
-
         /// Sets the value of [runtime][crate::model::task::InfrastructureSpec::runtime].
         ///
         /// Note that all the setters affecting `runtime` are mutually
@@ -31645,25 +30575,6 @@ pub mod task {
             })
         }
 
-        /// Sets the value of [runtime][crate::model::task::InfrastructureSpec::runtime]
-        /// to hold a `ContainerImage`.
-        ///
-        /// Note that all the setters affecting `runtime` are
-        /// mutually exclusive.
-        pub fn set_container_image<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::task::infrastructure_spec::ContainerImageRuntime>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.runtime = std::option::Option::Some(
-                crate::model::task::infrastructure_spec::Runtime::ContainerImage(v.into()),
-            );
-            self
-        }
-
         /// Sets the value of [network][crate::model::task::InfrastructureSpec::network].
         ///
         /// Note that all the setters affecting `network` are mutually
@@ -31695,25 +30606,6 @@ pub mod task {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [network][crate::model::task::InfrastructureSpec::network]
-        /// to hold a `VpcNetwork`.
-        ///
-        /// Note that all the setters affecting `network` are
-        /// mutually exclusive.
-        pub fn set_vpc_network<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::task::infrastructure_spec::VpcNetwork>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.network = std::option::Option::Some(
-                crate::model::task::infrastructure_spec::Network::VpcNetwork(v.into()),
-            );
-            self
         }
     }
 
@@ -31926,20 +30818,6 @@ pub mod task {
                 })
             }
 
-            /// Sets the value of [network_name][crate::model::task::infrastructure_spec::VpcNetwork::network_name]
-            /// to hold a `Network`.
-            ///
-            /// Note that all the setters affecting `network_name` are
-            /// mutually exclusive.
-            pub fn set_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.network_name = std::option::Option::Some(
-                    crate::model::task::infrastructure_spec::vpc_network::NetworkName::Network(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [network_name][crate::model::task::infrastructure_spec::VpcNetwork::network_name]
             /// if it holds a `SubNetwork`, `None` if the field is not set or
             /// holds a different branch.
@@ -31949,23 +30827,6 @@ pub mod task {
                     crate::model::task::infrastructure_spec::vpc_network::NetworkName::SubNetwork(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [network_name][crate::model::task::infrastructure_spec::VpcNetwork::network_name]
-            /// to hold a `SubNetwork`.
-            ///
-            /// Note that all the setters affecting `network_name` are
-            /// mutually exclusive.
-            pub fn set_sub_network<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.network_name = std::option::Option::Some(
-                    crate::model::task::infrastructure_spec::vpc_network::NetworkName::SubNetwork(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -32122,18 +30983,6 @@ pub mod task {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [trigger][crate::model::task::TriggerSpec::trigger]
-        /// to hold a `Schedule`.
-        ///
-        /// Note that all the setters affecting `trigger` are
-        /// mutually exclusive.
-        pub fn set_schedule<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.trigger = std::option::Option::Some(
-                crate::model::task::trigger_spec::Trigger::Schedule(v.into()),
-            );
-            self
         }
     }
 
@@ -32502,21 +31351,6 @@ pub mod task {
             })
         }
 
-        /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// to hold a `MainJarFileUri`.
-        ///
-        /// Note that all the setters affecting `driver` are
-        /// mutually exclusive.
-        pub fn set_main_jar_file_uri<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.driver = std::option::Option::Some(
-                crate::model::task::spark_task_config::Driver::MainJarFileUri(v.into()),
-            );
-            self
-        }
-
         /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
         /// if it holds a `MainClass`, `None` if the field is not set or
         /// holds a different branch.
@@ -32528,18 +31362,6 @@ pub mod task {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// to hold a `MainClass`.
-        ///
-        /// Note that all the setters affecting `driver` are
-        /// mutually exclusive.
-        pub fn set_main_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.driver = std::option::Option::Some(
-                crate::model::task::spark_task_config::Driver::MainClass(v.into()),
-            );
-            self
         }
 
         /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
@@ -32555,21 +31377,6 @@ pub mod task {
             })
         }
 
-        /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// to hold a `PythonScriptFile`.
-        ///
-        /// Note that all the setters affecting `driver` are
-        /// mutually exclusive.
-        pub fn set_python_script_file<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.driver = std::option::Option::Some(
-                crate::model::task::spark_task_config::Driver::PythonScriptFile(v.into()),
-            );
-            self
-        }
-
         /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
         /// if it holds a `SqlScriptFile`, `None` if the field is not set or
         /// holds a different branch.
@@ -32583,21 +31390,6 @@ pub mod task {
             })
         }
 
-        /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// to hold a `SqlScriptFile`.
-        ///
-        /// Note that all the setters affecting `driver` are
-        /// mutually exclusive.
-        pub fn set_sql_script_file<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.driver = std::option::Option::Some(
-                crate::model::task::spark_task_config::Driver::SqlScriptFile(v.into()),
-            );
-            self
-        }
-
         /// The value of [driver][crate::model::task::SparkTaskConfig::driver]
         /// if it holds a `SqlScript`, `None` if the field is not set or
         /// holds a different branch.
@@ -32609,18 +31401,6 @@ pub mod task {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [driver][crate::model::task::SparkTaskConfig::driver]
-        /// to hold a `SqlScript`.
-        ///
-        /// Note that all the setters affecting `driver` are
-        /// mutually exclusive.
-        pub fn set_sql_script<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.driver = std::option::Option::Some(
-                crate::model::task::spark_task_config::Driver::SqlScript(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/dataproc/v1/src/model.rs
+++ b/src/generated/cloud/dataproc/v1/src/model.rs
@@ -168,23 +168,6 @@ impl AutoscalingPolicy {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [algorithm][crate::model::AutoscalingPolicy::algorithm]
-    /// to hold a `BasicAlgorithm`.
-    ///
-    /// Note that all the setters affecting `algorithm` are
-    /// mutually exclusive.
-    pub fn set_basic_algorithm<
-        T: std::convert::Into<std::boxed::Box<crate::model::BasicAutoscalingAlgorithm>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.algorithm = std::option::Option::Some(
-            crate::model::autoscaling_policy::Algorithm::BasicAlgorithm(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for AutoscalingPolicy {
@@ -269,23 +252,6 @@ impl BasicAutoscalingAlgorithm {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [config][crate::model::BasicAutoscalingAlgorithm::config]
-    /// to hold a `YarnConfig`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_yarn_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::BasicYarnAutoscalingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(
-            crate::model::basic_autoscaling_algorithm::Config::YarnConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -1342,20 +1308,6 @@ impl Batch {
         })
     }
 
-    /// Sets the value of [batch_config][crate::model::Batch::batch_config]
-    /// to hold a `PysparkBatch`.
-    ///
-    /// Note that all the setters affecting `batch_config` are
-    /// mutually exclusive.
-    pub fn set_pyspark_batch<T: std::convert::Into<std::boxed::Box<crate::model::PySparkBatch>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.batch_config =
-            std::option::Option::Some(crate::model::batch::BatchConfig::PysparkBatch(v.into()));
-        self
-    }
-
     /// The value of [batch_config][crate::model::Batch::batch_config]
     /// if it holds a `SparkBatch`, `None` if the field is not set or
     /// holds a different branch.
@@ -1365,20 +1317,6 @@ impl Batch {
             crate::model::batch::BatchConfig::SparkBatch(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [batch_config][crate::model::Batch::batch_config]
-    /// to hold a `SparkBatch`.
-    ///
-    /// Note that all the setters affecting `batch_config` are
-    /// mutually exclusive.
-    pub fn set_spark_batch<T: std::convert::Into<std::boxed::Box<crate::model::SparkBatch>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.batch_config =
-            std::option::Option::Some(crate::model::batch::BatchConfig::SparkBatch(v.into()));
-        self
     }
 
     /// The value of [batch_config][crate::model::Batch::batch_config]
@@ -1394,20 +1332,6 @@ impl Batch {
         })
     }
 
-    /// Sets the value of [batch_config][crate::model::Batch::batch_config]
-    /// to hold a `SparkRBatch`.
-    ///
-    /// Note that all the setters affecting `batch_config` are
-    /// mutually exclusive.
-    pub fn set_spark_r_batch<T: std::convert::Into<std::boxed::Box<crate::model::SparkRBatch>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.batch_config =
-            std::option::Option::Some(crate::model::batch::BatchConfig::SparkRBatch(v.into()));
-        self
-    }
-
     /// The value of [batch_config][crate::model::Batch::batch_config]
     /// if it holds a `SparkSqlBatch`, `None` if the field is not set or
     /// holds a different branch.
@@ -1419,22 +1343,6 @@ impl Batch {
             crate::model::batch::BatchConfig::SparkSqlBatch(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [batch_config][crate::model::Batch::batch_config]
-    /// to hold a `SparkSqlBatch`.
-    ///
-    /// Note that all the setters affecting `batch_config` are
-    /// mutually exclusive.
-    pub fn set_spark_sql_batch<
-        T: std::convert::Into<std::boxed::Box<crate::model::SparkSqlBatch>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.batch_config =
-            std::option::Option::Some(crate::model::batch::BatchConfig::SparkSqlBatch(v.into()));
-        self
     }
 }
 
@@ -1922,20 +1830,6 @@ impl SparkBatch {
         })
     }
 
-    /// Sets the value of [driver][crate::model::SparkBatch::driver]
-    /// to hold a `MainJarFileUri`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_jar_file_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::spark_batch::Driver::MainJarFileUri(v.into()));
-        self
-    }
-
     /// The value of [driver][crate::model::SparkBatch::driver]
     /// if it holds a `MainClass`, `None` if the field is not set or
     /// holds a different branch.
@@ -1945,17 +1839,6 @@ impl SparkBatch {
             crate::model::spark_batch::Driver::MainClass(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [driver][crate::model::SparkBatch::driver]
-    /// to hold a `MainClass`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::spark_batch::Driver::MainClass(v.into()));
-        self
     }
 }
 
@@ -2682,25 +2565,6 @@ impl VirtualClusterConfig {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [infrastructure_config][crate::model::VirtualClusterConfig::infrastructure_config]
-    /// to hold a `KubernetesClusterConfig`.
-    ///
-    /// Note that all the setters affecting `infrastructure_config` are
-    /// mutually exclusive.
-    pub fn set_kubernetes_cluster_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::KubernetesClusterConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.infrastructure_config = std::option::Option::Some(
-            crate::model::virtual_cluster_config::InfrastructureConfig::KubernetesClusterConfig(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -5738,21 +5602,6 @@ impl LifecycleConfig {
         })
     }
 
-    /// Sets the value of [ttl][crate::model::LifecycleConfig::ttl]
-    /// to hold a `AutoDeleteTime`.
-    ///
-    /// Note that all the setters affecting `ttl` are
-    /// mutually exclusive.
-    pub fn set_auto_delete_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ttl = std::option::Option::Some(crate::model::lifecycle_config::Ttl::AutoDeleteTime(
-            v.into(),
-        ));
-        self
-    }
-
     /// The value of [ttl][crate::model::LifecycleConfig::ttl]
     /// if it holds a `AutoDeleteTtl`, `None` if the field is not set or
     /// holds a different branch.
@@ -5762,20 +5611,6 @@ impl LifecycleConfig {
             crate::model::lifecycle_config::Ttl::AutoDeleteTtl(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [ttl][crate::model::LifecycleConfig::ttl]
-    /// to hold a `AutoDeleteTtl`.
-    ///
-    /// Note that all the setters affecting `ttl` are
-    /// mutually exclusive.
-    pub fn set_auto_delete_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ttl =
-            std::option::Option::Some(crate::model::lifecycle_config::Ttl::AutoDeleteTtl(v.into()));
-        self
     }
 }
 
@@ -7820,20 +7655,6 @@ impl HadoopJob {
         })
     }
 
-    /// Sets the value of [driver][crate::model::HadoopJob::driver]
-    /// to hold a `MainJarFileUri`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_jar_file_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::hadoop_job::Driver::MainJarFileUri(v.into()));
-        self
-    }
-
     /// The value of [driver][crate::model::HadoopJob::driver]
     /// if it holds a `MainClass`, `None` if the field is not set or
     /// holds a different branch.
@@ -7843,17 +7664,6 @@ impl HadoopJob {
             crate::model::hadoop_job::Driver::MainClass(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [driver][crate::model::HadoopJob::driver]
-    /// to hold a `MainClass`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::hadoop_job::Driver::MainClass(v.into()));
-        self
     }
 }
 
@@ -8042,20 +7852,6 @@ impl SparkJob {
         })
     }
 
-    /// Sets the value of [driver][crate::model::SparkJob::driver]
-    /// to hold a `MainJarFileUri`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_jar_file_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::spark_job::Driver::MainJarFileUri(v.into()));
-        self
-    }
-
     /// The value of [driver][crate::model::SparkJob::driver]
     /// if it holds a `MainClass`, `None` if the field is not set or
     /// holds a different branch.
@@ -8065,17 +7861,6 @@ impl SparkJob {
             crate::model::spark_job::Driver::MainClass(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [driver][crate::model::SparkJob::driver]
-    /// to hold a `MainClass`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::spark_job::Driver::MainClass(v.into()));
-        self
     }
 }
 
@@ -8431,17 +8216,6 @@ impl HiveJob {
         })
     }
 
-    /// Sets the value of [queries][crate::model::HiveJob::queries]
-    /// to hold a `QueryFileUri`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_file_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::hive_job::Queries::QueryFileUri(v.into()));
-        self
-    }
-
     /// The value of [queries][crate::model::HiveJob::queries]
     /// if it holds a `QueryList`, `None` if the field is not set or
     /// holds a different branch.
@@ -8451,20 +8225,6 @@ impl HiveJob {
             crate::model::hive_job::Queries::QueryList(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [queries][crate::model::HiveJob::queries]
-    /// to hold a `QueryList`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_list<T: std::convert::Into<std::boxed::Box<crate::model::QueryList>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::hive_job::Queries::QueryList(v.into()));
-        self
     }
 }
 
@@ -8604,17 +8364,6 @@ impl SparkSqlJob {
         })
     }
 
-    /// Sets the value of [queries][crate::model::SparkSqlJob::queries]
-    /// to hold a `QueryFileUri`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_file_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::spark_sql_job::Queries::QueryFileUri(v.into()));
-        self
-    }
-
     /// The value of [queries][crate::model::SparkSqlJob::queries]
     /// if it holds a `QueryList`, `None` if the field is not set or
     /// holds a different branch.
@@ -8624,20 +8373,6 @@ impl SparkSqlJob {
             crate::model::spark_sql_job::Queries::QueryList(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [queries][crate::model::SparkSqlJob::queries]
-    /// to hold a `QueryList`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_list<T: std::convert::Into<std::boxed::Box<crate::model::QueryList>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::spark_sql_job::Queries::QueryList(v.into()));
-        self
     }
 }
 
@@ -8791,17 +8526,6 @@ impl PigJob {
         })
     }
 
-    /// Sets the value of [queries][crate::model::PigJob::queries]
-    /// to hold a `QueryFileUri`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_file_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::pig_job::Queries::QueryFileUri(v.into()));
-        self
-    }
-
     /// The value of [queries][crate::model::PigJob::queries]
     /// if it holds a `QueryList`, `None` if the field is not set or
     /// holds a different branch.
@@ -8811,20 +8535,6 @@ impl PigJob {
             crate::model::pig_job::Queries::QueryList(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [queries][crate::model::PigJob::queries]
-    /// to hold a `QueryList`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_list<T: std::convert::Into<std::boxed::Box<crate::model::QueryList>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::pig_job::Queries::QueryList(v.into()));
-        self
     }
 }
 
@@ -9092,17 +8802,6 @@ impl PrestoJob {
         })
     }
 
-    /// Sets the value of [queries][crate::model::PrestoJob::queries]
-    /// to hold a `QueryFileUri`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_file_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::presto_job::Queries::QueryFileUri(v.into()));
-        self
-    }
-
     /// The value of [queries][crate::model::PrestoJob::queries]
     /// if it holds a `QueryList`, `None` if the field is not set or
     /// holds a different branch.
@@ -9112,20 +8811,6 @@ impl PrestoJob {
             crate::model::presto_job::Queries::QueryList(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [queries][crate::model::PrestoJob::queries]
-    /// to hold a `QueryList`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_list<T: std::convert::Into<std::boxed::Box<crate::model::QueryList>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::presto_job::Queries::QueryList(v.into()));
-        self
     }
 }
 
@@ -9274,17 +8959,6 @@ impl TrinoJob {
         })
     }
 
-    /// Sets the value of [queries][crate::model::TrinoJob::queries]
-    /// to hold a `QueryFileUri`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_file_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::trino_job::Queries::QueryFileUri(v.into()));
-        self
-    }
-
     /// The value of [queries][crate::model::TrinoJob::queries]
     /// if it holds a `QueryList`, `None` if the field is not set or
     /// holds a different branch.
@@ -9294,20 +8968,6 @@ impl TrinoJob {
             crate::model::trino_job::Queries::QueryList(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [queries][crate::model::TrinoJob::queries]
-    /// to hold a `QueryList`.
-    ///
-    /// Note that all the setters affecting `queries` are
-    /// mutually exclusive.
-    pub fn set_query_list<T: std::convert::Into<std::boxed::Box<crate::model::QueryList>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.queries =
-            std::option::Option::Some(crate::model::trino_job::Queries::QueryList(v.into()));
-        self
     }
 }
 
@@ -9466,20 +9126,6 @@ impl FlinkJob {
         })
     }
 
-    /// Sets the value of [driver][crate::model::FlinkJob::driver]
-    /// to hold a `MainJarFileUri`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_jar_file_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::flink_job::Driver::MainJarFileUri(v.into()));
-        self
-    }
-
     /// The value of [driver][crate::model::FlinkJob::driver]
     /// if it holds a `MainClass`, `None` if the field is not set or
     /// holds a different branch.
@@ -9489,17 +9135,6 @@ impl FlinkJob {
             crate::model::flink_job::Driver::MainClass(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [driver][crate::model::FlinkJob::driver]
-    /// to hold a `MainClass`.
-    ///
-    /// Note that all the setters affecting `driver` are
-    /// mutually exclusive.
-    pub fn set_main_class<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.driver =
-            std::option::Option::Some(crate::model::flink_job::Driver::MainClass(v.into()));
-        self
     }
 }
 
@@ -10538,19 +10173,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `HadoopJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_hadoop_job<T: std::convert::Into<std::boxed::Box<crate::model::HadoopJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::HadoopJob(v.into()));
-        self
-    }
-
     /// The value of [type_job][crate::model::Job::type_job]
     /// if it holds a `SparkJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10560,19 +10182,6 @@ impl Job {
             crate::model::job::TypeJob::SparkJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `SparkJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_spark_job<T: std::convert::Into<std::boxed::Box<crate::model::SparkJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::SparkJob(v.into()));
-        self
     }
 
     /// The value of [type_job][crate::model::Job::type_job]
@@ -10586,19 +10195,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `PysparkJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_pyspark_job<T: std::convert::Into<std::boxed::Box<crate::model::PySparkJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::PysparkJob(v.into()));
-        self
-    }
-
     /// The value of [type_job][crate::model::Job::type_job]
     /// if it holds a `HiveJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10608,19 +10204,6 @@ impl Job {
             crate::model::job::TypeJob::HiveJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `HiveJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_hive_job<T: std::convert::Into<std::boxed::Box<crate::model::HiveJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::HiveJob(v.into()));
-        self
     }
 
     /// The value of [type_job][crate::model::Job::type_job]
@@ -10634,19 +10217,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `PigJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_pig_job<T: std::convert::Into<std::boxed::Box<crate::model::PigJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::PigJob(v.into()));
-        self
-    }
-
     /// The value of [type_job][crate::model::Job::type_job]
     /// if it holds a `SparkRJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10656,19 +10226,6 @@ impl Job {
             crate::model::job::TypeJob::SparkRJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `SparkRJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_spark_r_job<T: std::convert::Into<std::boxed::Box<crate::model::SparkRJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::SparkRJob(v.into()));
-        self
     }
 
     /// The value of [type_job][crate::model::Job::type_job]
@@ -10684,20 +10241,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `SparkSqlJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_spark_sql_job<T: std::convert::Into<std::boxed::Box<crate::model::SparkSqlJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job =
-            std::option::Option::Some(crate::model::job::TypeJob::SparkSqlJob(v.into()));
-        self
-    }
-
     /// The value of [type_job][crate::model::Job::type_job]
     /// if it holds a `PrestoJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10707,19 +10250,6 @@ impl Job {
             crate::model::job::TypeJob::PrestoJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `PrestoJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_presto_job<T: std::convert::Into<std::boxed::Box<crate::model::PrestoJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::PrestoJob(v.into()));
-        self
     }
 
     /// The value of [type_job][crate::model::Job::type_job]
@@ -10733,19 +10263,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `TrinoJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_trino_job<T: std::convert::Into<std::boxed::Box<crate::model::TrinoJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::TrinoJob(v.into()));
-        self
-    }
-
     /// The value of [type_job][crate::model::Job::type_job]
     /// if it holds a `FlinkJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10755,19 +10272,6 @@ impl Job {
             crate::model::job::TypeJob::FlinkJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [type_job][crate::model::Job::type_job]
-    /// to hold a `FlinkJob`.
-    ///
-    /// Note that all the setters affecting `type_job` are
-    /// mutually exclusive.
-    pub fn set_flink_job<T: std::convert::Into<std::boxed::Box<crate::model::FlinkJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.type_job = std::option::Option::Some(crate::model::job::TypeJob::FlinkJob(v.into()));
-        self
     }
 }
 
@@ -13453,23 +12957,6 @@ impl SessionTemplate {
         })
     }
 
-    /// Sets the value of [session_config][crate::model::SessionTemplate::session_config]
-    /// to hold a `JupyterSession`.
-    ///
-    /// Note that all the setters affecting `session_config` are
-    /// mutually exclusive.
-    pub fn set_jupyter_session<
-        T: std::convert::Into<std::boxed::Box<crate::model::JupyterConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.session_config = std::option::Option::Some(
-            crate::model::session_template::SessionConfig::JupyterSession(v.into()),
-        );
-        self
-    }
-
     /// The value of [session_config][crate::model::SessionTemplate::session_config]
     /// if it holds a `SparkConnectSession`, `None` if the field is not set or
     /// holds a different branch.
@@ -13483,23 +12970,6 @@ impl SessionTemplate {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [session_config][crate::model::SessionTemplate::session_config]
-    /// to hold a `SparkConnectSession`.
-    ///
-    /// Note that all the setters affecting `session_config` are
-    /// mutually exclusive.
-    pub fn set_spark_connect_session<
-        T: std::convert::Into<std::boxed::Box<crate::model::SparkConnectConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.session_config = std::option::Option::Some(
-            crate::model::session_template::SessionConfig::SparkConnectSession(v.into()),
-        );
-        self
     }
 }
 
@@ -14121,23 +13591,6 @@ impl Session {
         })
     }
 
-    /// Sets the value of [session_config][crate::model::Session::session_config]
-    /// to hold a `JupyterSession`.
-    ///
-    /// Note that all the setters affecting `session_config` are
-    /// mutually exclusive.
-    pub fn set_jupyter_session<
-        T: std::convert::Into<std::boxed::Box<crate::model::JupyterConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.session_config = std::option::Option::Some(
-            crate::model::session::SessionConfig::JupyterSession(v.into()),
-        );
-        self
-    }
-
     /// The value of [session_config][crate::model::Session::session_config]
     /// if it holds a `SparkConnectSession`, `None` if the field is not set or
     /// holds a different branch.
@@ -14151,23 +13604,6 @@ impl Session {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [session_config][crate::model::Session::session_config]
-    /// to hold a `SparkConnectSession`.
-    ///
-    /// Note that all the setters affecting `session_config` are
-    /// mutually exclusive.
-    pub fn set_spark_connect_session<
-        T: std::convert::Into<std::boxed::Box<crate::model::SparkConnectConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.session_config = std::option::Option::Some(
-            crate::model::session::SessionConfig::SparkConnectSession(v.into()),
-        );
-        self
     }
 }
 
@@ -14929,18 +14365,6 @@ impl ExecutionConfig {
         })
     }
 
-    /// Sets the value of [network][crate::model::ExecutionConfig::network]
-    /// to hold a `NetworkUri`.
-    ///
-    /// Note that all the setters affecting `network` are
-    /// mutually exclusive.
-    pub fn set_network_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.network = std::option::Option::Some(
-            crate::model::execution_config::Network::NetworkUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [network][crate::model::ExecutionConfig::network]
     /// if it holds a `SubnetworkUri`, `None` if the field is not set or
     /// holds a different branch.
@@ -14952,18 +14376,6 @@ impl ExecutionConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [network][crate::model::ExecutionConfig::network]
-    /// to hold a `SubnetworkUri`.
-    ///
-    /// Note that all the setters affecting `network` are
-    /// mutually exclusive.
-    pub fn set_subnetwork_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.network = std::option::Option::Some(
-            crate::model::execution_config::Network::SubnetworkUri(v.into()),
-        );
-        self
     }
 }
 
@@ -15511,23 +14923,6 @@ impl KubernetesClusterConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [config][crate::model::KubernetesClusterConfig::config]
-    /// to hold a `GkeClusterConfig`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_gke_cluster_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::GkeClusterConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(
-            crate::model::kubernetes_cluster_config::Config::GkeClusterConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -16953,23 +16348,6 @@ impl WorkflowTemplatePlacement {
         })
     }
 
-    /// Sets the value of [placement][crate::model::WorkflowTemplatePlacement::placement]
-    /// to hold a `ManagedCluster`.
-    ///
-    /// Note that all the setters affecting `placement` are
-    /// mutually exclusive.
-    pub fn set_managed_cluster<
-        T: std::convert::Into<std::boxed::Box<crate::model::ManagedCluster>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.placement = std::option::Option::Some(
-            crate::model::workflow_template_placement::Placement::ManagedCluster(v.into()),
-        );
-        self
-    }
-
     /// The value of [placement][crate::model::WorkflowTemplatePlacement::placement]
     /// if it holds a `ClusterSelector`, `None` if the field is not set or
     /// holds a different branch.
@@ -16983,23 +16361,6 @@ impl WorkflowTemplatePlacement {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [placement][crate::model::WorkflowTemplatePlacement::placement]
-    /// to hold a `ClusterSelector`.
-    ///
-    /// Note that all the setters affecting `placement` are
-    /// mutually exclusive.
-    pub fn set_cluster_selector<
-        T: std::convert::Into<std::boxed::Box<crate::model::ClusterSelector>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.placement = std::option::Option::Some(
-            crate::model::workflow_template_placement::Placement::ClusterSelector(v.into()),
-        );
-        self
     }
 }
 
@@ -17281,20 +16642,6 @@ impl OrderedJob {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `HadoopJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_hadoop_job<T: std::convert::Into<std::boxed::Box<crate::model::HadoopJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::HadoopJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::OrderedJob::job_type]
     /// if it holds a `SparkJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -17304,20 +16651,6 @@ impl OrderedJob {
             crate::model::ordered_job::JobType::SparkJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `SparkJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_spark_job<T: std::convert::Into<std::boxed::Box<crate::model::SparkJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::SparkJob(v.into()));
-        self
     }
 
     /// The value of [job_type][crate::model::OrderedJob::job_type]
@@ -17331,20 +16664,6 @@ impl OrderedJob {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `PysparkJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_pyspark_job<T: std::convert::Into<std::boxed::Box<crate::model::PySparkJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::PysparkJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::OrderedJob::job_type]
     /// if it holds a `HiveJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -17354,20 +16673,6 @@ impl OrderedJob {
             crate::model::ordered_job::JobType::HiveJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `HiveJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_hive_job<T: std::convert::Into<std::boxed::Box<crate::model::HiveJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::HiveJob(v.into()));
-        self
     }
 
     /// The value of [job_type][crate::model::OrderedJob::job_type]
@@ -17381,20 +16686,6 @@ impl OrderedJob {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `PigJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_pig_job<T: std::convert::Into<std::boxed::Box<crate::model::PigJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::PigJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::OrderedJob::job_type]
     /// if it holds a `SparkRJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -17404,20 +16695,6 @@ impl OrderedJob {
             crate::model::ordered_job::JobType::SparkRJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `SparkRJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_spark_r_job<T: std::convert::Into<std::boxed::Box<crate::model::SparkRJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::SparkRJob(v.into()));
-        self
     }
 
     /// The value of [job_type][crate::model::OrderedJob::job_type]
@@ -17433,20 +16710,6 @@ impl OrderedJob {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `SparkSqlJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_spark_sql_job<T: std::convert::Into<std::boxed::Box<crate::model::SparkSqlJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::SparkSqlJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::OrderedJob::job_type]
     /// if it holds a `PrestoJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -17456,20 +16719,6 @@ impl OrderedJob {
             crate::model::ordered_job::JobType::PrestoJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `PrestoJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_presto_job<T: std::convert::Into<std::boxed::Box<crate::model::PrestoJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::PrestoJob(v.into()));
-        self
     }
 
     /// The value of [job_type][crate::model::OrderedJob::job_type]
@@ -17483,20 +16732,6 @@ impl OrderedJob {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `TrinoJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_trino_job<T: std::convert::Into<std::boxed::Box<crate::model::TrinoJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::TrinoJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::OrderedJob::job_type]
     /// if it holds a `FlinkJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -17506,20 +16741,6 @@ impl OrderedJob {
             crate::model::ordered_job::JobType::FlinkJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::OrderedJob::job_type]
-    /// to hold a `FlinkJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_flink_job<T: std::convert::Into<std::boxed::Box<crate::model::FlinkJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::ordered_job::JobType::FlinkJob(v.into()));
-        self
     }
 }
 
@@ -17743,21 +16964,6 @@ impl ParameterValidation {
         })
     }
 
-    /// Sets the value of [validation_type][crate::model::ParameterValidation::validation_type]
-    /// to hold a `Regex`.
-    ///
-    /// Note that all the setters affecting `validation_type` are
-    /// mutually exclusive.
-    pub fn set_regex<T: std::convert::Into<std::boxed::Box<crate::model::RegexValidation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.validation_type = std::option::Option::Some(
-            crate::model::parameter_validation::ValidationType::Regex(v.into()),
-        );
-        self
-    }
-
     /// The value of [validation_type][crate::model::ParameterValidation::validation_type]
     /// if it holds a `Values`, `None` if the field is not set or
     /// holds a different branch.
@@ -17769,21 +16975,6 @@ impl ParameterValidation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [validation_type][crate::model::ParameterValidation::validation_type]
-    /// to hold a `Values`.
-    ///
-    /// Note that all the setters affecting `validation_type` are
-    /// mutually exclusive.
-    pub fn set_values<T: std::convert::Into<std::boxed::Box<crate::model::ValueValidation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.validation_type = std::option::Option::Some(
-            crate::model::parameter_validation::ValidationType::Values(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/datastream/v1/src/builder.rs
+++ b/src/generated/cloud/datastream/v1/src/builder.rs
@@ -730,34 +730,6 @@ pub mod datastream {
             self
         }
 
-        /// Sets the value of [target][crate::model::DiscoverConnectionProfileRequest::target]
-        /// to hold a `ConnectionProfile`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_connection_profile<
-            T: std::convert::Into<std::boxed::Box<crate::model::ConnectionProfile>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_connection_profile(v);
-            self
-        }
-
-        /// Sets the value of [target][crate::model::DiscoverConnectionProfileRequest::target]
-        /// to hold a `ConnectionProfileName`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_connection_profile_name<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_connection_profile_name(v);
-            self
-        }
-
         /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy].
         ///
         /// Note that all the setters affecting `hierarchy` are
@@ -772,26 +744,6 @@ pub mod datastream {
             self
         }
 
-        /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
-        /// to hold a `FullHierarchy`.
-        ///
-        /// Note that all the setters affecting `hierarchy` are
-        /// mutually exclusive.
-        pub fn set_full_hierarchy<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_full_hierarchy(v);
-            self
-        }
-
-        /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
-        /// to hold a `HierarchyDepth`.
-        ///
-        /// Note that all the setters affecting `hierarchy` are
-        /// mutually exclusive.
-        pub fn set_hierarchy_depth<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_hierarchy_depth(v);
-            self
-        }
-
         /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object].
         ///
         /// Note that all the setters affecting `data_object` are
@@ -803,64 +755,6 @@ pub mod datastream {
             v: T,
         ) -> Self {
             self.0.request.data_object = v.into();
-            self
-        }
-
-        /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-        /// to hold a `OracleRdbms`.
-        ///
-        /// Note that all the setters affecting `data_object` are
-        /// mutually exclusive.
-        pub fn set_oracle_rdbms<
-            T: std::convert::Into<std::boxed::Box<crate::model::OracleRdbms>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_oracle_rdbms(v);
-            self
-        }
-
-        /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-        /// to hold a `MysqlRdbms`.
-        ///
-        /// Note that all the setters affecting `data_object` are
-        /// mutually exclusive.
-        pub fn set_mysql_rdbms<T: std::convert::Into<std::boxed::Box<crate::model::MysqlRdbms>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_mysql_rdbms(v);
-            self
-        }
-
-        /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-        /// to hold a `PostgresqlRdbms`.
-        ///
-        /// Note that all the setters affecting `data_object` are
-        /// mutually exclusive.
-        pub fn set_postgresql_rdbms<
-            T: std::convert::Into<std::boxed::Box<crate::model::PostgresqlRdbms>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_postgresql_rdbms(v);
-            self
-        }
-
-        /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-        /// to hold a `SqlServerRdbms`.
-        ///
-        /// Note that all the setters affecting `data_object` are
-        /// mutually exclusive.
-        pub fn set_sql_server_rdbms<
-            T: std::convert::Into<std::boxed::Box<crate::model::SqlServerRdbms>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_sql_server_rdbms(v);
             self
         }
     }

--- a/src/generated/cloud/datastream/v1/src/model.rs
+++ b/src/generated/cloud/datastream/v1/src/model.rs
@@ -104,23 +104,6 @@ impl DiscoverConnectionProfileRequest {
         })
     }
 
-    /// Sets the value of [target][crate::model::DiscoverConnectionProfileRequest::target]
-    /// to hold a `ConnectionProfile`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_connection_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::ConnectionProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::Target::ConnectionProfile(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::DiscoverConnectionProfileRequest::target]
     /// if it holds a `ConnectionProfileName`, `None` if the field is not set or
     /// holds a different branch.
@@ -132,23 +115,6 @@ impl DiscoverConnectionProfileRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::DiscoverConnectionProfileRequest::target]
-    /// to hold a `ConnectionProfileName`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_connection_profile_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::Target::ConnectionProfileName(
-                v.into(),
-            ),
-        );
-        self
     }
 
     /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy].
@@ -180,18 +146,6 @@ impl DiscoverConnectionProfileRequest {
         })
     }
 
-    /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
-    /// to hold a `FullHierarchy`.
-    ///
-    /// Note that all the setters affecting `hierarchy` are
-    /// mutually exclusive.
-    pub fn set_full_hierarchy<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.hierarchy = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::Hierarchy::FullHierarchy(v.into()),
-        );
-        self
-    }
-
     /// The value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
     /// if it holds a `HierarchyDepth`, `None` if the field is not set or
     /// holds a different branch.
@@ -203,18 +157,6 @@ impl DiscoverConnectionProfileRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [hierarchy][crate::model::DiscoverConnectionProfileRequest::hierarchy]
-    /// to hold a `HierarchyDepth`.
-    ///
-    /// Note that all the setters affecting `hierarchy` are
-    /// mutually exclusive.
-    pub fn set_hierarchy_depth<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.hierarchy = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::Hierarchy::HierarchyDepth(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object].
@@ -246,21 +188,6 @@ impl DiscoverConnectionProfileRequest {
         })
     }
 
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-    /// to hold a `OracleRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_oracle_rdbms<T: std::convert::Into<std::boxed::Box<crate::model::OracleRdbms>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::DataObject::OracleRdbms(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
     /// if it holds a `MysqlRdbms`, `None` if the field is not set or
     /// holds a different branch.
@@ -272,21 +199,6 @@ impl DiscoverConnectionProfileRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-    /// to hold a `MysqlRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_mysql_rdbms<T: std::convert::Into<std::boxed::Box<crate::model::MysqlRdbms>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::DataObject::MysqlRdbms(v.into()),
-        );
-        self
     }
 
     /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
@@ -304,25 +216,6 @@ impl DiscoverConnectionProfileRequest {
         })
     }
 
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-    /// to hold a `PostgresqlRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_postgresql_rdbms<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostgresqlRdbms>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::DataObject::PostgresqlRdbms(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
     /// if it holds a `SqlServerRdbms`, `None` if the field is not set or
     /// holds a different branch.
@@ -336,23 +229,6 @@ impl DiscoverConnectionProfileRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileRequest::data_object]
-    /// to hold a `SqlServerRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_sql_server_rdbms<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerRdbms>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_request::DataObject::SqlServerRdbms(v.into()),
-        );
-        self
     }
 }
 
@@ -458,21 +334,6 @@ impl DiscoverConnectionProfileResponse {
         })
     }
 
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
-    /// to hold a `OracleRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_oracle_rdbms<T: std::convert::Into<std::boxed::Box<crate::model::OracleRdbms>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_response::DataObject::OracleRdbms(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
     /// if it holds a `MysqlRdbms`, `None` if the field is not set or
     /// holds a different branch.
@@ -484,21 +345,6 @@ impl DiscoverConnectionProfileResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
-    /// to hold a `MysqlRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_mysql_rdbms<T: std::convert::Into<std::boxed::Box<crate::model::MysqlRdbms>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_response::DataObject::MysqlRdbms(v.into()),
-        );
-        self
     }
 
     /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
@@ -516,25 +362,6 @@ impl DiscoverConnectionProfileResponse {
         })
     }
 
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
-    /// to hold a `PostgresqlRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_postgresql_rdbms<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostgresqlRdbms>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_response::DataObject::PostgresqlRdbms(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
     /// if it holds a `SqlServerRdbms`, `None` if the field is not set or
     /// holds a different branch.
@@ -548,25 +375,6 @@ impl DiscoverConnectionProfileResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_object][crate::model::DiscoverConnectionProfileResponse::data_object]
-    /// to hold a `SqlServerRdbms`.
-    ///
-    /// Note that all the setters affecting `data_object` are
-    /// mutually exclusive.
-    pub fn set_sql_server_rdbms<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerRdbms>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_object = std::option::Option::Some(
-            crate::model::discover_connection_profile_response::DataObject::SqlServerRdbms(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -3357,23 +3165,6 @@ impl SalesforceProfile {
         })
     }
 
-    /// Sets the value of [credentials][crate::model::SalesforceProfile::credentials]
-    /// to hold a `UserCredentials`.
-    ///
-    /// Note that all the setters affecting `credentials` are
-    /// mutually exclusive.
-    pub fn set_user_credentials<
-        T: std::convert::Into<std::boxed::Box<crate::model::salesforce_profile::UserCredentials>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.credentials = std::option::Option::Some(
-            crate::model::salesforce_profile::Credentials::UserCredentials(v.into()),
-        );
-        self
-    }
-
     /// The value of [credentials][crate::model::SalesforceProfile::credentials]
     /// if it holds a `Oauth2ClientCredentials`, `None` if the field is not set or
     /// holds a different branch.
@@ -3389,25 +3180,6 @@ impl SalesforceProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [credentials][crate::model::SalesforceProfile::credentials]
-    /// to hold a `Oauth2ClientCredentials`.
-    ///
-    /// Note that all the setters affecting `credentials` are
-    /// mutually exclusive.
-    pub fn set_oauth2_client_credentials<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::salesforce_profile::Oauth2ClientCredentials>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.credentials = std::option::Option::Some(
-            crate::model::salesforce_profile::Credentials::Oauth2ClientCredentials(v.into()),
-        );
-        self
     }
 }
 
@@ -3757,18 +3529,6 @@ impl ForwardSshTunnelConnectivity {
         })
     }
 
-    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
-    /// to hold a `Password`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_password<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::Password(v.into()),
-        );
-        self
-    }
-
     /// The value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
     /// if it holds a `PrivateKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -3780,20 +3540,6 @@ impl ForwardSshTunnelConnectivity {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authentication_method][crate::model::ForwardSshTunnelConnectivity::authentication_method]
-    /// to hold a `PrivateKey`.
-    ///
-    /// Note that all the setters affecting `authentication_method` are
-    /// mutually exclusive.
-    pub fn set_private_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.authentication_method = std::option::Option::Some(
-            crate::model::forward_ssh_tunnel_connectivity::AuthenticationMethod::PrivateKey(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -4510,25 +4256,6 @@ impl PostgresqlSslConfig {
         })
     }
 
-    /// Sets the value of [encryption_setting][crate::model::PostgresqlSslConfig::encryption_setting]
-    /// to hold a `ServerVerification`.
-    ///
-    /// Note that all the setters affecting `encryption_setting` are
-    /// mutually exclusive.
-    pub fn set_server_verification<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::postgresql_ssl_config::ServerVerification>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_setting = std::option::Option::Some(
-            crate::model::postgresql_ssl_config::EncryptionSetting::ServerVerification(v.into()),
-        );
-        self
-    }
-
     /// The value of [encryption_setting][crate::model::PostgresqlSslConfig::encryption_setting]
     /// if it holds a `ServerAndClientVerification`, `None` if the field is not set or
     /// holds a different branch.
@@ -4544,27 +4271,6 @@ impl PostgresqlSslConfig {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [encryption_setting][crate::model::PostgresqlSslConfig::encryption_setting]
-    /// to hold a `ServerAndClientVerification`.
-    ///
-    /// Note that all the setters affecting `encryption_setting` are
-    /// mutually exclusive.
-    pub fn set_server_and_client_verification<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::postgresql_ssl_config::ServerAndClientVerification>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_setting = std::option::Option::Some(
-            crate::model::postgresql_ssl_config::EncryptionSetting::ServerAndClientVerification(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -4849,23 +4555,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
-    /// to hold a `OracleProfile`.
-    ///
-    /// Note that all the setters affecting `profile` are
-    /// mutually exclusive.
-    pub fn set_oracle_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::OracleProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.profile = std::option::Option::Some(
-            crate::model::connection_profile::Profile::OracleProfile(v.into()),
-        );
-        self
-    }
-
     /// The value of [profile][crate::model::ConnectionProfile::profile]
     /// if it holds a `GcsProfile`, `None` if the field is not set or
     /// holds a different branch.
@@ -4877,21 +4566,6 @@ impl ConnectionProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
-    /// to hold a `GcsProfile`.
-    ///
-    /// Note that all the setters affecting `profile` are
-    /// mutually exclusive.
-    pub fn set_gcs_profile<T: std::convert::Into<std::boxed::Box<crate::model::GcsProfile>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.profile = std::option::Option::Some(
-            crate::model::connection_profile::Profile::GcsProfile(v.into()),
-        );
-        self
     }
 
     /// The value of [profile][crate::model::ConnectionProfile::profile]
@@ -4909,21 +4583,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
-    /// to hold a `MysqlProfile`.
-    ///
-    /// Note that all the setters affecting `profile` are
-    /// mutually exclusive.
-    pub fn set_mysql_profile<T: std::convert::Into<std::boxed::Box<crate::model::MysqlProfile>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.profile = std::option::Option::Some(
-            crate::model::connection_profile::Profile::MysqlProfile(v.into()),
-        );
-        self
-    }
-
     /// The value of [profile][crate::model::ConnectionProfile::profile]
     /// if it holds a `BigqueryProfile`, `None` if the field is not set or
     /// holds a different branch.
@@ -4937,23 +4596,6 @@ impl ConnectionProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
-    /// to hold a `BigqueryProfile`.
-    ///
-    /// Note that all the setters affecting `profile` are
-    /// mutually exclusive.
-    pub fn set_bigquery_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.profile = std::option::Option::Some(
-            crate::model::connection_profile::Profile::BigqueryProfile(v.into()),
-        );
-        self
     }
 
     /// The value of [profile][crate::model::ConnectionProfile::profile]
@@ -4971,23 +4613,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
-    /// to hold a `PostgresqlProfile`.
-    ///
-    /// Note that all the setters affecting `profile` are
-    /// mutually exclusive.
-    pub fn set_postgresql_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostgresqlProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.profile = std::option::Option::Some(
-            crate::model::connection_profile::Profile::PostgresqlProfile(v.into()),
-        );
-        self
-    }
-
     /// The value of [profile][crate::model::ConnectionProfile::profile]
     /// if it holds a `SqlServerProfile`, `None` if the field is not set or
     /// holds a different branch.
@@ -5003,23 +4628,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
-    /// to hold a `SqlServerProfile`.
-    ///
-    /// Note that all the setters affecting `profile` are
-    /// mutually exclusive.
-    pub fn set_sql_server_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.profile = std::option::Option::Some(
-            crate::model::connection_profile::Profile::SqlServerProfile(v.into()),
-        );
-        self
-    }
-
     /// The value of [profile][crate::model::ConnectionProfile::profile]
     /// if it holds a `SalesforceProfile`, `None` if the field is not set or
     /// holds a different branch.
@@ -5033,23 +4641,6 @@ impl ConnectionProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [profile][crate::model::ConnectionProfile::profile]
-    /// to hold a `SalesforceProfile`.
-    ///
-    /// Note that all the setters affecting `profile` are
-    /// mutually exclusive.
-    pub fn set_salesforce_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::SalesforceProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.profile = std::option::Option::Some(
-            crate::model::connection_profile::Profile::SalesforceProfile(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [connectivity][crate::model::ConnectionProfile::connectivity].
@@ -5081,23 +4672,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [connectivity][crate::model::ConnectionProfile::connectivity]
-    /// to hold a `StaticServiceIpConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_static_service_ip_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::StaticServiceIpConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::connection_profile::Connectivity::StaticServiceIpConnectivity(v.into()),
-        );
-        self
-    }
-
     /// The value of [connectivity][crate::model::ConnectionProfile::connectivity]
     /// if it holds a `ForwardSshConnectivity`, `None` if the field is not set or
     /// holds a different branch.
@@ -5113,23 +4687,6 @@ impl ConnectionProfile {
         })
     }
 
-    /// Sets the value of [connectivity][crate::model::ConnectionProfile::connectivity]
-    /// to hold a `ForwardSshConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_forward_ssh_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::ForwardSshTunnelConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::connection_profile::Connectivity::ForwardSshConnectivity(v.into()),
-        );
-        self
-    }
-
     /// The value of [connectivity][crate::model::ConnectionProfile::connectivity]
     /// if it holds a `PrivateConnectivity`, `None` if the field is not set or
     /// holds a different branch.
@@ -5143,23 +4700,6 @@ impl ConnectionProfile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connectivity][crate::model::ConnectionProfile::connectivity]
-    /// to hold a `PrivateConnectivity`.
-    ///
-    /// Note that all the setters affecting `connectivity` are
-    /// mutually exclusive.
-    pub fn set_private_connectivity<
-        T: std::convert::Into<std::boxed::Box<crate::model::PrivateConnectivity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connectivity = std::option::Option::Some(
-            crate::model::connection_profile::Connectivity::PrivateConnectivity(v.into()),
-        );
-        self
     }
 }
 
@@ -5564,23 +5104,6 @@ impl OracleSourceConfig {
         })
     }
 
-    /// Sets the value of [large_objects_handling][crate::model::OracleSourceConfig::large_objects_handling]
-    /// to hold a `DropLargeObjects`.
-    ///
-    /// Note that all the setters affecting `large_objects_handling` are
-    /// mutually exclusive.
-    pub fn set_drop_large_objects<
-        T: std::convert::Into<std::boxed::Box<crate::model::oracle_source_config::DropLargeObjects>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.large_objects_handling = std::option::Option::Some(
-            crate::model::oracle_source_config::LargeObjectsHandling::DropLargeObjects(v.into()),
-        );
-        self
-    }
-
     /// The value of [large_objects_handling][crate::model::OracleSourceConfig::large_objects_handling]
     /// if it holds a `StreamLargeObjects`, `None` if the field is not set or
     /// holds a different branch.
@@ -5595,23 +5118,6 @@ impl OracleSourceConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [large_objects_handling][crate::model::OracleSourceConfig::large_objects_handling]
-    /// to hold a `StreamLargeObjects`.
-    ///
-    /// Note that all the setters affecting `large_objects_handling` are
-    /// mutually exclusive.
-    pub fn set_stream_large_objects<
-        T: std::convert::Into<std::boxed::Box<crate::model::oracle_source_config::StreamLargeObjects>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.large_objects_handling = std::option::Option::Some(
-            crate::model::oracle_source_config::LargeObjectsHandling::StreamLargeObjects(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [cdc_method][crate::model::OracleSourceConfig::cdc_method].
@@ -5643,23 +5149,6 @@ impl OracleSourceConfig {
         })
     }
 
-    /// Sets the value of [cdc_method][crate::model::OracleSourceConfig::cdc_method]
-    /// to hold a `LogMiner`.
-    ///
-    /// Note that all the setters affecting `cdc_method` are
-    /// mutually exclusive.
-    pub fn set_log_miner<
-        T: std::convert::Into<std::boxed::Box<crate::model::oracle_source_config::LogMiner>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdc_method = std::option::Option::Some(
-            crate::model::oracle_source_config::CdcMethod::LogMiner(v.into()),
-        );
-        self
-    }
-
     /// The value of [cdc_method][crate::model::OracleSourceConfig::cdc_method]
     /// if it holds a `BinaryLogParser`, `None` if the field is not set or
     /// holds a different branch.
@@ -5674,23 +5163,6 @@ impl OracleSourceConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cdc_method][crate::model::OracleSourceConfig::cdc_method]
-    /// to hold a `BinaryLogParser`.
-    ///
-    /// Note that all the setters affecting `cdc_method` are
-    /// mutually exclusive.
-    pub fn set_binary_log_parser<
-        T: std::convert::Into<std::boxed::Box<crate::model::oracle_source_config::BinaryLogParser>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdc_method = std::option::Option::Some(
-            crate::model::oracle_source_config::CdcMethod::BinaryLogParser(v.into()),
-        );
-        self
     }
 }
 
@@ -5827,20 +5299,6 @@ pub mod oracle_source_config {
             })
         }
 
-        /// Sets the value of [log_file_access][crate::model::oracle_source_config::BinaryLogParser::log_file_access]
-        /// to hold a `OracleAsmLogFileAccess`.
-        ///
-        /// Note that all the setters affecting `log_file_access` are
-        /// mutually exclusive.
-        pub fn set_oracle_asm_log_file_access<T: std::convert::Into<std::boxed::Box<crate::model::oracle_source_config::binary_log_parser::OracleAsmLogFileAccess>>>(mut self, v: T) -> Self{
-            self.log_file_access = std::option::Option::Some(
-                crate::model::oracle_source_config::binary_log_parser::LogFileAccess::OracleAsmLogFileAccess(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [log_file_access][crate::model::oracle_source_config::BinaryLogParser::log_file_access]
         /// if it holds a `LogFileDirectories`, `None` if the field is not set or
         /// holds a different branch.
@@ -5856,29 +5314,6 @@ pub mod oracle_source_config {
                 crate::model::oracle_source_config::binary_log_parser::LogFileAccess::LogFileDirectories(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [log_file_access][crate::model::oracle_source_config::BinaryLogParser::log_file_access]
-        /// to hold a `LogFileDirectories`.
-        ///
-        /// Note that all the setters affecting `log_file_access` are
-        /// mutually exclusive.
-        pub fn set_log_file_directories<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::oracle_source_config::binary_log_parser::LogFileDirectories,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.log_file_access = std::option::Option::Some(
-                crate::model::oracle_source_config::binary_log_parser::LogFileAccess::LogFileDirectories(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -6666,23 +6101,6 @@ impl SqlServerSourceConfig {
         })
     }
 
-    /// Sets the value of [cdc_method][crate::model::SqlServerSourceConfig::cdc_method]
-    /// to hold a `TransactionLogs`.
-    ///
-    /// Note that all the setters affecting `cdc_method` are
-    /// mutually exclusive.
-    pub fn set_transaction_logs<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerTransactionLogs>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdc_method = std::option::Option::Some(
-            crate::model::sql_server_source_config::CdcMethod::TransactionLogs(v.into()),
-        );
-        self
-    }
-
     /// The value of [cdc_method][crate::model::SqlServerSourceConfig::cdc_method]
     /// if it holds a `ChangeTables`, `None` if the field is not set or
     /// holds a different branch.
@@ -6696,23 +6114,6 @@ impl SqlServerSourceConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cdc_method][crate::model::SqlServerSourceConfig::cdc_method]
-    /// to hold a `ChangeTables`.
-    ///
-    /// Note that all the setters affecting `cdc_method` are
-    /// mutually exclusive.
-    pub fn set_change_tables<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerChangeTables>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdc_method = std::option::Option::Some(
-            crate::model::sql_server_source_config::CdcMethod::ChangeTables(v.into()),
-        );
-        self
     }
 }
 
@@ -7132,23 +6533,6 @@ impl MysqlSourceConfig {
         })
     }
 
-    /// Sets the value of [cdc_method][crate::model::MysqlSourceConfig::cdc_method]
-    /// to hold a `BinaryLogPosition`.
-    ///
-    /// Note that all the setters affecting `cdc_method` are
-    /// mutually exclusive.
-    pub fn set_binary_log_position<
-        T: std::convert::Into<std::boxed::Box<crate::model::mysql_source_config::BinaryLogPosition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdc_method = std::option::Option::Some(
-            crate::model::mysql_source_config::CdcMethod::BinaryLogPosition(v.into()),
-        );
-        self
-    }
-
     /// The value of [cdc_method][crate::model::MysqlSourceConfig::cdc_method]
     /// if it holds a `Gtid`, `None` if the field is not set or
     /// holds a different branch.
@@ -7160,22 +6544,6 @@ impl MysqlSourceConfig {
             crate::model::mysql_source_config::CdcMethod::Gtid(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cdc_method][crate::model::MysqlSourceConfig::cdc_method]
-    /// to hold a `Gtid`.
-    ///
-    /// Note that all the setters affecting `cdc_method` are
-    /// mutually exclusive.
-    pub fn set_gtid<
-        T: std::convert::Into<std::boxed::Box<crate::model::mysql_source_config::Gtid>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdc_method =
-            std::option::Option::Some(crate::model::mysql_source_config::CdcMethod::Gtid(v.into()));
-        self
     }
 }
 
@@ -7515,23 +6883,6 @@ impl SourceConfig {
         })
     }
 
-    /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// to hold a `OracleSourceConfig`.
-    ///
-    /// Note that all the setters affecting `source_stream_config` are
-    /// mutually exclusive.
-    pub fn set_oracle_source_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::OracleSourceConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_stream_config = std::option::Option::Some(
-            crate::model::source_config::SourceStreamConfig::OracleSourceConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
     /// if it holds a `MysqlSourceConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -7545,23 +6896,6 @@ impl SourceConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// to hold a `MysqlSourceConfig`.
-    ///
-    /// Note that all the setters affecting `source_stream_config` are
-    /// mutually exclusive.
-    pub fn set_mysql_source_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::MysqlSourceConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_stream_config = std::option::Option::Some(
-            crate::model::source_config::SourceStreamConfig::MysqlSourceConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
@@ -7579,23 +6913,6 @@ impl SourceConfig {
         })
     }
 
-    /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// to hold a `PostgresqlSourceConfig`.
-    ///
-    /// Note that all the setters affecting `source_stream_config` are
-    /// mutually exclusive.
-    pub fn set_postgresql_source_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostgresqlSourceConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_stream_config = std::option::Option::Some(
-            crate::model::source_config::SourceStreamConfig::PostgresqlSourceConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
     /// if it holds a `SqlServerSourceConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -7611,23 +6928,6 @@ impl SourceConfig {
         })
     }
 
-    /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// to hold a `SqlServerSourceConfig`.
-    ///
-    /// Note that all the setters affecting `source_stream_config` are
-    /// mutually exclusive.
-    pub fn set_sql_server_source_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerSourceConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_stream_config = std::option::Option::Some(
-            crate::model::source_config::SourceStreamConfig::SqlServerSourceConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
     /// if it holds a `SalesforceSourceConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -7641,23 +6941,6 @@ impl SourceConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_stream_config][crate::model::SourceConfig::source_stream_config]
-    /// to hold a `SalesforceSourceConfig`.
-    ///
-    /// Note that all the setters affecting `source_stream_config` are
-    /// mutually exclusive.
-    pub fn set_salesforce_source_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::SalesforceSourceConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_stream_config = std::option::Option::Some(
-            crate::model::source_config::SourceStreamConfig::SalesforceSourceConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -8116,23 +7399,6 @@ impl GcsDestinationConfig {
         })
     }
 
-    /// Sets the value of [file_format][crate::model::GcsDestinationConfig::file_format]
-    /// to hold a `AvroFileFormat`.
-    ///
-    /// Note that all the setters affecting `file_format` are
-    /// mutually exclusive.
-    pub fn set_avro_file_format<
-        T: std::convert::Into<std::boxed::Box<crate::model::AvroFileFormat>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.file_format = std::option::Option::Some(
-            crate::model::gcs_destination_config::FileFormat::AvroFileFormat(v.into()),
-        );
-        self
-    }
-
     /// The value of [file_format][crate::model::GcsDestinationConfig::file_format]
     /// if it holds a `JsonFileFormat`, `None` if the field is not set or
     /// holds a different branch.
@@ -8146,23 +7412,6 @@ impl GcsDestinationConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [file_format][crate::model::GcsDestinationConfig::file_format]
-    /// to hold a `JsonFileFormat`.
-    ///
-    /// Note that all the setters affecting `file_format` are
-    /// mutually exclusive.
-    pub fn set_json_file_format<
-        T: std::convert::Into<std::boxed::Box<crate::model::JsonFileFormat>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.file_format = std::option::Option::Some(
-            crate::model::gcs_destination_config::FileFormat::JsonFileFormat(v.into()),
-        );
-        self
     }
 }
 
@@ -8279,27 +7528,6 @@ impl BigQueryDestinationConfig {
         })
     }
 
-    /// Sets the value of [dataset_config][crate::model::BigQueryDestinationConfig::dataset_config]
-    /// to hold a `SingleTargetDataset`.
-    ///
-    /// Note that all the setters affecting `dataset_config` are
-    /// mutually exclusive.
-    pub fn set_single_target_dataset<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::big_query_destination_config::SingleTargetDataset>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dataset_config = std::option::Option::Some(
-            crate::model::big_query_destination_config::DatasetConfig::SingleTargetDataset(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [dataset_config][crate::model::BigQueryDestinationConfig::dataset_config]
     /// if it holds a `SourceHierarchyDatasets`, `None` if the field is not set or
     /// holds a different branch.
@@ -8315,29 +7543,6 @@ impl BigQueryDestinationConfig {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dataset_config][crate::model::BigQueryDestinationConfig::dataset_config]
-    /// to hold a `SourceHierarchyDatasets`.
-    ///
-    /// Note that all the setters affecting `dataset_config` are
-    /// mutually exclusive.
-    pub fn set_source_hierarchy_datasets<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::big_query_destination_config::SourceHierarchyDatasets,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dataset_config = std::option::Option::Some(
-            crate::model::big_query_destination_config::DatasetConfig::SourceHierarchyDatasets(
-                v.into(),
-            ),
-        );
-        self
     }
 
     /// Sets the value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode].
@@ -8372,23 +7577,6 @@ impl BigQueryDestinationConfig {
         })
     }
 
-    /// Sets the value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode]
-    /// to hold a `Merge`.
-    ///
-    /// Note that all the setters affecting `write_mode` are
-    /// mutually exclusive.
-    pub fn set_merge<
-        T: std::convert::Into<std::boxed::Box<crate::model::big_query_destination_config::Merge>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.write_mode = std::option::Option::Some(
-            crate::model::big_query_destination_config::WriteMode::Merge(v.into()),
-        );
-        self
-    }
-
     /// The value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode]
     /// if it holds a `AppendOnly`, `None` if the field is not set or
     /// holds a different branch.
@@ -8403,23 +7591,6 @@ impl BigQueryDestinationConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [write_mode][crate::model::BigQueryDestinationConfig::write_mode]
-    /// to hold a `AppendOnly`.
-    ///
-    /// Note that all the setters affecting `write_mode` are
-    /// mutually exclusive.
-    pub fn set_append_only<
-        T: std::convert::Into<std::boxed::Box<crate::model::big_query_destination_config::AppendOnly>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.write_mode = std::option::Option::Some(
-            crate::model::big_query_destination_config::WriteMode::AppendOnly(v.into()),
-        );
-        self
     }
 }
 
@@ -9069,25 +8240,6 @@ impl DestinationConfig {
             })
     }
 
-    /// Sets the value of [destination_stream_config][crate::model::DestinationConfig::destination_stream_config]
-    /// to hold a `GcsDestinationConfig`.
-    ///
-    /// Note that all the setters affecting `destination_stream_config` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestinationConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination_stream_config = std::option::Option::Some(
-            crate::model::destination_config::DestinationStreamConfig::GcsDestinationConfig(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [destination_stream_config][crate::model::DestinationConfig::destination_stream_config]
     /// if it holds a `BigqueryDestinationConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9099,25 +8251,6 @@ impl DestinationConfig {
             crate::model::destination_config::DestinationStreamConfig::BigqueryDestinationConfig(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination_stream_config][crate::model::DestinationConfig::destination_stream_config]
-    /// to hold a `BigqueryDestinationConfig`.
-    ///
-    /// Note that all the setters affecting `destination_stream_config` are
-    /// mutually exclusive.
-    pub fn set_bigquery_destination_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryDestinationConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination_stream_config = std::option::Option::Some(
-            crate::model::destination_config::DestinationStreamConfig::BigqueryDestinationConfig(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -9365,23 +8498,6 @@ impl Stream {
         })
     }
 
-    /// Sets the value of [backfill_strategy][crate::model::Stream::backfill_strategy]
-    /// to hold a `BackfillAll`.
-    ///
-    /// Note that all the setters affecting `backfill_strategy` are
-    /// mutually exclusive.
-    pub fn set_backfill_all<
-        T: std::convert::Into<std::boxed::Box<crate::model::stream::BackfillAllStrategy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backfill_strategy = std::option::Option::Some(
-            crate::model::stream::BackfillStrategy::BackfillAll(v.into()),
-        );
-        self
-    }
-
     /// The value of [backfill_strategy][crate::model::Stream::backfill_strategy]
     /// if it holds a `BackfillNone`, `None` if the field is not set or
     /// holds a different branch.
@@ -9393,23 +8509,6 @@ impl Stream {
             crate::model::stream::BackfillStrategy::BackfillNone(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [backfill_strategy][crate::model::Stream::backfill_strategy]
-    /// to hold a `BackfillNone`.
-    ///
-    /// Note that all the setters affecting `backfill_strategy` are
-    /// mutually exclusive.
-    pub fn set_backfill_none<
-        T: std::convert::Into<std::boxed::Box<crate::model::stream::BackfillNoneStrategy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backfill_strategy = std::option::Option::Some(
-            crate::model::stream::BackfillStrategy::BackfillNone(v.into()),
-        );
-        self
     }
 }
 
@@ -9476,25 +8575,6 @@ pub mod stream {
             })
         }
 
-        /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// to hold a `OracleExcludedObjects`.
-        ///
-        /// Note that all the setters affecting `excluded_objects` are
-        /// mutually exclusive.
-        pub fn set_oracle_excluded_objects<
-            T: std::convert::Into<std::boxed::Box<crate::model::OracleRdbms>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.excluded_objects = std::option::Option::Some(
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::OracleExcludedObjects(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
         /// if it holds a `MysqlExcludedObjects`, `None` if the field is not set or
         /// holds a different branch.
@@ -9506,25 +8586,6 @@ pub mod stream {
                 crate::model::stream::backfill_all_strategy::ExcludedObjects::MysqlExcludedObjects(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// to hold a `MysqlExcludedObjects`.
-        ///
-        /// Note that all the setters affecting `excluded_objects` are
-        /// mutually exclusive.
-        pub fn set_mysql_excluded_objects<
-            T: std::convert::Into<std::boxed::Box<crate::model::MysqlRdbms>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.excluded_objects = std::option::Option::Some(
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::MysqlExcludedObjects(
-                    v.into(),
-                ),
-            );
-            self
         }
 
         /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
@@ -9540,25 +8601,6 @@ pub mod stream {
             })
         }
 
-        /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// to hold a `PostgresqlExcludedObjects`.
-        ///
-        /// Note that all the setters affecting `excluded_objects` are
-        /// mutually exclusive.
-        pub fn set_postgresql_excluded_objects<
-            T: std::convert::Into<std::boxed::Box<crate::model::PostgresqlRdbms>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.excluded_objects = std::option::Option::Some(
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::PostgresqlExcludedObjects(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
         /// if it holds a `SqlServerExcludedObjects`, `None` if the field is not set or
         /// holds a different branch.
@@ -9572,25 +8614,6 @@ pub mod stream {
             })
         }
 
-        /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// to hold a `SqlServerExcludedObjects`.
-        ///
-        /// Note that all the setters affecting `excluded_objects` are
-        /// mutually exclusive.
-        pub fn set_sql_server_excluded_objects<
-            T: std::convert::Into<std::boxed::Box<crate::model::SqlServerRdbms>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.excluded_objects = std::option::Option::Some(
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::SqlServerExcludedObjects(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
         /// if it holds a `SalesforceExcludedObjects`, `None` if the field is not set or
         /// holds a different branch.
@@ -9602,25 +8625,6 @@ pub mod stream {
                 crate::model::stream::backfill_all_strategy::ExcludedObjects::SalesforceExcludedObjects(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [excluded_objects][crate::model::stream::BackfillAllStrategy::excluded_objects]
-        /// to hold a `SalesforceExcludedObjects`.
-        ///
-        /// Note that all the setters affecting `excluded_objects` are
-        /// mutually exclusive.
-        pub fn set_salesforce_excluded_objects<
-            T: std::convert::Into<std::boxed::Box<crate::model::SalesforceOrg>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.excluded_objects = std::option::Option::Some(
-                crate::model::stream::backfill_all_strategy::ExcludedObjects::SalesforceExcludedObjects(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -10034,25 +9038,6 @@ impl SourceObjectIdentifier {
         })
     }
 
-    /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// to hold a `OracleIdentifier`.
-    ///
-    /// Note that all the setters affecting `source_identifier` are
-    /// mutually exclusive.
-    pub fn set_oracle_identifier<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::source_object_identifier::OracleObjectIdentifier>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_identifier = std::option::Option::Some(
-            crate::model::source_object_identifier::SourceIdentifier::OracleIdentifier(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
     /// if it holds a `MysqlIdentifier`, `None` if the field is not set or
     /// holds a different branch.
@@ -10068,25 +9053,6 @@ impl SourceObjectIdentifier {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// to hold a `MysqlIdentifier`.
-    ///
-    /// Note that all the setters affecting `source_identifier` are
-    /// mutually exclusive.
-    pub fn set_mysql_identifier<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::source_object_identifier::MysqlObjectIdentifier>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_identifier = std::option::Option::Some(
-            crate::model::source_object_identifier::SourceIdentifier::MysqlIdentifier(v.into()),
-        );
-        self
     }
 
     /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
@@ -10106,27 +9072,6 @@ impl SourceObjectIdentifier {
         })
     }
 
-    /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// to hold a `PostgresqlIdentifier`.
-    ///
-    /// Note that all the setters affecting `source_identifier` are
-    /// mutually exclusive.
-    pub fn set_postgresql_identifier<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::source_object_identifier::PostgresqlObjectIdentifier>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_identifier = std::option::Option::Some(
-            crate::model::source_object_identifier::SourceIdentifier::PostgresqlIdentifier(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
     /// if it holds a `SqlServerIdentifier`, `None` if the field is not set or
     /// holds a different branch.
@@ -10144,25 +9089,6 @@ impl SourceObjectIdentifier {
         })
     }
 
-    /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// to hold a `SqlServerIdentifier`.
-    ///
-    /// Note that all the setters affecting `source_identifier` are
-    /// mutually exclusive.
-    pub fn set_sql_server_identifier<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::source_object_identifier::SqlServerObjectIdentifier>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_identifier = std::option::Option::Some(
-            crate::model::source_object_identifier::SourceIdentifier::SqlServerIdentifier(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
     /// if it holds a `SalesforceIdentifier`, `None` if the field is not set or
     /// holds a different branch.
@@ -10178,27 +9104,6 @@ impl SourceObjectIdentifier {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_identifier][crate::model::SourceObjectIdentifier::source_identifier]
-    /// to hold a `SalesforceIdentifier`.
-    ///
-    /// Note that all the setters affecting `source_identifier` are
-    /// mutually exclusive.
-    pub fn set_salesforce_identifier<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::source_object_identifier::SalesforceObjectIdentifier>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_identifier = std::option::Option::Some(
-            crate::model::source_object_identifier::SourceIdentifier::SalesforceIdentifier(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -11438,23 +10343,6 @@ impl CdcStrategy {
         })
     }
 
-    /// Sets the value of [start_position][crate::model::CdcStrategy::start_position]
-    /// to hold a `MostRecentStartPosition`.
-    ///
-    /// Note that all the setters affecting `start_position` are
-    /// mutually exclusive.
-    pub fn set_most_recent_start_position<
-        T: std::convert::Into<std::boxed::Box<crate::model::cdc_strategy::MostRecentStartPosition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.start_position = std::option::Option::Some(
-            crate::model::cdc_strategy::StartPosition::MostRecentStartPosition(v.into()),
-        );
-        self
-    }
-
     /// The value of [start_position][crate::model::CdcStrategy::start_position]
     /// if it holds a `NextAvailableStartPosition`, `None` if the field is not set or
     /// holds a different branch.
@@ -11471,23 +10359,6 @@ impl CdcStrategy {
         })
     }
 
-    /// Sets the value of [start_position][crate::model::CdcStrategy::start_position]
-    /// to hold a `NextAvailableStartPosition`.
-    ///
-    /// Note that all the setters affecting `start_position` are
-    /// mutually exclusive.
-    pub fn set_next_available_start_position<
-        T: std::convert::Into<std::boxed::Box<crate::model::cdc_strategy::NextAvailableStartPosition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.start_position = std::option::Option::Some(
-            crate::model::cdc_strategy::StartPosition::NextAvailableStartPosition(v.into()),
-        );
-        self
-    }
-
     /// The value of [start_position][crate::model::CdcStrategy::start_position]
     /// if it holds a `SpecificStartPosition`, `None` if the field is not set or
     /// holds a different branch.
@@ -11502,23 +10373,6 @@ impl CdcStrategy {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [start_position][crate::model::CdcStrategy::start_position]
-    /// to hold a `SpecificStartPosition`.
-    ///
-    /// Note that all the setters affecting `start_position` are
-    /// mutually exclusive.
-    pub fn set_specific_start_position<
-        T: std::convert::Into<std::boxed::Box<crate::model::cdc_strategy::SpecificStartPosition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.start_position = std::option::Option::Some(
-            crate::model::cdc_strategy::StartPosition::SpecificStartPosition(v.into()),
-        );
-        self
     }
 }
 
@@ -11631,25 +10485,6 @@ pub mod cdc_strategy {
             })
         }
 
-        /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
-        /// to hold a `MysqlLogPosition`.
-        ///
-        /// Note that all the setters affecting `position` are
-        /// mutually exclusive.
-        pub fn set_mysql_log_position<
-            T: std::convert::Into<std::boxed::Box<crate::model::MysqlLogPosition>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.position = std::option::Option::Some(
-                crate::model::cdc_strategy::specific_start_position::Position::MysqlLogPosition(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
         /// if it holds a `OracleScnPosition`, `None` if the field is not set or
         /// holds a different branch.
@@ -11661,25 +10496,6 @@ pub mod cdc_strategy {
                 crate::model::cdc_strategy::specific_start_position::Position::OracleScnPosition(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
-        /// to hold a `OracleScnPosition`.
-        ///
-        /// Note that all the setters affecting `position` are
-        /// mutually exclusive.
-        pub fn set_oracle_scn_position<
-            T: std::convert::Into<std::boxed::Box<crate::model::OracleScnPosition>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.position = std::option::Option::Some(
-                crate::model::cdc_strategy::specific_start_position::Position::OracleScnPosition(
-                    v.into(),
-                ),
-            );
-            self
         }
 
         /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
@@ -11695,25 +10511,6 @@ pub mod cdc_strategy {
             })
         }
 
-        /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
-        /// to hold a `SqlServerLsnPosition`.
-        ///
-        /// Note that all the setters affecting `position` are
-        /// mutually exclusive.
-        pub fn set_sql_server_lsn_position<
-            T: std::convert::Into<std::boxed::Box<crate::model::SqlServerLsnPosition>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.position = std::option::Option::Some(
-                crate::model::cdc_strategy::specific_start_position::Position::SqlServerLsnPosition(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
         /// if it holds a `MysqlGtidPosition`, `None` if the field is not set or
         /// holds a different branch.
@@ -11725,25 +10522,6 @@ pub mod cdc_strategy {
                 crate::model::cdc_strategy::specific_start_position::Position::MysqlGtidPosition(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [position][crate::model::cdc_strategy::SpecificStartPosition::position]
-        /// to hold a `MysqlGtidPosition`.
-        ///
-        /// Note that all the setters affecting `position` are
-        /// mutually exclusive.
-        pub fn set_mysql_gtid_position<
-            T: std::convert::Into<std::boxed::Box<crate::model::MysqlGtidPosition>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.position = std::option::Option::Some(
-                crate::model::cdc_strategy::specific_start_position::Position::MysqlGtidPosition(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/deploy/v1/src/model.rs
+++ b/src/generated/cloud/deploy/v1/src/model.rs
@@ -387,23 +387,6 @@ impl DeliveryPipeline {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [pipeline][crate::model::DeliveryPipeline::pipeline]
-    /// to hold a `SerialPipeline`.
-    ///
-    /// Note that all the setters affecting `pipeline` are
-    /// mutually exclusive.
-    pub fn set_serial_pipeline<
-        T: std::convert::Into<std::boxed::Box<crate::model::SerialPipeline>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pipeline = std::option::Option::Some(
-            crate::model::delivery_pipeline::Pipeline::SerialPipeline(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DeliveryPipeline {
@@ -648,21 +631,6 @@ impl Strategy {
         })
     }
 
-    /// Sets the value of [deployment_strategy][crate::model::Strategy::deployment_strategy]
-    /// to hold a `Standard`.
-    ///
-    /// Note that all the setters affecting `deployment_strategy` are
-    /// mutually exclusive.
-    pub fn set_standard<T: std::convert::Into<std::boxed::Box<crate::model::Standard>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_strategy = std::option::Option::Some(
-            crate::model::strategy::DeploymentStrategy::Standard(v.into()),
-        );
-        self
-    }
-
     /// The value of [deployment_strategy][crate::model::Strategy::deployment_strategy]
     /// if it holds a `Canary`, `None` if the field is not set or
     /// holds a different branch.
@@ -672,20 +640,6 @@ impl Strategy {
             crate::model::strategy::DeploymentStrategy::Canary(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [deployment_strategy][crate::model::Strategy::deployment_strategy]
-    /// to hold a `Canary`.
-    ///
-    /// Note that all the setters affecting `deployment_strategy` are
-    /// mutually exclusive.
-    pub fn set_canary<T: std::convert::Into<std::boxed::Box<crate::model::Canary>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_strategy =
-            std::option::Option::Some(crate::model::strategy::DeploymentStrategy::Canary(v.into()));
-        self
     }
 }
 
@@ -912,22 +866,6 @@ impl Canary {
         })
     }
 
-    /// Sets the value of [mode][crate::model::Canary::mode]
-    /// to hold a `CanaryDeployment`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_canary_deployment<
-        T: std::convert::Into<std::boxed::Box<crate::model::CanaryDeployment>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode =
-            std::option::Option::Some(crate::model::canary::Mode::CanaryDeployment(v.into()));
-        self
-    }
-
     /// The value of [mode][crate::model::Canary::mode]
     /// if it holds a `CustomCanaryDeployment`, `None` if the field is not set or
     /// holds a different branch.
@@ -939,22 +877,6 @@ impl Canary {
             crate::model::canary::Mode::CustomCanaryDeployment(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [mode][crate::model::Canary::mode]
-    /// to hold a `CustomCanaryDeployment`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_custom_canary_deployment<
-        T: std::convert::Into<std::boxed::Box<crate::model::CustomCanaryDeployment>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode =
-            std::option::Option::Some(crate::model::canary::Mode::CustomCanaryDeployment(v.into()));
-        self
     }
 }
 
@@ -1265,23 +1187,6 @@ impl KubernetesConfig {
         })
     }
 
-    /// Sets the value of [service_definition][crate::model::KubernetesConfig::service_definition]
-    /// to hold a `GatewayServiceMesh`.
-    ///
-    /// Note that all the setters affecting `service_definition` are
-    /// mutually exclusive.
-    pub fn set_gateway_service_mesh<
-        T: std::convert::Into<std::boxed::Box<crate::model::kubernetes_config::GatewayServiceMesh>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_definition = std::option::Option::Some(
-            crate::model::kubernetes_config::ServiceDefinition::GatewayServiceMesh(v.into()),
-        );
-        self
-    }
-
     /// The value of [service_definition][crate::model::KubernetesConfig::service_definition]
     /// if it holds a `ServiceNetworking`, `None` if the field is not set or
     /// holds a different branch.
@@ -1296,23 +1201,6 @@ impl KubernetesConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [service_definition][crate::model::KubernetesConfig::service_definition]
-    /// to hold a `ServiceNetworking`.
-    ///
-    /// Note that all the setters affecting `service_definition` are
-    /// mutually exclusive.
-    pub fn set_service_networking<
-        T: std::convert::Into<std::boxed::Box<crate::model::kubernetes_config::ServiceNetworking>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.service_definition = std::option::Option::Some(
-            crate::model::kubernetes_config::ServiceDefinition::ServiceNetworking(v.into()),
-        );
-        self
     }
 }
 
@@ -1732,23 +1620,6 @@ impl RuntimeConfig {
         })
     }
 
-    /// Sets the value of [runtime_config][crate::model::RuntimeConfig::runtime_config]
-    /// to hold a `Kubernetes`.
-    ///
-    /// Note that all the setters affecting `runtime_config` are
-    /// mutually exclusive.
-    pub fn set_kubernetes<
-        T: std::convert::Into<std::boxed::Box<crate::model::KubernetesConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.runtime_config = std::option::Option::Some(
-            crate::model::runtime_config::RuntimeConfig::Kubernetes(v.into()),
-        );
-        self
-    }
-
     /// The value of [runtime_config][crate::model::RuntimeConfig::runtime_config]
     /// if it holds a `CloudRun`, `None` if the field is not set or
     /// holds a different branch.
@@ -1760,21 +1631,6 @@ impl RuntimeConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [runtime_config][crate::model::RuntimeConfig::runtime_config]
-    /// to hold a `CloudRun`.
-    ///
-    /// Note that all the setters affecting `runtime_config` are
-    /// mutually exclusive.
-    pub fn set_cloud_run<T: std::convert::Into<std::boxed::Box<crate::model::CloudRunConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.runtime_config = std::option::Option::Some(
-            crate::model::runtime_config::RuntimeConfig::CloudRun(v.into()),
-        );
-        self
     }
 }
 
@@ -2962,20 +2818,6 @@ impl Target {
         })
     }
 
-    /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
-    /// to hold a `Gke`.
-    ///
-    /// Note that all the setters affecting `deployment_target` are
-    /// mutually exclusive.
-    pub fn set_gke<T: std::convert::Into<std::boxed::Box<crate::model::GkeCluster>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_target =
-            std::option::Option::Some(crate::model::target::DeploymentTarget::Gke(v.into()));
-        self
-    }
-
     /// The value of [deployment_target][crate::model::Target::deployment_target]
     /// if it holds a `AnthosCluster`, `None` if the field is not set or
     /// holds a different branch.
@@ -2991,23 +2833,6 @@ impl Target {
         })
     }
 
-    /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
-    /// to hold a `AnthosCluster`.
-    ///
-    /// Note that all the setters affecting `deployment_target` are
-    /// mutually exclusive.
-    pub fn set_anthos_cluster<
-        T: std::convert::Into<std::boxed::Box<crate::model::AnthosCluster>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_target = std::option::Option::Some(
-            crate::model::target::DeploymentTarget::AnthosCluster(v.into()),
-        );
-        self
-    }
-
     /// The value of [deployment_target][crate::model::Target::deployment_target]
     /// if it holds a `Run`, `None` if the field is not set or
     /// holds a different branch.
@@ -3017,20 +2842,6 @@ impl Target {
             crate::model::target::DeploymentTarget::Run(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
-    /// to hold a `Run`.
-    ///
-    /// Note that all the setters affecting `deployment_target` are
-    /// mutually exclusive.
-    pub fn set_run<T: std::convert::Into<std::boxed::Box<crate::model::CloudRunLocation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_target =
-            std::option::Option::Some(crate::model::target::DeploymentTarget::Run(v.into()));
-        self
     }
 
     /// The value of [deployment_target][crate::model::Target::deployment_target]
@@ -3044,21 +2855,6 @@ impl Target {
         })
     }
 
-    /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
-    /// to hold a `MultiTarget`.
-    ///
-    /// Note that all the setters affecting `deployment_target` are
-    /// mutually exclusive.
-    pub fn set_multi_target<T: std::convert::Into<std::boxed::Box<crate::model::MultiTarget>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_target = std::option::Option::Some(
-            crate::model::target::DeploymentTarget::MultiTarget(v.into()),
-        );
-        self
-    }
-
     /// The value of [deployment_target][crate::model::Target::deployment_target]
     /// if it holds a `CustomTarget`, `None` if the field is not set or
     /// holds a different branch.
@@ -3070,21 +2866,6 @@ impl Target {
             crate::model::target::DeploymentTarget::CustomTarget(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [deployment_target][crate::model::Target::deployment_target]
-    /// to hold a `CustomTarget`.
-    ///
-    /// Note that all the setters affecting `deployment_target` are
-    /// mutually exclusive.
-    pub fn set_custom_target<T: std::convert::Into<std::boxed::Box<crate::model::CustomTarget>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.deployment_target = std::option::Option::Some(
-            crate::model::target::DeploymentTarget::CustomTarget(v.into()),
-        );
-        self
     }
 }
 
@@ -3250,21 +3031,6 @@ impl ExecutionConfig {
         })
     }
 
-    /// Sets the value of [execution_environment][crate::model::ExecutionConfig::execution_environment]
-    /// to hold a `DefaultPool`.
-    ///
-    /// Note that all the setters affecting `execution_environment` are
-    /// mutually exclusive.
-    pub fn set_default_pool<T: std::convert::Into<std::boxed::Box<crate::model::DefaultPool>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.execution_environment = std::option::Option::Some(
-            crate::model::execution_config::ExecutionEnvironment::DefaultPool(v.into()),
-        );
-        self
-    }
-
     /// The value of [execution_environment][crate::model::ExecutionConfig::execution_environment]
     /// if it holds a `PrivatePool`, `None` if the field is not set or
     /// holds a different branch.
@@ -3276,21 +3042,6 @@ impl ExecutionConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [execution_environment][crate::model::ExecutionConfig::execution_environment]
-    /// to hold a `PrivatePool`.
-    ///
-    /// Note that all the setters affecting `execution_environment` are
-    /// mutually exclusive.
-    pub fn set_private_pool<T: std::convert::Into<std::boxed::Box<crate::model::PrivatePool>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.execution_environment = std::option::Option::Some(
-            crate::model::execution_config::ExecutionEnvironment::PrivatePool(v.into()),
-        );
-        self
     }
 }
 
@@ -4500,23 +4251,6 @@ impl CustomTargetType {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [definition][crate::model::CustomTargetType::definition]
-    /// to hold a `CustomActions`.
-    ///
-    /// Note that all the setters affecting `definition` are
-    /// mutually exclusive.
-    pub fn set_custom_actions<
-        T: std::convert::Into<std::boxed::Box<crate::model::CustomTargetSkaffoldActions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.definition = std::option::Option::Some(
-            crate::model::custom_target_type::Definition::CustomActions(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for CustomTargetType {
@@ -4665,22 +4399,6 @@ impl SkaffoldModules {
         })
     }
 
-    /// Sets the value of [source][crate::model::SkaffoldModules::source]
-    /// to hold a `Git`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_git<
-        T: std::convert::Into<std::boxed::Box<crate::model::skaffold_modules::SkaffoldGitSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::skaffold_modules::Source::Git(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::SkaffoldModules::source]
     /// if it holds a `GoogleCloudStorage`, `None` if the field is not set or
     /// holds a different branch.
@@ -4697,23 +4415,6 @@ impl SkaffoldModules {
         })
     }
 
-    /// Sets the value of [source][crate::model::SkaffoldModules::source]
-    /// to hold a `GoogleCloudStorage`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_google_cloud_storage<
-        T: std::convert::Into<std::boxed::Box<crate::model::skaffold_modules::SkaffoldGCSSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::skaffold_modules::Source::GoogleCloudStorage(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::SkaffoldModules::source]
     /// if it holds a `GoogleCloudBuildRepo`, `None` if the field is not set or
     /// holds a different branch.
@@ -4728,23 +4429,6 @@ impl SkaffoldModules {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::SkaffoldModules::source]
-    /// to hold a `GoogleCloudBuildRepo`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_google_cloud_build_repo<
-        T: std::convert::Into<std::boxed::Box<crate::model::skaffold_modules::SkaffoldGCBRepoSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::skaffold_modules::Source::GoogleCloudBuildRepo(v.into()),
-        );
-        self
     }
 }
 
@@ -5941,23 +5625,6 @@ impl PolicyRule {
             crate::model::policy_rule::Rule::RolloutRestriction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule][crate::model::PolicyRule::rule]
-    /// to hold a `RolloutRestriction`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_rollout_restriction<
-        T: std::convert::Into<std::boxed::Box<crate::model::RolloutRestriction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(crate::model::policy_rule::Rule::RolloutRestriction(
-            v.into(),
-        ));
-        self
     }
 }
 
@@ -8249,17 +7916,6 @@ impl TargetArtifact {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [uri][crate::model::TargetArtifact::uri]
-    /// to hold a `ArtifactUri`.
-    ///
-    /// Note that all the setters affecting `uri` are
-    /// mutually exclusive.
-    pub fn set_artifact_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.uri =
-            std::option::Option::Some(crate::model::target_artifact::Uri::ArtifactUri(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for TargetArtifact {
@@ -10056,21 +9712,6 @@ impl Phase {
         })
     }
 
-    /// Sets the value of [jobs][crate::model::Phase::jobs]
-    /// to hold a `DeploymentJobs`.
-    ///
-    /// Note that all the setters affecting `jobs` are
-    /// mutually exclusive.
-    pub fn set_deployment_jobs<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeploymentJobs>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.jobs = std::option::Option::Some(crate::model::phase::Jobs::DeploymentJobs(v.into()));
-        self
-    }
-
     /// The value of [jobs][crate::model::Phase::jobs]
     /// if it holds a `ChildRolloutJobs`, `None` if the field is not set or
     /// holds a different branch.
@@ -10082,22 +9723,6 @@ impl Phase {
             crate::model::phase::Jobs::ChildRolloutJobs(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [jobs][crate::model::Phase::jobs]
-    /// to hold a `ChildRolloutJobs`.
-    ///
-    /// Note that all the setters affecting `jobs` are
-    /// mutually exclusive.
-    pub fn set_child_rollout_jobs<
-        T: std::convert::Into<std::boxed::Box<crate::model::ChildRolloutJobs>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.jobs =
-            std::option::Option::Some(crate::model::phase::Jobs::ChildRolloutJobs(v.into()));
-        self
     }
 }
 
@@ -10494,19 +10119,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::Job::job_type]
-    /// to hold a `DeployJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_deploy_job<T: std::convert::Into<std::boxed::Box<crate::model::DeployJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type = std::option::Option::Some(crate::model::job::JobType::DeployJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::Job::job_type]
     /// if it holds a `VerifyJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10516,19 +10128,6 @@ impl Job {
             crate::model::job::JobType::VerifyJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::Job::job_type]
-    /// to hold a `VerifyJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_verify_job<T: std::convert::Into<std::boxed::Box<crate::model::VerifyJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type = std::option::Option::Some(crate::model::job::JobType::VerifyJob(v.into()));
-        self
     }
 
     /// The value of [job_type][crate::model::Job::job_type]
@@ -10544,20 +10143,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::Job::job_type]
-    /// to hold a `PredeployJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_predeploy_job<T: std::convert::Into<std::boxed::Box<crate::model::PredeployJob>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::job::JobType::PredeployJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::Job::job_type]
     /// if it holds a `PostdeployJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10569,22 +10154,6 @@ impl Job {
             crate::model::job::JobType::PostdeployJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::Job::job_type]
-    /// to hold a `PostdeployJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_postdeploy_job<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostdeployJob>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::job::JobType::PostdeployJob(v.into()));
-        self
     }
 
     /// The value of [job_type][crate::model::Job::job_type]
@@ -10600,22 +10169,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [job_type][crate::model::Job::job_type]
-    /// to hold a `CreateChildRolloutJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_create_child_rollout_job<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateChildRolloutJob>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::job::JobType::CreateChildRolloutJob(v.into()));
-        self
-    }
-
     /// The value of [job_type][crate::model::Job::job_type]
     /// if it holds a `AdvanceChildRolloutJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -10627,22 +10180,6 @@ impl Job {
             crate::model::job::JobType::AdvanceChildRolloutJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_type][crate::model::Job::job_type]
-    /// to hold a `AdvanceChildRolloutJob`.
-    ///
-    /// Note that all the setters affecting `job_type` are
-    /// mutually exclusive.
-    pub fn set_advance_child_rollout_job<
-        T: std::convert::Into<std::boxed::Box<crate::model::AdvanceChildRolloutJob>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_type =
-            std::option::Option::Some(crate::model::job::JobType::AdvanceChildRolloutJob(v.into()));
-        self
     }
 }
 
@@ -12050,22 +11587,6 @@ impl JobRun {
         })
     }
 
-    /// Sets the value of [job_run][crate::model::JobRun::job_run]
-    /// to hold a `DeployJobRun`.
-    ///
-    /// Note that all the setters affecting `job_run` are
-    /// mutually exclusive.
-    pub fn set_deploy_job_run<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeployJobRun>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_run =
-            std::option::Option::Some(crate::model::job_run::JobRun::DeployJobRun(v.into()));
-        self
-    }
-
     /// The value of [job_run][crate::model::JobRun::job_run]
     /// if it holds a `VerifyJobRun`, `None` if the field is not set or
     /// holds a different branch.
@@ -12077,22 +11598,6 @@ impl JobRun {
             crate::model::job_run::JobRun::VerifyJobRun(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_run][crate::model::JobRun::job_run]
-    /// to hold a `VerifyJobRun`.
-    ///
-    /// Note that all the setters affecting `job_run` are
-    /// mutually exclusive.
-    pub fn set_verify_job_run<
-        T: std::convert::Into<std::boxed::Box<crate::model::VerifyJobRun>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_run =
-            std::option::Option::Some(crate::model::job_run::JobRun::VerifyJobRun(v.into()));
-        self
     }
 
     /// The value of [job_run][crate::model::JobRun::job_run]
@@ -12108,22 +11613,6 @@ impl JobRun {
         })
     }
 
-    /// Sets the value of [job_run][crate::model::JobRun::job_run]
-    /// to hold a `PredeployJobRun`.
-    ///
-    /// Note that all the setters affecting `job_run` are
-    /// mutually exclusive.
-    pub fn set_predeploy_job_run<
-        T: std::convert::Into<std::boxed::Box<crate::model::PredeployJobRun>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_run =
-            std::option::Option::Some(crate::model::job_run::JobRun::PredeployJobRun(v.into()));
-        self
-    }
-
     /// The value of [job_run][crate::model::JobRun::job_run]
     /// if it holds a `PostdeployJobRun`, `None` if the field is not set or
     /// holds a different branch.
@@ -12135,22 +11624,6 @@ impl JobRun {
             crate::model::job_run::JobRun::PostdeployJobRun(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_run][crate::model::JobRun::job_run]
-    /// to hold a `PostdeployJobRun`.
-    ///
-    /// Note that all the setters affecting `job_run` are
-    /// mutually exclusive.
-    pub fn set_postdeploy_job_run<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostdeployJobRun>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_run =
-            std::option::Option::Some(crate::model::job_run::JobRun::PostdeployJobRun(v.into()));
-        self
     }
 
     /// The value of [job_run][crate::model::JobRun::job_run]
@@ -12168,23 +11641,6 @@ impl JobRun {
         })
     }
 
-    /// Sets the value of [job_run][crate::model::JobRun::job_run]
-    /// to hold a `CreateChildRolloutJobRun`.
-    ///
-    /// Note that all the setters affecting `job_run` are
-    /// mutually exclusive.
-    pub fn set_create_child_rollout_job_run<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateChildRolloutJobRun>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_run = std::option::Option::Some(
-            crate::model::job_run::JobRun::CreateChildRolloutJobRun(v.into()),
-        );
-        self
-    }
-
     /// The value of [job_run][crate::model::JobRun::job_run]
     /// if it holds a `AdvanceChildRolloutJobRun`, `None` if the field is not set or
     /// holds a different branch.
@@ -12198,23 +11654,6 @@ impl JobRun {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_run][crate::model::JobRun::job_run]
-    /// to hold a `AdvanceChildRolloutJobRun`.
-    ///
-    /// Note that all the setters affecting `job_run` are
-    /// mutually exclusive.
-    pub fn set_advance_child_rollout_job_run<
-        T: std::convert::Into<std::boxed::Box<crate::model::AdvanceChildRolloutJobRun>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_run = std::option::Option::Some(
-            crate::model::job_run::JobRun::AdvanceChildRolloutJobRun(v.into()),
-        );
-        self
     }
 }
 
@@ -14167,23 +13606,6 @@ impl AutomationRule {
         })
     }
 
-    /// Sets the value of [rule][crate::model::AutomationRule::rule]
-    /// to hold a `PromoteReleaseRule`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_promote_release_rule<
-        T: std::convert::Into<std::boxed::Box<crate::model::PromoteReleaseRule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(
-            crate::model::automation_rule::Rule::PromoteReleaseRule(v.into()),
-        );
-        self
-    }
-
     /// The value of [rule][crate::model::AutomationRule::rule]
     /// if it holds a `AdvanceRolloutRule`, `None` if the field is not set or
     /// holds a different branch.
@@ -14197,23 +13619,6 @@ impl AutomationRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule][crate::model::AutomationRule::rule]
-    /// to hold a `AdvanceRolloutRule`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_advance_rollout_rule<
-        T: std::convert::Into<std::boxed::Box<crate::model::AdvanceRolloutRule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(
-            crate::model::automation_rule::Rule::AdvanceRolloutRule(v.into()),
-        );
-        self
     }
 
     /// The value of [rule][crate::model::AutomationRule::rule]
@@ -14231,23 +13636,6 @@ impl AutomationRule {
         })
     }
 
-    /// Sets the value of [rule][crate::model::AutomationRule::rule]
-    /// to hold a `RepairRolloutRule`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_repair_rollout_rule<
-        T: std::convert::Into<std::boxed::Box<crate::model::RepairRolloutRule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(
-            crate::model::automation_rule::Rule::RepairRolloutRule(v.into()),
-        );
-        self
-    }
-
     /// The value of [rule][crate::model::AutomationRule::rule]
     /// if it holds a `TimedPromoteReleaseRule`, `None` if the field is not set or
     /// holds a different branch.
@@ -14261,23 +13649,6 @@ impl AutomationRule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule][crate::model::AutomationRule::rule]
-    /// to hold a `TimedPromoteReleaseRule`.
-    ///
-    /// Note that all the setters affecting `rule` are
-    /// mutually exclusive.
-    pub fn set_timed_promote_release_rule<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimedPromoteReleaseRule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule = std::option::Option::Some(
-            crate::model::automation_rule::Rule::TimedPromoteReleaseRule(v.into()),
-        );
-        self
     }
 }
 
@@ -14748,21 +14119,6 @@ impl RepairPhaseConfig {
         })
     }
 
-    /// Sets the value of [repair_phase][crate::model::RepairPhaseConfig::repair_phase]
-    /// to hold a `Retry`.
-    ///
-    /// Note that all the setters affecting `repair_phase` are
-    /// mutually exclusive.
-    pub fn set_retry<T: std::convert::Into<std::boxed::Box<crate::model::Retry>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.repair_phase = std::option::Option::Some(
-            crate::model::repair_phase_config::RepairPhase::Retry(v.into()),
-        );
-        self
-    }
-
     /// The value of [repair_phase][crate::model::RepairPhaseConfig::repair_phase]
     /// if it holds a `Rollback`, `None` if the field is not set or
     /// holds a different branch.
@@ -14774,21 +14130,6 @@ impl RepairPhaseConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [repair_phase][crate::model::RepairPhaseConfig::repair_phase]
-    /// to hold a `Rollback`.
-    ///
-    /// Note that all the setters affecting `repair_phase` are
-    /// mutually exclusive.
-    pub fn set_rollback<T: std::convert::Into<std::boxed::Box<crate::model::Rollback>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.repair_phase = std::option::Option::Some(
-            crate::model::repair_phase_config::RepairPhase::Rollback(v.into()),
-        );
-        self
     }
 }
 
@@ -14990,25 +14331,6 @@ impl AutomationRuleCondition {
             crate::model::automation_rule_condition::RuleTypeCondition::TimedPromoteReleaseCondition(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [rule_type_condition][crate::model::AutomationRuleCondition::rule_type_condition]
-    /// to hold a `TimedPromoteReleaseCondition`.
-    ///
-    /// Note that all the setters affecting `rule_type_condition` are
-    /// mutually exclusive.
-    pub fn set_timed_promote_release_condition<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimedPromoteReleaseCondition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rule_type_condition = std::option::Option::Some(
-            crate::model::automation_rule_condition::RuleTypeCondition::TimedPromoteReleaseCondition(
-                v.into()
-            )
-        );
-        self
     }
 }
 
@@ -15838,23 +15160,6 @@ impl AutomationRun {
         })
     }
 
-    /// Sets the value of [operation][crate::model::AutomationRun::operation]
-    /// to hold a `PromoteReleaseOperation`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_promote_release_operation<
-        T: std::convert::Into<std::boxed::Box<crate::model::PromoteReleaseOperation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation = std::option::Option::Some(
-            crate::model::automation_run::Operation::PromoteReleaseOperation(v.into()),
-        );
-        self
-    }
-
     /// The value of [operation][crate::model::AutomationRun::operation]
     /// if it holds a `AdvanceRolloutOperation`, `None` if the field is not set or
     /// holds a different branch.
@@ -15868,23 +15173,6 @@ impl AutomationRun {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [operation][crate::model::AutomationRun::operation]
-    /// to hold a `AdvanceRolloutOperation`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_advance_rollout_operation<
-        T: std::convert::Into<std::boxed::Box<crate::model::AdvanceRolloutOperation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation = std::option::Option::Some(
-            crate::model::automation_run::Operation::AdvanceRolloutOperation(v.into()),
-        );
-        self
     }
 
     /// The value of [operation][crate::model::AutomationRun::operation]
@@ -15902,23 +15190,6 @@ impl AutomationRun {
         })
     }
 
-    /// Sets the value of [operation][crate::model::AutomationRun::operation]
-    /// to hold a `RepairRolloutOperation`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_repair_rollout_operation<
-        T: std::convert::Into<std::boxed::Box<crate::model::RepairRolloutOperation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation = std::option::Option::Some(
-            crate::model::automation_run::Operation::RepairRolloutOperation(v.into()),
-        );
-        self
-    }
-
     /// The value of [operation][crate::model::AutomationRun::operation]
     /// if it holds a `TimedPromoteReleaseOperation`, `None` if the field is not set or
     /// holds a different branch.
@@ -15932,23 +15203,6 @@ impl AutomationRun {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [operation][crate::model::AutomationRun::operation]
-    /// to hold a `TimedPromoteReleaseOperation`.
-    ///
-    /// Note that all the setters affecting `operation` are
-    /// mutually exclusive.
-    pub fn set_timed_promote_release_operation<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimedPromoteReleaseOperation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation = std::option::Option::Some(
-            crate::model::automation_run::Operation::TimedPromoteReleaseOperation(v.into()),
-        );
-        self
     }
 }
 
@@ -16455,20 +15709,6 @@ impl RepairPhase {
         })
     }
 
-    /// Sets the value of [repair_phase][crate::model::RepairPhase::repair_phase]
-    /// to hold a `Retry`.
-    ///
-    /// Note that all the setters affecting `repair_phase` are
-    /// mutually exclusive.
-    pub fn set_retry<T: std::convert::Into<std::boxed::Box<crate::model::RetryPhase>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.repair_phase =
-            std::option::Option::Some(crate::model::repair_phase::RepairPhase::Retry(v.into()));
-        self
-    }
-
     /// The value of [repair_phase][crate::model::RepairPhase::repair_phase]
     /// if it holds a `Rollback`, `None` if the field is not set or
     /// holds a different branch.
@@ -16478,20 +15718,6 @@ impl RepairPhase {
             crate::model::repair_phase::RepairPhase::Rollback(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [repair_phase][crate::model::RepairPhase::repair_phase]
-    /// to hold a `Rollback`.
-    ///
-    /// Note that all the setters affecting `repair_phase` are
-    /// mutually exclusive.
-    pub fn set_rollback<T: std::convert::Into<std::boxed::Box<crate::model::RollbackAttempt>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.repair_phase =
-            std::option::Option::Some(crate::model::repair_phase::RepairPhase::Rollback(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/developerconnect/v1/src/model.rs
+++ b/src/generated/cloud/developerconnect/v1/src/model.rs
@@ -240,21 +240,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `GithubConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_github_config<T: std::convert::Into<std::boxed::Box<crate::model::GitHubConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::GithubConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_config][crate::model::Connection::connection_config]
     /// if it holds a `GithubEnterpriseConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -268,23 +253,6 @@ impl Connection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `GithubEnterpriseConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_github_enterprise_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::GitHubEnterpriseConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [connection_config][crate::model::Connection::connection_config]
@@ -302,21 +270,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `GitlabConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_gitlab_config<T: std::convert::Into<std::boxed::Box<crate::model::GitLabConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::GitlabConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_config][crate::model::Connection::connection_config]
     /// if it holds a `GitlabEnterpriseConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -330,23 +283,6 @@ impl Connection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `GitlabEnterpriseConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_gitlab_enterprise_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::GitLabEnterpriseConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::GitlabEnterpriseConfig(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
@@ -677,41 +677,6 @@ pub mod agents {
             self.0.request.agent = v.into();
             self
         }
-
-        /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-        /// to hold a `AgentUri`.
-        ///
-        /// Note that all the setters affecting `agent` are
-        /// mutually exclusive.
-        pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_agent_uri(v);
-            self
-        }
-
-        /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-        /// to hold a `AgentContent`.
-        ///
-        /// Note that all the setters affecting `agent` are
-        /// mutually exclusive.
-        pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_agent_content(v);
-            self
-        }
-
-        /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-        /// to hold a `GitSource`.
-        ///
-        /// Note that all the setters affecting `agent` are
-        /// mutually exclusive.
-        pub fn set_git_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::restore_agent_request::GitSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_git_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -3269,32 +3234,6 @@ pub mod entity_types {
             self.0.request.destination = v.into();
             self
         }
-
-        /// Sets the value of [destination][crate::model::ExportEntityTypesRequest::destination]
-        /// to hold a `EntityTypesUri`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_entity_types_uri<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_entity_types_uri(v);
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportEntityTypesRequest::destination]
-        /// to hold a `EntityTypesContentInline`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_entity_types_content_inline<T: std::convert::Into<bool>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_entity_types_content_inline(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -3433,34 +3372,6 @@ pub mod entity_types {
             v: T,
         ) -> Self {
             self.0.request.entity_types = v.into();
-            self
-        }
-
-        /// Sets the value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
-        /// to hold a `EntityTypesUri`.
-        ///
-        /// Note that all the setters affecting `entity_types` are
-        /// mutually exclusive.
-        pub fn set_entity_types_uri<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_entity_types_uri(v);
-            self
-        }
-
-        /// Sets the value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
-        /// to hold a `EntityTypesContent`.
-        ///
-        /// Note that all the setters affecting `entity_types` are
-        /// mutually exclusive.
-        pub fn set_entity_types_content<
-            T: std::convert::Into<std::boxed::Box<crate::model::InlineSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_entity_types_content(v);
             self
         }
     }
@@ -7008,26 +6919,6 @@ pub mod flows {
             self.0.request.flow = v.into();
             self
         }
-
-        /// Sets the value of [flow][crate::model::ImportFlowRequest::flow]
-        /// to hold a `FlowUri`.
-        ///
-        /// Note that all the setters affecting `flow` are
-        /// mutually exclusive.
-        pub fn set_flow_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_flow_uri(v);
-            self
-        }
-
-        /// Sets the value of [flow][crate::model::ImportFlowRequest::flow]
-        /// to hold a `FlowContent`.
-        ///
-        /// Note that all the setters affecting `flow` are
-        /// mutually exclusive.
-        pub fn set_flow_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_flow_content(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -8966,31 +8857,6 @@ pub mod intents {
             self.0.request.intents = v.into();
             self
         }
-
-        /// Sets the value of [intents][crate::model::ImportIntentsRequest::intents]
-        /// to hold a `IntentsUri`.
-        ///
-        /// Note that all the setters affecting `intents` are
-        /// mutually exclusive.
-        pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_intents_uri(v);
-            self
-        }
-
-        /// Sets the value of [intents][crate::model::ImportIntentsRequest::intents]
-        /// to hold a `IntentsContent`.
-        ///
-        /// Note that all the setters affecting `intents` are
-        /// mutually exclusive.
-        pub fn set_intents_content<
-            T: std::convert::Into<std::boxed::Box<crate::model::InlineSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_intents_content(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -9127,26 +8993,6 @@ pub mod intents {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportIntentsRequest::destination]
-        /// to hold a `IntentsUri`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_intents_uri(v);
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportIntentsRequest::destination]
-        /// to hold a `IntentsContentInline`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_intents_content_inline<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_intents_content_inline(v);
             self
         }
     }
@@ -13786,26 +13632,6 @@ pub mod test_cases {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ImportTestCasesRequest::source]
-        /// to hold a `GcsUri`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_gcs_uri(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportTestCasesRequest::source]
-        /// to hold a `Content`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_content(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -13937,16 +13763,6 @@ pub mod test_cases {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportTestCasesRequest::destination]
-        /// to hold a `GcsUri`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_gcs_uri(v);
             self
         }
     }

--- a/src/generated/cloud/dialogflow/cx/v3/src/model.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/model.rs
@@ -846,27 +846,6 @@ pub mod agent {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [git_settings][crate::model::agent::GitIntegrationSettings::git_settings]
-        /// to hold a `GithubSettings`.
-        ///
-        /// Note that all the setters affecting `git_settings` are
-        /// mutually exclusive.
-        pub fn set_github_settings<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::agent::git_integration_settings::GithubSettings>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.git_settings = std::option::Option::Some(
-                crate::model::agent::git_integration_settings::GitSettings::GithubSettings(
-                    v.into(),
-                ),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for GitIntegrationSettings {
@@ -1802,18 +1781,6 @@ impl ExportAgentResponse {
         })
     }
 
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::AgentUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [agent][crate::model::ExportAgentResponse::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1827,18 +1794,6 @@ impl ExportAgentResponse {
         })
     }
 
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `AgentContent`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::AgentContent(v.into()),
-        );
-        self
-    }
-
     /// The value of [agent][crate::model::ExportAgentResponse::agent]
     /// if it holds a `CommitSha`, `None` if the field is not set or
     /// holds a different branch.
@@ -1850,18 +1805,6 @@ impl ExportAgentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `CommitSha`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_commit_sha<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::CommitSha(v.into()),
-        );
-        self
     }
 }
 
@@ -1975,18 +1918,6 @@ impl RestoreAgentRequest {
         })
     }
 
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::AgentUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [agent][crate::model::RestoreAgentRequest::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1998,18 +1929,6 @@ impl RestoreAgentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `AgentContent`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::AgentContent(v.into()),
-        );
-        self
     }
 
     /// The value of [agent][crate::model::RestoreAgentRequest::agent]
@@ -2025,23 +1944,6 @@ impl RestoreAgentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `GitSource`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_git_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::restore_agent_request::GitSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::GitSource(v.into()),
-        );
-        self
     }
 }
 
@@ -5720,21 +5622,6 @@ impl ExportEntityTypesRequest {
         })
     }
 
-    /// Sets the value of [destination][crate::model::ExportEntityTypesRequest::destination]
-    /// to hold a `EntityTypesUri`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_entity_types_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_entity_types_request::Destination::EntityTypesUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::ExportEntityTypesRequest::destination]
     /// if it holds a `EntityTypesContentInline`, `None` if the field is not set or
     /// holds a different branch.
@@ -5746,20 +5633,6 @@ impl ExportEntityTypesRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportEntityTypesRequest::destination]
-    /// to hold a `EntityTypesContentInline`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_entity_types_content_inline<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_entity_types_request::Destination::EntityTypesContentInline(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -5982,23 +5855,6 @@ impl ExportEntityTypesResponse {
         })
     }
 
-    /// Sets the value of [exported_entity_types][crate::model::ExportEntityTypesResponse::exported_entity_types]
-    /// to hold a `EntityTypesUri`.
-    ///
-    /// Note that all the setters affecting `exported_entity_types` are
-    /// mutually exclusive.
-    pub fn set_entity_types_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.exported_entity_types = std::option::Option::Some(
-            crate::model::export_entity_types_response::ExportedEntityTypes::EntityTypesUri(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [exported_entity_types][crate::model::ExportEntityTypesResponse::exported_entity_types]
     /// if it holds a `EntityTypesContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -6012,25 +5868,6 @@ impl ExportEntityTypesResponse {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [exported_entity_types][crate::model::ExportEntityTypesResponse::exported_entity_types]
-    /// to hold a `EntityTypesContent`.
-    ///
-    /// Note that all the setters affecting `exported_entity_types` are
-    /// mutually exclusive.
-    pub fn set_entity_types_content<
-        T: std::convert::Into<std::boxed::Box<crate::model::InlineDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.exported_entity_types = std::option::Option::Some(
-            crate::model::export_entity_types_response::ExportedEntityTypes::EntityTypesContent(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -6191,21 +6028,6 @@ impl ImportEntityTypesRequest {
         })
     }
 
-    /// Sets the value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
-    /// to hold a `EntityTypesUri`.
-    ///
-    /// Note that all the setters affecting `entity_types` are
-    /// mutually exclusive.
-    pub fn set_entity_types_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_types = std::option::Option::Some(
-            crate::model::import_entity_types_request::EntityTypes::EntityTypesUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
     /// if it holds a `EntityTypesContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -6219,23 +6041,6 @@ impl ImportEntityTypesRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entity_types][crate::model::ImportEntityTypesRequest::entity_types]
-    /// to hold a `EntityTypesContent`.
-    ///
-    /// Note that all the setters affecting `entity_types` are
-    /// mutually exclusive.
-    pub fn set_entity_types_content<
-        T: std::convert::Into<std::boxed::Box<crate::model::InlineSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_types = std::option::Option::Some(
-            crate::model::import_entity_types_request::EntityTypes::EntityTypesContent(v.into()),
-        );
-        self
     }
 }
 
@@ -8595,23 +8400,6 @@ pub mod experiment {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [variants][crate::model::experiment::Definition::variants]
-        /// to hold a `VersionVariants`.
-        ///
-        /// Note that all the setters affecting `variants` are
-        /// mutually exclusive.
-        pub fn set_version_variants<
-            T: std::convert::Into<std::boxed::Box<crate::model::VersionVariants>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.variants = std::option::Option::Some(
-                crate::model::experiment::definition::Variants::VersionVariants(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for Definition {
@@ -8859,18 +8647,6 @@ pub mod experiment {
                 })
             }
 
-            /// Sets the value of [value][crate::model::experiment::result::Metric::value]
-            /// to hold a `Ratio`.
-            ///
-            /// Note that all the setters affecting `value` are
-            /// mutually exclusive.
-            pub fn set_ratio<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-                self.value = std::option::Option::Some(
-                    crate::model::experiment::result::metric::Value::Ratio(v.into()),
-                );
-                self
-            }
-
             /// The value of [value][crate::model::experiment::result::Metric::value]
             /// if it holds a `Count`, `None` if the field is not set or
             /// holds a different branch.
@@ -8882,18 +8658,6 @@ pub mod experiment {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [value][crate::model::experiment::result::Metric::value]
-            /// to hold a `Count`.
-            ///
-            /// Note that all the setters affecting `value` are
-            /// mutually exclusive.
-            pub fn set_count<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-                self.value = std::option::Option::Some(
-                    crate::model::experiment::result::metric::Value::Count(v.into()),
-                );
-                self
             }
         }
 
@@ -9595,23 +9359,6 @@ impl VariantsHistory {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [variants][crate::model::VariantsHistory::variants]
-    /// to hold a `VersionVariants`.
-    ///
-    /// Note that all the setters affecting `variants` are
-    /// mutually exclusive.
-    pub fn set_version_variants<
-        T: std::convert::Into<std::boxed::Box<crate::model::VersionVariants>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.variants = std::option::Option::Some(
-            crate::model::variants_history::Variants::VersionVariants(v.into()),
-        );
-        self
     }
 }
 
@@ -11543,17 +11290,6 @@ impl ImportFlowRequest {
         })
     }
 
-    /// Sets the value of [flow][crate::model::ImportFlowRequest::flow]
-    /// to hold a `FlowUri`.
-    ///
-    /// Note that all the setters affecting `flow` are
-    /// mutually exclusive.
-    pub fn set_flow_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.flow =
-            std::option::Option::Some(crate::model::import_flow_request::Flow::FlowUri(v.into()));
-        self
-    }
-
     /// The value of [flow][crate::model::ImportFlowRequest::flow]
     /// if it holds a `FlowContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -11563,18 +11299,6 @@ impl ImportFlowRequest {
             crate::model::import_flow_request::Flow::FlowContent(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [flow][crate::model::ImportFlowRequest::flow]
-    /// to hold a `FlowContent`.
-    ///
-    /// Note that all the setters affecting `flow` are
-    /// mutually exclusive.
-    pub fn set_flow_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.flow = std::option::Option::Some(
-            crate::model::import_flow_request::Flow::FlowContent(v.into()),
-        );
-        self
     }
 }
 
@@ -11936,17 +11660,6 @@ impl ExportFlowResponse {
         })
     }
 
-    /// Sets the value of [flow][crate::model::ExportFlowResponse::flow]
-    /// to hold a `FlowUri`.
-    ///
-    /// Note that all the setters affecting `flow` are
-    /// mutually exclusive.
-    pub fn set_flow_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.flow =
-            std::option::Option::Some(crate::model::export_flow_response::Flow::FlowUri(v.into()));
-        self
-    }
-
     /// The value of [flow][crate::model::ExportFlowResponse::flow]
     /// if it holds a `FlowContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -11958,18 +11671,6 @@ impl ExportFlowResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [flow][crate::model::ExportFlowResponse::flow]
-    /// to hold a `FlowContent`.
-    ///
-    /// Note that all the setters affecting `flow` are
-    /// mutually exclusive.
-    pub fn set_flow_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.flow = std::option::Option::Some(
-            crate::model::export_flow_response::Flow::FlowContent(v.into()),
-        );
-        self
     }
 }
 
@@ -12374,25 +12075,6 @@ pub mod fulfillment {
                     })
                 }
 
-                /// Sets the value of [cases_or_message][crate::model::fulfillment::conditional_cases::case::CaseContent::cases_or_message]
-                /// to hold a `Message`.
-                ///
-                /// Note that all the setters affecting `cases_or_message` are
-                /// mutually exclusive.
-                pub fn set_message<
-                    T: std::convert::Into<std::boxed::Box<crate::model::ResponseMessage>>,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.cases_or_message = std::option::Option::Some(
-                        crate::model::fulfillment::conditional_cases::case::case_content::CasesOrMessage::Message(
-                            v.into()
-                        )
-                    );
-                    self
-                }
-
                 /// The value of [cases_or_message][crate::model::fulfillment::conditional_cases::case::CaseContent::cases_or_message]
                 /// if it holds a `AdditionalCases`, `None` if the field is not set or
                 /// holds a different branch.
@@ -12406,27 +12088,6 @@ pub mod fulfillment {
                         crate::model::fulfillment::conditional_cases::case::case_content::CasesOrMessage::AdditionalCases(v) => std::option::Option::Some(v),
                         _ => std::option::Option::None,
                     })
-                }
-
-                /// Sets the value of [cases_or_message][crate::model::fulfillment::conditional_cases::case::CaseContent::cases_or_message]
-                /// to hold a `AdditionalCases`.
-                ///
-                /// Note that all the setters affecting `cases_or_message` are
-                /// mutually exclusive.
-                pub fn set_additional_cases<
-                    T: std::convert::Into<
-                            std::boxed::Box<crate::model::fulfillment::ConditionalCases>,
-                        >,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.cases_or_message = std::option::Option::Some(
-                        crate::model::fulfillment::conditional_cases::case::case_content::CasesOrMessage::AdditionalCases(
-                            v.into()
-                        )
-                    );
-                    self
                 }
             }
 
@@ -14338,18 +13999,6 @@ impl ImportIntentsRequest {
         })
     }
 
-    /// Sets the value of [intents][crate::model::ImportIntentsRequest::intents]
-    /// to hold a `IntentsUri`.
-    ///
-    /// Note that all the setters affecting `intents` are
-    /// mutually exclusive.
-    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.intents = std::option::Option::Some(
-            crate::model::import_intents_request::Intents::IntentsUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [intents][crate::model::ImportIntentsRequest::intents]
     /// if it holds a `IntentsContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -14363,23 +14012,6 @@ impl ImportIntentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [intents][crate::model::ImportIntentsRequest::intents]
-    /// to hold a `IntentsContent`.
-    ///
-    /// Note that all the setters affecting `intents` are
-    /// mutually exclusive.
-    pub fn set_intents_content<
-        T: std::convert::Into<std::boxed::Box<crate::model::InlineSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.intents = std::option::Option::Some(
-            crate::model::import_intents_request::Intents::IntentsContent(v.into()),
-        );
-        self
     }
 }
 
@@ -14824,18 +14456,6 @@ impl ExportIntentsRequest {
         })
     }
 
-    /// Sets the value of [destination][crate::model::ExportIntentsRequest::destination]
-    /// to hold a `IntentsUri`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_intents_request::Destination::IntentsUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::ExportIntentsRequest::destination]
     /// if it holds a `IntentsContentInline`, `None` if the field is not set or
     /// holds a different branch.
@@ -14847,18 +14467,6 @@ impl ExportIntentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportIntentsRequest::destination]
-    /// to hold a `IntentsContentInline`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_intents_content_inline<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_intents_request::Destination::IntentsContentInline(v.into()),
-        );
-        self
     }
 }
 
@@ -15083,18 +14691,6 @@ impl ExportIntentsResponse {
         })
     }
 
-    /// Sets the value of [intents][crate::model::ExportIntentsResponse::intents]
-    /// to hold a `IntentsUri`.
-    ///
-    /// Note that all the setters affecting `intents` are
-    /// mutually exclusive.
-    pub fn set_intents_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.intents = std::option::Option::Some(
-            crate::model::export_intents_response::Intents::IntentsUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [intents][crate::model::ExportIntentsResponse::intents]
     /// if it holds a `IntentsContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -15108,23 +14704,6 @@ impl ExportIntentsResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [intents][crate::model::ExportIntentsResponse::intents]
-    /// to hold a `IntentsContent`.
-    ///
-    /// Note that all the setters affecting `intents` are
-    /// mutually exclusive.
-    pub fn set_intents_content<
-        T: std::convert::Into<std::boxed::Box<crate::model::InlineDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.intents = std::option::Option::Some(
-            crate::model::export_intents_response::Intents::IntentsContent(v.into()),
-        );
-        self
     }
 }
 
@@ -15797,17 +15376,6 @@ impl EventHandler {
         })
     }
 
-    /// Sets the value of [target][crate::model::EventHandler::target]
-    /// to hold a `TargetPage`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target =
-            std::option::Option::Some(crate::model::event_handler::Target::TargetPage(v.into()));
-        self
-    }
-
     /// The value of [target][crate::model::EventHandler::target]
     /// if it holds a `TargetFlow`, `None` if the field is not set or
     /// holds a different branch.
@@ -15817,17 +15385,6 @@ impl EventHandler {
             crate::model::event_handler::Target::TargetFlow(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::EventHandler::target]
-    /// to hold a `TargetFlow`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_target_flow<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target =
-            std::option::Option::Some(crate::model::event_handler::Target::TargetFlow(v.into()));
-        self
     }
 }
 
@@ -16011,17 +15568,6 @@ impl TransitionRoute {
         })
     }
 
-    /// Sets the value of [target][crate::model::TransitionRoute::target]
-    /// to hold a `TargetPage`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target =
-            std::option::Option::Some(crate::model::transition_route::Target::TargetPage(v.into()));
-        self
-    }
-
     /// The value of [target][crate::model::TransitionRoute::target]
     /// if it holds a `TargetFlow`, `None` if the field is not set or
     /// holds a different branch.
@@ -16031,17 +15577,6 @@ impl TransitionRoute {
             crate::model::transition_route::Target::TargetFlow(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::TransitionRoute::target]
-    /// to hold a `TargetFlow`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_target_flow<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target =
-            std::option::Option::Some(crate::model::transition_route::Target::TargetFlow(v.into()));
-        self
     }
 }
 
@@ -16625,18 +16160,6 @@ impl KnowledgeConnectorSettings {
         })
     }
 
-    /// Sets the value of [target][crate::model::KnowledgeConnectorSettings::target]
-    /// to hold a `TargetPage`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::knowledge_connector_settings::Target::TargetPage(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::KnowledgeConnectorSettings::target]
     /// if it holds a `TargetFlow`, `None` if the field is not set or
     /// holds a different branch.
@@ -16648,18 +16171,6 @@ impl KnowledgeConnectorSettings {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::KnowledgeConnectorSettings::target]
-    /// to hold a `TargetFlow`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_target_flow<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::knowledge_connector_settings::Target::TargetFlow(v.into()),
-        );
-        self
     }
 }
 
@@ -16787,22 +16298,6 @@ impl ResponseMessage {
         })
     }
 
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_text<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::Text>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message =
-            std::option::Option::Some(crate::model::response_message::Message::Text(v.into()));
-        self
-    }
-
     /// The value of [message][crate::model::ResponseMessage::message]
     /// if it holds a `Payload`, `None` if the field is not set or
     /// holds a different branch.
@@ -16812,20 +16307,6 @@ impl ResponseMessage {
             crate::model::response_message::Message::Payload(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `Payload`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_payload<T: std::convert::Into<std::boxed::Box<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message =
-            std::option::Option::Some(crate::model::response_message::Message::Payload(v.into()));
-        self
     }
 
     /// The value of [message][crate::model::ResponseMessage::message]
@@ -16844,23 +16325,6 @@ impl ResponseMessage {
         })
     }
 
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `ConversationSuccess`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_conversation_success<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::ConversationSuccess>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::response_message::Message::ConversationSuccess(v.into()),
-        );
-        self
-    }
-
     /// The value of [message][crate::model::ResponseMessage::message]
     /// if it holds a `OutputAudioText`, `None` if the field is not set or
     /// holds a different branch.
@@ -16875,23 +16339,6 @@ impl ResponseMessage {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `OutputAudioText`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_output_audio_text<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::OutputAudioText>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::response_message::Message::OutputAudioText(v.into()),
-        );
-        self
     }
 
     /// The value of [message][crate::model::ResponseMessage::message]
@@ -16910,23 +16357,6 @@ impl ResponseMessage {
         })
     }
 
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `LiveAgentHandoff`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_live_agent_handoff<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::LiveAgentHandoff>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::response_message::Message::LiveAgentHandoff(v.into()),
-        );
-        self
-    }
-
     /// The value of [message][crate::model::ResponseMessage::message]
     /// if it holds a `EndInteraction`, `None` if the field is not set or
     /// holds a different branch.
@@ -16942,23 +16372,6 @@ impl ResponseMessage {
         })
     }
 
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `EndInteraction`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_end_interaction<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::EndInteraction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::response_message::Message::EndInteraction(v.into()),
-        );
-        self
-    }
-
     /// The value of [message][crate::model::ResponseMessage::message]
     /// if it holds a `PlayAudio`, `None` if the field is not set or
     /// holds a different branch.
@@ -16972,22 +16385,6 @@ impl ResponseMessage {
         })
     }
 
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `PlayAudio`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_play_audio<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::PlayAudio>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message =
-            std::option::Option::Some(crate::model::response_message::Message::PlayAudio(v.into()));
-        self
-    }
-
     /// The value of [message][crate::model::ResponseMessage::message]
     /// if it holds a `MixedAudio`, `None` if the field is not set or
     /// holds a different branch.
@@ -16999,23 +16396,6 @@ impl ResponseMessage {
             crate::model::response_message::Message::MixedAudio(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `MixedAudio`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_mixed_audio<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::MixedAudio>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::response_message::Message::MixedAudio(v.into()),
-        );
-        self
     }
 
     /// The value of [message][crate::model::ResponseMessage::message]
@@ -17034,23 +16414,6 @@ impl ResponseMessage {
         })
     }
 
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `TelephonyTransferCall`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_telephony_transfer_call<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::TelephonyTransferCall>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::response_message::Message::TelephonyTransferCall(v.into()),
-        );
-        self
-    }
-
     /// The value of [message][crate::model::ResponseMessage::message]
     /// if it holds a `KnowledgeInfoCard`, `None` if the field is not set or
     /// holds a different branch.
@@ -17065,23 +16428,6 @@ impl ResponseMessage {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [message][crate::model::ResponseMessage::message]
-    /// to hold a `KnowledgeInfoCard`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_knowledge_info_card<
-        T: std::convert::Into<std::boxed::Box<crate::model::response_message::KnowledgeInfoCard>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::response_message::Message::KnowledgeInfoCard(v.into()),
-        );
-        self
     }
 }
 
@@ -17321,18 +16667,6 @@ pub mod response_message {
             })
         }
 
-        /// Sets the value of [source][crate::model::response_message::OutputAudioText::source]
-        /// to hold a `Text`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::response_message::output_audio_text::Source::Text(v.into()),
-            );
-            self
-        }
-
         /// The value of [source][crate::model::response_message::OutputAudioText::source]
         /// if it holds a `Ssml`, `None` if the field is not set or
         /// holds a different branch.
@@ -17344,18 +16678,6 @@ pub mod response_message {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::response_message::OutputAudioText::source]
-        /// to hold a `Ssml`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_ssml<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::response_message::output_audio_text::Source::Ssml(v.into()),
-            );
-            self
         }
     }
 
@@ -17572,18 +16894,6 @@ pub mod response_message {
                 })
             }
 
-            /// Sets the value of [content][crate::model::response_message::mixed_audio::Segment::content]
-            /// to hold a `Audio`.
-            ///
-            /// Note that all the setters affecting `content` are
-            /// mutually exclusive.
-            pub fn set_audio<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-                self.content = std::option::Option::Some(
-                    crate::model::response_message::mixed_audio::segment::Content::Audio(v.into()),
-                );
-                self
-            }
-
             /// The value of [content][crate::model::response_message::mixed_audio::Segment::content]
             /// if it holds a `Uri`, `None` if the field is not set or
             /// holds a different branch.
@@ -17595,18 +16905,6 @@ pub mod response_message {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [content][crate::model::response_message::mixed_audio::Segment::content]
-            /// to hold a `Uri`.
-            ///
-            /// Note that all the setters affecting `content` are
-            /// mutually exclusive.
-            pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.content = std::option::Option::Some(
-                    crate::model::response_message::mixed_audio::segment::Content::Uri(v.into()),
-                );
-                self
             }
         }
 
@@ -17687,23 +16985,6 @@ pub mod response_message {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [endpoint][crate::model::response_message::TelephonyTransferCall::endpoint]
-        /// to hold a `PhoneNumber`.
-        ///
-        /// Note that all the setters affecting `endpoint` are
-        /// mutually exclusive.
-        pub fn set_phone_number<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.endpoint = std::option::Option::Some(
-                crate::model::response_message::telephony_transfer_call::Endpoint::PhoneNumber(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -18589,18 +17870,6 @@ impl SecuritySettings {
         })
     }
 
-    /// Sets the value of [data_retention][crate::model::SecuritySettings::data_retention]
-    /// to hold a `RetentionWindowDays`.
-    ///
-    /// Note that all the setters affecting `data_retention` are
-    /// mutually exclusive.
-    pub fn set_retention_window_days<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.data_retention = std::option::Option::Some(
-            crate::model::security_settings::DataRetention::RetentionWindowDays(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_retention][crate::model::SecuritySettings::data_retention]
     /// if it holds a `RetentionStrategy`, `None` if the field is not set or
     /// holds a different branch.
@@ -18614,23 +17883,6 @@ impl SecuritySettings {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_retention][crate::model::SecuritySettings::data_retention]
-    /// to hold a `RetentionStrategy`.
-    ///
-    /// Note that all the setters affecting `data_retention` are
-    /// mutually exclusive.
-    pub fn set_retention_strategy<
-        T: std::convert::Into<crate::model::security_settings::RetentionStrategy>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_retention = std::option::Option::Some(
-            crate::model::security_settings::DataRetention::RetentionStrategy(v.into()),
-        );
-        self
     }
 }
 
@@ -20620,23 +19872,6 @@ impl StreamingDetectIntentResponse {
         })
     }
 
-    /// Sets the value of [response][crate::model::StreamingDetectIntentResponse::response]
-    /// to hold a `RecognitionResult`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_recognition_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::StreamingRecognitionResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response = std::option::Option::Some(
-            crate::model::streaming_detect_intent_response::Response::RecognitionResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [response][crate::model::StreamingDetectIntentResponse::response]
     /// if it holds a `DetectIntentResponse`, `None` if the field is not set or
     /// holds a different branch.
@@ -20650,25 +19885,6 @@ impl StreamingDetectIntentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response][crate::model::StreamingDetectIntentResponse::response]
-    /// to hold a `DetectIntentResponse`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_detect_intent_response<
-        T: std::convert::Into<std::boxed::Box<crate::model::DetectIntentResponse>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response = std::option::Option::Some(
-            crate::model::streaming_detect_intent_response::Response::DetectIntentResponse(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -22136,19 +21352,6 @@ impl QueryInput {
         })
     }
 
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::boxed::Box<crate::model::TextInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(crate::model::query_input::Input::Text(v.into()));
-        self
-    }
-
     /// The value of [input][crate::model::QueryInput::input]
     /// if it holds a `Intent`, `None` if the field is not set or
     /// holds a different branch.
@@ -22158,19 +21361,6 @@ impl QueryInput {
             crate::model::query_input::Input::Intent(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `Intent`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_intent<T: std::convert::Into<std::boxed::Box<crate::model::IntentInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(crate::model::query_input::Input::Intent(v.into()));
-        self
     }
 
     /// The value of [input][crate::model::QueryInput::input]
@@ -22184,19 +21374,6 @@ impl QueryInput {
         })
     }
 
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `Audio`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_audio<T: std::convert::Into<std::boxed::Box<crate::model::AudioInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(crate::model::query_input::Input::Audio(v.into()));
-        self
-    }
-
     /// The value of [input][crate::model::QueryInput::input]
     /// if it holds a `Event`, `None` if the field is not set or
     /// holds a different branch.
@@ -22208,19 +21385,6 @@ impl QueryInput {
         })
     }
 
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `Event`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_event<T: std::convert::Into<std::boxed::Box<crate::model::EventInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(crate::model::query_input::Input::Event(v.into()));
-        self
-    }
-
     /// The value of [input][crate::model::QueryInput::input]
     /// if it holds a `Dtmf`, `None` if the field is not set or
     /// holds a different branch.
@@ -22230,19 +21394,6 @@ impl QueryInput {
             crate::model::query_input::Input::Dtmf(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `Dtmf`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_dtmf<T: std::convert::Into<std::boxed::Box<crate::model::DtmfInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(crate::model::query_input::Input::Dtmf(v.into()));
-        self
     }
 }
 
@@ -22662,16 +21813,6 @@ impl QueryResult {
         })
     }
 
-    /// Sets the value of [query][crate::model::QueryResult::query]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(crate::model::query_result::Query::Text(v.into()));
-        self
-    }
-
     /// The value of [query][crate::model::QueryResult::query]
     /// if it holds a `TriggerIntent`, `None` if the field is not set or
     /// holds a different branch.
@@ -22681,17 +21822,6 @@ impl QueryResult {
             crate::model::query_result::Query::TriggerIntent(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::QueryResult::query]
-    /// to hold a `TriggerIntent`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_trigger_intent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::query_result::Query::TriggerIntent(v.into()));
-        self
     }
 
     /// The value of [query][crate::model::QueryResult::query]
@@ -22705,17 +21835,6 @@ impl QueryResult {
         })
     }
 
-    /// Sets the value of [query][crate::model::QueryResult::query]
-    /// to hold a `Transcript`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_transcript<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::query_result::Query::Transcript(v.into()));
-        self
-    }
-
     /// The value of [query][crate::model::QueryResult::query]
     /// if it holds a `TriggerEvent`, `None` if the field is not set or
     /// holds a different branch.
@@ -22727,17 +21846,6 @@ impl QueryResult {
         })
     }
 
-    /// Sets the value of [query][crate::model::QueryResult::query]
-    /// to hold a `TriggerEvent`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_trigger_event<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::query_result::Query::TriggerEvent(v.into()));
-        self
-    }
-
     /// The value of [query][crate::model::QueryResult::query]
     /// if it holds a `Dtmf`, `None` if the field is not set or
     /// holds a different branch.
@@ -22747,19 +21855,6 @@ impl QueryResult {
             crate::model::query_result::Query::Dtmf(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::QueryResult::query]
-    /// to hold a `Dtmf`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_dtmf<T: std::convert::Into<std::boxed::Box<crate::model::DtmfInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.query = std::option::Option::Some(crate::model::query_result::Query::Dtmf(v.into()));
-        self
     }
 }
 
@@ -23474,17 +22569,6 @@ impl MatchIntentResponse {
         })
     }
 
-    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::match_intent_response::Query::Text(v.into()));
-        self
-    }
-
     /// The value of [query][crate::model::MatchIntentResponse::query]
     /// if it holds a `TriggerIntent`, `None` if the field is not set or
     /// holds a different branch.
@@ -23496,18 +22580,6 @@ impl MatchIntentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
-    /// to hold a `TriggerIntent`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_trigger_intent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::match_intent_response::Query::TriggerIntent(v.into()),
-        );
-        self
     }
 
     /// The value of [query][crate::model::MatchIntentResponse::query]
@@ -23523,18 +22595,6 @@ impl MatchIntentResponse {
         })
     }
 
-    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
-    /// to hold a `Transcript`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_transcript<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::match_intent_response::Query::Transcript(v.into()),
-        );
-        self
-    }
-
     /// The value of [query][crate::model::MatchIntentResponse::query]
     /// if it holds a `TriggerEvent`, `None` if the field is not set or
     /// holds a different branch.
@@ -23546,18 +22606,6 @@ impl MatchIntentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::MatchIntentResponse::query]
-    /// to hold a `TriggerEvent`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_trigger_event<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::match_intent_response::Query::TriggerEvent(v.into()),
-        );
-        self
     }
 }
 
@@ -25233,21 +24281,6 @@ pub mod transition_coverage {
             })
         }
 
-        /// Sets the value of [kind][crate::model::transition_coverage::TransitionNode::kind]
-        /// to hold a `Page`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_page<T: std::convert::Into<std::boxed::Box<crate::model::Page>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::transition_coverage::transition_node::Kind::Page(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::transition_coverage::TransitionNode::kind]
         /// if it holds a `Flow`, `None` if the field is not set or
         /// holds a different branch.
@@ -25259,21 +24292,6 @@ pub mod transition_coverage {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::transition_coverage::TransitionNode::kind]
-        /// to hold a `Flow`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_flow<T: std::convert::Into<std::boxed::Box<crate::model::Flow>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::transition_coverage::transition_node::Kind::Flow(v.into()),
-            );
-            self
         }
     }
 
@@ -25412,23 +24430,6 @@ pub mod transition_coverage {
             })
         }
 
-        /// Sets the value of [detail][crate::model::transition_coverage::Transition::detail]
-        /// to hold a `TransitionRoute`.
-        ///
-        /// Note that all the setters affecting `detail` are
-        /// mutually exclusive.
-        pub fn set_transition_route<
-            T: std::convert::Into<std::boxed::Box<crate::model::TransitionRoute>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.detail = std::option::Option::Some(
-                crate::model::transition_coverage::transition::Detail::TransitionRoute(v.into()),
-            );
-            self
-        }
-
         /// The value of [detail][crate::model::transition_coverage::Transition::detail]
         /// if it holds a `EventHandler`, `None` if the field is not set or
         /// holds a different branch.
@@ -25442,23 +24443,6 @@ pub mod transition_coverage {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [detail][crate::model::transition_coverage::Transition::detail]
-        /// to hold a `EventHandler`.
-        ///
-        /// Note that all the setters affecting `detail` are
-        /// mutually exclusive.
-        pub fn set_event_handler<
-            T: std::convert::Into<std::boxed::Box<crate::model::EventHandler>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.detail = std::option::Option::Some(
-                crate::model::transition_coverage::transition::Detail::EventHandler(v.into()),
-            );
-            self
         }
     }
 
@@ -26023,23 +25007,6 @@ impl CalculateCoverageResponse {
         })
     }
 
-    /// Sets the value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
-    /// to hold a `IntentCoverage`.
-    ///
-    /// Note that all the setters affecting `coverage_type` are
-    /// mutually exclusive.
-    pub fn set_intent_coverage<
-        T: std::convert::Into<std::boxed::Box<crate::model::IntentCoverage>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.coverage_type = std::option::Option::Some(
-            crate::model::calculate_coverage_response::CoverageType::IntentCoverage(v.into()),
-        );
-        self
-    }
-
     /// The value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
     /// if it holds a `TransitionCoverage`, `None` if the field is not set or
     /// holds a different branch.
@@ -26055,23 +25022,6 @@ impl CalculateCoverageResponse {
         })
     }
 
-    /// Sets the value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
-    /// to hold a `TransitionCoverage`.
-    ///
-    /// Note that all the setters affecting `coverage_type` are
-    /// mutually exclusive.
-    pub fn set_transition_coverage<
-        T: std::convert::Into<std::boxed::Box<crate::model::TransitionCoverage>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.coverage_type = std::option::Option::Some(
-            crate::model::calculate_coverage_response::CoverageType::TransitionCoverage(v.into()),
-        );
-        self
-    }
-
     /// The value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
     /// if it holds a `RouteGroupCoverage`, `None` if the field is not set or
     /// holds a different branch.
@@ -26085,23 +25035,6 @@ impl CalculateCoverageResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [coverage_type][crate::model::CalculateCoverageResponse::coverage_type]
-    /// to hold a `RouteGroupCoverage`.
-    ///
-    /// Note that all the setters affecting `coverage_type` are
-    /// mutually exclusive.
-    pub fn set_route_group_coverage<
-        T: std::convert::Into<std::boxed::Box<crate::model::TransitionRouteGroupCoverage>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.coverage_type = std::option::Option::Some(
-            crate::model::calculate_coverage_response::CoverageType::RouteGroupCoverage(v.into()),
-        );
-        self
     }
 }
 
@@ -26981,18 +25914,6 @@ impl ImportTestCasesRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportTestCasesRequest::source]
-    /// to hold a `GcsUri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_test_cases_request::Source::GcsUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportTestCasesRequest::source]
     /// if it holds a `Content`, `None` if the field is not set or
     /// holds a different branch.
@@ -27004,18 +25925,6 @@ impl ImportTestCasesRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportTestCasesRequest::source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_test_cases_request::Source::Content(v.into()),
-        );
-        self
     }
 }
 
@@ -27277,18 +26186,6 @@ impl ExportTestCasesRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ExportTestCasesRequest::destination]
-    /// to hold a `GcsUri`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_test_cases_request::Destination::GcsUri(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExportTestCasesRequest {
@@ -27505,18 +26402,6 @@ impl ExportTestCasesResponse {
         })
     }
 
-    /// Sets the value of [destination][crate::model::ExportTestCasesResponse::destination]
-    /// to hold a `GcsUri`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_test_cases_response::Destination::GcsUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::ExportTestCasesResponse::destination]
     /// if it holds a `Content`, `None` if the field is not set or
     /// holds a different branch.
@@ -27528,18 +26413,6 @@ impl ExportTestCasesResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportTestCasesResponse::destination]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_test_cases_response::Destination::Content(v.into()),
-        );
-        self
     }
 }
 
@@ -29652,22 +28525,6 @@ impl Webhook {
         })
     }
 
-    /// Sets the value of [webhook][crate::model::Webhook::webhook]
-    /// to hold a `GenericWebService`.
-    ///
-    /// Note that all the setters affecting `webhook` are
-    /// mutually exclusive.
-    pub fn set_generic_web_service<
-        T: std::convert::Into<std::boxed::Box<crate::model::webhook::GenericWebService>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.webhook =
-            std::option::Option::Some(crate::model::webhook::Webhook::GenericWebService(v.into()));
-        self
-    }
-
     /// The value of [webhook][crate::model::Webhook::webhook]
     /// if it holds a `ServiceDirectory`, `None` if the field is not set or
     /// holds a different branch.
@@ -29679,22 +28536,6 @@ impl Webhook {
             crate::model::webhook::Webhook::ServiceDirectory(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [webhook][crate::model::Webhook::webhook]
-    /// to hold a `ServiceDirectory`.
-    ///
-    /// Note that all the setters affecting `webhook` are
-    /// mutually exclusive.
-    pub fn set_service_directory<
-        T: std::convert::Into<std::boxed::Box<crate::model::webhook::ServiceDirectoryConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.webhook =
-            std::option::Option::Some(crate::model::webhook::Webhook::ServiceDirectory(v.into()));
-        self
     }
 }
 
@@ -31045,17 +29886,6 @@ impl WebhookRequest {
         })
     }
 
-    /// Sets the value of [query][crate::model::WebhookRequest::query]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::webhook_request::Query::Text(v.into()));
-        self
-    }
-
     /// The value of [query][crate::model::WebhookRequest::query]
     /// if it holds a `TriggerIntent`, `None` if the field is not set or
     /// holds a different branch.
@@ -31065,18 +29895,6 @@ impl WebhookRequest {
             crate::model::webhook_request::Query::TriggerIntent(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::WebhookRequest::query]
-    /// to hold a `TriggerIntent`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_trigger_intent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query = std::option::Option::Some(
-            crate::model::webhook_request::Query::TriggerIntent(v.into()),
-        );
-        self
     }
 
     /// The value of [query][crate::model::WebhookRequest::query]
@@ -31090,17 +29908,6 @@ impl WebhookRequest {
         })
     }
 
-    /// Sets the value of [query][crate::model::WebhookRequest::query]
-    /// to hold a `Transcript`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_transcript<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::webhook_request::Query::Transcript(v.into()));
-        self
-    }
-
     /// The value of [query][crate::model::WebhookRequest::query]
     /// if it holds a `TriggerEvent`, `None` if the field is not set or
     /// holds a different branch.
@@ -31112,17 +29919,6 @@ impl WebhookRequest {
         })
     }
 
-    /// Sets the value of [query][crate::model::WebhookRequest::query]
-    /// to hold a `TriggerEvent`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_trigger_event<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::webhook_request::Query::TriggerEvent(v.into()));
-        self
-    }
-
     /// The value of [query][crate::model::WebhookRequest::query]
     /// if it holds a `DtmfDigits`, `None` if the field is not set or
     /// holds a different branch.
@@ -31132,17 +29928,6 @@ impl WebhookRequest {
             crate::model::webhook_request::Query::DtmfDigits(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [query][crate::model::WebhookRequest::query]
-    /// to hold a `DtmfDigits`.
-    ///
-    /// Note that all the setters affecting `query` are
-    /// mutually exclusive.
-    pub fn set_dtmf_digits<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.query =
-            std::option::Option::Some(crate::model::webhook_request::Query::DtmfDigits(v.into()));
-        self
     }
 }
 
@@ -31538,18 +30323,6 @@ impl WebhookResponse {
         })
     }
 
-    /// Sets the value of [transition][crate::model::WebhookResponse::transition]
-    /// to hold a `TargetPage`.
-    ///
-    /// Note that all the setters affecting `transition` are
-    /// mutually exclusive.
-    pub fn set_target_page<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.transition = std::option::Option::Some(
-            crate::model::webhook_response::Transition::TargetPage(v.into()),
-        );
-        self
-    }
-
     /// The value of [transition][crate::model::WebhookResponse::transition]
     /// if it holds a `TargetFlow`, `None` if the field is not set or
     /// holds a different branch.
@@ -31561,18 +30334,6 @@ impl WebhookResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transition][crate::model::WebhookResponse::transition]
-    /// to hold a `TargetFlow`.
-    ///
-    /// Note that all the setters affecting `transition` are
-    /// mutually exclusive.
-    pub fn set_target_flow<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.transition = std::option::Option::Some(
-            crate::model::webhook_response::Transition::TargetFlow(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/dialogflow/v2/src/builder.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builder.rs
@@ -668,26 +668,6 @@ pub mod agents {
             self.0.request.agent = v.into();
             self
         }
-
-        /// Sets the value of [agent][crate::model::ImportAgentRequest::agent]
-        /// to hold a `AgentUri`.
-        ///
-        /// Note that all the setters affecting `agent` are
-        /// mutually exclusive.
-        pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_agent_uri(v);
-            self
-        }
-
-        /// Sets the value of [agent][crate::model::ImportAgentRequest::agent]
-        /// to hold a `AgentContent`.
-        ///
-        /// Note that all the setters affecting `agent` are
-        /// mutually exclusive.
-        pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_agent_content(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -799,26 +779,6 @@ pub mod agents {
             v: T,
         ) -> Self {
             self.0.request.agent = v.into();
-            self
-        }
-
-        /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-        /// to hold a `AgentUri`.
-        ///
-        /// Note that all the setters affecting `agent` are
-        /// mutually exclusive.
-        pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_agent_uri(v);
-            self
-        }
-
-        /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-        /// to hold a `AgentContent`.
-        ///
-        /// Note that all the setters affecting `agent` are
-        /// mutually exclusive.
-        pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_agent_content(v);
             self
         }
     }
@@ -3680,32 +3640,6 @@ pub mod conversations {
             v: T,
         ) -> Self {
             self.0.request.generator_resource = v.into();
-            self
-        }
-
-        /// Sets the value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
-        /// to hold a `Generator`.
-        ///
-        /// Note that all the setters affecting `generator_resource` are
-        /// mutually exclusive.
-        pub fn set_generator<T: std::convert::Into<std::boxed::Box<crate::model::Generator>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_generator(v);
-            self
-        }
-
-        /// Sets the value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
-        /// to hold a `GeneratorName`.
-        ///
-        /// Note that all the setters affecting `generator_resource` are
-        /// mutually exclusive.
-        pub fn set_generator_name<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_generator_name(v);
             self
         }
     }
@@ -8342,19 +8276,6 @@ pub mod documents {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSources>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -8703,16 +8624,6 @@ pub mod documents {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ReloadDocumentRequest::source]
-        /// to hold a `ContentUri`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_content_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_content_uri(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -8841,21 +8752,6 @@ pub mod documents {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportDocumentRequest::destination]
-        /// to hold a `GcsDestination`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_destination<
-            T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_destination(v);
             self
         }
     }
@@ -10496,34 +10392,6 @@ pub mod entity_types {
             v: T,
         ) -> Self {
             self.0.request.entity_type_batch = v.into();
-            self
-        }
-
-        /// Sets the value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
-        /// to hold a `EntityTypeBatchUri`.
-        ///
-        /// Note that all the setters affecting `entity_type_batch` are
-        /// mutually exclusive.
-        pub fn set_entity_type_batch_uri<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_entity_type_batch_uri(v);
-            self
-        }
-
-        /// Sets the value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
-        /// to hold a `EntityTypeBatchInline`.
-        ///
-        /// Note that all the setters affecting `entity_type_batch` are
-        /// mutually exclusive.
-        pub fn set_entity_type_batch_inline<
-            T: std::convert::Into<std::boxed::Box<crate::model::EntityTypeBatch>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_entity_type_batch_inline(v);
             self
         }
     }
@@ -14445,34 +14313,6 @@ pub mod intents {
             self.0.request.intent_batch = v.into();
             self
         }
-
-        /// Sets the value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
-        /// to hold a `IntentBatchUri`.
-        ///
-        /// Note that all the setters affecting `intent_batch` are
-        /// mutually exclusive.
-        pub fn set_intent_batch_uri<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_intent_batch_uri(v);
-            self
-        }
-
-        /// Sets the value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
-        /// to hold a `IntentBatchInline`.
-        ///
-        /// Note that all the setters affecting `intent_batch` are
-        /// mutually exclusive.
-        pub fn set_intent_batch_inline<
-            T: std::convert::Into<std::boxed::Box<crate::model::IntentBatch>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_intent_batch_inline(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -16344,60 +16184,6 @@ pub mod participants {
             v: T,
         ) -> Self {
             self.0.request.input = v.into();
-            self
-        }
-
-        /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-        /// to hold a `TextInput`.
-        ///
-        /// Note that all the setters affecting `input` are
-        /// mutually exclusive.
-        pub fn set_text_input<T: std::convert::Into<std::boxed::Box<crate::model::TextInput>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_text_input(v);
-            self
-        }
-
-        /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-        /// to hold a `AudioInput`.
-        ///
-        /// Note that all the setters affecting `input` are
-        /// mutually exclusive.
-        pub fn set_audio_input<T: std::convert::Into<std::boxed::Box<crate::model::AudioInput>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_audio_input(v);
-            self
-        }
-
-        /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-        /// to hold a `EventInput`.
-        ///
-        /// Note that all the setters affecting `input` are
-        /// mutually exclusive.
-        pub fn set_event_input<T: std::convert::Into<std::boxed::Box<crate::model::EventInput>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_event_input(v);
-            self
-        }
-
-        /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-        /// to hold a `SuggestionInput`.
-        ///
-        /// Note that all the setters affecting `input` are
-        /// mutually exclusive.
-        pub fn set_suggestion_input<
-            T: std::convert::Into<std::boxed::Box<crate::model::SuggestionInput>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_suggestion_input(v);
             self
         }
     }

--- a/src/generated/cloud/dialogflow/v2/src/model.rs
+++ b/src/generated/cloud/dialogflow/v2/src/model.rs
@@ -1025,18 +1025,6 @@ impl ExportAgentResponse {
         })
     }
 
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::AgentUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [agent][crate::model::ExportAgentResponse::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1048,18 +1036,6 @@ impl ExportAgentResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::ExportAgentResponse::agent]
-    /// to hold a `AgentContent`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::export_agent_response::Agent::AgentContent(v.into()),
-        );
-        self
     }
 }
 
@@ -1146,18 +1122,6 @@ impl ImportAgentRequest {
         })
     }
 
-    /// Sets the value of [agent][crate::model::ImportAgentRequest::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::import_agent_request::Agent::AgentUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [agent][crate::model::ImportAgentRequest::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1169,18 +1133,6 @@ impl ImportAgentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::ImportAgentRequest::agent]
-    /// to hold a `AgentContent`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::import_agent_request::Agent::AgentContent(v.into()),
-        );
-        self
     }
 }
 
@@ -1273,18 +1225,6 @@ impl RestoreAgentRequest {
         })
     }
 
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `AgentUri`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::AgentUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [agent][crate::model::RestoreAgentRequest::agent]
     /// if it holds a `AgentContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -1296,18 +1236,6 @@ impl RestoreAgentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent][crate::model::RestoreAgentRequest::agent]
-    /// to hold a `AgentContent`.
-    ///
-    /// Note that all the setters affecting `agent` are
-    /// mutually exclusive.
-    pub fn set_agent_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.agent = std::option::Option::Some(
-            crate::model::restore_agent_request::Agent::AgentContent(v.into()),
-        );
-        self
     }
 }
 
@@ -1500,23 +1428,6 @@ impl AnswerRecord {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [record][crate::model::AnswerRecord::record]
-    /// to hold a `AgentAssistantRecord`.
-    ///
-    /// Note that all the setters affecting `record` are
-    /// mutually exclusive.
-    pub fn set_agent_assistant_record<
-        T: std::convert::Into<std::boxed::Box<crate::model::AgentAssistantRecord>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.record = std::option::Option::Some(
-            crate::model::answer_record::Record::AgentAssistantRecord(v.into()),
-        );
-        self
     }
 }
 
@@ -1869,23 +1780,6 @@ impl AnswerFeedback {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [detail_feedback][crate::model::AnswerFeedback::detail_feedback]
-    /// to hold a `AgentAssistantDetailFeedback`.
-    ///
-    /// Note that all the setters affecting `detail_feedback` are
-    /// mutually exclusive.
-    pub fn set_agent_assistant_detail_feedback<
-        T: std::convert::Into<std::boxed::Box<crate::model::AgentAssistantFeedback>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.detail_feedback = std::option::Option::Some(
-            crate::model::answer_feedback::DetailFeedback::AgentAssistantDetailFeedback(v.into()),
-        );
-        self
     }
 }
 
@@ -2845,23 +2739,6 @@ impl AgentAssistantRecord {
         })
     }
 
-    /// Sets the value of [answer][crate::model::AgentAssistantRecord::answer]
-    /// to hold a `ArticleSuggestionAnswer`.
-    ///
-    /// Note that all the setters affecting `answer` are
-    /// mutually exclusive.
-    pub fn set_article_suggestion_answer<
-        T: std::convert::Into<std::boxed::Box<crate::model::ArticleAnswer>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.answer = std::option::Option::Some(
-            crate::model::agent_assistant_record::Answer::ArticleSuggestionAnswer(v.into()),
-        );
-        self
-    }
-
     /// The value of [answer][crate::model::AgentAssistantRecord::answer]
     /// if it holds a `FaqAnswer`, `None` if the field is not set or
     /// holds a different branch.
@@ -2873,21 +2750,6 @@ impl AgentAssistantRecord {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [answer][crate::model::AgentAssistantRecord::answer]
-    /// to hold a `FaqAnswer`.
-    ///
-    /// Note that all the setters affecting `answer` are
-    /// mutually exclusive.
-    pub fn set_faq_answer<T: std::convert::Into<std::boxed::Box<crate::model::FaqAnswer>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.answer = std::option::Option::Some(
-            crate::model::agent_assistant_record::Answer::FaqAnswer(v.into()),
-        );
-        self
     }
 
     /// The value of [answer][crate::model::AgentAssistantRecord::answer]
@@ -2903,23 +2765,6 @@ impl AgentAssistantRecord {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [answer][crate::model::AgentAssistantRecord::answer]
-    /// to hold a `DialogflowAssistAnswer`.
-    ///
-    /// Note that all the setters affecting `answer` are
-    /// mutually exclusive.
-    pub fn set_dialogflow_assist_answer<
-        T: std::convert::Into<std::boxed::Box<crate::model::DialogflowAssistAnswer>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.answer = std::option::Option::Some(
-            crate::model::agent_assistant_record::Answer::DialogflowAssistAnswer(v.into()),
-        );
-        self
     }
 }
 
@@ -6462,23 +6307,6 @@ impl GenerateStatelessSuggestionRequest {
         })
     }
 
-    /// Sets the value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
-    /// to hold a `Generator`.
-    ///
-    /// Note that all the setters affecting `generator_resource` are
-    /// mutually exclusive.
-    pub fn set_generator<T: std::convert::Into<std::boxed::Box<crate::model::Generator>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.generator_resource = std::option::Option::Some(
-            crate::model::generate_stateless_suggestion_request::GeneratorResource::Generator(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
     /// if it holds a `GeneratorName`, `None` if the field is not set or
     /// holds a different branch.
@@ -6488,20 +6316,6 @@ impl GenerateStatelessSuggestionRequest {
             crate::model::generate_stateless_suggestion_request::GeneratorResource::GeneratorName(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [generator_resource][crate::model::GenerateStatelessSuggestionRequest::generator_resource]
-    /// to hold a `GeneratorName`.
-    ///
-    /// Note that all the setters affecting `generator_resource` are
-    /// mutually exclusive.
-    pub fn set_generator_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.generator_resource = std::option::Option::Some(
-            crate::model::generate_stateless_suggestion_request::GeneratorResource::GeneratorName(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -8143,20 +7957,6 @@ impl InputConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::InputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSources>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::input_config::Source::GcsSource(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for InputConfig {
@@ -8891,23 +8691,6 @@ impl ConversationEvent {
         })
     }
 
-    /// Sets the value of [payload][crate::model::ConversationEvent::payload]
-    /// to hold a `NewMessagePayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_new_message_payload<
-        T: std::convert::Into<std::boxed::Box<crate::model::Message>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.payload = std::option::Option::Some(
-            crate::model::conversation_event::Payload::NewMessagePayload(v.into()),
-        );
-        self
-    }
-
     /// The value of [payload][crate::model::ConversationEvent::payload]
     /// if it holds a `NewRecognitionResultPayload`, `None` if the field is not set or
     /// holds a different branch.
@@ -8921,23 +8704,6 @@ impl ConversationEvent {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [payload][crate::model::ConversationEvent::payload]
-    /// to hold a `NewRecognitionResultPayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_new_recognition_result_payload<
-        T: std::convert::Into<std::boxed::Box<crate::model::StreamingRecognitionResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.payload = std::option::Option::Some(
-            crate::model::conversation_event::Payload::NewRecognitionResultPayload(v.into()),
-        );
-        self
     }
 }
 
@@ -9300,25 +9066,6 @@ impl ConversationModel {
         })
     }
 
-    /// Sets the value of [model_metadata][crate::model::ConversationModel::model_metadata]
-    /// to hold a `ArticleSuggestionModelMetadata`.
-    ///
-    /// Note that all the setters affecting `model_metadata` are
-    /// mutually exclusive.
-    pub fn set_article_suggestion_model_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::ArticleSuggestionModelMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.model_metadata = std::option::Option::Some(
-            crate::model::conversation_model::ModelMetadata::ArticleSuggestionModelMetadata(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [model_metadata][crate::model::ConversationModel::model_metadata]
     /// if it holds a `SmartReplyModelMetadata`, `None` if the field is not set or
     /// holds a different branch.
@@ -9332,23 +9079,6 @@ impl ConversationModel {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [model_metadata][crate::model::ConversationModel::model_metadata]
-    /// to hold a `SmartReplyModelMetadata`.
-    ///
-    /// Note that all the setters affecting `model_metadata` are
-    /// mutually exclusive.
-    pub fn set_smart_reply_model_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::SmartReplyModelMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.model_metadata = std::option::Option::Some(
-            crate::model::conversation_model::ModelMetadata::SmartReplyModelMetadata(v.into()),
-        );
-        self
     }
 }
 
@@ -9816,23 +9546,6 @@ impl ConversationModelEvaluation {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [metrics][crate::model::ConversationModelEvaluation::metrics]
-    /// to hold a `SmartReplyMetrics`.
-    ///
-    /// Note that all the setters affecting `metrics` are
-    /// mutually exclusive.
-    pub fn set_smart_reply_metrics<
-        T: std::convert::Into<std::boxed::Box<crate::model::SmartReplyMetrics>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metrics = std::option::Option::Some(
-            crate::model::conversation_model_evaluation::Metrics::SmartReplyMetrics(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ConversationModelEvaluation {
@@ -9924,23 +9637,6 @@ impl EvaluationConfig {
         })
     }
 
-    /// Sets the value of [model_specific_config][crate::model::EvaluationConfig::model_specific_config]
-    /// to hold a `SmartReplyConfig`.
-    ///
-    /// Note that all the setters affecting `model_specific_config` are
-    /// mutually exclusive.
-    pub fn set_smart_reply_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::evaluation_config::SmartReplyConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.model_specific_config = std::option::Option::Some(
-            crate::model::evaluation_config::ModelSpecificConfig::SmartReplyConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [model_specific_config][crate::model::EvaluationConfig::model_specific_config]
     /// if it holds a `SmartComposeConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9955,23 +9651,6 @@ impl EvaluationConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [model_specific_config][crate::model::EvaluationConfig::model_specific_config]
-    /// to hold a `SmartComposeConfig`.
-    ///
-    /// Note that all the setters affecting `model_specific_config` are
-    /// mutually exclusive.
-    pub fn set_smart_compose_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::evaluation_config::SmartComposeConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.model_specific_config = std::option::Option::Some(
-            crate::model::evaluation_config::ModelSpecificConfig::SmartComposeConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -12683,20 +12362,6 @@ pub mod human_agent_assistant_config {
             })
         }
 
-        /// Sets the value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
-        /// to hold a `KnowledgeBaseQuerySource`.
-        ///
-        /// Note that all the setters affecting `query_source` are
-        /// mutually exclusive.
-        pub fn set_knowledge_base_query_source<T: std::convert::Into<std::boxed::Box<crate::model::human_agent_assistant_config::suggestion_query_config::KnowledgeBaseQuerySource>>>(mut self, v: T) -> Self{
-            self.query_source = std::option::Option::Some(
-                crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::KnowledgeBaseQuerySource(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
         /// if it holds a `DocumentQuerySource`, `None` if the field is not set or
         /// holds a different branch.
@@ -12708,20 +12373,6 @@ pub mod human_agent_assistant_config {
             })
         }
 
-        /// Sets the value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
-        /// to hold a `DocumentQuerySource`.
-        ///
-        /// Note that all the setters affecting `query_source` are
-        /// mutually exclusive.
-        pub fn set_document_query_source<T: std::convert::Into<std::boxed::Box<crate::model::human_agent_assistant_config::suggestion_query_config::DocumentQuerySource>>>(mut self, v: T) -> Self{
-            self.query_source = std::option::Option::Some(
-                crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::DocumentQuerySource(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
         /// if it holds a `DialogflowQuerySource`, `None` if the field is not set or
         /// holds a different branch.
@@ -12731,20 +12382,6 @@ pub mod human_agent_assistant_config {
                 crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::DialogflowQuerySource(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [query_source][crate::model::human_agent_assistant_config::SuggestionQueryConfig::query_source]
-        /// to hold a `DialogflowQuerySource`.
-        ///
-        /// Note that all the setters affecting `query_source` are
-        /// mutually exclusive.
-        pub fn set_dialogflow_query_source<T: std::convert::Into<std::boxed::Box<crate::model::human_agent_assistant_config::suggestion_query_config::DialogflowQuerySource>>>(mut self, v: T) -> Self{
-            self.query_source = std::option::Option::Some(
-                crate::model::human_agent_assistant_config::suggestion_query_config::QuerySource::DialogflowQuerySource(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -13458,25 +13095,6 @@ impl HumanAgentHandoffConfig {
         })
     }
 
-    /// Sets the value of [agent_service][crate::model::HumanAgentHandoffConfig::agent_service]
-    /// to hold a `LivePersonConfig`.
-    ///
-    /// Note that all the setters affecting `agent_service` are
-    /// mutually exclusive.
-    pub fn set_live_person_config<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::human_agent_handoff_config::LivePersonConfig>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.agent_service = std::option::Option::Some(
-            crate::model::human_agent_handoff_config::AgentService::LivePersonConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [agent_service][crate::model::HumanAgentHandoffConfig::agent_service]
     /// if it holds a `SalesforceLiveAgentConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -13492,29 +13110,6 @@ impl HumanAgentHandoffConfig {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [agent_service][crate::model::HumanAgentHandoffConfig::agent_service]
-    /// to hold a `SalesforceLiveAgentConfig`.
-    ///
-    /// Note that all the setters affecting `agent_service` are
-    /// mutually exclusive.
-    pub fn set_salesforce_live_agent_config<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::human_agent_handoff_config::SalesforceLiveAgentConfig,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.agent_service = std::option::Option::Some(
-            crate::model::human_agent_handoff_config::AgentService::SalesforceLiveAgentConfig(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -14575,17 +14170,6 @@ impl Document {
         })
     }
 
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `ContentUri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::document::Source::ContentUri(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Document::source]
     /// if it holds a `RawContent`, `None` if the field is not set or
     /// holds a different branch.
@@ -14595,17 +14179,6 @@ impl Document {
             crate::model::document::Source::RawContent(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `RawContent`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_raw_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::document::Source::RawContent(v.into()));
-        self
     }
 }
 
@@ -15334,21 +14907,6 @@ impl ImportDocumentsRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSources>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::GcsSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ImportDocumentsRequest {
@@ -15670,18 +15228,6 @@ impl ReloadDocumentRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::ReloadDocumentRequest::source]
-    /// to hold a `ContentUri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::reload_document_request::Source::ContentUri(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ReloadDocumentRequest {
@@ -15800,23 +15346,6 @@ impl ExportDocumentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportDocumentRequest::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_document_request::Destination::GcsDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -15948,25 +15477,6 @@ impl KnowledgeOperationMetadata {
             crate::model::knowledge_operation_metadata::OperationMetadata::ExportOperationMetadata(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [operation_metadata][crate::model::KnowledgeOperationMetadata::operation_metadata]
-    /// to hold a `ExportOperationMetadata`.
-    ///
-    /// Note that all the setters affecting `operation_metadata` are
-    /// mutually exclusive.
-    pub fn set_export_operation_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExportOperationMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.operation_metadata = std::option::Option::Some(
-            crate::model::knowledge_operation_metadata::OperationMetadata::ExportOperationMetadata(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -17212,23 +16722,6 @@ impl BatchUpdateEntityTypesRequest {
         })
     }
 
-    /// Sets the value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
-    /// to hold a `EntityTypeBatchUri`.
-    ///
-    /// Note that all the setters affecting `entity_type_batch` are
-    /// mutually exclusive.
-    pub fn set_entity_type_batch_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_type_batch = std::option::Option::Some(
-            crate::model::batch_update_entity_types_request::EntityTypeBatch::EntityTypeBatchUri(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
     /// if it holds a `EntityTypeBatchInline`, `None` if the field is not set or
     /// holds a different branch.
@@ -17240,25 +16733,6 @@ impl BatchUpdateEntityTypesRequest {
             crate::model::batch_update_entity_types_request::EntityTypeBatch::EntityTypeBatchInline(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [entity_type_batch][crate::model::BatchUpdateEntityTypesRequest::entity_type_batch]
-    /// to hold a `EntityTypeBatchInline`.
-    ///
-    /// Note that all the setters affecting `entity_type_batch` are
-    /// mutually exclusive.
-    pub fn set_entity_type_batch_inline<
-        T: std::convert::Into<std::boxed::Box<crate::model::EntityTypeBatch>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.entity_type_batch = std::option::Option::Some(
-            crate::model::batch_update_entity_types_request::EntityTypeBatch::EntityTypeBatchInline(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -18663,23 +18137,6 @@ impl Fulfillment {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [fulfillment][crate::model::Fulfillment::fulfillment]
-    /// to hold a `GenericWebService`.
-    ///
-    /// Note that all the setters affecting `fulfillment` are
-    /// mutually exclusive.
-    pub fn set_generic_web_service<
-        T: std::convert::Into<std::boxed::Box<crate::model::fulfillment::GenericWebService>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.fulfillment = std::option::Option::Some(
-            crate::model::fulfillment::Fulfillment::GenericWebService(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for Fulfillment {
@@ -19813,23 +19270,6 @@ impl FewShotExample {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [instruction_list][crate::model::FewShotExample::instruction_list]
-    /// to hold a `SummarizationSectionList`.
-    ///
-    /// Note that all the setters affecting `instruction_list` are
-    /// mutually exclusive.
-    pub fn set_summarization_section_list<
-        T: std::convert::Into<std::boxed::Box<crate::model::SummarizationSectionList>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.instruction_list = std::option::Option::Some(
-            crate::model::few_shot_example::InstructionList::SummarizationSectionList(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for FewShotExample {
@@ -20434,22 +19874,6 @@ impl Generator {
         })
     }
 
-    /// Sets the value of [context][crate::model::Generator::context]
-    /// to hold a `FreeFormContext`.
-    ///
-    /// Note that all the setters affecting `context` are
-    /// mutually exclusive.
-    pub fn set_free_form_context<
-        T: std::convert::Into<std::boxed::Box<crate::model::FreeFormContext>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.context =
-            std::option::Option::Some(crate::model::generator::Context::FreeFormContext(v.into()));
-        self
-    }
-
     /// The value of [context][crate::model::Generator::context]
     /// if it holds a `SummarizationContext`, `None` if the field is not set or
     /// holds a different branch.
@@ -20463,23 +19887,6 @@ impl Generator {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [context][crate::model::Generator::context]
-    /// to hold a `SummarizationContext`.
-    ///
-    /// Note that all the setters affecting `context` are
-    /// mutually exclusive.
-    pub fn set_summarization_context<
-        T: std::convert::Into<std::boxed::Box<crate::model::SummarizationContext>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.context = std::option::Option::Some(
-            crate::model::generator::Context::SummarizationContext(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [foundation_model][crate::model::Generator::foundation_model].
@@ -20507,18 +19914,6 @@ impl Generator {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [foundation_model][crate::model::Generator::foundation_model]
-    /// to hold a `PublishedModel`.
-    ///
-    /// Note that all the setters affecting `foundation_model` are
-    /// mutually exclusive.
-    pub fn set_published_model<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.foundation_model = std::option::Option::Some(
-            crate::model::generator::FoundationModel::PublishedModel(v.into()),
-        );
-        self
     }
 }
 
@@ -20728,23 +20123,6 @@ impl GeneratorSuggestion {
         })
     }
 
-    /// Sets the value of [suggestion][crate::model::GeneratorSuggestion::suggestion]
-    /// to hold a `FreeFormSuggestion`.
-    ///
-    /// Note that all the setters affecting `suggestion` are
-    /// mutually exclusive.
-    pub fn set_free_form_suggestion<
-        T: std::convert::Into<std::boxed::Box<crate::model::FreeFormSuggestion>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion = std::option::Option::Some(
-            crate::model::generator_suggestion::Suggestion::FreeFormSuggestion(v.into()),
-        );
-        self
-    }
-
     /// The value of [suggestion][crate::model::GeneratorSuggestion::suggestion]
     /// if it holds a `SummarySuggestion`, `None` if the field is not set or
     /// holds a different branch.
@@ -20758,23 +20136,6 @@ impl GeneratorSuggestion {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [suggestion][crate::model::GeneratorSuggestion::suggestion]
-    /// to hold a `SummarySuggestion`.
-    ///
-    /// Note that all the setters affecting `suggestion` are
-    /// mutually exclusive.
-    pub fn set_summary_suggestion<
-        T: std::convert::Into<std::boxed::Box<crate::model::SummarySuggestion>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion = std::option::Option::Some(
-            crate::model::generator_suggestion::Suggestion::SummarySuggestion(v.into()),
-        );
-        self
     }
 }
 
@@ -21706,22 +21067,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `Text`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_text<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::Text>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message =
-                std::option::Option::Some(crate::model::intent::message::Message::Text(v.into()));
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `Image`, `None` if the field is not set or
         /// holds a different branch.
@@ -21733,22 +21078,6 @@ pub mod intent {
                 crate::model::intent::message::Message::Image(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `Image`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_image<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::Image>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message =
-                std::option::Option::Some(crate::model::intent::message::Message::Image(v.into()));
-            self
         }
 
         /// The value of [message][crate::model::intent::Message::message]
@@ -21767,23 +21096,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `QuickReplies`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_quick_replies<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::QuickReplies>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::QuickReplies(v.into()),
-            );
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `Card`, `None` if the field is not set or
         /// holds a different branch.
@@ -21797,22 +21109,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `Card`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_card<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::Card>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message =
-                std::option::Option::Some(crate::model::intent::message::Message::Card(v.into()));
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `Payload`, `None` if the field is not set or
         /// holds a different branch.
@@ -21822,21 +21118,6 @@ pub mod intent {
                 crate::model::intent::message::Message::Payload(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `Payload`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_payload<T: std::convert::Into<std::boxed::Box<wkt::Struct>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::Payload(v.into()),
-            );
-            self
         }
 
         /// The value of [message][crate::model::intent::Message::message]
@@ -21855,23 +21136,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `SimpleResponses`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_simple_responses<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::SimpleResponses>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::SimpleResponses(v.into()),
-            );
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `BasicCard`, `None` if the field is not set or
         /// holds a different branch.
@@ -21886,23 +21150,6 @@ pub mod intent {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `BasicCard`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_basic_card<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::BasicCard>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::BasicCard(v.into()),
-            );
-            self
         }
 
         /// The value of [message][crate::model::intent::Message::message]
@@ -21921,23 +21168,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `Suggestions`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_suggestions<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::Suggestions>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::Suggestions(v.into()),
-            );
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `LinkOutSuggestion`, `None` if the field is not set or
         /// holds a different branch.
@@ -21952,23 +21182,6 @@ pub mod intent {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `LinkOutSuggestion`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_link_out_suggestion<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::LinkOutSuggestion>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::LinkOutSuggestion(v.into()),
-            );
-            self
         }
 
         /// The value of [message][crate::model::intent::Message::message]
@@ -21987,23 +21200,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `ListSelect`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_list_select<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::ListSelect>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::ListSelect(v.into()),
-            );
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `CarouselSelect`, `None` if the field is not set or
         /// holds a different branch.
@@ -22018,23 +21214,6 @@ pub mod intent {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `CarouselSelect`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_carousel_select<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::CarouselSelect>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::CarouselSelect(v.into()),
-            );
-            self
         }
 
         /// The value of [message][crate::model::intent::Message::message]
@@ -22053,23 +21232,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `BrowseCarouselCard`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_browse_carousel_card<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::BrowseCarouselCard>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::BrowseCarouselCard(v.into()),
-            );
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `TableCard`, `None` if the field is not set or
         /// holds a different branch.
@@ -22086,23 +21248,6 @@ pub mod intent {
             })
         }
 
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `TableCard`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_table_card<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::TableCard>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::TableCard(v.into()),
-            );
-            self
-        }
-
         /// The value of [message][crate::model::intent::Message::message]
         /// if it holds a `MediaContent`, `None` if the field is not set or
         /// holds a different branch.
@@ -22117,23 +21262,6 @@ pub mod intent {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [message][crate::model::intent::Message::message]
-        /// to hold a `MediaContent`.
-        ///
-        /// Note that all the setters affecting `message` are
-        /// mutually exclusive.
-        pub fn set_media_content<
-            T: std::convert::Into<std::boxed::Box<crate::model::intent::message::MediaContent>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.message = std::option::Option::Some(
-                crate::model::intent::message::Message::MediaContent(v.into()),
-            );
-            self
         }
     }
 
@@ -23282,25 +22410,6 @@ pub mod intent {
                     })
                 }
 
-                /// Sets the value of [image][crate::model::intent::message::media_content::ResponseMediaObject::image]
-                /// to hold a `LargeImage`.
-                ///
-                /// Note that all the setters affecting `image` are
-                /// mutually exclusive.
-                pub fn set_large_image<
-                    T: std::convert::Into<std::boxed::Box<crate::model::intent::message::Image>>,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.image = std::option::Option::Some(
-                        crate::model::intent::message::media_content::response_media_object::Image::LargeImage(
-                            v.into()
-                        )
-                    );
-                    self
-                }
-
                 /// The value of [image][crate::model::intent::message::media_content::ResponseMediaObject::image]
                 /// if it holds a `Icon`, `None` if the field is not set or
                 /// holds a different branch.
@@ -23313,25 +22422,6 @@ pub mod intent {
                         crate::model::intent::message::media_content::response_media_object::Image::Icon(v) => std::option::Option::Some(v),
                         _ => std::option::Option::None,
                     })
-                }
-
-                /// Sets the value of [image][crate::model::intent::message::media_content::ResponseMediaObject::image]
-                /// to hold a `Icon`.
-                ///
-                /// Note that all the setters affecting `image` are
-                /// mutually exclusive.
-                pub fn set_icon<
-                    T: std::convert::Into<std::boxed::Box<crate::model::intent::message::Image>>,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.image = std::option::Option::Some(
-                        crate::model::intent::message::media_content::response_media_object::Image::Icon(
-                            v.into()
-                        )
-                    );
-                    self
                 }
             }
 
@@ -25313,21 +24403,6 @@ impl BatchUpdateIntentsRequest {
         })
     }
 
-    /// Sets the value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
-    /// to hold a `IntentBatchUri`.
-    ///
-    /// Note that all the setters affecting `intent_batch` are
-    /// mutually exclusive.
-    pub fn set_intent_batch_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.intent_batch = std::option::Option::Some(
-            crate::model::batch_update_intents_request::IntentBatch::IntentBatchUri(v.into()),
-        );
-        self
-    }
-
     /// The value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
     /// if it holds a `IntentBatchInline`, `None` if the field is not set or
     /// holds a different branch.
@@ -25341,23 +24416,6 @@ impl BatchUpdateIntentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [intent_batch][crate::model::BatchUpdateIntentsRequest::intent_batch]
-    /// to hold a `IntentBatchInline`.
-    ///
-    /// Note that all the setters affecting `intent_batch` are
-    /// mutually exclusive.
-    pub fn set_intent_batch_inline<
-        T: std::convert::Into<std::boxed::Box<crate::model::IntentBatch>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.intent_batch = std::option::Option::Some(
-            crate::model::batch_update_intents_request::IntentBatch::IntentBatchInline(v.into()),
-        );
-        self
     }
 }
 
@@ -26770,21 +25828,6 @@ impl AnalyzeContentRequest {
         })
     }
 
-    /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-    /// to hold a `TextInput`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_text_input<T: std::convert::Into<std::boxed::Box<crate::model::TextInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::analyze_content_request::Input::TextInput(v.into()),
-        );
-        self
-    }
-
     /// The value of [input][crate::model::AnalyzeContentRequest::input]
     /// if it holds a `AudioInput`, `None` if the field is not set or
     /// holds a different branch.
@@ -26796,21 +25839,6 @@ impl AnalyzeContentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-    /// to hold a `AudioInput`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_audio_input<T: std::convert::Into<std::boxed::Box<crate::model::AudioInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::analyze_content_request::Input::AudioInput(v.into()),
-        );
-        self
     }
 
     /// The value of [input][crate::model::AnalyzeContentRequest::input]
@@ -26826,21 +25854,6 @@ impl AnalyzeContentRequest {
         })
     }
 
-    /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-    /// to hold a `EventInput`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_event_input<T: std::convert::Into<std::boxed::Box<crate::model::EventInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::analyze_content_request::Input::EventInput(v.into()),
-        );
-        self
-    }
-
     /// The value of [input][crate::model::AnalyzeContentRequest::input]
     /// if it holds a `SuggestionInput`, `None` if the field is not set or
     /// holds a different branch.
@@ -26854,23 +25867,6 @@ impl AnalyzeContentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::AnalyzeContentRequest::input]
-    /// to hold a `SuggestionInput`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_suggestion_input<
-        T: std::convert::Into<std::boxed::Box<crate::model::SuggestionInput>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::analyze_content_request::Input::SuggestionInput(v.into()),
-        );
-        self
     }
 }
 
@@ -27340,23 +26336,6 @@ impl StreamingAnalyzeContentRequest {
         })
     }
 
-    /// Sets the value of [config][crate::model::StreamingAnalyzeContentRequest::config]
-    /// to hold a `AudioConfig`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_audio_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::InputAudioConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(
-            crate::model::streaming_analyze_content_request::Config::AudioConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [config][crate::model::StreamingAnalyzeContentRequest::config]
     /// if it holds a `TextConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -27370,23 +26349,6 @@ impl StreamingAnalyzeContentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [config][crate::model::StreamingAnalyzeContentRequest::config]
-    /// to hold a `TextConfig`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_text_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::InputTextConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(
-            crate::model::streaming_analyze_content_request::Config::TextConfig(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input].
@@ -27418,18 +26380,6 @@ impl StreamingAnalyzeContentRequest {
         })
     }
 
-    /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
-    /// to hold a `InputAudio`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_input_audio<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::streaming_analyze_content_request::Input::InputAudio(v.into()),
-        );
-        self
-    }
-
     /// The value of [input][crate::model::StreamingAnalyzeContentRequest::input]
     /// if it holds a `InputText`, `None` if the field is not set or
     /// holds a different branch.
@@ -27441,18 +26391,6 @@ impl StreamingAnalyzeContentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
-    /// to hold a `InputText`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_input_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::streaming_analyze_content_request::Input::InputText(v.into()),
-        );
-        self
     }
 
     /// The value of [input][crate::model::StreamingAnalyzeContentRequest::input]
@@ -27468,23 +26406,6 @@ impl StreamingAnalyzeContentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::StreamingAnalyzeContentRequest::input]
-    /// to hold a `InputDtmf`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_input_dtmf<
-        T: std::convert::Into<std::boxed::Box<crate::model::TelephonyDtmfEvents>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(
-            crate::model::streaming_analyze_content_request::Input::InputDtmf(v.into()),
-        );
-        self
     }
 }
 
@@ -28975,17 +27896,6 @@ impl IntentSuggestion {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [intent][crate::model::IntentSuggestion::intent]
-    /// to hold a `IntentV2`.
-    ///
-    /// Note that all the setters affecting `intent` are
-    /// mutually exclusive.
-    pub fn set_intent_v2<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.intent =
-            std::option::Option::Some(crate::model::intent_suggestion::Intent::IntentV2(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for IntentSuggestion {
@@ -29072,21 +27982,6 @@ impl DialogflowAssistAnswer {
         })
     }
 
-    /// Sets the value of [result][crate::model::DialogflowAssistAnswer::result]
-    /// to hold a `QueryResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_query_result<T: std::convert::Into<std::boxed::Box<crate::model::QueryResult>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::dialogflow_assist_answer::Result::QueryResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::DialogflowAssistAnswer::result]
     /// if it holds a `IntentSuggestion`, `None` if the field is not set or
     /// holds a different branch.
@@ -29100,23 +27995,6 @@ impl DialogflowAssistAnswer {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::DialogflowAssistAnswer::result]
-    /// to hold a `IntentSuggestion`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_intent_suggestion<
-        T: std::convert::Into<std::boxed::Box<crate::model::IntentSuggestion>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::dialogflow_assist_answer::Result::IntentSuggestion(v.into()),
-        );
-        self
     }
 }
 
@@ -29202,21 +28080,6 @@ impl SuggestionResult {
         })
     }
 
-    /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `suggestion_response` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion_response = std::option::Option::Some(
-            crate::model::suggestion_result::SuggestionResponse::Error(v.into()),
-        );
-        self
-    }
-
     /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
     /// if it holds a `SuggestArticlesResponse`, `None` if the field is not set or
     /// holds a different branch.
@@ -29230,23 +28093,6 @@ impl SuggestionResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// to hold a `SuggestArticlesResponse`.
-    ///
-    /// Note that all the setters affecting `suggestion_response` are
-    /// mutually exclusive.
-    pub fn set_suggest_articles_response<
-        T: std::convert::Into<std::boxed::Box<crate::model::SuggestArticlesResponse>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion_response = std::option::Option::Some(
-            crate::model::suggestion_result::SuggestionResponse::SuggestArticlesResponse(v.into()),
-        );
-        self
     }
 
     /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
@@ -29264,25 +28110,6 @@ impl SuggestionResult {
         })
     }
 
-    /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// to hold a `SuggestKnowledgeAssistResponse`.
-    ///
-    /// Note that all the setters affecting `suggestion_response` are
-    /// mutually exclusive.
-    pub fn set_suggest_knowledge_assist_response<
-        T: std::convert::Into<std::boxed::Box<crate::model::SuggestKnowledgeAssistResponse>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion_response = std::option::Option::Some(
-            crate::model::suggestion_result::SuggestionResponse::SuggestKnowledgeAssistResponse(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
     /// if it holds a `SuggestFaqAnswersResponse`, `None` if the field is not set or
     /// holds a different branch.
@@ -29296,25 +28123,6 @@ impl SuggestionResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// to hold a `SuggestFaqAnswersResponse`.
-    ///
-    /// Note that all the setters affecting `suggestion_response` are
-    /// mutually exclusive.
-    pub fn set_suggest_faq_answers_response<
-        T: std::convert::Into<std::boxed::Box<crate::model::SuggestFaqAnswersResponse>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion_response = std::option::Option::Some(
-            crate::model::suggestion_result::SuggestionResponse::SuggestFaqAnswersResponse(
-                v.into(),
-            ),
-        );
-        self
     }
 
     /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
@@ -29332,25 +28140,6 @@ impl SuggestionResult {
         })
     }
 
-    /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// to hold a `SuggestSmartRepliesResponse`.
-    ///
-    /// Note that all the setters affecting `suggestion_response` are
-    /// mutually exclusive.
-    pub fn set_suggest_smart_replies_response<
-        T: std::convert::Into<std::boxed::Box<crate::model::SuggestSmartRepliesResponse>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion_response = std::option::Option::Some(
-            crate::model::suggestion_result::SuggestionResponse::SuggestSmartRepliesResponse(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
     /// if it holds a `GenerateSuggestionsResponse`, `None` if the field is not set or
     /// holds a different branch.
@@ -29364,25 +28153,6 @@ impl SuggestionResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [suggestion_response][crate::model::SuggestionResult::suggestion_response]
-    /// to hold a `GenerateSuggestionsResponse`.
-    ///
-    /// Note that all the setters affecting `suggestion_response` are
-    /// mutually exclusive.
-    pub fn set_generate_suggestions_response<
-        T: std::convert::Into<std::boxed::Box<crate::model::GenerateSuggestionsResponse>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.suggestion_response = std::option::Option::Some(
-            crate::model::suggestion_result::SuggestionResponse::GenerateSuggestionsResponse(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -29987,29 +28757,6 @@ pub mod knowledge_assist_answer {
             })
         }
 
-        /// Sets the value of [source][crate::model::knowledge_assist_answer::KnowledgeAnswer::source]
-        /// to hold a `FaqSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_faq_source<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::knowledge_assist_answer::knowledge_answer::FaqSource,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::knowledge_assist_answer::knowledge_answer::Source::FaqSource(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [source][crate::model::knowledge_assist_answer::KnowledgeAnswer::source]
         /// if it holds a `GenerativeSource`, `None` if the field is not set or
         /// holds a different branch.
@@ -30025,29 +28772,6 @@ pub mod knowledge_assist_answer {
                 crate::model::knowledge_assist_answer::knowledge_answer::Source::GenerativeSource(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::knowledge_assist_answer::KnowledgeAnswer::source]
-        /// to hold a `GenerativeSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_generative_source<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::knowledge_assist_answer::knowledge_answer::GenerativeSource,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::knowledge_assist_answer::knowledge_answer::Source::GenerativeSource(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -30689,22 +29413,6 @@ impl QueryInput {
         })
     }
 
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `AudioConfig`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_audio_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::InputAudioConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input =
-            std::option::Option::Some(crate::model::query_input::Input::AudioConfig(v.into()));
-        self
-    }
-
     /// The value of [input][crate::model::QueryInput::input]
     /// if it holds a `Text`, `None` if the field is not set or
     /// holds a different branch.
@@ -30716,19 +29424,6 @@ impl QueryInput {
         })
     }
 
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::boxed::Box<crate::model::TextInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(crate::model::query_input::Input::Text(v.into()));
-        self
-    }
-
     /// The value of [input][crate::model::QueryInput::input]
     /// if it holds a `Event`, `None` if the field is not set or
     /// holds a different branch.
@@ -30738,19 +29433,6 @@ impl QueryInput {
             crate::model::query_input::Input::Event(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input][crate::model::QueryInput::input]
-    /// to hold a `Event`.
-    ///
-    /// Note that all the setters affecting `input` are
-    /// mutually exclusive.
-    pub fn set_event<T: std::convert::Into<std::boxed::Box<crate::model::EventInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input = std::option::Option::Some(crate::model::query_input::Input::Event(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -272,38 +272,6 @@ pub mod completion_service {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::import_suggestion_deny_list_entries_request::InlineSource,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -547,53 +515,6 @@ pub mod completion_service {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::import_completion_suggestions_request::InlineSource,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-        /// to hold a `BigquerySource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_bigquery_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_bigquery_source(v);
             self
         }
     }
@@ -4463,141 +4384,6 @@ pub mod document_service {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::import_documents_request::InlineSource>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `BigquerySource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_bigquery_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_bigquery_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `FhirStoreSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_fhir_store_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::FhirStoreSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_fhir_store_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `SpannerSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_spanner_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::SpannerSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_spanner_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `CloudSqlSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_cloud_sql_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_cloud_sql_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `FirestoreSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_firestore_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::FirestoreSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_firestore_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `AlloyDbSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_alloy_db_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::AlloyDbSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_alloy_db_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-        /// to hold a `BigtableSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_bigtable_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::BigtableSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_bigtable_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -4735,36 +4521,6 @@ pub mod document_service {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::PurgeDocumentsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::PurgeDocumentsRequest::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::purge_documents_request::InlineSource>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_source(v);
             self
         }
     }
@@ -9530,23 +9286,6 @@ pub mod search_tuning_service {
             self.0.request.training_input = v.into();
             self
         }
-
-        /// Sets the value of [training_input][crate::model::TrainCustomModelRequest::training_input]
-        /// to hold a `GcsTrainingInput`.
-        ///
-        /// Note that all the setters affecting `training_input` are
-        /// mutually exclusive.
-        pub fn set_gcs_training_input<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::train_custom_model_request::GcsTrainingInput>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_training_input(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -12517,51 +12256,6 @@ pub mod user_event_service {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::import_user_events_request::InlineSource>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
-        /// to hold a `BigquerySource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_bigquery_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_bigquery_source(v);
             self
         }
     }

--- a/src/generated/cloud/discoveryengine/v1/src/model.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/model.rs
@@ -496,25 +496,6 @@ pub mod answer {
             })
         }
 
-        /// Sets the value of [content][crate::model::answer::Reference::content]
-        /// to hold a `UnstructuredDocumentInfo`.
-        ///
-        /// Note that all the setters affecting `content` are
-        /// mutually exclusive.
-        pub fn set_unstructured_document_info<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::answer::reference::UnstructuredDocumentInfo>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.content = std::option::Option::Some(
-                crate::model::answer::reference::Content::UnstructuredDocumentInfo(v.into()),
-            );
-            self
-        }
-
         /// The value of [content][crate::model::answer::Reference::content]
         /// if it holds a `ChunkInfo`, `None` if the field is not set or
         /// holds a different branch.
@@ -529,23 +510,6 @@ pub mod answer {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [content][crate::model::answer::Reference::content]
-        /// to hold a `ChunkInfo`.
-        ///
-        /// Note that all the setters affecting `content` are
-        /// mutually exclusive.
-        pub fn set_chunk_info<
-            T: std::convert::Into<std::boxed::Box<crate::model::answer::reference::ChunkInfo>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.content = std::option::Option::Some(
-                crate::model::answer::reference::Content::ChunkInfo(v.into()),
-            );
-            self
         }
 
         /// The value of [content][crate::model::answer::Reference::content]
@@ -563,25 +527,6 @@ pub mod answer {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [content][crate::model::answer::Reference::content]
-        /// to hold a `StructuredDocumentInfo`.
-        ///
-        /// Note that all the setters affecting `content` are
-        /// mutually exclusive.
-        pub fn set_structured_document_info<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::answer::reference::StructuredDocumentInfo>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.content = std::option::Option::Some(
-                crate::model::answer::reference::Content::StructuredDocumentInfo(v.into()),
-            );
-            self
         }
     }
 
@@ -1153,25 +1098,6 @@ pub mod answer {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [action][crate::model::answer::step::Action::action]
-            /// to hold a `SearchAction`.
-            ///
-            /// Note that all the setters affecting `action` are
-            /// mutually exclusive.
-            pub fn set_search_action<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::answer::step::action::SearchAction>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.action = std::option::Option::Some(
-                    crate::model::answer::step::action::Action::SearchAction(v.into()),
-                );
-                self
             }
         }
 
@@ -2647,16 +2573,6 @@ impl Interval {
         })
     }
 
-    /// Sets the value of [min][crate::model::Interval::min]
-    /// to hold a `Minimum`.
-    ///
-    /// Note that all the setters affecting `min` are
-    /// mutually exclusive.
-    pub fn set_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.min = std::option::Option::Some(crate::model::interval::Min::Minimum(v.into()));
-        self
-    }
-
     /// The value of [min][crate::model::Interval::min]
     /// if it holds a `ExclusiveMinimum`, `None` if the field is not set or
     /// holds a different branch.
@@ -2666,17 +2582,6 @@ impl Interval {
             crate::model::interval::Min::ExclusiveMinimum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [min][crate::model::Interval::min]
-    /// to hold a `ExclusiveMinimum`.
-    ///
-    /// Note that all the setters affecting `min` are
-    /// mutually exclusive.
-    pub fn set_exclusive_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.min =
-            std::option::Option::Some(crate::model::interval::Min::ExclusiveMinimum(v.into()));
-        self
     }
 
     /// Sets the value of [max][crate::model::Interval::max].
@@ -2702,16 +2607,6 @@ impl Interval {
         })
     }
 
-    /// Sets the value of [max][crate::model::Interval::max]
-    /// to hold a `Maximum`.
-    ///
-    /// Note that all the setters affecting `max` are
-    /// mutually exclusive.
-    pub fn set_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.max = std::option::Option::Some(crate::model::interval::Max::Maximum(v.into()));
-        self
-    }
-
     /// The value of [max][crate::model::Interval::max]
     /// if it holds a `ExclusiveMaximum`, `None` if the field is not set or
     /// holds a different branch.
@@ -2721,17 +2616,6 @@ impl Interval {
             crate::model::interval::Max::ExclusiveMaximum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [max][crate::model::Interval::max]
-    /// to hold a `ExclusiveMaximum`.
-    ///
-    /// Note that all the setters affecting `max` are
-    /// mutually exclusive.
-    pub fn set_exclusive_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.max =
-            std::option::Option::Some(crate::model::interval::Max::ExclusiveMaximum(v.into()));
-        self
     }
 }
 
@@ -3341,18 +3225,6 @@ impl CompletionSuggestion {
         })
     }
 
-    /// Sets the value of [ranking_info][crate::model::CompletionSuggestion::ranking_info]
-    /// to hold a `GlobalScore`.
-    ///
-    /// Note that all the setters affecting `ranking_info` are
-    /// mutually exclusive.
-    pub fn set_global_score<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.ranking_info = std::option::Option::Some(
-            crate::model::completion_suggestion::RankingInfo::GlobalScore(v.into()),
-        );
-        self
-    }
-
     /// The value of [ranking_info][crate::model::CompletionSuggestion::ranking_info]
     /// if it holds a `Frequency`, `None` if the field is not set or
     /// holds a different branch.
@@ -3364,18 +3236,6 @@ impl CompletionSuggestion {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [ranking_info][crate::model::CompletionSuggestion::ranking_info]
-    /// to hold a `Frequency`.
-    ///
-    /// Note that all the setters affecting `ranking_info` are
-    /// mutually exclusive.
-    pub fn set_frequency<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.ranking_info = std::option::Option::Some(
-            crate::model::completion_suggestion::RankingInfo::Frequency(v.into()),
-        );
-        self
     }
 }
 
@@ -3966,22 +3826,6 @@ impl Control {
         })
     }
 
-    /// Sets the value of [action][crate::model::Control::action]
-    /// to hold a `BoostAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_boost_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::control::BoostAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::control::Action::BoostAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Control::action]
     /// if it holds a `FilterAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3993,22 +3837,6 @@ impl Control {
             crate::model::control::Action::FilterAction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Control::action]
-    /// to hold a `FilterAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_filter_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::control::FilterAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::control::Action::FilterAction(v.into()));
-        self
     }
 
     /// The value of [action][crate::model::Control::action]
@@ -4024,22 +3852,6 @@ impl Control {
         })
     }
 
-    /// Sets the value of [action][crate::model::Control::action]
-    /// to hold a `RedirectAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_redirect_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::control::RedirectAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::control::Action::RedirectAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Control::action]
     /// if it holds a `SynonymsAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -4053,22 +3865,6 @@ impl Control {
         })
     }
 
-    /// Sets the value of [action][crate::model::Control::action]
-    /// to hold a `SynonymsAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_synonyms_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::control::SynonymsAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::control::Action::SynonymsAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Control::action]
     /// if it holds a `PromoteAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -4080,22 +3876,6 @@ impl Control {
             crate::model::control::Action::PromoteAction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Control::action]
-    /// to hold a `PromoteAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_promote_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::control::PromoteAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::control::Action::PromoteAction(v.into()));
-        self
     }
 }
 
@@ -4198,18 +3978,6 @@ pub mod control {
             })
         }
 
-        /// Sets the value of [boost_spec][crate::model::control::BoostAction::boost_spec]
-        /// to hold a `FixedBoost`.
-        ///
-        /// Note that all the setters affecting `boost_spec` are
-        /// mutually exclusive.
-        pub fn set_fixed_boost<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.boost_spec = std::option::Option::Some(
-                crate::model::control::boost_action::BoostSpec::FixedBoost(v.into()),
-            );
-            self
-        }
-
         /// The value of [boost_spec][crate::model::control::BoostAction::boost_spec]
         /// if it holds a `InterpolationBoostSpec`, `None` if the field is not set or
         /// holds a different branch.
@@ -4225,25 +3993,6 @@ pub mod control {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [boost_spec][crate::model::control::BoostAction::boost_spec]
-        /// to hold a `InterpolationBoostSpec`.
-        ///
-        /// Note that all the setters affecting `boost_spec` are
-        /// mutually exclusive.
-        pub fn set_interpolation_boost_spec<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::control::boost_action::InterpolationBoostSpec>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.boost_spec = std::option::Option::Some(
-                crate::model::control::boost_action::BoostSpec::InterpolationBoostSpec(v.into()),
-            );
-            self
         }
     }
 
@@ -5651,21 +5400,6 @@ impl ConversationMessage {
         })
     }
 
-    /// Sets the value of [message][crate::model::ConversationMessage::message]
-    /// to hold a `UserInput`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_user_input<T: std::convert::Into<std::boxed::Box<crate::model::TextInput>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message = std::option::Option::Some(
-            crate::model::conversation_message::Message::UserInput(v.into()),
-        );
-        self
-    }
-
     /// The value of [message][crate::model::ConversationMessage::message]
     /// if it holds a `Reply`, `None` if the field is not set or
     /// holds a different branch.
@@ -5675,20 +5409,6 @@ impl ConversationMessage {
             crate::model::conversation_message::Message::Reply(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [message][crate::model::ConversationMessage::message]
-    /// to hold a `Reply`.
-    ///
-    /// Note that all the setters affecting `message` are
-    /// mutually exclusive.
-    pub fn set_reply<T: std::convert::Into<std::boxed::Box<crate::model::Reply>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message =
-            std::option::Option::Some(crate::model::conversation_message::Message::Reply(v.into()));
-        self
     }
 }
 
@@ -7346,25 +7066,6 @@ pub mod answer_query_request {
             })
         }
 
-        /// Sets the value of [input][crate::model::answer_query_request::SearchSpec::input]
-        /// to hold a `SearchParams`.
-        ///
-        /// Note that all the setters affecting `input` are
-        /// mutually exclusive.
-        pub fn set_search_params<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::answer_query_request::search_spec::SearchParams>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.input = std::option::Option::Some(
-                crate::model::answer_query_request::search_spec::Input::SearchParams(v.into()),
-            );
-            self
-        }
-
         /// The value of [input][crate::model::answer_query_request::SearchSpec::input]
         /// if it holds a `SearchResultList`, `None` if the field is not set or
         /// holds a different branch.
@@ -7380,27 +7081,6 @@ pub mod answer_query_request {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [input][crate::model::answer_query_request::SearchSpec::input]
-        /// to hold a `SearchResultList`.
-        ///
-        /// Note that all the setters affecting `input` are
-        /// mutually exclusive.
-        pub fn set_search_result_list<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::answer_query_request::search_spec::SearchResultList,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.input = std::option::Option::Some(
-                crate::model::answer_query_request::search_spec::Input::SearchResultList(v.into()),
-            );
-            self
         }
     }
 
@@ -7635,20 +7315,6 @@ pub mod answer_query_request {
                     })
                 }
 
-                /// Sets the value of [content][crate::model::answer_query_request::search_spec::search_result_list::SearchResult::content]
-                /// to hold a `UnstructuredDocumentInfo`.
-                ///
-                /// Note that all the setters affecting `content` are
-                /// mutually exclusive.
-                pub fn set_unstructured_document_info<T: std::convert::Into<std::boxed::Box<crate::model::answer_query_request::search_spec::search_result_list::search_result::UnstructuredDocumentInfo>>>(mut self, v: T) -> Self{
-                    self.content = std::option::Option::Some(
-                        crate::model::answer_query_request::search_spec::search_result_list::search_result::Content::UnstructuredDocumentInfo(
-                            v.into()
-                        )
-                    );
-                    self
-                }
-
                 /// The value of [content][crate::model::answer_query_request::search_spec::search_result_list::SearchResult::content]
                 /// if it holds a `ChunkInfo`, `None` if the field is not set or
                 /// holds a different branch.
@@ -7658,20 +7324,6 @@ pub mod answer_query_request {
                         crate::model::answer_query_request::search_spec::search_result_list::search_result::Content::ChunkInfo(v) => std::option::Option::Some(v),
                         _ => std::option::Option::None,
                     })
-                }
-
-                /// Sets the value of [content][crate::model::answer_query_request::search_spec::search_result_list::SearchResult::content]
-                /// to hold a `ChunkInfo`.
-                ///
-                /// Note that all the setters affecting `content` are
-                /// mutually exclusive.
-                pub fn set_chunk_info<T: std::convert::Into<std::boxed::Box<crate::model::answer_query_request::search_spec::search_result_list::search_result::ChunkInfo>>>(mut self, v: T) -> Self{
-                    self.content = std::option::Option::Some(
-                        crate::model::answer_query_request::search_spec::search_result_list::search_result::Content::ChunkInfo(
-                            v.into()
-                        )
-                    );
-                    self
                 }
             }
 
@@ -8694,20 +8346,6 @@ pub mod answer_query_request {
                     crate::model::answer_query_request::end_user_spec::end_user_meta_data::Content::ChunkInfo(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [content][crate::model::answer_query_request::end_user_spec::EndUserMetaData::content]
-            /// to hold a `ChunkInfo`.
-            ///
-            /// Note that all the setters affecting `content` are
-            /// mutually exclusive.
-            pub fn set_chunk_info<T: std::convert::Into<std::boxed::Box<crate::model::answer_query_request::end_user_spec::end_user_meta_data::ChunkInfo>>>(mut self, v: T) -> Self{
-                self.content = std::option::Option::Some(
-                    crate::model::answer_query_request::end_user_spec::end_user_meta_data::Content::ChunkInfo(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -11084,19 +10722,6 @@ impl Document {
         })
     }
 
-    /// Sets the value of [data][crate::model::Document::data]
-    /// to hold a `StructData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_struct_data<T: std::convert::Into<std::boxed::Box<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data = std::option::Option::Some(crate::model::document::Data::StructData(v.into()));
-        self
-    }
-
     /// The value of [data][crate::model::Document::data]
     /// if it holds a `JsonData`, `None` if the field is not set or
     /// holds a different branch.
@@ -11106,16 +10731,6 @@ impl Document {
             crate::model::document::Data::JsonData(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::Document::data]
-    /// to hold a `JsonData`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_json_data<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data = std::option::Option::Some(crate::model::document::Data::JsonData(v.into()));
-        self
     }
 }
 
@@ -11193,18 +10808,6 @@ pub mod document {
             })
         }
 
-        /// Sets the value of [content][crate::model::document::Content::content]
-        /// to hold a `RawBytes`.
-        ///
-        /// Note that all the setters affecting `content` are
-        /// mutually exclusive.
-        pub fn set_raw_bytes<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.content = std::option::Option::Some(
-                crate::model::document::content::Content::RawBytes(v.into()),
-            );
-            self
-        }
-
         /// The value of [content][crate::model::document::Content::content]
         /// if it holds a `Uri`, `None` if the field is not set or
         /// holds a different branch.
@@ -11214,17 +10817,6 @@ pub mod document {
                 crate::model::document::content::Content::Uri(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [content][crate::model::document::Content::content]
-        /// to hold a `Uri`.
-        ///
-        /// Note that all the setters affecting `content` are
-        /// mutually exclusive.
-        pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.content =
-                std::option::Option::Some(crate::model::document::content::Content::Uri(v.into()));
-            self
         }
     }
 
@@ -11521,20 +11113,6 @@ pub mod document_processing_config {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [chunk_mode][crate::model::document_processing_config::ChunkingConfig::chunk_mode]
-        /// to hold a `LayoutBasedChunkingConfig`.
-        ///
-        /// Note that all the setters affecting `chunk_mode` are
-        /// mutually exclusive.
-        pub fn set_layout_based_chunking_config<T: std::convert::Into<std::boxed::Box<crate::model::document_processing_config::chunking_config::LayoutBasedChunkingConfig>>>(mut self, v: T) -> Self{
-            self.chunk_mode = std::option::Option::Some(
-                crate::model::document_processing_config::chunking_config::ChunkMode::LayoutBasedChunkingConfig(
-                    v.into()
-                )
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for ChunkingConfig {
@@ -11658,20 +11236,6 @@ pub mod document_processing_config {
             })
         }
 
-        /// Sets the value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
-        /// to hold a `DigitalParsingConfig`.
-        ///
-        /// Note that all the setters affecting `type_dedicated_config` are
-        /// mutually exclusive.
-        pub fn set_digital_parsing_config<T: std::convert::Into<std::boxed::Box<crate::model::document_processing_config::parsing_config::DigitalParsingConfig>>>(mut self, v: T) -> Self{
-            self.type_dedicated_config = std::option::Option::Some(
-                crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::DigitalParsingConfig(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
         /// if it holds a `OcrParsingConfig`, `None` if the field is not set or
         /// holds a different branch.
@@ -11689,29 +11253,6 @@ pub mod document_processing_config {
             })
         }
 
-        /// Sets the value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
-        /// to hold a `OcrParsingConfig`.
-        ///
-        /// Note that all the setters affecting `type_dedicated_config` are
-        /// mutually exclusive.
-        pub fn set_ocr_parsing_config<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::document_processing_config::parsing_config::OcrParsingConfig,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.type_dedicated_config = std::option::Option::Some(
-                crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::OcrParsingConfig(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
         /// if it holds a `LayoutParsingConfig`, `None` if the field is not set or
         /// holds a different branch.
@@ -11727,20 +11268,6 @@ pub mod document_processing_config {
                 crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::LayoutParsingConfig(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [type_dedicated_config][crate::model::document_processing_config::ParsingConfig::type_dedicated_config]
-        /// to hold a `LayoutParsingConfig`.
-        ///
-        /// Note that all the setters affecting `type_dedicated_config` are
-        /// mutually exclusive.
-        pub fn set_layout_parsing_config<T: std::convert::Into<std::boxed::Box<crate::model::document_processing_config::parsing_config::LayoutParsingConfig>>>(mut self, v: T) -> Self{
-            self.type_dedicated_config = std::option::Option::Some(
-                crate::model::document_processing_config::parsing_config::TypeDedicatedConfig::LayoutParsingConfig(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -12494,29 +12021,6 @@ pub mod batch_get_documents_metadata_request {
             })
         }
 
-        /// Sets the value of [matcher][crate::model::batch_get_documents_metadata_request::Matcher::matcher]
-        /// to hold a `UrisMatcher`.
-        ///
-        /// Note that all the setters affecting `matcher` are
-        /// mutually exclusive.
-        pub fn set_uris_matcher<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::batch_get_documents_metadata_request::UrisMatcher,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.matcher = std::option::Option::Some(
-                crate::model::batch_get_documents_metadata_request::matcher::Matcher::UrisMatcher(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [matcher][crate::model::batch_get_documents_metadata_request::Matcher::matcher]
         /// if it holds a `FhirMatcher`, `None` if the field is not set or
         /// holds a different branch.
@@ -12530,29 +12034,6 @@ pub mod batch_get_documents_metadata_request {
                 crate::model::batch_get_documents_metadata_request::matcher::Matcher::FhirMatcher(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [matcher][crate::model::batch_get_documents_metadata_request::Matcher::matcher]
-        /// to hold a `FhirMatcher`.
-        ///
-        /// Note that all the setters affecting `matcher` are
-        /// mutually exclusive.
-        pub fn set_fhir_matcher<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::batch_get_documents_metadata_request::FhirMatcher,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.matcher = std::option::Option::Some(
-                crate::model::batch_get_documents_metadata_request::matcher::Matcher::FhirMatcher(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -12782,20 +12263,6 @@ pub mod batch_get_documents_metadata_response {
                 })
             }
 
-            /// Sets the value of [matcher_value][crate::model::batch_get_documents_metadata_response::document_metadata::MatcherValue::matcher_value]
-            /// to hold a `Uri`.
-            ///
-            /// Note that all the setters affecting `matcher_value` are
-            /// mutually exclusive.
-            pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.matcher_value = std::option::Option::Some(
-                    crate::model::batch_get_documents_metadata_response::document_metadata::matcher_value::MatcherValue::Uri(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [matcher_value][crate::model::batch_get_documents_metadata_response::document_metadata::MatcherValue::matcher_value]
             /// if it holds a `FhirResource`, `None` if the field is not set or
             /// holds a different branch.
@@ -12805,23 +12272,6 @@ pub mod batch_get_documents_metadata_response {
                     crate::model::batch_get_documents_metadata_response::document_metadata::matcher_value::MatcherValue::FhirResource(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [matcher_value][crate::model::batch_get_documents_metadata_response::document_metadata::MatcherValue::matcher_value]
-            /// to hold a `FhirResource`.
-            ///
-            /// Note that all the setters affecting `matcher_value` are
-            /// mutually exclusive.
-            pub fn set_fhir_resource<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.matcher_value = std::option::Option::Some(
-                    crate::model::batch_get_documents_metadata_response::document_metadata::matcher_value::MatcherValue::FhirResource(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -13210,23 +12660,6 @@ impl Engine {
         })
     }
 
-    /// Sets the value of [engine_config][crate::model::Engine::engine_config]
-    /// to hold a `ChatEngineConfig`.
-    ///
-    /// Note that all the setters affecting `engine_config` are
-    /// mutually exclusive.
-    pub fn set_chat_engine_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::engine::ChatEngineConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.engine_config = std::option::Option::Some(
-            crate::model::engine::EngineConfig::ChatEngineConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [engine_config][crate::model::Engine::engine_config]
     /// if it holds a `SearchEngineConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -13240,23 +12673,6 @@ impl Engine {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [engine_config][crate::model::Engine::engine_config]
-    /// to hold a `SearchEngineConfig`.
-    ///
-    /// Note that all the setters affecting `engine_config` are
-    /// mutually exclusive.
-    pub fn set_search_engine_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::engine::SearchEngineConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.engine_config = std::option::Option::Some(
-            crate::model::engine::EngineConfig::SearchEngineConfig(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [engine_metadata][crate::model::Engine::engine_metadata].
@@ -13286,23 +12702,6 @@ impl Engine {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [engine_metadata][crate::model::Engine::engine_metadata]
-    /// to hold a `ChatEngineMetadata`.
-    ///
-    /// Note that all the setters affecting `engine_metadata` are
-    /// mutually exclusive.
-    pub fn set_chat_engine_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::engine::ChatEngineMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.engine_metadata = std::option::Option::Some(
-            crate::model::engine::EngineMetadata::ChatEngineMetadata(v.into()),
-        );
-        self
     }
 }
 
@@ -14268,18 +13667,6 @@ pub mod grounded_generation_content {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [data][crate::model::grounded_generation_content::Part::data]
-        /// to hold a `Text`.
-        ///
-        /// Note that all the setters affecting `data` are
-        /// mutually exclusive.
-        pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.data = std::option::Option::Some(
-                crate::model::grounded_generation_content::part::Data::Text(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for Part {
@@ -14859,20 +14246,6 @@ pub mod generate_grounded_content_request {
             })
         }
 
-        /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
-        /// to hold a `InlineSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_source<T: std::convert::Into<std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::InlineSource>>>(mut self, v: T) -> Self{
-            self.source = std::option::Option::Some(
-                crate::model::generate_grounded_content_request::grounding_source::Source::InlineSource(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
         /// if it holds a `SearchSource`, `None` if the field is not set or
         /// holds a different branch.
@@ -14890,20 +14263,6 @@ pub mod generate_grounded_content_request {
             })
         }
 
-        /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
-        /// to hold a `SearchSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_search_source<T: std::convert::Into<std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::SearchSource>>>(mut self, v: T) -> Self{
-            self.source = std::option::Option::Some(
-                crate::model::generate_grounded_content_request::grounding_source::Source::SearchSource(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
         /// if it holds a `GoogleSearchSource`, `None` if the field is not set or
         /// holds a different branch.
@@ -14915,20 +14274,6 @@ pub mod generate_grounded_content_request {
             })
         }
 
-        /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
-        /// to hold a `GoogleSearchSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_google_search_source<T: std::convert::Into<std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::GoogleSearchSource>>>(mut self, v: T) -> Self{
-            self.source = std::option::Option::Some(
-                crate::model::generate_grounded_content_request::grounding_source::Source::GoogleSearchSource(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
         /// if it holds a `EnterpriseWebRetrievalSource`, `None` if the field is not set or
         /// holds a different branch.
@@ -14938,20 +14283,6 @@ pub mod generate_grounded_content_request {
                 crate::model::generate_grounded_content_request::grounding_source::Source::EnterpriseWebRetrievalSource(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::generate_grounded_content_request::GroundingSource::source]
-        /// to hold a `EnterpriseWebRetrievalSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_enterprise_web_retrieval_source<T: std::convert::Into<std::boxed::Box<crate::model::generate_grounded_content_request::grounding_source::EnterpriseWebRetrievalSource>>>(mut self, v: T) -> Self{
-            self.source = std::option::Option::Some(
-                crate::model::generate_grounded_content_request::grounding_source::Source::EnterpriseWebRetrievalSource(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -16870,21 +16201,6 @@ impl BigQuerySource {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [partition][crate::model::BigQuerySource::partition]
-    /// to hold a `PartitionDate`.
-    ///
-    /// Note that all the setters affecting `partition` are
-    /// mutually exclusive.
-    pub fn set_partition_date<T: std::convert::Into<std::boxed::Box<gtype::model::Date>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.partition = std::option::Option::Some(
-            crate::model::big_query_source::Partition::PartitionDate(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BigQuerySource {
@@ -17974,18 +17290,6 @@ impl ImportErrorConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ImportErrorConfig::destination]
-    /// to hold a `GcsPrefix`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::import_error_config::Destination::GcsPrefix(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ImportErrorConfig {
@@ -18089,23 +17393,6 @@ impl ImportUserEventsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
-    /// to hold a `InlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::import_user_events_request::InlineSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_user_events_request::Source::InlineSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportUserEventsRequest::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -18117,21 +17404,6 @@ impl ImportUserEventsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_user_events_request::Source::GcsSource(v.into()),
-        );
-        self
     }
 
     /// The value of [source][crate::model::ImportUserEventsRequest::source]
@@ -18147,23 +17419,6 @@ impl ImportUserEventsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportUserEventsRequest::source]
-    /// to hold a `BigquerySource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_bigquery_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_user_events_request::Source::BigquerySource(v.into()),
-        );
-        self
     }
 }
 
@@ -18685,23 +17940,6 @@ impl ImportDocumentsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `InlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::import_documents_request::InlineSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::InlineSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -18713,21 +17951,6 @@ impl ImportDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::GcsSource(v.into()),
-        );
-        self
     }
 
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
@@ -18745,23 +17968,6 @@ impl ImportDocumentsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `BigquerySource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_bigquery_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::BigquerySource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
     /// if it holds a `FhirStoreSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -18775,23 +17981,6 @@ impl ImportDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `FhirStoreSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_fhir_store_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::FhirStoreSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::FhirStoreSource(v.into()),
-        );
-        self
     }
 
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
@@ -18809,23 +17998,6 @@ impl ImportDocumentsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `SpannerSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_spanner_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::SpannerSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::SpannerSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
     /// if it holds a `CloudSqlSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -18839,23 +18011,6 @@ impl ImportDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `CloudSqlSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::CloudSqlSource(v.into()),
-        );
-        self
     }
 
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
@@ -18873,23 +18028,6 @@ impl ImportDocumentsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `FirestoreSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_firestore_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::FirestoreSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::FirestoreSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
     /// if it holds a `AlloyDbSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -18905,23 +18043,6 @@ impl ImportDocumentsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `AlloyDbSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_alloy_db_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::AlloyDbSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::AlloyDbSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportDocumentsRequest::source]
     /// if it holds a `BigtableSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -18935,23 +18056,6 @@ impl ImportDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportDocumentsRequest::source]
-    /// to hold a `BigtableSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_bigtable_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigtableSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_documents_request::Source::BigtableSource(v.into()),
-        );
-        self
     }
 }
 
@@ -19295,29 +18399,6 @@ impl ImportSuggestionDenyListEntriesRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
-    /// to hold a `InlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_source<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::import_suggestion_deny_list_entries_request::InlineSource,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_suggestion_deny_list_entries_request::Source::InlineSource(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -19329,21 +18410,6 @@ impl ImportSuggestionDenyListEntriesRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportSuggestionDenyListEntriesRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_suggestion_deny_list_entries_request::Source::GcsSource(v.into()),
-        );
-        self
     }
 }
 
@@ -19617,25 +18683,6 @@ impl ImportCompletionSuggestionsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-    /// to hold a `InlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_source<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::import_completion_suggestions_request::InlineSource>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_completion_suggestions_request::Source::InlineSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -19647,21 +18694,6 @@ impl ImportCompletionSuggestionsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_completion_suggestions_request::Source::GcsSource(v.into()),
-        );
-        self
     }
 
     /// The value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
@@ -19677,23 +18709,6 @@ impl ImportCompletionSuggestionsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportCompletionSuggestionsRequest::source]
-    /// to hold a `BigquerySource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_bigquery_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_completion_suggestions_request::Source::BigquerySource(v.into()),
-        );
-        self
     }
 }
 
@@ -20567,18 +19582,6 @@ impl PurgeErrorConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::PurgeErrorConfig::destination]
-    /// to hold a `GcsPrefix`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::purge_error_config::Destination::GcsPrefix(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for PurgeErrorConfig {
@@ -20705,21 +19708,6 @@ impl PurgeDocumentsRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::PurgeDocumentsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::purge_documents_request::Source::GcsSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::PurgeDocumentsRequest::source]
     /// if it holds a `InlineSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -20734,23 +19722,6 @@ impl PurgeDocumentsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::PurgeDocumentsRequest::source]
-    /// to hold a `InlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::purge_documents_request::InlineSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::purge_documents_request::Source::InlineSource(v.into()),
-        );
-        self
     }
 }
 
@@ -22334,20 +21305,6 @@ impl Schema {
         })
     }
 
-    /// Sets the value of [schema][crate::model::Schema::schema]
-    /// to hold a `StructSchema`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_struct_schema<T: std::convert::Into<std::boxed::Box<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schema =
-            std::option::Option::Some(crate::model::schema::Schema::StructSchema(v.into()));
-        self
-    }
-
     /// The value of [schema][crate::model::Schema::schema]
     /// if it holds a `JsonSchema`, `None` if the field is not set or
     /// holds a different branch.
@@ -22357,16 +21314,6 @@ impl Schema {
             crate::model::schema::Schema::JsonSchema(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schema][crate::model::Schema::schema]
-    /// to hold a `JsonSchema`.
-    ///
-    /// Note that all the setters affecting `schema` are
-    /// mutually exclusive.
-    pub fn set_json_schema<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.schema = std::option::Option::Some(crate::model::schema::Schema::JsonSchema(v.into()));
-        self
     }
 }
 
@@ -23532,18 +22479,6 @@ pub mod search_request {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [image][crate::model::search_request::ImageQuery::image]
-        /// to hold a `ImageBytes`.
-        ///
-        /// Note that all the setters affecting `image` are
-        /// mutually exclusive.
-        pub fn set_image_bytes<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.image = std::option::Option::Some(
-                crate::model::search_request::image_query::Image::ImageBytes(v.into()),
-            );
-            self
         }
     }
 
@@ -26782,18 +25717,6 @@ pub mod search_response {
                 })
             }
 
-            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
-            /// to hold a `Value`.
-            ///
-            /// Note that all the setters affecting `facet_value` are
-            /// mutually exclusive.
-            pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.facet_value = std::option::Option::Some(
-                    crate::model::search_response::facet::facet_value::FacetValue::Value(v.into()),
-                );
-                self
-            }
-
             /// The value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
             /// if it holds a `Interval`, `None` if the field is not set or
             /// holds a different branch.
@@ -26807,23 +25730,6 @@ pub mod search_response {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
-            /// to hold a `Interval`.
-            ///
-            /// Note that all the setters affecting `facet_value` are
-            /// mutually exclusive.
-            pub fn set_interval<T: std::convert::Into<std::boxed::Box<crate::model::Interval>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.facet_value = std::option::Option::Some(
-                    crate::model::search_response::facet::facet_value::FacetValue::Interval(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -27872,25 +26778,6 @@ impl TrainCustomModelRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [training_input][crate::model::TrainCustomModelRequest::training_input]
-    /// to hold a `GcsTrainingInput`.
-    ///
-    /// Note that all the setters affecting `training_input` are
-    /// mutually exclusive.
-    pub fn set_gcs_training_input<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::train_custom_model_request::GcsTrainingInput>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.training_input = std::option::Option::Some(
-            crate::model::train_custom_model_request::TrainingInput::GcsTrainingInput(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for TrainCustomModelRequest {
@@ -28561,23 +27448,6 @@ impl ServingConfig {
         })
     }
 
-    /// Sets the value of [vertical_config][crate::model::ServingConfig::vertical_config]
-    /// to hold a `MediaConfig`.
-    ///
-    /// Note that all the setters affecting `vertical_config` are
-    /// mutually exclusive.
-    pub fn set_media_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::serving_config::MediaConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vertical_config = std::option::Option::Some(
-            crate::model::serving_config::VerticalConfig::MediaConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [vertical_config][crate::model::ServingConfig::vertical_config]
     /// if it holds a `GenericConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -28591,23 +27461,6 @@ impl ServingConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [vertical_config][crate::model::ServingConfig::vertical_config]
-    /// to hold a `GenericConfig`.
-    ///
-    /// Note that all the setters affecting `vertical_config` are
-    /// mutually exclusive.
-    pub fn set_generic_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::serving_config::GenericConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vertical_config = std::option::Option::Some(
-            crate::model::serving_config::VerticalConfig::GenericConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -28741,23 +27594,6 @@ pub mod serving_config {
             })
         }
 
-        /// Sets the value of [demote_content_watched][crate::model::serving_config::MediaConfig::demote_content_watched]
-        /// to hold a `ContentWatchedPercentageThreshold`.
-        ///
-        /// Note that all the setters affecting `demote_content_watched` are
-        /// mutually exclusive.
-        pub fn set_content_watched_percentage_threshold<T: std::convert::Into<f32>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.demote_content_watched = std::option::Option::Some(
-                crate::model::serving_config::media_config::DemoteContentWatched::ContentWatchedPercentageThreshold(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [demote_content_watched][crate::model::serving_config::MediaConfig::demote_content_watched]
         /// if it holds a `ContentWatchedSecondsThreshold`, `None` if the field is not set or
         /// holds a different branch.
@@ -28767,23 +27603,6 @@ pub mod serving_config {
                 crate::model::serving_config::media_config::DemoteContentWatched::ContentWatchedSecondsThreshold(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [demote_content_watched][crate::model::serving_config::MediaConfig::demote_content_watched]
-        /// to hold a `ContentWatchedSecondsThreshold`.
-        ///
-        /// Note that all the setters affecting `demote_content_watched` are
-        /// mutually exclusive.
-        pub fn set_content_watched_seconds_threshold<T: std::convert::Into<f32>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.demote_content_watched = std::option::Option::Some(
-                crate::model::serving_config::media_config::DemoteContentWatched::ContentWatchedSecondsThreshold(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -29301,16 +28120,6 @@ impl Query {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [content][crate::model::Query::content]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.content = std::option::Option::Some(crate::model::query::Content::Text(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Query {
@@ -29579,25 +28388,6 @@ pub mod target_site {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [failure][crate::model::target_site::FailureReason::failure]
-        /// to hold a `QuotaFailure`.
-        ///
-        /// Note that all the setters affecting `failure` are
-        /// mutually exclusive.
-        pub fn set_quota_failure<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::target_site::failure_reason::QuotaFailure>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.failure = std::option::Option::Some(
-                crate::model::target_site::failure_reason::Failure::QuotaFailure(v.into()),
-            );
-            self
         }
     }
 
@@ -30205,16 +28995,6 @@ impl Sitemap {
             crate::model::sitemap::Feed::Uri(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [feed][crate::model::Sitemap::feed]
-    /// to hold a `Uri`.
-    ///
-    /// Note that all the setters affecting `feed` are
-    /// mutually exclusive.
-    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.feed = std::option::Option::Some(crate::model::sitemap::Feed::Uri(v.into()));
-        self
     }
 }
 
@@ -31207,23 +29987,6 @@ pub mod fetch_sitemaps_request {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [matcher][crate::model::fetch_sitemaps_request::Matcher::matcher]
-        /// to hold a `UrisMatcher`.
-        ///
-        /// Note that all the setters affecting `matcher` are
-        /// mutually exclusive.
-        pub fn set_uris_matcher<
-            T: std::convert::Into<std::boxed::Box<crate::model::fetch_sitemaps_request::UrisMatcher>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.matcher = std::option::Option::Some(
-                crate::model::fetch_sitemaps_request::matcher::Matcher::UrisMatcher(v.into()),
-            );
-            self
         }
     }
 
@@ -33510,18 +32273,6 @@ impl DocumentInfo {
         })
     }
 
-    /// Sets the value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
-    /// to hold a `Id`.
-    ///
-    /// Note that all the setters affecting `document_descriptor` are
-    /// mutually exclusive.
-    pub fn set_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.document_descriptor = std::option::Option::Some(
-            crate::model::document_info::DocumentDescriptor::Id(v.into()),
-        );
-        self
-    }
-
     /// The value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
     /// if it holds a `Name`, `None` if the field is not set or
     /// holds a different branch.
@@ -33535,18 +32286,6 @@ impl DocumentInfo {
         })
     }
 
-    /// Sets the value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
-    /// to hold a `Name`.
-    ///
-    /// Note that all the setters affecting `document_descriptor` are
-    /// mutually exclusive.
-    pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.document_descriptor = std::option::Option::Some(
-            crate::model::document_info::DocumentDescriptor::Name(v.into()),
-        );
-        self
-    }
-
     /// The value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
     /// if it holds a `Uri`, `None` if the field is not set or
     /// holds a different branch.
@@ -33556,18 +32295,6 @@ impl DocumentInfo {
             crate::model::document_info::DocumentDescriptor::Uri(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [document_descriptor][crate::model::DocumentInfo::document_descriptor]
-    /// to hold a `Uri`.
-    ///
-    /// Note that all the setters affecting `document_descriptor` are
-    /// mutually exclusive.
-    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.document_descriptor = std::option::Option::Some(
-            crate::model::document_info::DocumentDescriptor::Uri(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/documentai/v1/src/builder.rs
+++ b/src/generated/cloud/documentai/v1/src/builder.rs
@@ -174,51 +174,6 @@ pub mod document_processor_service {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ProcessRequest::source]
-        /// to hold a `InlineDocument`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_document<
-            T: std::convert::Into<std::boxed::Box<crate::model::Document>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_document(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ProcessRequest::source]
-        /// to hold a `RawDocument`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_raw_document<
-            T: std::convert::Into<std::boxed::Box<crate::model::RawDocument>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_raw_document(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ProcessRequest::source]
-        /// to hold a `GcsDocument`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_document<
-            T: std::convert::Into<std::boxed::Box<crate::model::GcsDocument>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_document(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -932,35 +887,6 @@ pub mod document_processor_service {
             v: T,
         ) -> Self {
             self.0.request.processor_flags = v.into();
-            self
-        }
-
-        /// Sets the value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
-        /// to hold a `CustomDocumentExtractionOptions`.
-        ///
-        /// Note that all the setters affecting `processor_flags` are
-        /// mutually exclusive.
-        pub fn set_custom_document_extraction_options<T: std::convert::Into<std::boxed::Box<crate::model::train_processor_version_request::CustomDocumentExtractionOptions>>>(mut self, v: T) -> Self{
-            self.0.request = self.0.request.set_custom_document_extraction_options(v);
-            self
-        }
-
-        /// Sets the value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
-        /// to hold a `FoundationModelTuningOptions`.
-        ///
-        /// Note that all the setters affecting `processor_flags` are
-        /// mutually exclusive.
-        pub fn set_foundation_model_tuning_options<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::train_processor_version_request::FoundationModelTuningOptions,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_foundation_model_tuning_options(v);
             self
         }
     }
@@ -2111,21 +2037,6 @@ pub mod document_processor_service {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ReviewDocumentRequest::source]
-        /// to hold a `InlineDocument`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_inline_document<
-            T: std::convert::Into<std::boxed::Box<crate::model::Document>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inline_document(v);
             self
         }
     }

--- a/src/generated/cloud/documentai/v1/src/model.rs
+++ b/src/generated/cloud/documentai/v1/src/model.rs
@@ -365,16 +365,6 @@ impl Document {
         })
     }
 
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `Uri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(crate::model::document::Source::Uri(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Document::source]
     /// if it holds a `Content`, `None` if the field is not set or
     /// holds a different branch.
@@ -384,16 +374,6 @@ impl Document {
             crate::model::document::Source::Content(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(crate::model::document::Source::Content(v.into()));
-        self
     }
 }
 
@@ -3103,23 +3083,6 @@ pub mod document {
                 })
             }
 
-            /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// to hold a `MoneyValue`.
-            ///
-            /// Note that all the setters affecting `structured_value` are
-            /// mutually exclusive.
-            pub fn set_money_value<T: std::convert::Into<std::boxed::Box<gtype::model::Money>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.structured_value = std::option::Option::Some(
-                    crate::model::document::entity::normalized_value::StructuredValue::MoneyValue(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// if it holds a `DateValue`, `None` if the field is not set or
             /// holds a different branch.
@@ -3129,23 +3092,6 @@ pub mod document {
                     crate::model::document::entity::normalized_value::StructuredValue::DateValue(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// to hold a `DateValue`.
-            ///
-            /// Note that all the setters affecting `structured_value` are
-            /// mutually exclusive.
-            pub fn set_date_value<T: std::convert::Into<std::boxed::Box<gtype::model::Date>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.structured_value = std::option::Option::Some(
-                    crate::model::document::entity::normalized_value::StructuredValue::DateValue(
-                        v.into(),
-                    ),
-                );
-                self
             }
 
             /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
@@ -3161,25 +3107,6 @@ pub mod document {
                 })
             }
 
-            /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// to hold a `DatetimeValue`.
-            ///
-            /// Note that all the setters affecting `structured_value` are
-            /// mutually exclusive.
-            pub fn set_datetime_value<
-                T: std::convert::Into<std::boxed::Box<gtype::model::DateTime>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.structured_value = std::option::Option::Some(
-                    crate::model::document::entity::normalized_value::StructuredValue::DatetimeValue(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// if it holds a `AddressValue`, `None` if the field is not set or
             /// holds a different branch.
@@ -3193,25 +3120,6 @@ pub mod document {
                 })
             }
 
-            /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// to hold a `AddressValue`.
-            ///
-            /// Note that all the setters affecting `structured_value` are
-            /// mutually exclusive.
-            pub fn set_address_value<
-                T: std::convert::Into<std::boxed::Box<gtype::model::PostalAddress>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.structured_value = std::option::Option::Some(
-                    crate::model::document::entity::normalized_value::StructuredValue::AddressValue(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// if it holds a `BooleanValue`, `None` if the field is not set or
             /// holds a different branch.
@@ -3221,20 +3129,6 @@ pub mod document {
                     crate::model::document::entity::normalized_value::StructuredValue::BooleanValue(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// to hold a `BooleanValue`.
-            ///
-            /// Note that all the setters affecting `structured_value` are
-            /// mutually exclusive.
-            pub fn set_boolean_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-                self.structured_value = std::option::Option::Some(
-                    crate::model::document::entity::normalized_value::StructuredValue::BooleanValue(
-                        v.into(),
-                    ),
-                );
-                self
             }
 
             /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
@@ -3248,20 +3142,6 @@ pub mod document {
                 })
             }
 
-            /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// to hold a `IntegerValue`.
-            ///
-            /// Note that all the setters affecting `structured_value` are
-            /// mutually exclusive.
-            pub fn set_integer_value<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                self.structured_value = std::option::Option::Some(
-                    crate::model::document::entity::normalized_value::StructuredValue::IntegerValue(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
             /// if it holds a `FloatValue`, `None` if the field is not set or
             /// holds a different branch.
@@ -3271,20 +3151,6 @@ pub mod document {
                     crate::model::document::entity::normalized_value::StructuredValue::FloatValue(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [structured_value][crate::model::document::entity::NormalizedValue::structured_value]
-            /// to hold a `FloatValue`.
-            ///
-            /// Note that all the setters affecting `structured_value` are
-            /// mutually exclusive.
-            pub fn set_float_value<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-                self.structured_value = std::option::Option::Some(
-                    crate::model::document::entity::normalized_value::StructuredValue::FloatValue(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -4301,18 +4167,6 @@ pub mod document {
             })
         }
 
-        /// Sets the value of [source][crate::model::document::Revision::source]
-        /// to hold a `Agent`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_agent<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::document::revision::Source::Agent(v.into()),
-            );
-            self
-        }
-
         /// The value of [source][crate::model::document::Revision::source]
         /// if it holds a `Processor`, `None` if the field is not set or
         /// holds a different branch.
@@ -4324,18 +4178,6 @@ pub mod document {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::document::Revision::source]
-        /// to hold a `Processor`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_processor<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::document::revision::Source::Processor(v.into()),
-            );
-            self
         }
     }
 
@@ -4624,20 +4466,6 @@ pub mod document {
                 })
             }
 
-            /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
-            /// to hold a `TextBlock`.
-            ///
-            /// Note that all the setters affecting `block` are
-            /// mutually exclusive.
-            pub fn set_text_block<T: std::convert::Into<std::boxed::Box<crate::model::document::document_layout::document_layout_block::LayoutTextBlock>>>(mut self, v: T) -> Self{
-                self.block = std::option::Option::Some(
-                    crate::model::document::document_layout::document_layout_block::Block::TextBlock(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
             /// if it holds a `TableBlock`, `None` if the field is not set or
             /// holds a different branch.
@@ -4647,20 +4475,6 @@ pub mod document {
                     crate::model::document::document_layout::document_layout_block::Block::TableBlock(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
-            /// to hold a `TableBlock`.
-            ///
-            /// Note that all the setters affecting `block` are
-            /// mutually exclusive.
-            pub fn set_table_block<T: std::convert::Into<std::boxed::Box<crate::model::document::document_layout::document_layout_block::LayoutTableBlock>>>(mut self, v: T) -> Self{
-                self.block = std::option::Option::Some(
-                    crate::model::document::document_layout::document_layout_block::Block::TableBlock(
-                        v.into()
-                    )
-                );
-                self
             }
 
             /// The value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
@@ -4678,20 +4492,6 @@ pub mod document {
                     crate::model::document::document_layout::document_layout_block::Block::ListBlock(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [block][crate::model::document::document_layout::DocumentLayoutBlock::block]
-            /// to hold a `ListBlock`.
-            ///
-            /// Note that all the setters affecting `block` are
-            /// mutually exclusive.
-            pub fn set_list_block<T: std::convert::Into<std::boxed::Box<crate::model::document::document_layout::document_layout_block::LayoutListBlock>>>(mut self, v: T) -> Self{
-                self.block = std::option::Option::Some(
-                    crate::model::document::document_layout::document_layout_block::Block::ListBlock(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -5652,21 +5452,6 @@ impl BatchDocumentsInputConfig {
         })
     }
 
-    /// Sets the value of [source][crate::model::BatchDocumentsInputConfig::source]
-    /// to hold a `GcsPrefix`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_prefix<T: std::convert::Into<std::boxed::Box<crate::model::GcsPrefix>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::batch_documents_input_config::Source::GcsPrefix(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::BatchDocumentsInputConfig::source]
     /// if it holds a `GcsDocuments`, `None` if the field is not set or
     /// holds a different branch.
@@ -5680,21 +5465,6 @@ impl BatchDocumentsInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::BatchDocumentsInputConfig::source]
-    /// to hold a `GcsDocuments`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_documents<T: std::convert::Into<std::boxed::Box<crate::model::GcsDocuments>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::batch_documents_input_config::Source::GcsDocuments(v.into()),
-        );
-        self
     }
 }
 
@@ -5771,23 +5541,6 @@ impl DocumentOutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::DocumentOutputConfig::destination]
-    /// to hold a `GcsOutputConfig`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_output_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::document_output_config::GcsOutputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::document_output_config::Destination::GcsOutputConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -6279,23 +6032,6 @@ impl ProcessOptions {
         })
     }
 
-    /// Sets the value of [page_range][crate::model::ProcessOptions::page_range]
-    /// to hold a `IndividualPageSelector`.
-    ///
-    /// Note that all the setters affecting `page_range` are
-    /// mutually exclusive.
-    pub fn set_individual_page_selector<
-        T: std::convert::Into<std::boxed::Box<crate::model::process_options::IndividualPageSelector>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.page_range = std::option::Option::Some(
-            crate::model::process_options::PageRange::IndividualPageSelector(v.into()),
-        );
-        self
-    }
-
     /// The value of [page_range][crate::model::ProcessOptions::page_range]
     /// if it holds a `FromStart`, `None` if the field is not set or
     /// holds a different branch.
@@ -6307,18 +6043,6 @@ impl ProcessOptions {
         })
     }
 
-    /// Sets the value of [page_range][crate::model::ProcessOptions::page_range]
-    /// to hold a `FromStart`.
-    ///
-    /// Note that all the setters affecting `page_range` are
-    /// mutually exclusive.
-    pub fn set_from_start<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.page_range = std::option::Option::Some(
-            crate::model::process_options::PageRange::FromStart(v.into()),
-        );
-        self
-    }
-
     /// The value of [page_range][crate::model::ProcessOptions::page_range]
     /// if it holds a `FromEnd`, `None` if the field is not set or
     /// holds a different branch.
@@ -6328,17 +6052,6 @@ impl ProcessOptions {
             crate::model::process_options::PageRange::FromEnd(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [page_range][crate::model::ProcessOptions::page_range]
-    /// to hold a `FromEnd`.
-    ///
-    /// Note that all the setters affecting `page_range` are
-    /// mutually exclusive.
-    pub fn set_from_end<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.page_range =
-            std::option::Option::Some(crate::model::process_options::PageRange::FromEnd(v.into()));
-        self
     }
 }
 
@@ -6680,21 +6393,6 @@ impl ProcessRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ProcessRequest::source]
-    /// to hold a `InlineDocument`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_document<T: std::convert::Into<std::boxed::Box<crate::model::Document>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::process_request::Source::InlineDocument(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ProcessRequest::source]
     /// if it holds a `RawDocument`, `None` if the field is not set or
     /// holds a different branch.
@@ -6706,20 +6404,6 @@ impl ProcessRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ProcessRequest::source]
-    /// to hold a `RawDocument`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_raw_document<T: std::convert::Into<std::boxed::Box<crate::model::RawDocument>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::process_request::Source::RawDocument(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::ProcessRequest::source]
     /// if it holds a `GcsDocument`, `None` if the field is not set or
     /// holds a different branch.
@@ -6729,20 +6413,6 @@ impl ProcessRequest {
             crate::model::process_request::Source::GcsDocument(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ProcessRequest::source]
-    /// to hold a `GcsDocument`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_document<T: std::convert::Into<std::boxed::Box<crate::model::GcsDocument>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::process_request::Source::GcsDocument(v.into()));
-        self
     }
 }
 
@@ -8984,29 +8654,6 @@ impl TrainProcessorVersionRequest {
         })
     }
 
-    /// Sets the value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
-    /// to hold a `CustomDocumentExtractionOptions`.
-    ///
-    /// Note that all the setters affecting `processor_flags` are
-    /// mutually exclusive.
-    pub fn set_custom_document_extraction_options<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::train_processor_version_request::CustomDocumentExtractionOptions,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.processor_flags = std::option::Option::Some(
-            crate::model::train_processor_version_request::ProcessorFlags::CustomDocumentExtractionOptions(
-                v.into()
-            )
-        );
-        self
-    }
-
     /// The value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
     /// if it holds a `FoundationModelTuningOptions`, `None` if the field is not set or
     /// holds a different branch.
@@ -9022,29 +8669,6 @@ impl TrainProcessorVersionRequest {
             crate::model::train_processor_version_request::ProcessorFlags::FoundationModelTuningOptions(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [processor_flags][crate::model::TrainProcessorVersionRequest::processor_flags]
-    /// to hold a `FoundationModelTuningOptions`.
-    ///
-    /// Note that all the setters affecting `processor_flags` are
-    /// mutually exclusive.
-    pub fn set_foundation_model_tuning_options<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::train_processor_version_request::FoundationModelTuningOptions,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.processor_flags = std::option::Option::Some(
-            crate::model::train_processor_version_request::ProcessorFlags::FoundationModelTuningOptions(
-                v.into()
-            )
-        );
-        self
     }
 }
 
@@ -9649,21 +9273,6 @@ impl ReviewDocumentRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ReviewDocumentRequest::source]
-    /// to hold a `InlineDocument`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_inline_document<T: std::convert::Into<std::boxed::Box<crate::model::Document>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::review_document_request::Source::InlineDocument(v.into()),
-        );
-        self
     }
 }
 
@@ -10559,25 +10168,6 @@ pub mod document_schema {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value_source][crate::model::document_schema::EntityType::value_source]
-        /// to hold a `EnumValues`.
-        ///
-        /// Note that all the setters affecting `value_source` are
-        /// mutually exclusive.
-        pub fn set_enum_values<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::document_schema::entity_type::EnumValues>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value_source = std::option::Option::Some(
-                crate::model::document_schema::entity_type::ValueSource::EnumValues(v.into()),
-            );
-            self
         }
     }
 
@@ -12354,20 +11944,6 @@ pub mod processor_version {
             })
         }
 
-        /// Sets the value of [model_info][crate::model::processor_version::GenAiModelInfo::model_info]
-        /// to hold a `FoundationGenAiModelInfo`.
-        ///
-        /// Note that all the setters affecting `model_info` are
-        /// mutually exclusive.
-        pub fn set_foundation_gen_ai_model_info<T: std::convert::Into<std::boxed::Box<crate::model::processor_version::gen_ai_model_info::FoundationGenAiModelInfo>>>(mut self, v: T) -> Self{
-            self.model_info = std::option::Option::Some(
-                crate::model::processor_version::gen_ai_model_info::ModelInfo::FoundationGenAiModelInfo(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [model_info][crate::model::processor_version::GenAiModelInfo::model_info]
         /// if it holds a `CustomGenAiModelInfo`, `None` if the field is not set or
         /// holds a different branch.
@@ -12383,29 +11959,6 @@ pub mod processor_version {
                 crate::model::processor_version::gen_ai_model_info::ModelInfo::CustomGenAiModelInfo(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [model_info][crate::model::processor_version::GenAiModelInfo::model_info]
-        /// to hold a `CustomGenAiModelInfo`.
-        ///
-        /// Note that all the setters affecting `model_info` are
-        /// mutually exclusive.
-        pub fn set_custom_gen_ai_model_info<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::processor_version::gen_ai_model_info::CustomGenAiModelInfo,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.model_info = std::option::Option::Some(
-                crate::model::processor_version::gen_ai_model_info::ModelInfo::CustomGenAiModelInfo(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/domains/v1/src/model.rs
+++ b/src/generated/cloud/domains/v1/src/model.rs
@@ -826,22 +826,6 @@ impl DnsSettings {
         })
     }
 
-    /// Sets the value of [dns_provider][crate::model::DnsSettings::dns_provider]
-    /// to hold a `CustomDns`.
-    ///
-    /// Note that all the setters affecting `dns_provider` are
-    /// mutually exclusive.
-    pub fn set_custom_dns<
-        T: std::convert::Into<std::boxed::Box<crate::model::dns_settings::CustomDns>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dns_provider =
-            std::option::Option::Some(crate::model::dns_settings::DnsProvider::CustomDns(v.into()));
-        self
-    }
-
     /// The value of [dns_provider][crate::model::DnsSettings::dns_provider]
     /// if it holds a `GoogleDomainsDns`, `None` if the field is not set or
     /// holds a different branch.
@@ -855,23 +839,6 @@ impl DnsSettings {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dns_provider][crate::model::DnsSettings::dns_provider]
-    /// to hold a `GoogleDomainsDns`.
-    ///
-    /// Note that all the setters affecting `dns_provider` are
-    /// mutually exclusive.
-    pub fn set_google_domains_dns<
-        T: std::convert::Into<std::boxed::Box<crate::model::dns_settings::GoogleDomainsDns>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dns_provider = std::option::Option::Some(
-            crate::model::dns_settings::DnsProvider::GoogleDomainsDns(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/edgecontainer/v1/src/model.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/model.rs
@@ -450,23 +450,6 @@ pub mod cluster {
             })
         }
 
-        /// Sets the value of [config][crate::model::cluster::ControlPlane::config]
-        /// to hold a `Remote`.
-        ///
-        /// Note that all the setters affecting `config` are
-        /// mutually exclusive.
-        pub fn set_remote<
-            T: std::convert::Into<std::boxed::Box<crate::model::cluster::control_plane::Remote>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.config = std::option::Option::Some(
-                crate::model::cluster::control_plane::Config::Remote(v.into()),
-            );
-            self
-        }
-
         /// The value of [config][crate::model::cluster::ControlPlane::config]
         /// if it holds a `Local`, `None` if the field is not set or
         /// holds a different branch.
@@ -481,23 +464,6 @@ pub mod cluster {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [config][crate::model::cluster::ControlPlane::config]
-        /// to hold a `Local`.
-        ///
-        /// Note that all the setters affecting `config` are
-        /// mutually exclusive.
-        pub fn set_local<
-            T: std::convert::Into<std::boxed::Box<crate::model::cluster::control_plane::Local>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.config = std::option::Option::Some(
-                crate::model::cluster::control_plane::Config::Local(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/eventarc/v1/src/model.rs
+++ b/src/generated/cloud/eventarc/v1/src/model.rs
@@ -191,17 +191,6 @@ impl Channel {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [transport][crate::model::Channel::transport]
-    /// to hold a `PubsubTopic`.
-    ///
-    /// Note that all the setters affecting `transport` are
-    /// mutually exclusive.
-    pub fn set_pubsub_topic<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.transport =
-            std::option::Option::Some(crate::model::channel::Transport::PubsubTopic(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Channel {
@@ -4884,25 +4873,6 @@ pub mod pipeline {
             })
         }
 
-        /// Sets the value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
-        /// to hold a `Protobuf`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_protobuf<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::pipeline::message_payload_format::ProtobufFormat>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::pipeline::message_payload_format::Kind::Protobuf(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
         /// if it holds a `Avro`, `None` if the field is not set or
         /// holds a different branch.
@@ -4920,25 +4890,6 @@ pub mod pipeline {
             })
         }
 
-        /// Sets the value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
-        /// to hold a `Avro`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_avro<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::pipeline::message_payload_format::AvroFormat>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::pipeline::message_payload_format::Kind::Avro(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
         /// if it holds a `Json`, `None` if the field is not set or
         /// holds a different branch.
@@ -4954,25 +4905,6 @@ pub mod pipeline {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::pipeline::MessagePayloadFormat::kind]
-        /// to hold a `Json`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_json<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::pipeline::message_payload_format::JsonFormat>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::pipeline::message_payload_format::Kind::Json(v.into()),
-            );
-            self
         }
     }
 
@@ -5210,23 +5142,6 @@ pub mod pipeline {
             })
         }
 
-        /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
-        /// to hold a `HttpEndpoint`.
-        ///
-        /// Note that all the setters affecting `destination_descriptor` are
-        /// mutually exclusive.
-        pub fn set_http_endpoint<
-            T: std::convert::Into<std::boxed::Box<crate::model::pipeline::destination::HttpEndpoint>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.destination_descriptor = std::option::Option::Some(
-                crate::model::pipeline::destination::DestinationDescriptor::HttpEndpoint(v.into()),
-            );
-            self
-        }
-
         /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
         /// if it holds a `Workflow`, `None` if the field is not set or
         /// holds a different branch.
@@ -5238,18 +5153,6 @@ pub mod pipeline {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
-        /// to hold a `Workflow`.
-        ///
-        /// Note that all the setters affecting `destination_descriptor` are
-        /// mutually exclusive.
-        pub fn set_workflow<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.destination_descriptor = std::option::Option::Some(
-                crate::model::pipeline::destination::DestinationDescriptor::Workflow(v.into()),
-            );
-            self
         }
 
         /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
@@ -5265,18 +5168,6 @@ pub mod pipeline {
             })
         }
 
-        /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
-        /// to hold a `MessageBus`.
-        ///
-        /// Note that all the setters affecting `destination_descriptor` are
-        /// mutually exclusive.
-        pub fn set_message_bus<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.destination_descriptor = std::option::Option::Some(
-                crate::model::pipeline::destination::DestinationDescriptor::MessageBus(v.into()),
-            );
-            self
-        }
-
         /// The value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
         /// if it holds a `Topic`, `None` if the field is not set or
         /// holds a different branch.
@@ -5288,18 +5179,6 @@ pub mod pipeline {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [destination_descriptor][crate::model::pipeline::Destination::destination_descriptor]
-        /// to hold a `Topic`.
-        ///
-        /// Note that all the setters affecting `destination_descriptor` are
-        /// mutually exclusive.
-        pub fn set_topic<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.destination_descriptor = std::option::Option::Some(
-                crate::model::pipeline::destination::DestinationDescriptor::Topic(v.into()),
-            );
-            self
         }
     }
 
@@ -5616,29 +5495,6 @@ pub mod pipeline {
                 })
             }
 
-            /// Sets the value of [authentication_method_descriptor][crate::model::pipeline::destination::AuthenticationConfig::authentication_method_descriptor]
-            /// to hold a `GoogleOidc`.
-            ///
-            /// Note that all the setters affecting `authentication_method_descriptor` are
-            /// mutually exclusive.
-            pub fn set_google_oidc<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::pipeline::destination::authentication_config::OidcToken,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.authentication_method_descriptor = std::option::Option::Some(
-                    crate::model::pipeline::destination::authentication_config::AuthenticationMethodDescriptor::GoogleOidc(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [authentication_method_descriptor][crate::model::pipeline::destination::AuthenticationConfig::authentication_method_descriptor]
             /// if it holds a `OauthToken`, `None` if the field is not set or
             /// holds a different branch.
@@ -5654,29 +5510,6 @@ pub mod pipeline {
                     crate::model::pipeline::destination::authentication_config::AuthenticationMethodDescriptor::OauthToken(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [authentication_method_descriptor][crate::model::pipeline::destination::AuthenticationConfig::authentication_method_descriptor]
-            /// to hold a `OauthToken`.
-            ///
-            /// Note that all the setters affecting `authentication_method_descriptor` are
-            /// mutually exclusive.
-            pub fn set_oauth_token<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::pipeline::destination::authentication_config::OAuthToken,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.authentication_method_descriptor = std::option::Option::Some(
-                    crate::model::pipeline::destination::authentication_config::AuthenticationMethodDescriptor::OauthToken(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -5917,23 +5750,6 @@ pub mod pipeline {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [mediation_descriptor][crate::model::pipeline::Mediation::mediation_descriptor]
-        /// to hold a `Transformation`.
-        ///
-        /// Note that all the setters affecting `mediation_descriptor` are
-        /// mutually exclusive.
-        pub fn set_transformation<
-            T: std::convert::Into<std::boxed::Box<crate::model::pipeline::mediation::Transformation>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.mediation_descriptor = std::option::Option::Some(
-                crate::model::pipeline::mediation::MediationDescriptor::Transformation(v.into()),
-            );
-            self
         }
     }
 
@@ -6523,20 +6339,6 @@ impl Destination {
         })
     }
 
-    /// Sets the value of [descriptor][crate::model::Destination::descriptor]
-    /// to hold a `CloudRun`.
-    ///
-    /// Note that all the setters affecting `descriptor` are
-    /// mutually exclusive.
-    pub fn set_cloud_run<T: std::convert::Into<std::boxed::Box<crate::model::CloudRun>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.descriptor =
-            std::option::Option::Some(crate::model::destination::Descriptor::CloudRun(v.into()));
-        self
-    }
-
     /// The value of [descriptor][crate::model::Destination::descriptor]
     /// if it holds a `CloudFunction`, `None` if the field is not set or
     /// holds a different branch.
@@ -6546,18 +6348,6 @@ impl Destination {
             crate::model::destination::Descriptor::CloudFunction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [descriptor][crate::model::Destination::descriptor]
-    /// to hold a `CloudFunction`.
-    ///
-    /// Note that all the setters affecting `descriptor` are
-    /// mutually exclusive.
-    pub fn set_cloud_function<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.descriptor = std::option::Option::Some(
-            crate::model::destination::Descriptor::CloudFunction(v.into()),
-        );
-        self
     }
 
     /// The value of [descriptor][crate::model::Destination::descriptor]
@@ -6571,20 +6361,6 @@ impl Destination {
         })
     }
 
-    /// Sets the value of [descriptor][crate::model::Destination::descriptor]
-    /// to hold a `Gke`.
-    ///
-    /// Note that all the setters affecting `descriptor` are
-    /// mutually exclusive.
-    pub fn set_gke<T: std::convert::Into<std::boxed::Box<crate::model::Gke>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.descriptor =
-            std::option::Option::Some(crate::model::destination::Descriptor::Gke(v.into()));
-        self
-    }
-
     /// The value of [descriptor][crate::model::Destination::descriptor]
     /// if it holds a `Workflow`, `None` if the field is not set or
     /// holds a different branch.
@@ -6594,17 +6370,6 @@ impl Destination {
             crate::model::destination::Descriptor::Workflow(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [descriptor][crate::model::Destination::descriptor]
-    /// to hold a `Workflow`.
-    ///
-    /// Note that all the setters affecting `descriptor` are
-    /// mutually exclusive.
-    pub fn set_workflow<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.descriptor =
-            std::option::Option::Some(crate::model::destination::Descriptor::Workflow(v.into()));
-        self
     }
 
     /// The value of [descriptor][crate::model::Destination::descriptor]
@@ -6618,21 +6383,6 @@ impl Destination {
             crate::model::destination::Descriptor::HttpEndpoint(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [descriptor][crate::model::Destination::descriptor]
-    /// to hold a `HttpEndpoint`.
-    ///
-    /// Note that all the setters affecting `descriptor` are
-    /// mutually exclusive.
-    pub fn set_http_endpoint<T: std::convert::Into<std::boxed::Box<crate::model::HttpEndpoint>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.descriptor = std::option::Option::Some(
-            crate::model::destination::Descriptor::HttpEndpoint(v.into()),
-        );
-        self
     }
 }
 
@@ -6718,20 +6468,6 @@ impl Transport {
             crate::model::transport::Intermediary::Pubsub(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [intermediary][crate::model::Transport::intermediary]
-    /// to hold a `Pubsub`.
-    ///
-    /// Note that all the setters affecting `intermediary` are
-    /// mutually exclusive.
-    pub fn set_pubsub<T: std::convert::Into<std::boxed::Box<crate::model::Pubsub>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.intermediary =
-            std::option::Option::Some(crate::model::transport::Intermediary::Pubsub(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/filestore/v1/src/builder.rs
+++ b/src/generated/cloud/filestore/v1/src/builder.rs
@@ -596,19 +596,6 @@ pub mod cloud_filestore_manager {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::RestoreInstanceRequest::source]
-        /// to hold a `SourceBackup`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_source_backup<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_source_backup(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/filestore/v1/src/model.rs
+++ b/src/generated/cloud/filestore/v1/src/model.rs
@@ -497,18 +497,6 @@ impl FileShareConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::FileShareConfig::source]
-    /// to hold a `SourceBackup`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::file_share_config::Source::SourceBackup(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for FileShareConfig {
@@ -1897,23 +1885,6 @@ pub mod instance {
             })
         }
 
-        /// Sets the value of [mode][crate::model::instance::PerformanceConfig::mode]
-        /// to hold a `IopsPerTb`.
-        ///
-        /// Note that all the setters affecting `mode` are
-        /// mutually exclusive.
-        pub fn set_iops_per_tb<
-            T: std::convert::Into<std::boxed::Box<crate::model::instance::IOPSPerTB>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.mode = std::option::Option::Some(
-                crate::model::instance::performance_config::Mode::IopsPerTb(v.into()),
-            );
-            self
-        }
-
         /// The value of [mode][crate::model::instance::PerformanceConfig::mode]
         /// if it holds a `FixedIops`, `None` if the field is not set or
         /// holds a different branch.
@@ -1927,23 +1898,6 @@ pub mod instance {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [mode][crate::model::instance::PerformanceConfig::mode]
-        /// to hold a `FixedIops`.
-        ///
-        /// Note that all the setters affecting `mode` are
-        /// mutually exclusive.
-        pub fn set_fixed_iops<
-            T: std::convert::Into<std::boxed::Box<crate::model::instance::FixedIOPS>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.mode = std::option::Option::Some(
-                crate::model::instance::performance_config::Mode::FixedIops(v.into()),
-            );
-            self
         }
     }
 
@@ -2923,18 +2877,6 @@ impl RestoreInstanceRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::RestoreInstanceRequest::source]
-    /// to hold a `SourceBackup`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_instance_request::Source::SourceBackup(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/functions/v2/src/model.rs
+++ b/src/generated/cloud/functions/v2/src/model.rs
@@ -765,17 +765,6 @@ impl RepoSource {
         })
     }
 
-    /// Sets the value of [revision][crate::model::RepoSource::revision]
-    /// to hold a `BranchName`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_branch_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision =
-            std::option::Option::Some(crate::model::repo_source::Revision::BranchName(v.into()));
-        self
-    }
-
     /// The value of [revision][crate::model::RepoSource::revision]
     /// if it holds a `TagName`, `None` if the field is not set or
     /// holds a different branch.
@@ -787,17 +776,6 @@ impl RepoSource {
         })
     }
 
-    /// Sets the value of [revision][crate::model::RepoSource::revision]
-    /// to hold a `TagName`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_tag_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision =
-            std::option::Option::Some(crate::model::repo_source::Revision::TagName(v.into()));
-        self
-    }
-
     /// The value of [revision][crate::model::RepoSource::revision]
     /// if it holds a `CommitSha`, `None` if the field is not set or
     /// holds a different branch.
@@ -807,17 +785,6 @@ impl RepoSource {
             crate::model::repo_source::Revision::CommitSha(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [revision][crate::model::RepoSource::revision]
-    /// to hold a `CommitSha`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_commit_sha<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision =
-            std::option::Option::Some(crate::model::repo_source::Revision::CommitSha(v.into()));
-        self
     }
 }
 
@@ -899,22 +866,6 @@ impl Source {
         })
     }
 
-    /// Sets the value of [source][crate::model::Source::source]
-    /// to hold a `StorageSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_storage_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::StorageSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::source::Source::StorageSource(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Source::source]
     /// if it holds a `RepoSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -926,19 +877,6 @@ impl Source {
         })
     }
 
-    /// Sets the value of [source][crate::model::Source::source]
-    /// to hold a `RepoSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_repo_source<T: std::convert::Into<std::boxed::Box<crate::model::RepoSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(crate::model::source::Source::RepoSource(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Source::source]
     /// if it holds a `GitUri`, `None` if the field is not set or
     /// holds a different branch.
@@ -948,16 +886,6 @@ impl Source {
             crate::model::source::Source::GitUri(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Source::source]
-    /// to hold a `GitUri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_git_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(crate::model::source::Source::GitUri(v.into()));
-        self
     }
 }
 
@@ -1269,23 +1197,6 @@ impl BuildConfig {
         })
     }
 
-    /// Sets the value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
-    /// to hold a `AutomaticUpdatePolicy`.
-    ///
-    /// Note that all the setters affecting `runtime_update_policy` are
-    /// mutually exclusive.
-    pub fn set_automatic_update_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::AutomaticUpdatePolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.runtime_update_policy = std::option::Option::Some(
-            crate::model::build_config::RuntimeUpdatePolicy::AutomaticUpdatePolicy(v.into()),
-        );
-        self
-    }
-
     /// The value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
     /// if it holds a `OnDeployUpdatePolicy`, `None` if the field is not set or
     /// holds a different branch.
@@ -1299,23 +1210,6 @@ impl BuildConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [runtime_update_policy][crate::model::BuildConfig::runtime_update_policy]
-    /// to hold a `OnDeployUpdatePolicy`.
-    ///
-    /// Note that all the setters affecting `runtime_update_policy` are
-    /// mutually exclusive.
-    pub fn set_on_deploy_update_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::OnDeployUpdatePolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.runtime_update_policy = std::option::Option::Some(
-            crate::model::build_config::RuntimeUpdatePolicy::OnDeployUpdatePolicy(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/gkebackup/v1/src/model.rs
+++ b/src/generated/cloud/gkebackup/v1/src/model.rs
@@ -465,17 +465,6 @@ impl Backup {
         })
     }
 
-    /// Sets the value of [backup_scope][crate::model::Backup::backup_scope]
-    /// to hold a `AllNamespaces`.
-    ///
-    /// Note that all the setters affecting `backup_scope` are
-    /// mutually exclusive.
-    pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.backup_scope =
-            std::option::Option::Some(crate::model::backup::BackupScope::AllNamespaces(v.into()));
-        self
-    }
-
     /// The value of [backup_scope][crate::model::Backup::backup_scope]
     /// if it holds a `SelectedNamespaces`, `None` if the field is not set or
     /// holds a different branch.
@@ -491,23 +480,6 @@ impl Backup {
         })
     }
 
-    /// Sets the value of [backup_scope][crate::model::Backup::backup_scope]
-    /// to hold a `SelectedNamespaces`.
-    ///
-    /// Note that all the setters affecting `backup_scope` are
-    /// mutually exclusive.
-    pub fn set_selected_namespaces<
-        T: std::convert::Into<std::boxed::Box<crate::model::Namespaces>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_scope = std::option::Option::Some(
-            crate::model::backup::BackupScope::SelectedNamespaces(v.into()),
-        );
-        self
-    }
-
     /// The value of [backup_scope][crate::model::Backup::backup_scope]
     /// if it holds a `SelectedApplications`, `None` if the field is not set or
     /// holds a different branch.
@@ -521,23 +493,6 @@ impl Backup {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [backup_scope][crate::model::Backup::backup_scope]
-    /// to hold a `SelectedApplications`.
-    ///
-    /// Note that all the setters affecting `backup_scope` are
-    /// mutually exclusive.
-    pub fn set_selected_applications<
-        T: std::convert::Into<std::boxed::Box<crate::model::NamespacedNames>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_scope = std::option::Option::Some(
-            crate::model::backup::BackupScope::SelectedApplications(v.into()),
-        );
-        self
     }
 }
 
@@ -649,18 +604,6 @@ pub mod backup {
             })
         }
 
-        /// Sets the value of [platform_version][crate::model::backup::ClusterMetadata::platform_version]
-        /// to hold a `GkeVersion`.
-        ///
-        /// Note that all the setters affecting `platform_version` are
-        /// mutually exclusive.
-        pub fn set_gke_version<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.platform_version = std::option::Option::Some(
-                crate::model::backup::cluster_metadata::PlatformVersion::GkeVersion(v.into()),
-            );
-            self
-        }
-
         /// The value of [platform_version][crate::model::backup::ClusterMetadata::platform_version]
         /// if it holds a `AnthosVersion`, `None` if the field is not set or
         /// holds a different branch.
@@ -672,21 +615,6 @@ pub mod backup {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [platform_version][crate::model::backup::ClusterMetadata::platform_version]
-        /// to hold a `AnthosVersion`.
-        ///
-        /// Note that all the setters affecting `platform_version` are
-        /// mutually exclusive.
-        pub fn set_anthos_version<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.platform_version = std::option::Option::Some(
-                crate::model::backup::cluster_metadata::PlatformVersion::AnthosVersion(v.into()),
-            );
-            self
         }
     }
 
@@ -1618,18 +1546,6 @@ pub mod backup_plan {
             })
         }
 
-        /// Sets the value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
-        /// to hold a `AllNamespaces`.
-        ///
-        /// Note that all the setters affecting `backup_scope` are
-        /// mutually exclusive.
-        pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.backup_scope = std::option::Option::Some(
-                crate::model::backup_plan::backup_config::BackupScope::AllNamespaces(v.into()),
-            );
-            self
-        }
-
         /// The value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
         /// if it holds a `SelectedNamespaces`, `None` if the field is not set or
         /// holds a different branch.
@@ -1645,23 +1561,6 @@ pub mod backup_plan {
             })
         }
 
-        /// Sets the value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
-        /// to hold a `SelectedNamespaces`.
-        ///
-        /// Note that all the setters affecting `backup_scope` are
-        /// mutually exclusive.
-        pub fn set_selected_namespaces<
-            T: std::convert::Into<std::boxed::Box<crate::model::Namespaces>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.backup_scope = std::option::Option::Some(
-                crate::model::backup_plan::backup_config::BackupScope::SelectedNamespaces(v.into()),
-            );
-            self
-        }
-
         /// The value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
         /// if it holds a `SelectedApplications`, `None` if the field is not set or
         /// holds a different branch.
@@ -1675,25 +1574,6 @@ pub mod backup_plan {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [backup_scope][crate::model::backup_plan::BackupConfig::backup_scope]
-        /// to hold a `SelectedApplications`.
-        ///
-        /// Note that all the setters affecting `backup_scope` are
-        /// mutually exclusive.
-        pub fn set_selected_applications<
-            T: std::convert::Into<std::boxed::Box<crate::model::NamespacedNames>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.backup_scope = std::option::Option::Some(
-                crate::model::backup_plan::backup_config::BackupScope::SelectedApplications(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -2034,23 +1914,6 @@ impl ExclusionWindow {
         })
     }
 
-    /// Sets the value of [recurrence][crate::model::ExclusionWindow::recurrence]
-    /// to hold a `SingleOccurrenceDate`.
-    ///
-    /// Note that all the setters affecting `recurrence` are
-    /// mutually exclusive.
-    pub fn set_single_occurrence_date<
-        T: std::convert::Into<std::boxed::Box<gtype::model::Date>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recurrence = std::option::Option::Some(
-            crate::model::exclusion_window::Recurrence::SingleOccurrenceDate(v.into()),
-        );
-        self
-    }
-
     /// The value of [recurrence][crate::model::ExclusionWindow::recurrence]
     /// if it holds a `Daily`, `None` if the field is not set or
     /// holds a different branch.
@@ -2060,17 +1923,6 @@ impl ExclusionWindow {
             crate::model::exclusion_window::Recurrence::Daily(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [recurrence][crate::model::ExclusionWindow::recurrence]
-    /// to hold a `Daily`.
-    ///
-    /// Note that all the setters affecting `recurrence` are
-    /// mutually exclusive.
-    pub fn set_daily<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.recurrence =
-            std::option::Option::Some(crate::model::exclusion_window::Recurrence::Daily(v.into()));
-        self
     }
 
     /// The value of [recurrence][crate::model::ExclusionWindow::recurrence]
@@ -2086,23 +1938,6 @@ impl ExclusionWindow {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [recurrence][crate::model::ExclusionWindow::recurrence]
-    /// to hold a `DaysOfWeek`.
-    ///
-    /// Note that all the setters affecting `recurrence` are
-    /// mutually exclusive.
-    pub fn set_days_of_week<
-        T: std::convert::Into<std::boxed::Box<crate::model::exclusion_window::DayOfWeekList>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recurrence = std::option::Option::Some(
-            crate::model::exclusion_window::Recurrence::DaysOfWeek(v.into()),
-        );
-        self
     }
 }
 
@@ -6864,18 +6699,6 @@ impl RestoreConfig {
             })
     }
 
-    /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// to hold a `AllNamespaces`.
-    ///
-    /// Note that all the setters affecting `namespaced_resource_restore_scope` are
-    /// mutually exclusive.
-    pub fn set_all_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.namespaced_resource_restore_scope = std::option::Option::Some(
-            crate::model::restore_config::NamespacedResourceRestoreScope::AllNamespaces(v.into()),
-        );
-        self
-    }
-
     /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
     /// if it holds a `SelectedNamespaces`, `None` if the field is not set or
     /// holds a different branch.
@@ -6889,25 +6712,6 @@ impl RestoreConfig {
         })
     }
 
-    /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// to hold a `SelectedNamespaces`.
-    ///
-    /// Note that all the setters affecting `namespaced_resource_restore_scope` are
-    /// mutually exclusive.
-    pub fn set_selected_namespaces<
-        T: std::convert::Into<std::boxed::Box<crate::model::Namespaces>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.namespaced_resource_restore_scope = std::option::Option::Some(
-            crate::model::restore_config::NamespacedResourceRestoreScope::SelectedNamespaces(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
     /// if it holds a `SelectedApplications`, `None` if the field is not set or
     /// holds a different branch.
@@ -6919,25 +6723,6 @@ impl RestoreConfig {
             crate::model::restore_config::NamespacedResourceRestoreScope::SelectedApplications(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// to hold a `SelectedApplications`.
-    ///
-    /// Note that all the setters affecting `namespaced_resource_restore_scope` are
-    /// mutually exclusive.
-    pub fn set_selected_applications<
-        T: std::convert::Into<std::boxed::Box<crate::model::NamespacedNames>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.namespaced_resource_restore_scope = std::option::Option::Some(
-            crate::model::restore_config::NamespacedResourceRestoreScope::SelectedApplications(
-                v.into(),
-            ),
-        );
-        self
     }
 
     /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
@@ -6955,18 +6740,6 @@ impl RestoreConfig {
             })
     }
 
-    /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// to hold a `NoNamespaces`.
-    ///
-    /// Note that all the setters affecting `namespaced_resource_restore_scope` are
-    /// mutually exclusive.
-    pub fn set_no_namespaces<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.namespaced_resource_restore_scope = std::option::Option::Some(
-            crate::model::restore_config::NamespacedResourceRestoreScope::NoNamespaces(v.into()),
-        );
-        self
-    }
-
     /// The value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
     /// if it holds a `ExcludedNamespaces`, `None` if the field is not set or
     /// holds a different branch.
@@ -6978,25 +6751,6 @@ impl RestoreConfig {
             crate::model::restore_config::NamespacedResourceRestoreScope::ExcludedNamespaces(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [namespaced_resource_restore_scope][crate::model::RestoreConfig::namespaced_resource_restore_scope]
-    /// to hold a `ExcludedNamespaces`.
-    ///
-    /// Note that all the setters affecting `namespaced_resource_restore_scope` are
-    /// mutually exclusive.
-    pub fn set_excluded_namespaces<
-        T: std::convert::Into<std::boxed::Box<crate::model::Namespaces>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.namespaced_resource_restore_scope = std::option::Option::Some(
-            crate::model::restore_config::NamespacedResourceRestoreScope::ExcludedNamespaces(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -7745,25 +7499,6 @@ pub mod restore_config {
                 crate::model::restore_config::volume_data_restore_policy_binding::Scope::VolumeType(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [scope][crate::model::restore_config::VolumeDataRestorePolicyBinding::scope]
-        /// to hold a `VolumeType`.
-        ///
-        /// Note that all the setters affecting `scope` are
-        /// mutually exclusive.
-        pub fn set_volume_type<
-            T: std::convert::Into<crate::model::volume_type_enum::VolumeType>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.scope = std::option::Option::Some(
-                crate::model::restore_config::volume_data_restore_policy_binding::Scope::VolumeType(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -8570,23 +8305,6 @@ impl VolumeDataRestorePolicyOverride {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [scope][crate::model::VolumeDataRestorePolicyOverride::scope]
-    /// to hold a `SelectedPvcs`.
-    ///
-    /// Note that all the setters affecting `scope` are
-    /// mutually exclusive.
-    pub fn set_selected_pvcs<
-        T: std::convert::Into<std::boxed::Box<crate::model::NamespacedNames>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scope = std::option::Option::Some(
-            crate::model::volume_data_restore_policy_override::Scope::SelectedPvcs(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/gkehub/v1/src/model.rs
+++ b/src/generated/cloud/gkehub/v1/src/model.rs
@@ -684,23 +684,6 @@ impl CommonFeatureSpec {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [feature_spec][crate::model::CommonFeatureSpec::feature_spec]
-    /// to hold a `Multiclusteringress`.
-    ///
-    /// Note that all the setters affecting `feature_spec` are
-    /// mutually exclusive.
-    pub fn set_multiclusteringress<
-        T: std::convert::Into<std::boxed::Box<gkehub_multiclusteringress_v1::model::FeatureSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.feature_spec = std::option::Option::Some(
-            crate::model::common_feature_spec::FeatureSpec::Multiclusteringress(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for CommonFeatureSpec {
@@ -807,23 +790,6 @@ impl MembershipFeatureSpec {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [feature_spec][crate::model::MembershipFeatureSpec::feature_spec]
-    /// to hold a `Configmanagement`.
-    ///
-    /// Note that all the setters affecting `feature_spec` are
-    /// mutually exclusive.
-    pub fn set_configmanagement<
-        T: std::convert::Into<std::boxed::Box<gkehub_configmanagement_v1::model::MembershipSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.feature_spec = std::option::Option::Some(
-            crate::model::membership_feature_spec::FeatureSpec::Configmanagement(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for MembershipFeatureSpec {
@@ -909,23 +875,6 @@ impl MembershipFeatureState {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [feature_state][crate::model::MembershipFeatureState::feature_state]
-    /// to hold a `Configmanagement`.
-    ///
-    /// Note that all the setters affecting `feature_state` are
-    /// mutually exclusive.
-    pub fn set_configmanagement<
-        T: std::convert::Into<std::boxed::Box<gkehub_configmanagement_v1::model::MembershipState>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.feature_state = std::option::Option::Some(
-            crate::model::membership_feature_state::FeatureState::Configmanagement(v.into()),
-        );
-        self
     }
 }
 
@@ -1169,21 +1118,6 @@ impl Membership {
             crate::model::membership::Type::Endpoint(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Membership::r#type]
-    /// to hold a `Endpoint`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_endpoint<
-        T: std::convert::Into<std::boxed::Box<crate::model::MembershipEndpoint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::membership::Type::Endpoint(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/kms/v1/src/builder.rs
+++ b/src/generated/cloud/kms/v1/src/builder.rs
@@ -3804,19 +3804,6 @@ pub mod key_management_service {
             self.0.request.wrapped_key_material = v.into();
             self
         }
-
-        /// Sets the value of [wrapped_key_material][crate::model::ImportCryptoKeyVersionRequest::wrapped_key_material]
-        /// to hold a `RsaAesWrappedKey`.
-        ///
-        /// Note that all the setters affecting `wrapped_key_material` are
-        /// mutually exclusive.
-        pub fn set_rsa_aes_wrapped_key<T: std::convert::Into<::bytes::Bytes>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_rsa_aes_wrapped_key(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/kms/v1/src/model.rs
+++ b/src/generated/cloud/kms/v1/src/model.rs
@@ -2263,21 +2263,6 @@ impl CryptoKey {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [rotation_schedule][crate::model::CryptoKey::rotation_schedule]
-    /// to hold a `RotationPeriod`.
-    ///
-    /// Note that all the setters affecting `rotation_schedule` are
-    /// mutually exclusive.
-    pub fn set_rotation_period<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rotation_schedule = std::option::Option::Some(
-            crate::model::crypto_key::RotationSchedule::RotationPeriod(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for CryptoKey {
@@ -6584,20 +6569,6 @@ impl ImportCryptoKeyVersionRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [wrapped_key_material][crate::model::ImportCryptoKeyVersionRequest::wrapped_key_material]
-    /// to hold a `RsaAesWrappedKey`.
-    ///
-    /// Note that all the setters affecting `wrapped_key_material` are
-    /// mutually exclusive.
-    pub fn set_rsa_aes_wrapped_key<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.wrapped_key_material = std::option::Option::Some(
-            crate::model::import_crypto_key_version_request::WrappedKeyMaterial::RsaAesWrappedKey(
-                v.into(),
-            ),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ImportCryptoKeyVersionRequest {
@@ -9514,16 +9485,6 @@ impl Digest {
         })
     }
 
-    /// Sets the value of [digest][crate::model::Digest::digest]
-    /// to hold a `Sha256`.
-    ///
-    /// Note that all the setters affecting `digest` are
-    /// mutually exclusive.
-    pub fn set_sha256<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha256(v.into()));
-        self
-    }
-
     /// The value of [digest][crate::model::Digest::digest]
     /// if it holds a `Sha384`, `None` if the field is not set or
     /// holds a different branch.
@@ -9535,16 +9496,6 @@ impl Digest {
         })
     }
 
-    /// Sets the value of [digest][crate::model::Digest::digest]
-    /// to hold a `Sha384`.
-    ///
-    /// Note that all the setters affecting `digest` are
-    /// mutually exclusive.
-    pub fn set_sha384<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha384(v.into()));
-        self
-    }
-
     /// The value of [digest][crate::model::Digest::digest]
     /// if it holds a `Sha512`, `None` if the field is not set or
     /// holds a different branch.
@@ -9554,16 +9505,6 @@ impl Digest {
             crate::model::digest::Digest::Sha512(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [digest][crate::model::Digest::digest]
-    /// to hold a `Sha512`.
-    ///
-    /// Note that all the setters affecting `digest` are
-    /// mutually exclusive.
-    pub fn set_sha512<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.digest = std::option::Option::Some(crate::model::digest::Digest::Sha512(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/language/v2/src/model.rs
+++ b/src/generated/cloud/language/v2/src/model.rs
@@ -103,16 +103,6 @@ impl Document {
         })
     }
 
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(crate::model::document::Source::Content(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Document::source]
     /// if it holds a `GcsContentUri`, `None` if the field is not set or
     /// holds a different branch.
@@ -122,17 +112,6 @@ impl Document {
             crate::model::document::Source::GcsContentUri(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Document::source]
-    /// to hold a `GcsContentUri`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_content_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::document::Source::GcsContentUri(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/licensemanager/v1/src/model.rs
+++ b/src/generated/cloud/licensemanager/v1/src/model.rs
@@ -398,23 +398,6 @@ impl BillingInfo {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [current_billing_info][crate::model::BillingInfo::current_billing_info]
-    /// to hold a `UserCountBilling`.
-    ///
-    /// Note that all the setters affecting `current_billing_info` are
-    /// mutually exclusive.
-    pub fn set_user_count_billing<
-        T: std::convert::Into<std::boxed::Box<crate::model::UserCountBillingInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.current_billing_info = std::option::Option::Some(
-            crate::model::billing_info::CurrentBillingInfo::UserCountBilling(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BillingInfo {
@@ -1789,25 +1772,6 @@ impl QueryConfigurationLicenseUsageResponse {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::QueryConfigurationLicenseUsageResponse::details]
-    /// to hold a `UserCountUsage`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_user_count_usage<
-        T: std::convert::Into<std::boxed::Box<crate::model::UserCountUsage>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::query_configuration_license_usage_response::Details::UserCountUsage(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/lustre/v1/src/builder.rs
+++ b/src/generated/cloud/lustre/v1/src/builder.rs
@@ -704,19 +704,6 @@ pub mod lustre {
             self
         }
 
-        /// Sets the value of [source][crate::model::ImportDataRequest::source]
-        /// to hold a `GcsPath`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_path<T: std::convert::Into<std::boxed::Box<crate::model::GcsPath>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_path(v);
-            self
-        }
-
         /// Sets the value of [destination][crate::model::ImportDataRequest::destination].
         ///
         /// Note that all the setters affecting `destination` are
@@ -726,19 +713,6 @@ pub mod lustre {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ImportDataRequest::destination]
-        /// to hold a `LustrePath`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_lustre_path<T: std::convert::Into<std::boxed::Box<crate::model::LustrePath>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_lustre_path(v);
             self
         }
     }
@@ -868,19 +842,6 @@ pub mod lustre {
             self
         }
 
-        /// Sets the value of [source][crate::model::ExportDataRequest::source]
-        /// to hold a `LustrePath`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_lustre_path<T: std::convert::Into<std::boxed::Box<crate::model::LustrePath>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_lustre_path(v);
-            self
-        }
-
         /// Sets the value of [destination][crate::model::ExportDataRequest::destination].
         ///
         /// Note that all the setters affecting `destination` are
@@ -890,19 +851,6 @@ pub mod lustre {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportDataRequest::destination]
-        /// to hold a `GcsPath`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_path<T: std::convert::Into<std::boxed::Box<crate::model::GcsPath>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_path(v);
             self
         }
     }

--- a/src/generated/cloud/lustre/v1/src/model.rs
+++ b/src/generated/cloud/lustre/v1/src/model.rs
@@ -952,20 +952,6 @@ impl ImportDataRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportDataRequest::source]
-    /// to hold a `GcsPath`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_path<T: std::convert::Into<std::boxed::Box<crate::model::GcsPath>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::import_data_request::Source::GcsPath(v.into()));
-        self
-    }
-
     /// Sets the value of [destination][crate::model::ImportDataRequest::destination].
     ///
     /// Note that all the setters affecting `destination` are mutually
@@ -991,21 +977,6 @@ impl ImportDataRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ImportDataRequest::destination]
-    /// to hold a `LustrePath`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_lustre_path<T: std::convert::Into<std::boxed::Box<crate::model::LustrePath>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::import_data_request::Destination::LustrePath(v.into()),
-        );
-        self
     }
 }
 
@@ -1123,21 +1094,6 @@ impl ExportDataRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ExportDataRequest::source]
-    /// to hold a `LustrePath`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_lustre_path<T: std::convert::Into<std::boxed::Box<crate::model::LustrePath>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::export_data_request::Source::LustrePath(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [destination][crate::model::ExportDataRequest::destination].
     ///
     /// Note that all the setters affecting `destination` are mutually
@@ -1163,21 +1119,6 @@ impl ExportDataRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportDataRequest::destination]
-    /// to hold a `GcsPath`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_path<T: std::convert::Into<std::boxed::Box<crate::model::GcsPath>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_data_request::Destination::GcsPath(v.into()),
-        );
-        self
     }
 }
 
@@ -1874,23 +1815,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
-    /// to hold a `SourceLustrePath`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_lustre_path<
-        T: std::convert::Into<std::boxed::Box<crate::model::LustrePath>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Source::SourceLustrePath(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::TransferOperationMetadata::source]
     /// if it holds a `SourceGcsPath`, `None` if the field is not set or
     /// holds a different branch.
@@ -1902,21 +1826,6 @@ impl TransferOperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
-    /// to hold a `SourceGcsPath`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_gcs_path<T: std::convert::Into<std::boxed::Box<crate::model::GcsPath>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Source::SourceGcsPath(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination].
@@ -1950,23 +1859,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]
-    /// to hold a `DestinationGcsPath`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_gcs_path<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsPath>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Destination::DestinationGcsPath(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::TransferOperationMetadata::destination]
     /// if it holds a `DestinationLustrePath`, `None` if the field is not set or
     /// holds a different branch.
@@ -1980,23 +1872,6 @@ impl TransferOperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]
-    /// to hold a `DestinationLustrePath`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_lustre_path<
-        T: std::convert::Into<std::boxed::Box<crate::model::LustrePath>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Destination::DestinationLustrePath(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/memorystore/v1/src/builder.rs
+++ b/src/generated/cloud/memorystore/v1/src/builder.rs
@@ -1342,16 +1342,6 @@ pub mod memorystore {
             self.0.request.destination = v.into();
             self
         }
-
-        /// Sets the value of [destination][crate::model::ExportBackupRequest::destination]
-        /// to hold a `GcsBucket`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_gcs_bucket(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/memorystore/v1/src/model.rs
+++ b/src/generated/cloud/memorystore/v1/src/model.rs
@@ -499,22 +499,6 @@ impl Instance {
         })
     }
 
-    /// Sets the value of [import_sources][crate::model::Instance::import_sources]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `import_sources` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::instance::GcsBackupSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_sources =
-            std::option::Option::Some(crate::model::instance::ImportSources::GcsSource(v.into()));
-        self
-    }
-
     /// The value of [import_sources][crate::model::Instance::import_sources]
     /// if it holds a `ManagedBackupSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -528,23 +512,6 @@ impl Instance {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [import_sources][crate::model::Instance::import_sources]
-    /// to hold a `ManagedBackupSource`.
-    ///
-    /// Note that all the setters affecting `import_sources` are
-    /// mutually exclusive.
-    pub fn set_managed_backup_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::instance::ManagedBackupSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_sources = std::option::Option::Some(
-            crate::model::instance::ImportSources::ManagedBackupSource(v.into()),
-        );
-        self
     }
 }
 
@@ -605,23 +572,6 @@ pub mod instance {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [info][crate::model::instance::StateInfo::info]
-        /// to hold a `UpdateInfo`.
-        ///
-        /// Note that all the setters affecting `info` are
-        /// mutually exclusive.
-        pub fn set_update_info<
-            T: std::convert::Into<std::boxed::Box<crate::model::instance::state_info::UpdateInfo>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.info = std::option::Option::Some(
-                crate::model::instance::state_info::Info::UpdateInfo(v.into()),
-            );
-            self
         }
     }
 
@@ -891,23 +841,6 @@ pub mod instance {
             })
         }
 
-        /// Sets the value of [connection][crate::model::instance::ConnectionDetail::connection]
-        /// to hold a `PscAutoConnection`.
-        ///
-        /// Note that all the setters affecting `connection` are
-        /// mutually exclusive.
-        pub fn set_psc_auto_connection<
-            T: std::convert::Into<std::boxed::Box<crate::model::PscAutoConnection>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.connection = std::option::Option::Some(
-                crate::model::instance::connection_detail::Connection::PscAutoConnection(v.into()),
-            );
-            self
-        }
-
         /// The value of [connection][crate::model::instance::ConnectionDetail::connection]
         /// if it holds a `PscConnection`, `None` if the field is not set or
         /// holds a different branch.
@@ -921,23 +854,6 @@ pub mod instance {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [connection][crate::model::instance::ConnectionDetail::connection]
-        /// to hold a `PscConnection`.
-        ///
-        /// Note that all the setters affecting `connection` are
-        /// mutually exclusive.
-        pub fn set_psc_connection<
-            T: std::convert::Into<std::boxed::Box<crate::model::PscConnection>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.connection = std::option::Option::Some(
-                crate::model::instance::connection_detail::Connection::PscConnection(v.into()),
-            );
-            self
         }
     }
 
@@ -1765,25 +1681,6 @@ impl AutomatedBackupConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schedule][crate::model::AutomatedBackupConfig::schedule]
-    /// to hold a `FixedFrequencySchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_fixed_frequency_schedule<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::automated_backup_config::FixedFrequencySchedule>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::automated_backup_config::Schedule::FixedFrequencySchedule(v.into()),
-        );
-        self
     }
 }
 
@@ -3317,17 +3214,6 @@ impl PscAutoConnection {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [ports][crate::model::PscAutoConnection::ports]
-    /// to hold a `Port`.
-    ///
-    /// Note that all the setters affecting `ports` are
-    /// mutually exclusive.
-    pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.ports =
-            std::option::Option::Some(crate::model::psc_auto_connection::Ports::Port(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for PscAutoConnection {
@@ -3495,16 +3381,6 @@ impl PscConnection {
             crate::model::psc_connection::Ports::Port(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [ports][crate::model::PscConnection::ports]
-    /// to hold a `Port`.
-    ///
-    /// Note that all the setters affecting `ports` are
-    /// mutually exclusive.
-    pub fn set_port<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.ports = std::option::Option::Some(crate::model::psc_connection::Ports::Port(v.into()));
-        self
     }
 }
 
@@ -5464,18 +5340,6 @@ impl ExportBackupRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ExportBackupRequest::destination]
-    /// to hold a `GcsBucket`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_backup_request::Destination::GcsBucket(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExportBackupRequest {
@@ -5656,25 +5520,6 @@ impl CertificateAuthority {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [server_ca][crate::model::CertificateAuthority::server_ca]
-    /// to hold a `ManagedServerCa`.
-    ///
-    /// Note that all the setters affecting `server_ca` are
-    /// mutually exclusive.
-    pub fn set_managed_server_ca<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::certificate_authority::ManagedCertificateAuthority>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.server_ca = std::option::Option::Some(
-            crate::model::certificate_authority::ServerCa::ManagedServerCa(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/metastore/v1/src/builder.rs
+++ b/src/generated/cloud/metastore/v1/src/builder.rs
@@ -1167,19 +1167,6 @@ pub mod dataproc_metastore {
             self.0.request.destination = v.into();
             self
         }
-
-        /// Sets the value of [destination][crate::model::ExportMetadataRequest::destination]
-        /// to hold a `DestinationGcsFolder`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_destination_gcs_folder<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_destination_gcs_folder(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/metastore/v1/src/model.rs
+++ b/src/generated/cloud/metastore/v1/src/model.rs
@@ -346,23 +346,6 @@ impl Service {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [metastore_config][crate::model::Service::metastore_config]
-    /// to hold a `HiveMetastoreConfig`.
-    ///
-    /// Note that all the setters affecting `metastore_config` are
-    /// mutually exclusive.
-    pub fn set_hive_metastore_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::HiveMetastoreConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metastore_config = std::option::Option::Some(
-            crate::model::service::MetastoreConfig::HiveMetastoreConfig(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for Service {
@@ -1359,16 +1342,6 @@ impl Secret {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [value][crate::model::Secret::value]
-    /// to hold a `CloudSecret`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_cloud_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value = std::option::Option::Some(crate::model::secret::Value::CloudSecret(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Secret {
@@ -1619,18 +1592,6 @@ pub mod network_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [vpc_resource][crate::model::network_config::Consumer::vpc_resource]
-        /// to hold a `Subnetwork`.
-        ///
-        /// Note that all the setters affecting `vpc_resource` are
-        /// mutually exclusive.
-        pub fn set_subnetwork<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.vpc_resource = std::option::Option::Some(
-                crate::model::network_config::consumer::VpcResource::Subnetwork(v.into()),
-            );
-            self
         }
     }
 
@@ -2005,23 +1966,6 @@ impl MetadataImport {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [metadata][crate::model::MetadataImport::metadata]
-    /// to hold a `DatabaseDump`.
-    ///
-    /// Note that all the setters affecting `metadata` are
-    /// mutually exclusive.
-    pub fn set_database_dump<
-        T: std::convert::Into<std::boxed::Box<crate::model::metadata_import::DatabaseDump>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = std::option::Option::Some(
-            crate::model::metadata_import::Metadata::DatabaseDump(v.into()),
-        );
-        self
     }
 }
 
@@ -2500,21 +2444,6 @@ impl MetadataExport {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::MetadataExport::destination]
-    /// to hold a `DestinationGcsUri`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_gcs_uri<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::metadata_export::Destination::DestinationGcsUri(v.into()),
-        );
-        self
     }
 }
 
@@ -3383,21 +3312,6 @@ impl ScalingConfig {
         })
     }
 
-    /// Sets the value of [scaling_model][crate::model::ScalingConfig::scaling_model]
-    /// to hold a `InstanceSize`.
-    ///
-    /// Note that all the setters affecting `scaling_model` are
-    /// mutually exclusive.
-    pub fn set_instance_size<T: std::convert::Into<crate::model::scaling_config::InstanceSize>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.scaling_model = std::option::Option::Some(
-            crate::model::scaling_config::ScalingModel::InstanceSize(v.into()),
-        );
-        self
-    }
-
     /// The value of [scaling_model][crate::model::ScalingConfig::scaling_model]
     /// if it holds a `ScalingFactor`, `None` if the field is not set or
     /// holds a different branch.
@@ -3409,18 +3323,6 @@ impl ScalingConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [scaling_model][crate::model::ScalingConfig::scaling_model]
-    /// to hold a `ScalingFactor`.
-    ///
-    /// Note that all the setters affecting `scaling_model` are
-    /// mutually exclusive.
-    pub fn set_scaling_factor<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-        self.scaling_model = std::option::Option::Some(
-            crate::model::scaling_config::ScalingModel::ScalingFactor(v.into()),
-        );
-        self
     }
 }
 
@@ -4878,21 +4780,6 @@ impl ExportMetadataRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportMetadataRequest::destination]
-    /// to hold a `DestinationGcsFolder`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_gcs_folder<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_metadata_request::Destination::DestinationGcsFolder(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/migrationcenter/v1/src/model.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/model.rs
@@ -209,22 +209,6 @@ impl Asset {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [asset_details][crate::model::Asset::asset_details]
-    /// to hold a `MachineDetails`.
-    ///
-    /// Note that all the setters affecting `asset_details` are
-    /// mutually exclusive.
-    pub fn set_machine_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::MachineDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.asset_details =
-            std::option::Option::Some(crate::model::asset::AssetDetails::MachineDetails(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Asset {
@@ -487,22 +471,6 @@ impl ImportJob {
         })
     }
 
-    /// Sets the value of [report][crate::model::ImportJob::report]
-    /// to hold a `ValidationReport`.
-    ///
-    /// Note that all the setters affecting `report` are
-    /// mutually exclusive.
-    pub fn set_validation_report<
-        T: std::convert::Into<std::boxed::Box<crate::model::ValidationReport>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.report =
-            std::option::Option::Some(crate::model::import_job::Report::ValidationReport(v.into()));
-        self
-    }
-
     /// The value of [report][crate::model::ImportJob::report]
     /// if it holds a `ExecutionReport`, `None` if the field is not set or
     /// holds a different branch.
@@ -514,22 +482,6 @@ impl ImportJob {
             crate::model::import_job::Report::ExecutionReport(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [report][crate::model::ImportJob::report]
-    /// to hold a `ExecutionReport`.
-    ///
-    /// Note that all the setters affecting `report` are
-    /// mutually exclusive.
-    pub fn set_execution_report<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExecutionReport>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.report =
-            std::option::Option::Some(crate::model::import_job::Report::ExecutionReport(v.into()));
-        self
     }
 }
 
@@ -828,23 +780,6 @@ impl ImportDataFile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [file_info][crate::model::ImportDataFile::file_info]
-    /// to hold a `UploadFileInfo`.
-    ///
-    /// Note that all the setters affecting `file_info` are
-    /// mutually exclusive.
-    pub fn set_upload_file_info<
-        T: std::convert::Into<std::boxed::Box<crate::model::UploadFileInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.file_info = std::option::Option::Some(
-            crate::model::import_data_file::FileInfo::UploadFileInfo(v.into()),
-        );
-        self
     }
 }
 
@@ -6184,23 +6119,6 @@ impl AssetFrame {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [frame_data][crate::model::AssetFrame::frame_data]
-    /// to hold a `MachineDetails`.
-    ///
-    /// Note that all the setters affecting `frame_data` are
-    /// mutually exclusive.
-    pub fn set_machine_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::MachineDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.frame_data = std::option::Option::Some(
-            crate::model::asset_frame::FrameData::MachineDetails(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for AssetFrame {
@@ -7667,20 +7585,6 @@ impl DiskEntry {
             crate::model::disk_entry::PlatformSpecific::Vmware(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [platform_specific][crate::model::DiskEntry::platform_specific]
-    /// to hold a `Vmware`.
-    ///
-    /// Note that all the setters affecting `platform_specific` are
-    /// mutually exclusive.
-    pub fn set_vmware<T: std::convert::Into<std::boxed::Box<crate::model::VmwareDiskConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.platform_specific =
-            std::option::Option::Some(crate::model::disk_entry::PlatformSpecific::Vmware(v.into()));
-        self
     }
 }
 
@@ -10427,23 +10331,6 @@ impl PlatformDetails {
         })
     }
 
-    /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// to hold a `VmwareDetails`.
-    ///
-    /// Note that all the setters affecting `vendor_details` are
-    /// mutually exclusive.
-    pub fn set_vmware_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::VmwarePlatformDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vendor_details = std::option::Option::Some(
-            crate::model::platform_details::VendorDetails::VmwareDetails(v.into()),
-        );
-        self
-    }
-
     /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
     /// if it holds a `AwsEc2Details`, `None` if the field is not set or
     /// holds a different branch.
@@ -10457,23 +10344,6 @@ impl PlatformDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// to hold a `AwsEc2Details`.
-    ///
-    /// Note that all the setters affecting `vendor_details` are
-    /// mutually exclusive.
-    pub fn set_aws_ec2_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::AwsEc2PlatformDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vendor_details = std::option::Option::Some(
-            crate::model::platform_details::VendorDetails::AwsEc2Details(v.into()),
-        );
-        self
     }
 
     /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
@@ -10491,23 +10361,6 @@ impl PlatformDetails {
         })
     }
 
-    /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// to hold a `AzureVmDetails`.
-    ///
-    /// Note that all the setters affecting `vendor_details` are
-    /// mutually exclusive.
-    pub fn set_azure_vm_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::AzureVmPlatformDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vendor_details = std::option::Option::Some(
-            crate::model::platform_details::VendorDetails::AzureVmDetails(v.into()),
-        );
-        self
-    }
-
     /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
     /// if it holds a `GenericDetails`, `None` if the field is not set or
     /// holds a different branch.
@@ -10523,23 +10376,6 @@ impl PlatformDetails {
         })
     }
 
-    /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// to hold a `GenericDetails`.
-    ///
-    /// Note that all the setters affecting `vendor_details` are
-    /// mutually exclusive.
-    pub fn set_generic_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::GenericPlatformDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vendor_details = std::option::Option::Some(
-            crate::model::platform_details::VendorDetails::GenericDetails(v.into()),
-        );
-        self
-    }
-
     /// The value of [vendor_details][crate::model::PlatformDetails::vendor_details]
     /// if it holds a `PhysicalDetails`, `None` if the field is not set or
     /// holds a different branch.
@@ -10553,23 +10389,6 @@ impl PlatformDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [vendor_details][crate::model::PlatformDetails::vendor_details]
-    /// to hold a `PhysicalDetails`.
-    ///
-    /// Note that all the setters affecting `vendor_details` are
-    /// mutually exclusive.
-    pub fn set_physical_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::PhysicalPlatformDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vendor_details = std::option::Option::Some(
-            crate::model::platform_details::VendorDetails::PhysicalDetails(v.into()),
-        );
-        self
     }
 }
 
@@ -11579,22 +11398,6 @@ impl Insight {
         })
     }
 
-    /// Sets the value of [insight][crate::model::Insight::insight]
-    /// to hold a `MigrationInsight`.
-    ///
-    /// Note that all the setters affecting `insight` are
-    /// mutually exclusive.
-    pub fn set_migration_insight<
-        T: std::convert::Into<std::boxed::Box<crate::model::MigrationInsight>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.insight =
-            std::option::Option::Some(crate::model::insight::Insight::MigrationInsight(v.into()));
-        self
-    }
-
     /// The value of [insight][crate::model::Insight::insight]
     /// if it holds a `GenericInsight`, `None` if the field is not set or
     /// holds a different branch.
@@ -11606,22 +11409,6 @@ impl Insight {
             crate::model::insight::Insight::GenericInsight(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [insight][crate::model::Insight::insight]
-    /// to hold a `GenericInsight`.
-    ///
-    /// Note that all the setters affecting `insight` are
-    /// mutually exclusive.
-    pub fn set_generic_insight<
-        T: std::convert::Into<std::boxed::Box<crate::model::GenericInsight>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.insight =
-            std::option::Option::Some(crate::model::insight::Insight::GenericInsight(v.into()));
-        self
     }
 }
 
@@ -11771,23 +11558,6 @@ impl MigrationInsight {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [migration_target][crate::model::MigrationInsight::migration_target]
-    /// to hold a `ComputeEngineTarget`.
-    ///
-    /// Note that all the setters affecting `migration_target` are
-    /// mutually exclusive.
-    pub fn set_compute_engine_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeEngineMigrationTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.migration_target = std::option::Option::Some(
-            crate::model::migration_insight::MigrationTarget::ComputeEngineTarget(v.into()),
-        );
-        self
     }
 }
 
@@ -12217,21 +11987,6 @@ impl Aggregation {
         })
     }
 
-    /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
-    /// to hold a `Count`.
-    ///
-    /// Note that all the setters affecting `aggregation_function` are
-    /// mutually exclusive.
-    pub fn set_count<T: std::convert::Into<std::boxed::Box<crate::model::aggregation::Count>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.aggregation_function = std::option::Option::Some(
-            crate::model::aggregation::AggregationFunction::Count(v.into()),
-        );
-        self
-    }
-
     /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
     /// if it holds a `Sum`, `None` if the field is not set or
     /// holds a different branch.
@@ -12241,21 +11996,6 @@ impl Aggregation {
             crate::model::aggregation::AggregationFunction::Sum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
-    /// to hold a `Sum`.
-    ///
-    /// Note that all the setters affecting `aggregation_function` are
-    /// mutually exclusive.
-    pub fn set_sum<T: std::convert::Into<std::boxed::Box<crate::model::aggregation::Sum>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.aggregation_function = std::option::Option::Some(
-            crate::model::aggregation::AggregationFunction::Sum(v.into()),
-        );
-        self
     }
 
     /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
@@ -12273,23 +12013,6 @@ impl Aggregation {
         })
     }
 
-    /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
-    /// to hold a `Histogram`.
-    ///
-    /// Note that all the setters affecting `aggregation_function` are
-    /// mutually exclusive.
-    pub fn set_histogram<
-        T: std::convert::Into<std::boxed::Box<crate::model::aggregation::Histogram>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.aggregation_function = std::option::Option::Some(
-            crate::model::aggregation::AggregationFunction::Histogram(v.into()),
-        );
-        self
-    }
-
     /// The value of [aggregation_function][crate::model::Aggregation::aggregation_function]
     /// if it holds a `Frequency`, `None` if the field is not set or
     /// holds a different branch.
@@ -12303,23 +12026,6 @@ impl Aggregation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [aggregation_function][crate::model::Aggregation::aggregation_function]
-    /// to hold a `Frequency`.
-    ///
-    /// Note that all the setters affecting `aggregation_function` are
-    /// mutually exclusive.
-    pub fn set_frequency<
-        T: std::convert::Into<std::boxed::Box<crate::model::aggregation::Frequency>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.aggregation_function = std::option::Option::Some(
-            crate::model::aggregation::AggregationFunction::Frequency(v.into()),
-        );
-        self
     }
 }
 
@@ -12516,22 +12222,6 @@ impl AggregationResult {
         })
     }
 
-    /// Sets the value of [result][crate::model::AggregationResult::result]
-    /// to hold a `Count`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_count<
-        T: std::convert::Into<std::boxed::Box<crate::model::aggregation_result::Count>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::aggregation_result::Result::Count(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::AggregationResult::result]
     /// if it holds a `Sum`, `None` if the field is not set or
     /// holds a different branch.
@@ -12543,22 +12233,6 @@ impl AggregationResult {
             crate::model::aggregation_result::Result::Sum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::AggregationResult::result]
-    /// to hold a `Sum`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_sum<
-        T: std::convert::Into<std::boxed::Box<crate::model::aggregation_result::Sum>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::aggregation_result::Result::Sum(v.into()));
-        self
     }
 
     /// The value of [result][crate::model::AggregationResult::result]
@@ -12574,23 +12248,6 @@ impl AggregationResult {
         })
     }
 
-    /// Sets the value of [result][crate::model::AggregationResult::result]
-    /// to hold a `Histogram`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_histogram<
-        T: std::convert::Into<std::boxed::Box<crate::model::aggregation_result::Histogram>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::aggregation_result::Result::Histogram(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::AggregationResult::result]
     /// if it holds a `Frequency`, `None` if the field is not set or
     /// holds a different branch.
@@ -12602,23 +12259,6 @@ impl AggregationResult {
             crate::model::aggregation_result::Result::Frequency(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::AggregationResult::result]
-    /// to hold a `Frequency`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_frequency<
-        T: std::convert::Into<std::boxed::Box<crate::model::aggregation_result::Frequency>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::aggregation_result::Result::Frequency(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/modelarmor/v1/src/model.rs
+++ b/src/generated/cloud/modelarmor/v1/src/model.rs
@@ -1423,23 +1423,6 @@ impl SdpFilterSettings {
         })
     }
 
-    /// Sets the value of [sdp_configuration][crate::model::SdpFilterSettings::sdp_configuration]
-    /// to hold a `BasicConfig`.
-    ///
-    /// Note that all the setters affecting `sdp_configuration` are
-    /// mutually exclusive.
-    pub fn set_basic_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::SdpBasicConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sdp_configuration = std::option::Option::Some(
-            crate::model::sdp_filter_settings::SdpConfiguration::BasicConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [sdp_configuration][crate::model::SdpFilterSettings::sdp_configuration]
     /// if it holds a `AdvancedConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -1453,23 +1436,6 @@ impl SdpFilterSettings {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [sdp_configuration][crate::model::SdpFilterSettings::sdp_configuration]
-    /// to hold a `AdvancedConfig`.
-    ///
-    /// Note that all the setters affecting `sdp_configuration` are
-    /// mutually exclusive.
-    pub fn set_advanced_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::SdpAdvancedConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sdp_configuration = std::option::Option::Some(
-            crate::model::sdp_filter_settings::SdpConfiguration::AdvancedConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -2137,23 +2103,6 @@ impl FilterResult {
         })
     }
 
-    /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
-    /// to hold a `RaiFilterResult`.
-    ///
-    /// Note that all the setters affecting `filter_result` are
-    /// mutually exclusive.
-    pub fn set_rai_filter_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::RaiFilterResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter_result = std::option::Option::Some(
-            crate::model::filter_result::FilterResult::RaiFilterResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter_result][crate::model::FilterResult::filter_result]
     /// if it holds a `SdpFilterResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -2167,23 +2116,6 @@ impl FilterResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
-    /// to hold a `SdpFilterResult`.
-    ///
-    /// Note that all the setters affecting `filter_result` are
-    /// mutually exclusive.
-    pub fn set_sdp_filter_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::SdpFilterResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter_result = std::option::Option::Some(
-            crate::model::filter_result::FilterResult::SdpFilterResult(v.into()),
-        );
-        self
     }
 
     /// The value of [filter_result][crate::model::FilterResult::filter_result]
@@ -2201,23 +2133,6 @@ impl FilterResult {
         })
     }
 
-    /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
-    /// to hold a `PiAndJailbreakFilterResult`.
-    ///
-    /// Note that all the setters affecting `filter_result` are
-    /// mutually exclusive.
-    pub fn set_pi_and_jailbreak_filter_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::PiAndJailbreakFilterResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter_result = std::option::Option::Some(
-            crate::model::filter_result::FilterResult::PiAndJailbreakFilterResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter_result][crate::model::FilterResult::filter_result]
     /// if it holds a `MaliciousUriFilterResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -2231,23 +2146,6 @@ impl FilterResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
-    /// to hold a `MaliciousUriFilterResult`.
-    ///
-    /// Note that all the setters affecting `filter_result` are
-    /// mutually exclusive.
-    pub fn set_malicious_uri_filter_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::MaliciousUriFilterResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter_result = std::option::Option::Some(
-            crate::model::filter_result::FilterResult::MaliciousUriFilterResult(v.into()),
-        );
-        self
     }
 
     /// The value of [filter_result][crate::model::FilterResult::filter_result]
@@ -2265,23 +2163,6 @@ impl FilterResult {
         })
     }
 
-    /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
-    /// to hold a `CsamFilterFilterResult`.
-    ///
-    /// Note that all the setters affecting `filter_result` are
-    /// mutually exclusive.
-    pub fn set_csam_filter_filter_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::CsamFilterResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter_result = std::option::Option::Some(
-            crate::model::filter_result::FilterResult::CsamFilterFilterResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter_result][crate::model::FilterResult::filter_result]
     /// if it holds a `VirusScanFilterResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -2295,23 +2176,6 @@ impl FilterResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter_result][crate::model::FilterResult::filter_result]
-    /// to hold a `VirusScanFilterResult`.
-    ///
-    /// Note that all the setters affecting `filter_result` are
-    /// mutually exclusive.
-    pub fn set_virus_scan_filter_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::VirusScanFilterResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter_result = std::option::Option::Some(
-            crate::model::filter_result::FilterResult::VirusScanFilterResult(v.into()),
-        );
-        self
     }
 }
 
@@ -2550,23 +2414,6 @@ impl SdpFilterResult {
         })
     }
 
-    /// Sets the value of [result][crate::model::SdpFilterResult::result]
-    /// to hold a `InspectResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_inspect_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::SdpInspectResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::sdp_filter_result::Result::InspectResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::SdpFilterResult::result]
     /// if it holds a `DeidentifyResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -2580,23 +2427,6 @@ impl SdpFilterResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::SdpFilterResult::result]
-    /// to hold a `DeidentifyResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_deidentify_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::SdpDeidentifyResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::sdp_filter_result::Result::DeidentifyResult(v.into()),
-        );
-        self
     }
 }
 
@@ -2765,17 +2595,6 @@ impl DataItem {
         })
     }
 
-    /// Sets the value of [data_item][crate::model::DataItem::data_item]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `data_item` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data_item =
-            std::option::Option::Some(crate::model::data_item::DataItem::Text(v.into()));
-        self
-    }
-
     /// The value of [data_item][crate::model::DataItem::data_item]
     /// if it holds a `ByteItem`, `None` if the field is not set or
     /// holds a different branch.
@@ -2785,20 +2604,6 @@ impl DataItem {
             crate::model::data_item::DataItem::ByteItem(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_item][crate::model::DataItem::data_item]
-    /// to hold a `ByteItem`.
-    ///
-    /// Note that all the setters affecting `data_item` are
-    /// mutually exclusive.
-    pub fn set_byte_item<T: std::convert::Into<std::boxed::Box<crate::model::ByteDataItem>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_item =
-            std::option::Option::Some(crate::model::data_item::DataItem::ByteItem(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/netapp/v1/src/model.rs
+++ b/src/generated/cloud/netapp/v1/src/model.rs
@@ -9834,18 +9834,6 @@ impl RestoreParameters {
         })
     }
 
-    /// Sets the value of [source][crate::model::RestoreParameters::source]
-    /// to hold a `SourceSnapshot`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_snapshot<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_parameters::Source::SourceSnapshot(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::RestoreParameters::source]
     /// if it holds a `SourceBackup`, `None` if the field is not set or
     /// holds a different branch.
@@ -9857,18 +9845,6 @@ impl RestoreParameters {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::RestoreParameters::source]
-    /// to hold a `SourceBackup`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_parameters::Source::SourceBackup(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/networkconnectivity/v1/src/model.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/model.rs
@@ -8953,23 +8953,6 @@ impl PolicyBasedRoute {
         })
     }
 
-    /// Sets the value of [target][crate::model::PolicyBasedRoute::target]
-    /// to hold a `VirtualMachine`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_virtual_machine<
-        T: std::convert::Into<std::boxed::Box<crate::model::policy_based_route::VirtualMachine>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::policy_based_route::Target::VirtualMachine(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::PolicyBasedRoute::target]
     /// if it holds a `InterconnectAttachment`, `None` if the field is not set or
     /// holds a different branch.
@@ -8985,25 +8968,6 @@ impl PolicyBasedRoute {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::PolicyBasedRoute::target]
-    /// to hold a `InterconnectAttachment`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_interconnect_attachment<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::policy_based_route::InterconnectAttachment>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::policy_based_route::Target::InterconnectAttachment(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [next_hop][crate::model::PolicyBasedRoute::next_hop].
@@ -9033,18 +8997,6 @@ impl PolicyBasedRoute {
         })
     }
 
-    /// Sets the value of [next_hop][crate::model::PolicyBasedRoute::next_hop]
-    /// to hold a `NextHopIlbIp`.
-    ///
-    /// Note that all the setters affecting `next_hop` are
-    /// mutually exclusive.
-    pub fn set_next_hop_ilb_ip<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.next_hop = std::option::Option::Some(
-            crate::model::policy_based_route::NextHop::NextHopIlbIp(v.into()),
-        );
-        self
-    }
-
     /// The value of [next_hop][crate::model::PolicyBasedRoute::next_hop]
     /// if it holds a `NextHopOtherRoutes`, `None` if the field is not set or
     /// holds a different branch.
@@ -9058,23 +9010,6 @@ impl PolicyBasedRoute {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [next_hop][crate::model::PolicyBasedRoute::next_hop]
-    /// to hold a `NextHopOtherRoutes`.
-    ///
-    /// Note that all the setters affecting `next_hop` are
-    /// mutually exclusive.
-    pub fn set_next_hop_other_routes<
-        T: std::convert::Into<crate::model::policy_based_route::OtherRoutes>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.next_hop = std::option::Option::Some(
-            crate::model::policy_based_route::NextHop::NextHopOtherRoutes(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/networkmanagement/v1/src/model.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/model.rs
@@ -2391,20 +2391,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Instance`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_instance<T: std::convert::Into<std::boxed::Box<crate::model::InstanceInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::Instance(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `Firewall`, `None` if the field is not set or
     /// holds a different branch.
@@ -2414,20 +2400,6 @@ impl Step {
             crate::model::step::StepInfo::Firewall(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Firewall`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_firewall<T: std::convert::Into<std::boxed::Box<crate::model::FirewallInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::Firewall(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2441,19 +2413,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Route`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_route<T: std::convert::Into<std::boxed::Box<crate::model::RouteInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Route(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `Endpoint`, `None` if the field is not set or
     /// holds a different branch.
@@ -2463,20 +2422,6 @@ impl Step {
             crate::model::step::StepInfo::Endpoint(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Endpoint`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_endpoint<T: std::convert::Into<std::boxed::Box<crate::model::EndpointInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::Endpoint(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2492,22 +2437,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `GoogleService`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_google_service<
-        T: std::convert::Into<std::boxed::Box<crate::model::GoogleServiceInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::GoogleService(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `ForwardingRule`, `None` if the field is not set or
     /// holds a different branch.
@@ -2519,22 +2448,6 @@ impl Step {
             crate::model::step::StepInfo::ForwardingRule(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `ForwardingRule`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_forwarding_rule<
-        T: std::convert::Into<std::boxed::Box<crate::model::ForwardingRuleInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::ForwardingRule(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2550,20 +2463,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `VpnGateway`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_vpn_gateway<T: std::convert::Into<std::boxed::Box<crate::model::VpnGatewayInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::VpnGateway(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `VpnTunnel`, `None` if the field is not set or
     /// holds a different branch.
@@ -2573,20 +2472,6 @@ impl Step {
             crate::model::step::StepInfo::VpnTunnel(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `VpnTunnel`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_vpn_tunnel<T: std::convert::Into<std::boxed::Box<crate::model::VpnTunnelInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::VpnTunnel(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2600,22 +2485,6 @@ impl Step {
             crate::model::step::StepInfo::VpcConnector(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `VpcConnector`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_vpc_connector<
-        T: std::convert::Into<std::boxed::Box<crate::model::VpcConnectorInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::VpcConnector(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2633,23 +2502,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `DirectVpcEgressConnection`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_direct_vpc_egress_connection<
-        T: std::convert::Into<std::boxed::Box<crate::model::DirectVpcEgressConnectionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(
-            crate::model::step::StepInfo::DirectVpcEgressConnection(v.into()),
-        );
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `ServerlessExternalConnection`, `None` if the field is not set or
     /// holds a different branch.
@@ -2665,23 +2517,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `ServerlessExternalConnection`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_serverless_external_connection<
-        T: std::convert::Into<std::boxed::Box<crate::model::ServerlessExternalConnectionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(
-            crate::model::step::StepInfo::ServerlessExternalConnection(v.into()),
-        );
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `Deliver`, `None` if the field is not set or
     /// holds a different branch.
@@ -2691,19 +2526,6 @@ impl Step {
             crate::model::step::StepInfo::Deliver(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Deliver`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_deliver<T: std::convert::Into<std::boxed::Box<crate::model::DeliverInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Deliver(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2717,19 +2539,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Forward`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_forward<T: std::convert::Into<std::boxed::Box<crate::model::ForwardInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Forward(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `Abort`, `None` if the field is not set or
     /// holds a different branch.
@@ -2741,19 +2550,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Abort`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_abort<T: std::convert::Into<std::boxed::Box<crate::model::AbortInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Abort(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `Drop`, `None` if the field is not set or
     /// holds a different branch.
@@ -2763,19 +2559,6 @@ impl Step {
             crate::model::step::StepInfo::Drop(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Drop`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_drop<T: std::convert::Into<std::boxed::Box<crate::model::DropInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Drop(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2792,23 +2575,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `LoadBalancer`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    #[deprecated]
-    pub fn set_load_balancer<
-        T: std::convert::Into<std::boxed::Box<crate::model::LoadBalancerInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::LoadBalancer(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `Network`, `None` if the field is not set or
     /// holds a different branch.
@@ -2820,19 +2586,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Network`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_network<T: std::convert::Into<std::boxed::Box<crate::model::NetworkInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Network(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `GkeMaster`, `None` if the field is not set or
     /// holds a different branch.
@@ -2842,20 +2595,6 @@ impl Step {
             crate::model::step::StepInfo::GkeMaster(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `GkeMaster`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_gke_master<T: std::convert::Into<std::boxed::Box<crate::model::GKEMasterInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::GkeMaster(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2871,22 +2610,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `CloudSqlInstance`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql_instance<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSQLInstanceInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::CloudSqlInstance(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `RedisInstance`, `None` if the field is not set or
     /// holds a different branch.
@@ -2898,22 +2621,6 @@ impl Step {
             crate::model::step::StepInfo::RedisInstance(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `RedisInstance`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_redis_instance<
-        T: std::convert::Into<std::boxed::Box<crate::model::RedisInstanceInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::RedisInstance(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2929,22 +2636,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `RedisCluster`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_redis_cluster<
-        T: std::convert::Into<std::boxed::Box<crate::model::RedisClusterInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::RedisCluster(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `CloudFunction`, `None` if the field is not set or
     /// holds a different branch.
@@ -2956,22 +2647,6 @@ impl Step {
             crate::model::step::StepInfo::CloudFunction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `CloudFunction`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_cloud_function<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudFunctionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::CloudFunction(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -2987,22 +2662,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `AppEngineVersion`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_app_engine_version<
-        T: std::convert::Into<std::boxed::Box<crate::model::AppEngineVersionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::AppEngineVersion(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `CloudRunRevision`, `None` if the field is not set or
     /// holds a different branch.
@@ -3016,22 +2675,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `CloudRunRevision`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_cloud_run_revision<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudRunRevisionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::CloudRunRevision(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `Nat`, `None` if the field is not set or
     /// holds a different branch.
@@ -3041,19 +2684,6 @@ impl Step {
             crate::model::step::StepInfo::Nat(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `Nat`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_nat<T: std::convert::Into<std::boxed::Box<crate::model::NatInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(crate::model::step::StepInfo::Nat(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -3067,22 +2697,6 @@ impl Step {
             crate::model::step::StepInfo::ProxyConnection(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `ProxyConnection`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_proxy_connection<
-        T: std::convert::Into<std::boxed::Box<crate::model::ProxyConnectionInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::ProxyConnection(v.into()));
-        self
     }
 
     /// The value of [step_info][crate::model::Step::step_info]
@@ -3100,23 +2714,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `LoadBalancerBackendInfo`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_load_balancer_backend_info<
-        T: std::convert::Into<std::boxed::Box<crate::model::LoadBalancerBackendInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info = std::option::Option::Some(
-            crate::model::step::StepInfo::LoadBalancerBackendInfo(v.into()),
-        );
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `StorageBucket`, `None` if the field is not set or
     /// holds a different branch.
@@ -3130,22 +2727,6 @@ impl Step {
         })
     }
 
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `StorageBucket`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_storage_bucket<
-        T: std::convert::Into<std::boxed::Box<crate::model::StorageBucketInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::StorageBucket(v.into()));
-        self
-    }
-
     /// The value of [step_info][crate::model::Step::step_info]
     /// if it holds a `ServerlessNeg`, `None` if the field is not set or
     /// holds a different branch.
@@ -3157,22 +2738,6 @@ impl Step {
             crate::model::step::StepInfo::ServerlessNeg(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_info][crate::model::Step::step_info]
-    /// to hold a `ServerlessNeg`.
-    ///
-    /// Note that all the setters affecting `step_info` are
-    /// mutually exclusive.
-    pub fn set_serverless_neg<
-        T: std::convert::Into<std::boxed::Box<crate::model::ServerlessNegInfo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_info =
-            std::option::Option::Some(crate::model::step::StepInfo::ServerlessNeg(v.into()));
-        self
     }
 }
 
@@ -10924,21 +10489,6 @@ impl VpcFlowLogsConfig {
         })
     }
 
-    /// Sets the value of [target_resource][crate::model::VpcFlowLogsConfig::target_resource]
-    /// to hold a `InterconnectAttachment`.
-    ///
-    /// Note that all the setters affecting `target_resource` are
-    /// mutually exclusive.
-    pub fn set_interconnect_attachment<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_resource = std::option::Option::Some(
-            crate::model::vpc_flow_logs_config::TargetResource::InterconnectAttachment(v.into()),
-        );
-        self
-    }
-
     /// The value of [target_resource][crate::model::VpcFlowLogsConfig::target_resource]
     /// if it holds a `VpnTunnel`, `None` if the field is not set or
     /// holds a different branch.
@@ -10950,18 +10500,6 @@ impl VpcFlowLogsConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_resource][crate::model::VpcFlowLogsConfig::target_resource]
-    /// to hold a `VpnTunnel`.
-    ///
-    /// Note that all the setters affecting `target_resource` are
-    /// mutually exclusive.
-    pub fn set_vpn_tunnel<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.target_resource = std::option::Option::Some(
-            crate::model::vpc_flow_logs_config::TargetResource::VpnTunnel(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/networksecurity/v1/src/model.rs
+++ b/src/generated/cloud/networksecurity/v1/src/model.rs
@@ -440,23 +440,6 @@ pub mod authorization_policy {
                         _ => std::option::Option::None,
                     })
                 }
-
-                /// Sets the value of [r#type][crate::model::authorization_policy::rule::destination::HttpHeaderMatch::r#type]
-                /// to hold a `RegexMatch`.
-                ///
-                /// Note that all the setters affecting `r#type` are
-                /// mutually exclusive.
-                pub fn set_regex_match<T: std::convert::Into<std::string::String>>(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.r#type = std::option::Option::Some(
-                        crate::model::authorization_policy::rule::destination::http_header_match::Type::RegexMatch(
-                            v.into()
-                        )
-                    );
-                    self
-                }
             }
 
             impl wkt::message::Message for HttpHeaderMatch {
@@ -2032,20 +2015,6 @@ impl ValidationCA {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::ValidationCA::r#type]
-    /// to hold a `GrpcEndpoint`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_grpc_endpoint<T: std::convert::Into<std::boxed::Box<crate::model::GrpcEndpoint>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::validation_ca::Type::GrpcEndpoint(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::ValidationCA::r#type]
     /// if it holds a `CertificateProviderInstance`, `None` if the field is not set or
     /// holds a different branch.
@@ -2059,23 +2028,6 @@ impl ValidationCA {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::ValidationCA::r#type]
-    /// to hold a `CertificateProviderInstance`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_certificate_provider_instance<
-        T: std::convert::Into<std::boxed::Box<crate::model::CertificateProviderInstance>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::validation_ca::Type::CertificateProviderInstance(v.into()),
-        );
-        self
     }
 }
 
@@ -2193,21 +2145,6 @@ impl CertificateProvider {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::CertificateProvider::r#type]
-    /// to hold a `GrpcEndpoint`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_grpc_endpoint<T: std::convert::Into<std::boxed::Box<crate::model::GrpcEndpoint>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::certificate_provider::Type::GrpcEndpoint(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::CertificateProvider::r#type]
     /// if it holds a `CertificateProviderInstance`, `None` if the field is not set or
     /// holds a different branch.
@@ -2221,23 +2158,6 @@ impl CertificateProvider {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::CertificateProvider::r#type]
-    /// to hold a `CertificateProviderInstance`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_certificate_provider_instance<
-        T: std::convert::Into<std::boxed::Box<crate::model::CertificateProviderInstance>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::certificate_provider::Type::CertificateProviderInstance(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/networkservices/v1/src/model.rs
+++ b/src/generated/cloud/networkservices/v1/src/model.rs
@@ -227,23 +227,6 @@ impl EndpointMatcher {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [matcher_type][crate::model::EndpointMatcher::matcher_type]
-    /// to hold a `MetadataLabelMatcher`.
-    ///
-    /// Note that all the setters affecting `matcher_type` are
-    /// mutually exclusive.
-    pub fn set_metadata_label_matcher<
-        T: std::convert::Into<std::boxed::Box<crate::model::endpoint_matcher::MetadataLabelMatcher>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.matcher_type = std::option::Option::Some(
-            crate::model::endpoint_matcher::MatcherType::MetadataLabelMatcher(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for EndpointMatcher {
@@ -3902,21 +3885,6 @@ pub mod grpc_route {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [destination_type][crate::model::grpc_route::Destination::destination_type]
-        /// to hold a `ServiceName`.
-        ///
-        /// Note that all the setters affecting `destination_type` are
-        /// mutually exclusive.
-        pub fn set_service_name<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.destination_type = std::option::Option::Some(
-                crate::model::grpc_route::destination::DestinationType::ServiceName(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for Destination {
@@ -4886,18 +4854,6 @@ pub mod http_route {
             })
         }
 
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `ExactMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_exact_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::ExactMatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
         /// if it holds a `RegexMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -4909,18 +4865,6 @@ pub mod http_route {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `RegexMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_regex_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::RegexMatch(v.into()),
-            );
-            self
         }
 
         /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
@@ -4936,21 +4880,6 @@ pub mod http_route {
             })
         }
 
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `PrefixMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_prefix_match<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::PrefixMatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
         /// if it holds a `PresentMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -4964,18 +4893,6 @@ pub mod http_route {
             })
         }
 
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `PresentMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_present_match<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::PresentMatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
         /// if it holds a `SuffixMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -4987,21 +4904,6 @@ pub mod http_route {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `SuffixMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_suffix_match<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::SuffixMatch(v.into()),
-            );
-            self
         }
 
         /// The value of [match_type][crate::model::http_route::HeaderMatch::match_type]
@@ -5019,25 +4921,6 @@ pub mod http_route {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::HeaderMatch::match_type]
-        /// to hold a `RangeMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_range_match<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::http_route::header_match::IntegerRange>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::header_match::MatchType::RangeMatch(v.into()),
-            );
-            self
         }
     }
 
@@ -5180,18 +5063,6 @@ pub mod http_route {
             })
         }
 
-        /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
-        /// to hold a `ExactMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_exact_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::query_parameter_match::MatchType::ExactMatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
         /// if it holds a `RegexMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -5205,18 +5076,6 @@ pub mod http_route {
             })
         }
 
-        /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
-        /// to hold a `RegexMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_regex_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::query_parameter_match::MatchType::RegexMatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
         /// if it holds a `PresentMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -5228,18 +5087,6 @@ pub mod http_route {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [match_type][crate::model::http_route::QueryParameterMatch::match_type]
-        /// to hold a `PresentMatch`.
-        ///
-        /// Note that all the setters affecting `match_type` are
-        /// mutually exclusive.
-        pub fn set_present_match<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.match_type = std::option::Option::Some(
-                crate::model::http_route::query_parameter_match::MatchType::PresentMatch(v.into()),
-            );
-            self
         }
     }
 
@@ -5371,21 +5218,6 @@ pub mod http_route {
             })
         }
 
-        /// Sets the value of [path_match][crate::model::http_route::RouteMatch::path_match]
-        /// to hold a `FullPathMatch`.
-        ///
-        /// Note that all the setters affecting `path_match` are
-        /// mutually exclusive.
-        pub fn set_full_path_match<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.path_match = std::option::Option::Some(
-                crate::model::http_route::route_match::PathMatch::FullPathMatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [path_match][crate::model::http_route::RouteMatch::path_match]
         /// if it holds a `PrefixMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -5399,21 +5231,6 @@ pub mod http_route {
             })
         }
 
-        /// Sets the value of [path_match][crate::model::http_route::RouteMatch::path_match]
-        /// to hold a `PrefixMatch`.
-        ///
-        /// Note that all the setters affecting `path_match` are
-        /// mutually exclusive.
-        pub fn set_prefix_match<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.path_match = std::option::Option::Some(
-                crate::model::http_route::route_match::PathMatch::PrefixMatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [path_match][crate::model::http_route::RouteMatch::path_match]
         /// if it holds a `RegexMatch`, `None` if the field is not set or
         /// holds a different branch.
@@ -5425,18 +5242,6 @@ pub mod http_route {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [path_match][crate::model::http_route::RouteMatch::path_match]
-        /// to hold a `RegexMatch`.
-        ///
-        /// Note that all the setters affecting `path_match` are
-        /// mutually exclusive.
-        pub fn set_regex_match<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.path_match = std::option::Option::Some(
-                crate::model::http_route::route_match::PathMatch::RegexMatch(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/notebooks/v2/src/model.rs
+++ b/src/generated/cloud/notebooks/v2/src/model.rs
@@ -603,16 +603,6 @@ impl VmImage {
         })
     }
 
-    /// Sets the value of [image][crate::model::VmImage::image]
-    /// to hold a `Name`.
-    ///
-    /// Note that all the setters affecting `image` are
-    /// mutually exclusive.
-    pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.image = std::option::Option::Some(crate::model::vm_image::Image::Name(v.into()));
-        self
-    }
-
     /// The value of [image][crate::model::VmImage::image]
     /// if it holds a `Family`, `None` if the field is not set or
     /// holds a different branch.
@@ -622,16 +612,6 @@ impl VmImage {
             crate::model::vm_image::Image::Family(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [image][crate::model::VmImage::image]
-    /// to hold a `Family`.
-    ///
-    /// Note that all the setters affecting `image` are
-    /// mutually exclusive.
-    pub fn set_family<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.image = std::option::Option::Some(crate::model::vm_image::Image::Family(v.into()));
-        self
     }
 }
 
@@ -1473,19 +1453,6 @@ impl GceSetup {
         })
     }
 
-    /// Sets the value of [image][crate::model::GceSetup::image]
-    /// to hold a `VmImage`.
-    ///
-    /// Note that all the setters affecting `image` are
-    /// mutually exclusive.
-    pub fn set_vm_image<T: std::convert::Into<std::boxed::Box<crate::model::VmImage>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.image = std::option::Option::Some(crate::model::gce_setup::Image::VmImage(v.into()));
-        self
-    }
-
     /// The value of [image][crate::model::GceSetup::image]
     /// if it holds a `ContainerImage`, `None` if the field is not set or
     /// holds a different branch.
@@ -1497,22 +1464,6 @@ impl GceSetup {
             crate::model::gce_setup::Image::ContainerImage(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [image][crate::model::GceSetup::image]
-    /// to hold a `ContainerImage`.
-    ///
-    /// Note that all the setters affecting `image` are
-    /// mutually exclusive.
-    pub fn set_container_image<
-        T: std::convert::Into<std::boxed::Box<crate::model::ContainerImage>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.image =
-            std::option::Option::Some(crate::model::gce_setup::Image::ContainerImage(v.into()));
-        self
     }
 }
 
@@ -2158,20 +2109,6 @@ impl Instance {
             crate::model::instance::Infrastructure::GceSetup(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [infrastructure][crate::model::Instance::infrastructure]
-    /// to hold a `GceSetup`.
-    ///
-    /// Note that all the setters affecting `infrastructure` are
-    /// mutually exclusive.
-    pub fn set_gce_setup<T: std::convert::Into<std::boxed::Box<crate::model::GceSetup>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.infrastructure =
-            std::option::Option::Some(crate::model::instance::Infrastructure::GceSetup(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/optimization/v1/src/model.rs
+++ b/src/generated/cloud/optimization/v1/src/model.rs
@@ -89,20 +89,6 @@ impl InputConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::InputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::input_config::Source::GcsSource(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for InputConfig {
@@ -188,23 +174,6 @@ impl OutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::OutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::output_config::Destination::GcsDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -5384,20 +5353,6 @@ impl Waypoint {
         })
     }
 
-    /// Sets the value of [location_type][crate::model::Waypoint::location_type]
-    /// to hold a `Location`.
-    ///
-    /// Note that all the setters affecting `location_type` are
-    /// mutually exclusive.
-    pub fn set_location<T: std::convert::Into<std::boxed::Box<crate::model::Location>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location_type =
-            std::option::Option::Some(crate::model::waypoint::LocationType::Location(v.into()));
-        self
-    }
-
     /// The value of [location_type][crate::model::Waypoint::location_type]
     /// if it holds a `PlaceId`, `None` if the field is not set or
     /// holds a different branch.
@@ -5407,17 +5362,6 @@ impl Waypoint {
             crate::model::waypoint::LocationType::PlaceId(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location_type][crate::model::Waypoint::location_type]
-    /// to hold a `PlaceId`.
-    ///
-    /// Note that all the setters affecting `location_type` are
-    /// mutually exclusive.
-    pub fn set_place_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.location_type =
-            std::option::Option::Some(crate::model::waypoint::LocationType::PlaceId(v.into()));
-        self
     }
 }
 
@@ -8346,20 +8290,6 @@ pub mod optimize_tours_validation_error {
             })
         }
 
-        /// Sets the value of [index_or_key][crate::model::optimize_tours_validation_error::FieldReference::index_or_key]
-        /// to hold a `Index`.
-        ///
-        /// Note that all the setters affecting `index_or_key` are
-        /// mutually exclusive.
-        pub fn set_index<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.index_or_key = std::option::Option::Some(
-                crate::model::optimize_tours_validation_error::field_reference::IndexOrKey::Index(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [index_or_key][crate::model::optimize_tours_validation_error::FieldReference::index_or_key]
         /// if it holds a `Key`, `None` if the field is not set or
         /// holds a different branch.
@@ -8371,20 +8301,6 @@ pub mod optimize_tours_validation_error {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [index_or_key][crate::model::optimize_tours_validation_error::FieldReference::index_or_key]
-        /// to hold a `Key`.
-        ///
-        /// Note that all the setters affecting `index_or_key` are
-        /// mutually exclusive.
-        pub fn set_key<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.index_or_key = std::option::Option::Some(
-                crate::model::optimize_tours_validation_error::field_reference::IndexOrKey::Key(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/model.rs
@@ -3888,23 +3888,6 @@ impl IPAllocationPolicy {
         })
     }
 
-    /// Sets the value of [cluster_ip_allocation][crate::model::IPAllocationPolicy::cluster_ip_allocation]
-    /// to hold a `ClusterSecondaryRangeName`.
-    ///
-    /// Note that all the setters affecting `cluster_ip_allocation` are
-    /// mutually exclusive.
-    pub fn set_cluster_secondary_range_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cluster_ip_allocation = std::option::Option::Some(
-            crate::model::ip_allocation_policy::ClusterIpAllocation::ClusterSecondaryRangeName(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [cluster_ip_allocation][crate::model::IPAllocationPolicy::cluster_ip_allocation]
     /// if it holds a `ClusterIpv4CidrBlock`, `None` if the field is not set or
     /// holds a different branch.
@@ -3916,21 +3899,6 @@ impl IPAllocationPolicy {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cluster_ip_allocation][crate::model::IPAllocationPolicy::cluster_ip_allocation]
-    /// to hold a `ClusterIpv4CidrBlock`.
-    ///
-    /// Note that all the setters affecting `cluster_ip_allocation` are
-    /// mutually exclusive.
-    pub fn set_cluster_ipv4_cidr_block<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cluster_ip_allocation = std::option::Option::Some(
-            crate::model::ip_allocation_policy::ClusterIpAllocation::ClusterIpv4CidrBlock(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation].
@@ -3960,23 +3928,6 @@ impl IPAllocationPolicy {
         })
     }
 
-    /// Sets the value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation]
-    /// to hold a `ServicesSecondaryRangeName`.
-    ///
-    /// Note that all the setters affecting `services_ip_allocation` are
-    /// mutually exclusive.
-    pub fn set_services_secondary_range_name<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.services_ip_allocation = std::option::Option::Some(
-            crate::model::ip_allocation_policy::ServicesIpAllocation::ServicesSecondaryRangeName(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation]
     /// if it holds a `ServicesIpv4CidrBlock`, `None` if the field is not set or
     /// holds a different branch.
@@ -3988,23 +3939,6 @@ impl IPAllocationPolicy {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [services_ip_allocation][crate::model::IPAllocationPolicy::services_ip_allocation]
-    /// to hold a `ServicesIpv4CidrBlock`.
-    ///
-    /// Note that all the setters affecting `services_ip_allocation` are
-    /// mutually exclusive.
-    pub fn set_services_ipv4_cidr_block<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.services_ip_allocation = std::option::Option::Some(
-            crate::model::ip_allocation_policy::ServicesIpAllocation::ServicesIpv4CidrBlock(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/orgpolicy/v1/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v1/src/model.rs
@@ -146,22 +146,6 @@ impl Policy {
         })
     }
 
-    /// Sets the value of [policy_type][crate::model::Policy::policy_type]
-    /// to hold a `ListPolicy`.
-    ///
-    /// Note that all the setters affecting `policy_type` are
-    /// mutually exclusive.
-    pub fn set_list_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::policy::ListPolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.policy_type =
-            std::option::Option::Some(crate::model::policy::PolicyType::ListPolicy(v.into()));
-        self
-    }
-
     /// The value of [policy_type][crate::model::Policy::policy_type]
     /// if it holds a `BooleanPolicy`, `None` if the field is not set or
     /// holds a different branch.
@@ -175,22 +159,6 @@ impl Policy {
         })
     }
 
-    /// Sets the value of [policy_type][crate::model::Policy::policy_type]
-    /// to hold a `BooleanPolicy`.
-    ///
-    /// Note that all the setters affecting `policy_type` are
-    /// mutually exclusive.
-    pub fn set_boolean_policy<
-        T: std::convert::Into<std::boxed::Box<crate::model::policy::BooleanPolicy>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.policy_type =
-            std::option::Option::Some(crate::model::policy::PolicyType::BooleanPolicy(v.into()));
-        self
-    }
-
     /// The value of [policy_type][crate::model::Policy::policy_type]
     /// if it holds a `RestoreDefault`, `None` if the field is not set or
     /// holds a different branch.
@@ -202,22 +170,6 @@ impl Policy {
             crate::model::policy::PolicyType::RestoreDefault(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [policy_type][crate::model::Policy::policy_type]
-    /// to hold a `RestoreDefault`.
-    ///
-    /// Note that all the setters affecting `policy_type` are
-    /// mutually exclusive.
-    pub fn set_restore_default<
-        T: std::convert::Into<std::boxed::Box<crate::model::policy::RestoreDefault>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.policy_type =
-            std::option::Option::Some(crate::model::policy::PolicyType::RestoreDefault(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/orgpolicy/v2/src/model.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/model.rs
@@ -186,23 +186,6 @@ impl Constraint {
         })
     }
 
-    /// Sets the value of [constraint_type][crate::model::Constraint::constraint_type]
-    /// to hold a `ListConstraint`.
-    ///
-    /// Note that all the setters affecting `constraint_type` are
-    /// mutually exclusive.
-    pub fn set_list_constraint<
-        T: std::convert::Into<std::boxed::Box<crate::model::constraint::ListConstraint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.constraint_type = std::option::Option::Some(
-            crate::model::constraint::ConstraintType::ListConstraint(v.into()),
-        );
-        self
-    }
-
     /// The value of [constraint_type][crate::model::Constraint::constraint_type]
     /// if it holds a `BooleanConstraint`, `None` if the field is not set or
     /// holds a different branch.
@@ -216,23 +199,6 @@ impl Constraint {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [constraint_type][crate::model::Constraint::constraint_type]
-    /// to hold a `BooleanConstraint`.
-    ///
-    /// Note that all the setters affecting `constraint_type` are
-    /// mutually exclusive.
-    pub fn set_boolean_constraint<
-        T: std::convert::Into<std::boxed::Box<crate::model::constraint::BooleanConstraint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.constraint_type = std::option::Option::Some(
-            crate::model::constraint::ConstraintType::BooleanConstraint(v.into()),
-        );
-        self
     }
 }
 
@@ -2000,25 +1966,6 @@ pub mod policy_spec {
             })
         }
 
-        /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
-        /// to hold a `Values`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_values<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::policy_spec::policy_rule::StringValues>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::policy_spec::policy_rule::Kind::Values(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
         /// if it holds a `AllowAll`, `None` if the field is not set or
         /// holds a different branch.
@@ -2030,18 +1977,6 @@ pub mod policy_spec {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
-        /// to hold a `AllowAll`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_allow_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::policy_spec::policy_rule::Kind::AllowAll(v.into()),
-            );
-            self
         }
 
         /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
@@ -2057,18 +1992,6 @@ pub mod policy_spec {
             })
         }
 
-        /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
-        /// to hold a `DenyAll`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_deny_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::policy_spec::policy_rule::Kind::DenyAll(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::policy_spec::PolicyRule::kind]
         /// if it holds a `Enforce`, `None` if the field is not set or
         /// holds a different branch.
@@ -2080,18 +2003,6 @@ pub mod policy_spec {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::policy_spec::PolicyRule::kind]
-        /// to hold a `Enforce`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_enforce<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::policy_spec::policy_rule::Kind::Enforce(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/osconfig/v1/src/model.rs
+++ b/src/generated/cloud/osconfig/v1/src/model.rs
@@ -355,23 +355,6 @@ pub mod inventory {
             })
         }
 
-        /// Sets the value of [details][crate::model::inventory::Item::details]
-        /// to hold a `InstalledPackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_installed_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::SoftwarePackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::item::Details::InstalledPackage(v.into()),
-            );
-            self
-        }
-
         /// The value of [details][crate::model::inventory::Item::details]
         /// if it holds a `AvailablePackage`, `None` if the field is not set or
         /// holds a different branch.
@@ -386,23 +369,6 @@ pub mod inventory {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [details][crate::model::inventory::Item::details]
-        /// to hold a `AvailablePackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_available_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::SoftwarePackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::item::Details::AvailablePackage(v.into()),
-            );
-            self
         }
     }
 
@@ -745,23 +711,6 @@ pub mod inventory {
             })
         }
 
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `YumPackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_yum_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::VersionedPackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::YumPackage(v.into()),
-            );
-            self
-        }
-
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
         /// if it holds a `AptPackage`, `None` if the field is not set or
         /// holds a different branch.
@@ -776,23 +725,6 @@ pub mod inventory {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `AptPackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_apt_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::VersionedPackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::AptPackage(v.into()),
-            );
-            self
         }
 
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
@@ -811,23 +743,6 @@ pub mod inventory {
             })
         }
 
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `ZypperPackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_zypper_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::VersionedPackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::ZypperPackage(v.into()),
-            );
-            self
-        }
-
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
         /// if it holds a `GoogetPackage`, `None` if the field is not set or
         /// holds a different branch.
@@ -842,23 +757,6 @@ pub mod inventory {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `GoogetPackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_googet_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::VersionedPackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::GoogetPackage(v.into()),
-            );
-            self
         }
 
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
@@ -876,23 +774,6 @@ pub mod inventory {
             })
         }
 
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `ZypperPatch`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_zypper_patch<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::ZypperPatch>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::ZypperPatch(v.into()),
-            );
-            self
-        }
-
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
         /// if it holds a `WuaPackage`, `None` if the field is not set or
         /// holds a different branch.
@@ -907,23 +788,6 @@ pub mod inventory {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `WuaPackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_wua_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::WindowsUpdatePackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::WuaPackage(v.into()),
-            );
-            self
         }
 
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
@@ -943,25 +807,6 @@ pub mod inventory {
             })
         }
 
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `QfePackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_qfe_package<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::inventory::WindowsQuickFixEngineeringPackage>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::QfePackage(v.into()),
-            );
-            self
-        }
-
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
         /// if it holds a `CosPackage`, `None` if the field is not set or
         /// holds a different branch.
@@ -978,23 +823,6 @@ pub mod inventory {
             })
         }
 
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `CosPackage`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_cos_package<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::VersionedPackage>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::CosPackage(v.into()),
-            );
-            self
-        }
-
         /// The value of [details][crate::model::inventory::SoftwarePackage::details]
         /// if it holds a `WindowsApplication`, `None` if the field is not set or
         /// holds a different branch.
@@ -1009,23 +837,6 @@ pub mod inventory {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [details][crate::model::inventory::SoftwarePackage::details]
-        /// to hold a `WindowsApplication`.
-        ///
-        /// Note that all the setters affecting `details` are
-        /// mutually exclusive.
-        pub fn set_windows_application<
-            T: std::convert::Into<std::boxed::Box<crate::model::inventory::WindowsApplication>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.details = std::option::Option::Some(
-                crate::model::inventory::software_package::Details::WindowsApplication(v.into()),
-            );
-            self
         }
     }
 
@@ -1959,23 +1770,6 @@ pub mod os_policy {
             })
         }
 
-        /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
-        /// to hold a `Pkg`.
-        ///
-        /// Note that all the setters affecting `resource_type` are
-        /// mutually exclusive.
-        pub fn set_pkg<
-            T: std::convert::Into<std::boxed::Box<crate::model::os_policy::resource::PackageResource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.resource_type = std::option::Option::Some(
-                crate::model::os_policy::resource::ResourceType::Pkg(v.into()),
-            );
-            self
-        }
-
         /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
         /// if it holds a `Repository`, `None` if the field is not set or
         /// holds a different branch.
@@ -1991,25 +1785,6 @@ pub mod os_policy {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
-        /// to hold a `Repository`.
-        ///
-        /// Note that all the setters affecting `resource_type` are
-        /// mutually exclusive.
-        pub fn set_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::os_policy::resource::RepositoryResource>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.resource_type = std::option::Option::Some(
-                crate::model::os_policy::resource::ResourceType::Repository(v.into()),
-            );
-            self
         }
 
         /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
@@ -2028,23 +1803,6 @@ pub mod os_policy {
             })
         }
 
-        /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
-        /// to hold a `Exec`.
-        ///
-        /// Note that all the setters affecting `resource_type` are
-        /// mutually exclusive.
-        pub fn set_exec<
-            T: std::convert::Into<std::boxed::Box<crate::model::os_policy::resource::ExecResource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.resource_type = std::option::Option::Some(
-                crate::model::os_policy::resource::ResourceType::Exec(v.into()),
-            );
-            self
-        }
-
         /// The value of [resource_type][crate::model::os_policy::Resource::resource_type]
         /// if it holds a `File`, `None` if the field is not set or
         /// holds a different branch.
@@ -2059,23 +1817,6 @@ pub mod os_policy {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [resource_type][crate::model::os_policy::Resource::resource_type]
-        /// to hold a `File`.
-        ///
-        /// Note that all the setters affecting `resource_type` are
-        /// mutually exclusive.
-        pub fn set_file<
-            T: std::convert::Into<std::boxed::Box<crate::model::os_policy::resource::FileResource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.resource_type = std::option::Option::Some(
-                crate::model::os_policy::resource::ResourceType::File(v.into()),
-            );
-            self
         }
     }
 
@@ -2156,25 +1897,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [r#type][crate::model::os_policy::resource::File::r#type]
-            /// to hold a `Remote`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_remote<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::os_policy::resource::file::Remote>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::os_policy::resource::file::Type::Remote(v.into()),
-                );
-                self
-            }
-
             /// The value of [r#type][crate::model::os_policy::resource::File::r#type]
             /// if it holds a `Gcs`, `None` if the field is not set or
             /// holds a different branch.
@@ -2191,23 +1913,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [r#type][crate::model::os_policy::resource::File::r#type]
-            /// to hold a `Gcs`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_gcs<
-                T: std::convert::Into<std::boxed::Box<crate::model::os_policy::resource::file::Gcs>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::os_policy::resource::file::Type::Gcs(v.into()),
-                );
-                self
-            }
-
             /// The value of [r#type][crate::model::os_policy::resource::File::r#type]
             /// if it holds a `LocalPath`, `None` if the field is not set or
             /// holds a different branch.
@@ -2219,21 +1924,6 @@ pub mod os_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [r#type][crate::model::os_policy::resource::File::r#type]
-            /// to hold a `LocalPath`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_local_path<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::os_policy::resource::file::Type::LocalPath(v.into()),
-                );
-                self
             }
         }
 
@@ -2440,27 +2130,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// to hold a `Apt`.
-            ///
-            /// Note that all the setters affecting `system_package` are
-            /// mutually exclusive.
-            pub fn set_apt<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::os_policy::resource::package_resource::Apt>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.system_package = std::option::Option::Some(
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Apt(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
             /// if it holds a `Deb`, `None` if the field is not set or
             /// holds a different branch.
@@ -2476,27 +2145,6 @@ pub mod os_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// to hold a `Deb`.
-            ///
-            /// Note that all the setters affecting `system_package` are
-            /// mutually exclusive.
-            pub fn set_deb<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::os_policy::resource::package_resource::Deb>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.system_package = std::option::Option::Some(
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Deb(
-                        v.into(),
-                    ),
-                );
-                self
             }
 
             /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
@@ -2516,27 +2164,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// to hold a `Yum`.
-            ///
-            /// Note that all the setters affecting `system_package` are
-            /// mutually exclusive.
-            pub fn set_yum<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::os_policy::resource::package_resource::Yum>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.system_package = std::option::Option::Some(
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Yum(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
             /// if it holds a `Zypper`, `None` if the field is not set or
             /// holds a different branch.
@@ -2552,29 +2179,6 @@ pub mod os_policy {
                     ) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// to hold a `Zypper`.
-            ///
-            /// Note that all the setters affecting `system_package` are
-            /// mutually exclusive.
-            pub fn set_zypper<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::os_policy::resource::package_resource::Zypper,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.system_package = std::option::Option::Some(
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Zypper(
-                        v.into(),
-                    ),
-                );
-                self
             }
 
             /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
@@ -2594,27 +2198,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// to hold a `Rpm`.
-            ///
-            /// Note that all the setters affecting `system_package` are
-            /// mutually exclusive.
-            pub fn set_rpm<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::os_policy::resource::package_resource::Rpm>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.system_package = std::option::Option::Some(
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Rpm(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
             /// if it holds a `Googet`, `None` if the field is not set or
             /// holds a different branch.
@@ -2632,29 +2215,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// to hold a `Googet`.
-            ///
-            /// Note that all the setters affecting `system_package` are
-            /// mutually exclusive.
-            pub fn set_googet<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::os_policy::resource::package_resource::GooGet,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.system_package = std::option::Option::Some(
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Googet(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
             /// if it holds a `Msi`, `None` if the field is not set or
             /// holds a different branch.
@@ -2670,27 +2230,6 @@ pub mod os_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [system_package][crate::model::os_policy::resource::PackageResource::system_package]
-            /// to hold a `Msi`.
-            ///
-            /// Note that all the setters affecting `system_package` are
-            /// mutually exclusive.
-            pub fn set_msi<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::os_policy::resource::package_resource::Msi>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.system_package = std::option::Option::Some(
-                    crate::model::os_policy::resource::package_resource::SystemPackage::Msi(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -3241,29 +2780,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
-            /// to hold a `Apt`.
-            ///
-            /// Note that all the setters affecting `repository` are
-            /// mutually exclusive.
-            pub fn set_apt<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::os_policy::resource::repository_resource::AptRepository,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.repository = std::option::Option::Some(
-                    crate::model::os_policy::resource::repository_resource::Repository::Apt(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
             /// if it holds a `Yum`, `None` if the field is not set or
             /// holds a different branch.
@@ -3281,29 +2797,6 @@ pub mod os_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
-            /// to hold a `Yum`.
-            ///
-            /// Note that all the setters affecting `repository` are
-            /// mutually exclusive.
-            pub fn set_yum<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::os_policy::resource::repository_resource::YumRepository,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.repository = std::option::Option::Some(
-                    crate::model::os_policy::resource::repository_resource::Repository::Yum(
-                        v.into(),
-                    ),
-                );
-                self
             }
 
             /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
@@ -3325,20 +2818,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
-            /// to hold a `Zypper`.
-            ///
-            /// Note that all the setters affecting `repository` are
-            /// mutually exclusive.
-            pub fn set_zypper<T: std::convert::Into<std::boxed::Box<crate::model::os_policy::resource::repository_resource::ZypperRepository>>>(mut self, v: T) -> Self{
-                self.repository = std::option::Option::Some(
-                    crate::model::os_policy::resource::repository_resource::Repository::Zypper(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
             /// if it holds a `Goo`, `None` if the field is not set or
             /// holds a different branch.
@@ -3356,29 +2835,6 @@ pub mod os_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [repository][crate::model::os_policy::resource::RepositoryResource::repository]
-            /// to hold a `Goo`.
-            ///
-            /// Note that all the setters affecting `repository` are
-            /// mutually exclusive.
-            pub fn set_goo<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::os_policy::resource::repository_resource::GooRepository,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.repository = std::option::Option::Some(
-                    crate::model::os_policy::resource::repository_resource::Repository::Goo(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -4056,25 +3512,6 @@ pub mod os_policy {
                     })
                 }
 
-                /// Sets the value of [source][crate::model::os_policy::resource::exec_resource::Exec::source]
-                /// to hold a `File`.
-                ///
-                /// Note that all the setters affecting `source` are
-                /// mutually exclusive.
-                pub fn set_file<
-                    T: std::convert::Into<std::boxed::Box<crate::model::os_policy::resource::File>>,
-                >(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.source = std::option::Option::Some(
-                        crate::model::os_policy::resource::exec_resource::exec::Source::File(
-                            v.into(),
-                        ),
-                    );
-                    self
-                }
-
                 /// The value of [source][crate::model::os_policy::resource::exec_resource::Exec::source]
                 /// if it holds a `Script`, `None` if the field is not set or
                 /// holds a different branch.
@@ -4086,23 +3523,6 @@ pub mod os_policy {
                         ) => std::option::Option::Some(v),
                         _ => std::option::Option::None,
                     })
-                }
-
-                /// Sets the value of [source][crate::model::os_policy::resource::exec_resource::Exec::source]
-                /// to hold a `Script`.
-                ///
-                /// Note that all the setters affecting `source` are
-                /// mutually exclusive.
-                pub fn set_script<T: std::convert::Into<std::string::String>>(
-                    mut self,
-                    v: T,
-                ) -> Self {
-                    self.source = std::option::Option::Some(
-                        crate::model::os_policy::resource::exec_resource::exec::Source::Script(
-                            v.into(),
-                        ),
-                    );
-                    self
                 }
             }
 
@@ -4383,23 +3803,6 @@ pub mod os_policy {
                 })
             }
 
-            /// Sets the value of [source][crate::model::os_policy::resource::FileResource::source]
-            /// to hold a `File`.
-            ///
-            /// Note that all the setters affecting `source` are
-            /// mutually exclusive.
-            pub fn set_file<
-                T: std::convert::Into<std::boxed::Box<crate::model::os_policy::resource::File>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.source = std::option::Option::Some(
-                    crate::model::os_policy::resource::file_resource::Source::File(v.into()),
-                );
-                self
-            }
-
             /// The value of [source][crate::model::os_policy::resource::FileResource::source]
             /// if it holds a `Content`, `None` if the field is not set or
             /// holds a different branch.
@@ -4411,18 +3814,6 @@ pub mod os_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [source][crate::model::os_policy::resource::FileResource::source]
-            /// to hold a `Content`.
-            ///
-            /// Note that all the setters affecting `source` are
-            /// mutually exclusive.
-            pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.source = std::option::Option::Some(
-                    crate::model::os_policy::resource::file_resource::Source::Content(v.into()),
-                );
-                self
             }
         }
 
@@ -5320,20 +4711,6 @@ pub mod os_policy_assignment_report {
                     crate::model::os_policy_assignment_report::os_policy_compliance::os_policy_resource_compliance::Output::ExecResourceOutput(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [output][crate::model::os_policy_assignment_report::os_policy_compliance::OSPolicyResourceCompliance::output]
-            /// to hold a `ExecResourceOutput`.
-            ///
-            /// Note that all the setters affecting `output` are
-            /// mutually exclusive.
-            pub fn set_exec_resource_output<T: std::convert::Into<std::boxed::Box<crate::model::os_policy_assignment_report::os_policy_compliance::os_policy_resource_compliance::ExecResourceOutput>>>(mut self, v: T) -> Self{
-                self.output = std::option::Option::Some(
-                    crate::model::os_policy_assignment_report::os_policy_compliance::os_policy_resource_compliance::Output::ExecResourceOutput(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -7359,17 +6736,6 @@ impl FixedOrPercent {
         })
     }
 
-    /// Sets the value of [mode][crate::model::FixedOrPercent::mode]
-    /// to hold a `Fixed`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_fixed<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.mode =
-            std::option::Option::Some(crate::model::fixed_or_percent::Mode::Fixed(v.into()));
-        self
-    }
-
     /// The value of [mode][crate::model::FixedOrPercent::mode]
     /// if it holds a `Percent`, `None` if the field is not set or
     /// holds a different branch.
@@ -7379,17 +6745,6 @@ impl FixedOrPercent {
             crate::model::fixed_or_percent::Mode::Percent(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [mode][crate::model::FixedOrPercent::mode]
-    /// to hold a `Percent`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_percent<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.mode =
-            std::option::Option::Some(crate::model::fixed_or_percent::Mode::Percent(v.into()));
-        self
     }
 }
 
@@ -7606,23 +6961,6 @@ impl PatchDeployment {
         })
     }
 
-    /// Sets the value of [schedule][crate::model::PatchDeployment::schedule]
-    /// to hold a `OneTimeSchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_one_time_schedule<
-        T: std::convert::Into<std::boxed::Box<crate::model::OneTimeSchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::patch_deployment::Schedule::OneTimeSchedule(v.into()),
-        );
-        self
-    }
-
     /// The value of [schedule][crate::model::PatchDeployment::schedule]
     /// if it holds a `RecurringSchedule`, `None` if the field is not set or
     /// holds a different branch.
@@ -7636,23 +6974,6 @@ impl PatchDeployment {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schedule][crate::model::PatchDeployment::schedule]
-    /// to hold a `RecurringSchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_recurring_schedule<
-        T: std::convert::Into<std::boxed::Box<crate::model::RecurringSchedule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::patch_deployment::Schedule::RecurringSchedule(v.into()),
-        );
-        self
     }
 }
 
@@ -7989,21 +7310,6 @@ impl RecurringSchedule {
         })
     }
 
-    /// Sets the value of [schedule_config][crate::model::RecurringSchedule::schedule_config]
-    /// to hold a `Weekly`.
-    ///
-    /// Note that all the setters affecting `schedule_config` are
-    /// mutually exclusive.
-    pub fn set_weekly<T: std::convert::Into<std::boxed::Box<crate::model::WeeklySchedule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule_config = std::option::Option::Some(
-            crate::model::recurring_schedule::ScheduleConfig::Weekly(v.into()),
-        );
-        self
-    }
-
     /// The value of [schedule_config][crate::model::RecurringSchedule::schedule_config]
     /// if it holds a `Monthly`, `None` if the field is not set or
     /// holds a different branch.
@@ -8015,21 +7321,6 @@ impl RecurringSchedule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schedule_config][crate::model::RecurringSchedule::schedule_config]
-    /// to hold a `Monthly`.
-    ///
-    /// Note that all the setters affecting `schedule_config` are
-    /// mutually exclusive.
-    pub fn set_monthly<T: std::convert::Into<std::boxed::Box<crate::model::MonthlySchedule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule_config = std::option::Option::Some(
-            crate::model::recurring_schedule::ScheduleConfig::Monthly(v.into()),
-        );
-        self
     }
 }
 
@@ -8280,23 +7571,6 @@ impl MonthlySchedule {
         })
     }
 
-    /// Sets the value of [day_of_month][crate::model::MonthlySchedule::day_of_month]
-    /// to hold a `WeekDayOfMonth`.
-    ///
-    /// Note that all the setters affecting `day_of_month` are
-    /// mutually exclusive.
-    pub fn set_week_day_of_month<
-        T: std::convert::Into<std::boxed::Box<crate::model::WeekDayOfMonth>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.day_of_month = std::option::Option::Some(
-            crate::model::monthly_schedule::DayOfMonth::WeekDayOfMonth(v.into()),
-        );
-        self
-    }
-
     /// The value of [day_of_month][crate::model::MonthlySchedule::day_of_month]
     /// if it holds a `MonthDay`, `None` if the field is not set or
     /// holds a different branch.
@@ -8306,18 +7580,6 @@ impl MonthlySchedule {
             crate::model::monthly_schedule::DayOfMonth::MonthDay(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [day_of_month][crate::model::MonthlySchedule::day_of_month]
-    /// to hold a `MonthDay`.
-    ///
-    /// Note that all the setters affecting `day_of_month` are
-    /// mutually exclusive.
-    pub fn set_month_day<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.day_of_month = std::option::Option::Some(
-            crate::model::monthly_schedule::DayOfMonth::MonthDay(v.into()),
-        );
-        self
     }
 }
 
@@ -11268,18 +10530,6 @@ impl ExecStepConfig {
         })
     }
 
-    /// Sets the value of [executable][crate::model::ExecStepConfig::executable]
-    /// to hold a `LocalPath`.
-    ///
-    /// Note that all the setters affecting `executable` are
-    /// mutually exclusive.
-    pub fn set_local_path<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.executable = std::option::Option::Some(
-            crate::model::exec_step_config::Executable::LocalPath(v.into()),
-        );
-        self
-    }
-
     /// The value of [executable][crate::model::ExecStepConfig::executable]
     /// if it holds a `GcsObject`, `None` if the field is not set or
     /// holds a different branch.
@@ -11291,21 +10541,6 @@ impl ExecStepConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [executable][crate::model::ExecStepConfig::executable]
-    /// to hold a `GcsObject`.
-    ///
-    /// Note that all the setters affecting `executable` are
-    /// mutually exclusive.
-    pub fn set_gcs_object<T: std::convert::Into<std::boxed::Box<crate::model::GcsObject>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.executable = std::option::Option::Some(
-            crate::model::exec_step_config::Executable::GcsObject(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/parallelstore/v1/src/builder.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builder.rs
@@ -720,21 +720,6 @@ pub mod parallelstore {
             self
         }
 
-        /// Sets the value of [source][crate::model::ImportDataRequest::source]
-        /// to hold a `SourceGcsBucket`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_source_gcs_bucket<
-            T: std::convert::Into<std::boxed::Box<crate::model::SourceGcsBucket>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_source_gcs_bucket(v);
-            self
-        }
-
         /// Sets the value of [destination][crate::model::ImportDataRequest::destination].
         ///
         /// Note that all the setters affecting `destination` are
@@ -744,21 +729,6 @@ pub mod parallelstore {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ImportDataRequest::destination]
-        /// to hold a `DestinationParallelstore`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_destination_parallelstore<
-            T: std::convert::Into<std::boxed::Box<crate::model::DestinationParallelstore>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_destination_parallelstore(v);
             self
         }
     }
@@ -890,21 +860,6 @@ pub mod parallelstore {
             self
         }
 
-        /// Sets the value of [source][crate::model::ExportDataRequest::source]
-        /// to hold a `SourceParallelstore`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_source_parallelstore<
-            T: std::convert::Into<std::boxed::Box<crate::model::SourceParallelstore>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_source_parallelstore(v);
-            self
-        }
-
         /// Sets the value of [destination][crate::model::ExportDataRequest::destination].
         ///
         /// Note that all the setters affecting `destination` are
@@ -914,21 +869,6 @@ pub mod parallelstore {
             v: T,
         ) -> Self {
             self.0.request.destination = v.into();
-            self
-        }
-
-        /// Sets the value of [destination][crate::model::ExportDataRequest::destination]
-        /// to hold a `DestinationGcsBucket`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_destination_gcs_bucket<
-            T: std::convert::Into<std::boxed::Box<crate::model::DestinationGcsBucket>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_destination_gcs_bucket(v);
             self
         }
     }

--- a/src/generated/cloud/parallelstore/v1/src/model.rs
+++ b/src/generated/cloud/parallelstore/v1/src/model.rs
@@ -1179,23 +1179,6 @@ impl ImportDataRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportDataRequest::source]
-    /// to hold a `SourceGcsBucket`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_gcs_bucket<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceGcsBucket>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_data_request::Source::SourceGcsBucket(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [destination][crate::model::ImportDataRequest::destination].
     ///
     /// Note that all the setters affecting `destination` are mutually
@@ -1223,23 +1206,6 @@ impl ImportDataRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ImportDataRequest::destination]
-    /// to hold a `DestinationParallelstore`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_parallelstore<
-        T: std::convert::Into<std::boxed::Box<crate::model::DestinationParallelstore>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::import_data_request::Destination::DestinationParallelstore(v.into()),
-        );
-        self
     }
 }
 
@@ -1378,23 +1344,6 @@ impl ExportDataRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ExportDataRequest::source]
-    /// to hold a `SourceParallelstore`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_parallelstore<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceParallelstore>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::export_data_request::Source::SourceParallelstore(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [destination][crate::model::ExportDataRequest::destination].
     ///
     /// Note that all the setters affecting `destination` are mutually
@@ -1422,23 +1371,6 @@ impl ExportDataRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportDataRequest::destination]
-    /// to hold a `DestinationGcsBucket`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_gcs_bucket<
-        T: std::convert::Into<std::boxed::Box<crate::model::DestinationGcsBucket>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_data_request::Destination::DestinationGcsBucket(v.into()),
-        );
-        self
     }
 }
 
@@ -1959,23 +1891,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
-    /// to hold a `SourceParallelstore`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_parallelstore<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceParallelstore>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Source::SourceParallelstore(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::TransferOperationMetadata::source]
     /// if it holds a `SourceGcsBucket`, `None` if the field is not set or
     /// holds a different branch.
@@ -1989,23 +1904,6 @@ impl TransferOperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::TransferOperationMetadata::source]
-    /// to hold a `SourceGcsBucket`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_source_gcs_bucket<
-        T: std::convert::Into<std::boxed::Box<crate::model::SourceGcsBucket>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Source::SourceGcsBucket(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination].
@@ -2039,23 +1937,6 @@ impl TransferOperationMetadata {
         })
     }
 
-    /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]
-    /// to hold a `DestinationGcsBucket`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_gcs_bucket<
-        T: std::convert::Into<std::boxed::Box<crate::model::DestinationGcsBucket>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Destination::DestinationGcsBucket(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::TransferOperationMetadata::destination]
     /// if it holds a `DestinationParallelstore`, `None` if the field is not set or
     /// holds a different branch.
@@ -2069,25 +1950,6 @@ impl TransferOperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::TransferOperationMetadata::destination]
-    /// to hold a `DestinationParallelstore`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_destination_parallelstore<
-        T: std::convert::Into<std::boxed::Box<crate::model::DestinationParallelstore>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::transfer_operation_metadata::Destination::DestinationParallelstore(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/policysimulator/v1/src/model.rs
+++ b/src/generated/cloud/policysimulator/v1/src/model.rs
@@ -1170,20 +1170,6 @@ impl ReplayResult {
         })
     }
 
-    /// Sets the value of [result][crate::model::ReplayResult::result]
-    /// to hold a `Diff`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_diff<T: std::convert::Into<std::boxed::Box<crate::model::ReplayDiff>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::replay_result::Result::Diff(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::ReplayResult::result]
     /// if it holds a `Error`, `None` if the field is not set or
     /// holds a different branch.
@@ -1193,20 +1179,6 @@ impl ReplayResult {
             crate::model::replay_result::Result::Error(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::ReplayResult::result]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::replay_result::Result::Error(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/model.rs
@@ -180,29 +180,6 @@ pub mod check_onboarding_status_response {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [finding_type][crate::model::check_onboarding_status_response::Finding::finding_type]
-        /// to hold a `IamAccessDenied`.
-        ///
-        /// Note that all the setters affecting `finding_type` are
-        /// mutually exclusive.
-        pub fn set_iam_access_denied<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::check_onboarding_status_response::finding::IAMAccessDenied,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.finding_type = std::option::Option::Some(
-                crate::model::check_onboarding_status_response::finding::FindingType::IamAccessDenied(
-                    v.into()
-                )
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for Finding {
@@ -516,29 +493,6 @@ pub mod entitlement {
             })
         }
 
-        /// Sets the value of [justification_type][crate::model::entitlement::RequesterJustificationConfig::justification_type]
-        /// to hold a `NotMandatory`.
-        ///
-        /// Note that all the setters affecting `justification_type` are
-        /// mutually exclusive.
-        pub fn set_not_mandatory<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::entitlement::requester_justification_config::NotMandatory,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.justification_type = std::option::Option::Some(
-                crate::model::entitlement::requester_justification_config::JustificationType::NotMandatory(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [justification_type][crate::model::entitlement::RequesterJustificationConfig::justification_type]
         /// if it holds a `Unstructured`, `None` if the field is not set or
         /// holds a different branch.
@@ -554,29 +508,6 @@ pub mod entitlement {
                 crate::model::entitlement::requester_justification_config::JustificationType::Unstructured(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [justification_type][crate::model::entitlement::RequesterJustificationConfig::justification_type]
-        /// to hold a `Unstructured`.
-        ///
-        /// Note that all the setters affecting `justification_type` are
-        /// mutually exclusive.
-        pub fn set_unstructured<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::entitlement::requester_justification_config::Unstructured,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.justification_type = std::option::Option::Some(
-                crate::model::entitlement::requester_justification_config::JustificationType::Unstructured(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -955,23 +886,6 @@ impl ApprovalWorkflow {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [approval_workflow][crate::model::ApprovalWorkflow::approval_workflow]
-    /// to hold a `ManualApprovals`.
-    ///
-    /// Note that all the setters affecting `approval_workflow` are
-    /// mutually exclusive.
-    pub fn set_manual_approvals<
-        T: std::convert::Into<std::boxed::Box<crate::model::ManualApprovals>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.approval_workflow = std::option::Option::Some(
-            crate::model::approval_workflow::ApprovalWorkflow::ManualApprovals(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ApprovalWorkflow {
@@ -1176,23 +1090,6 @@ impl PrivilegedAccess {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [access_type][crate::model::PrivilegedAccess::access_type]
-    /// to hold a `GcpIamAccess`.
-    ///
-    /// Note that all the setters affecting `access_type` are
-    /// mutually exclusive.
-    pub fn set_gcp_iam_access<
-        T: std::convert::Into<std::boxed::Box<crate::model::privileged_access::GcpIamAccess>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.access_type = std::option::Option::Some(
-            crate::model::privileged_access::AccessType::GcpIamAccess(v.into()),
-        );
-        self
     }
 }
 
@@ -2318,25 +2215,6 @@ pub mod grant {
                 })
             }
 
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Requested`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_requested<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::grant::timeline::event::Requested>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Requested(v.into()),
-                );
-                self
-            }
-
             /// The value of [event][crate::model::grant::timeline::Event::event]
             /// if it holds a `Approved`, `None` if the field is not set or
             /// holds a different branch.
@@ -2351,23 +2229,6 @@ pub mod grant {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Approved`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_approved<
-                T: std::convert::Into<std::boxed::Box<crate::model::grant::timeline::event::Approved>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Approved(v.into()),
-                );
-                self
             }
 
             /// The value of [event][crate::model::grant::timeline::Event::event]
@@ -2386,23 +2247,6 @@ pub mod grant {
                 })
             }
 
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Denied`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_denied<
-                T: std::convert::Into<std::boxed::Box<crate::model::grant::timeline::event::Denied>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Denied(v.into()),
-                );
-                self
-            }
-
             /// The value of [event][crate::model::grant::timeline::Event::event]
             /// if it holds a `Revoked`, `None` if the field is not set or
             /// holds a different branch.
@@ -2417,23 +2261,6 @@ pub mod grant {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Revoked`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_revoked<
-                T: std::convert::Into<std::boxed::Box<crate::model::grant::timeline::event::Revoked>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Revoked(v.into()),
-                );
-                self
             }
 
             /// The value of [event][crate::model::grant::timeline::Event::event]
@@ -2453,25 +2280,6 @@ pub mod grant {
                 })
             }
 
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Scheduled`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_scheduled<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::grant::timeline::event::Scheduled>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Scheduled(v.into()),
-                );
-                self
-            }
-
             /// The value of [event][crate::model::grant::timeline::Event::event]
             /// if it holds a `Activated`, `None` if the field is not set or
             /// holds a different branch.
@@ -2487,25 +2295,6 @@ pub mod grant {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Activated`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_activated<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::grant::timeline::event::Activated>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Activated(v.into()),
-                );
-                self
             }
 
             /// The value of [event][crate::model::grant::timeline::Event::event]
@@ -2525,25 +2314,6 @@ pub mod grant {
                 })
             }
 
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `ActivationFailed`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_activation_failed<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::grant::timeline::event::ActivationFailed>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::ActivationFailed(v.into()),
-                );
-                self
-            }
-
             /// The value of [event][crate::model::grant::timeline::Event::event]
             /// if it holds a `Expired`, `None` if the field is not set or
             /// holds a different branch.
@@ -2558,23 +2328,6 @@ pub mod grant {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Expired`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_expired<
-                T: std::convert::Into<std::boxed::Box<crate::model::grant::timeline::event::Expired>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Expired(v.into()),
-                );
-                self
             }
 
             /// The value of [event][crate::model::grant::timeline::Event::event]
@@ -2593,23 +2346,6 @@ pub mod grant {
                 })
             }
 
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `Ended`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_ended<
-                T: std::convert::Into<std::boxed::Box<crate::model::grant::timeline::event::Ended>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::Ended(v.into()),
-                );
-                self
-            }
-
             /// The value of [event][crate::model::grant::timeline::Event::event]
             /// if it holds a `ExternallyModified`, `None` if the field is not set or
             /// holds a different branch.
@@ -2625,25 +2361,6 @@ pub mod grant {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [event][crate::model::grant::timeline::Event::event]
-            /// to hold a `ExternallyModified`.
-            ///
-            /// Note that all the setters affecting `event` are
-            /// mutually exclusive.
-            pub fn set_externally_modified<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::grant::timeline::event::ExternallyModified>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.event = std::option::Option::Some(
-                    crate::model::grant::timeline::event::Event::ExternallyModified(v.into()),
-                );
-                self
             }
         }
 
@@ -3331,21 +3048,6 @@ impl Justification {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [justification][crate::model::Justification::justification]
-    /// to hold a `UnstructuredJustification`.
-    ///
-    /// Note that all the setters affecting `justification` are
-    /// mutually exclusive.
-    pub fn set_unstructured_justification<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.justification = std::option::Option::Some(
-            crate::model::justification::Justification::UnstructuredJustification(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/model.rs
@@ -1035,18 +1035,6 @@ impl EndpointVerificationInfo {
         })
     }
 
-    /// Sets the value of [endpoint][crate::model::EndpointVerificationInfo::endpoint]
-    /// to hold a `EmailAddress`.
-    ///
-    /// Note that all the setters affecting `endpoint` are
-    /// mutually exclusive.
-    pub fn set_email_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.endpoint = std::option::Option::Some(
-            crate::model::endpoint_verification_info::Endpoint::EmailAddress(v.into()),
-        );
-        self
-    }
-
     /// The value of [endpoint][crate::model::EndpointVerificationInfo::endpoint]
     /// if it holds a `PhoneNumber`, `None` if the field is not set or
     /// holds a different branch.
@@ -1058,18 +1046,6 @@ impl EndpointVerificationInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [endpoint][crate::model::EndpointVerificationInfo::endpoint]
-    /// to hold a `PhoneNumber`.
-    ///
-    /// Note that all the setters affecting `endpoint` are
-    /// mutually exclusive.
-    pub fn set_phone_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.endpoint = std::option::Option::Some(
-            crate::model::endpoint_verification_info::Endpoint::PhoneNumber(v.into()),
-        );
-        self
     }
 }
 
@@ -2678,16 +2654,6 @@ impl UserId {
         })
     }
 
-    /// Sets the value of [id_oneof][crate::model::UserId::id_oneof]
-    /// to hold a `Email`.
-    ///
-    /// Note that all the setters affecting `id_oneof` are
-    /// mutually exclusive.
-    pub fn set_email<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.id_oneof = std::option::Option::Some(crate::model::user_id::IdOneof::Email(v.into()));
-        self
-    }
-
     /// The value of [id_oneof][crate::model::UserId::id_oneof]
     /// if it holds a `PhoneNumber`, `None` if the field is not set or
     /// holds a different branch.
@@ -2699,17 +2665,6 @@ impl UserId {
         })
     }
 
-    /// Sets the value of [id_oneof][crate::model::UserId::id_oneof]
-    /// to hold a `PhoneNumber`.
-    ///
-    /// Note that all the setters affecting `id_oneof` are
-    /// mutually exclusive.
-    pub fn set_phone_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.id_oneof =
-            std::option::Option::Some(crate::model::user_id::IdOneof::PhoneNumber(v.into()));
-        self
-    }
-
     /// The value of [id_oneof][crate::model::UserId::id_oneof]
     /// if it holds a `Username`, `None` if the field is not set or
     /// holds a different branch.
@@ -2719,17 +2674,6 @@ impl UserId {
             crate::model::user_id::IdOneof::Username(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [id_oneof][crate::model::UserId::id_oneof]
-    /// to hold a `Username`.
-    ///
-    /// Note that all the setters affecting `id_oneof` are
-    /// mutually exclusive.
-    pub fn set_username<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.id_oneof =
-            std::option::Option::Some(crate::model::user_id::IdOneof::Username(v.into()));
-        self
     }
 }
 
@@ -5343,22 +5287,6 @@ impl Key {
         })
     }
 
-    /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
-    /// to hold a `WebSettings`.
-    ///
-    /// Note that all the setters affecting `platform_settings` are
-    /// mutually exclusive.
-    pub fn set_web_settings<
-        T: std::convert::Into<std::boxed::Box<crate::model::WebKeySettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.platform_settings =
-            std::option::Option::Some(crate::model::key::PlatformSettings::WebSettings(v.into()));
-        self
-    }
-
     /// The value of [platform_settings][crate::model::Key::platform_settings]
     /// if it holds a `AndroidSettings`, `None` if the field is not set or
     /// holds a different branch.
@@ -5370,23 +5298,6 @@ impl Key {
             crate::model::key::PlatformSettings::AndroidSettings(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
-    /// to hold a `AndroidSettings`.
-    ///
-    /// Note that all the setters affecting `platform_settings` are
-    /// mutually exclusive.
-    pub fn set_android_settings<
-        T: std::convert::Into<std::boxed::Box<crate::model::AndroidKeySettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.platform_settings = std::option::Option::Some(
-            crate::model::key::PlatformSettings::AndroidSettings(v.into()),
-        );
-        self
     }
 
     /// The value of [platform_settings][crate::model::Key::platform_settings]
@@ -5402,22 +5313,6 @@ impl Key {
         })
     }
 
-    /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
-    /// to hold a `IosSettings`.
-    ///
-    /// Note that all the setters affecting `platform_settings` are
-    /// mutually exclusive.
-    pub fn set_ios_settings<
-        T: std::convert::Into<std::boxed::Box<crate::model::IOSKeySettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.platform_settings =
-            std::option::Option::Some(crate::model::key::PlatformSettings::IosSettings(v.into()));
-        self
-    }
-
     /// The value of [platform_settings][crate::model::Key::platform_settings]
     /// if it holds a `ExpressSettings`, `None` if the field is not set or
     /// holds a different branch.
@@ -5429,23 +5324,6 @@ impl Key {
             crate::model::key::PlatformSettings::ExpressSettings(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [platform_settings][crate::model::Key::platform_settings]
-    /// to hold a `ExpressSettings`.
-    ///
-    /// Note that all the setters affecting `platform_settings` are
-    /// mutually exclusive.
-    pub fn set_express_settings<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExpressKeySettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.platform_settings = std::option::Option::Some(
-            crate::model::key::PlatformSettings::ExpressSettings(v.into()),
-        );
-        self
     }
 }
 
@@ -6527,23 +6405,6 @@ impl FirewallAction {
         })
     }
 
-    /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// to hold a `Allow`.
-    ///
-    /// Note that all the setters affecting `firewall_action_oneof` are
-    /// mutually exclusive.
-    pub fn set_allow<
-        T: std::convert::Into<std::boxed::Box<crate::model::firewall_action::AllowAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.firewall_action_oneof = std::option::Option::Some(
-            crate::model::firewall_action::FirewallActionOneof::Allow(v.into()),
-        );
-        self
-    }
-
     /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
     /// if it holds a `Block`, `None` if the field is not set or
     /// holds a different branch.
@@ -6557,23 +6418,6 @@ impl FirewallAction {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// to hold a `Block`.
-    ///
-    /// Note that all the setters affecting `firewall_action_oneof` are
-    /// mutually exclusive.
-    pub fn set_block<
-        T: std::convert::Into<std::boxed::Box<crate::model::firewall_action::BlockAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.firewall_action_oneof = std::option::Option::Some(
-            crate::model::firewall_action::FirewallActionOneof::Block(v.into()),
-        );
-        self
     }
 
     /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
@@ -6593,25 +6437,6 @@ impl FirewallAction {
         })
     }
 
-    /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// to hold a `IncludeRecaptchaScript`.
-    ///
-    /// Note that all the setters affecting `firewall_action_oneof` are
-    /// mutually exclusive.
-    pub fn set_include_recaptcha_script<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::firewall_action::IncludeRecaptchaScriptAction>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.firewall_action_oneof = std::option::Option::Some(
-            crate::model::firewall_action::FirewallActionOneof::IncludeRecaptchaScript(v.into()),
-        );
-        self
-    }
-
     /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
     /// if it holds a `Redirect`, `None` if the field is not set or
     /// holds a different branch.
@@ -6625,23 +6450,6 @@ impl FirewallAction {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// to hold a `Redirect`.
-    ///
-    /// Note that all the setters affecting `firewall_action_oneof` are
-    /// mutually exclusive.
-    pub fn set_redirect<
-        T: std::convert::Into<std::boxed::Box<crate::model::firewall_action::RedirectAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.firewall_action_oneof = std::option::Option::Some(
-            crate::model::firewall_action::FirewallActionOneof::Redirect(v.into()),
-        );
-        self
     }
 
     /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
@@ -6660,23 +6468,6 @@ impl FirewallAction {
         })
     }
 
-    /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// to hold a `Substitute`.
-    ///
-    /// Note that all the setters affecting `firewall_action_oneof` are
-    /// mutually exclusive.
-    pub fn set_substitute<
-        T: std::convert::Into<std::boxed::Box<crate::model::firewall_action::SubstituteAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.firewall_action_oneof = std::option::Option::Some(
-            crate::model::firewall_action::FirewallActionOneof::Substitute(v.into()),
-        );
-        self
-    }
-
     /// The value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
     /// if it holds a `SetHeader`, `None` if the field is not set or
     /// holds a different branch.
@@ -6690,23 +6481,6 @@ impl FirewallAction {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [firewall_action_oneof][crate::model::FirewallAction::firewall_action_oneof]
-    /// to hold a `SetHeader`.
-    ///
-    /// Note that all the setters affecting `firewall_action_oneof` are
-    /// mutually exclusive.
-    pub fn set_set_header<
-        T: std::convert::Into<std::boxed::Box<crate::model::firewall_action::SetHeaderAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.firewall_action_oneof = std::option::Option::Some(
-            crate::model::firewall_action::FirewallActionOneof::SetHeader(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/recommender/v1/src/model.rs
+++ b/src/generated/cloud/recommender/v1/src/model.rs
@@ -1576,17 +1576,6 @@ impl Operation {
         })
     }
 
-    /// Sets the value of [path_value][crate::model::Operation::path_value]
-    /// to hold a `Value`.
-    ///
-    /// Note that all the setters affecting `path_value` are
-    /// mutually exclusive.
-    pub fn set_value<T: std::convert::Into<std::boxed::Box<wkt::Value>>>(mut self, v: T) -> Self {
-        self.path_value =
-            std::option::Option::Some(crate::model::operation::PathValue::Value(v.into()));
-        self
-    }
-
     /// The value of [path_value][crate::model::Operation::path_value]
     /// if it holds a `ValueMatcher`, `None` if the field is not set or
     /// holds a different branch.
@@ -1598,20 +1587,6 @@ impl Operation {
             crate::model::operation::PathValue::ValueMatcher(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [path_value][crate::model::Operation::path_value]
-    /// to hold a `ValueMatcher`.
-    ///
-    /// Note that all the setters affecting `path_value` are
-    /// mutually exclusive.
-    pub fn set_value_matcher<T: std::convert::Into<std::boxed::Box<crate::model::ValueMatcher>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.path_value =
-            std::option::Option::Some(crate::model::operation::PathValue::ValueMatcher(v.into()));
-        self
     }
 }
 
@@ -1686,18 +1661,6 @@ impl ValueMatcher {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [match_variant][crate::model::ValueMatcher::match_variant]
-    /// to hold a `MatchesPattern`.
-    ///
-    /// Note that all the setters affecting `match_variant` are
-    /// mutually exclusive.
-    pub fn set_matches_pattern<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.match_variant = std::option::Option::Some(
-            crate::model::value_matcher::MatchVariant::MatchesPattern(v.into()),
-        );
-        self
     }
 }
 
@@ -2130,22 +2093,6 @@ impl Impact {
         })
     }
 
-    /// Sets the value of [projection][crate::model::Impact::projection]
-    /// to hold a `CostProjection`.
-    ///
-    /// Note that all the setters affecting `projection` are
-    /// mutually exclusive.
-    pub fn set_cost_projection<
-        T: std::convert::Into<std::boxed::Box<crate::model::CostProjection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.projection =
-            std::option::Option::Some(crate::model::impact::Projection::CostProjection(v.into()));
-        self
-    }
-
     /// The value of [projection][crate::model::Impact::projection]
     /// if it holds a `SecurityProjection`, `None` if the field is not set or
     /// holds a different branch.
@@ -2157,23 +2104,6 @@ impl Impact {
             crate::model::impact::Projection::SecurityProjection(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [projection][crate::model::Impact::projection]
-    /// to hold a `SecurityProjection`.
-    ///
-    /// Note that all the setters affecting `projection` are
-    /// mutually exclusive.
-    pub fn set_security_projection<
-        T: std::convert::Into<std::boxed::Box<crate::model::SecurityProjection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.projection = std::option::Option::Some(
-            crate::model::impact::Projection::SecurityProjection(v.into()),
-        );
-        self
     }
 
     /// The value of [projection][crate::model::Impact::projection]
@@ -2191,23 +2121,6 @@ impl Impact {
         })
     }
 
-    /// Sets the value of [projection][crate::model::Impact::projection]
-    /// to hold a `SustainabilityProjection`.
-    ///
-    /// Note that all the setters affecting `projection` are
-    /// mutually exclusive.
-    pub fn set_sustainability_projection<
-        T: std::convert::Into<std::boxed::Box<crate::model::SustainabilityProjection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.projection = std::option::Option::Some(
-            crate::model::impact::Projection::SustainabilityProjection(v.into()),
-        );
-        self
-    }
-
     /// The value of [projection][crate::model::Impact::projection]
     /// if it holds a `ReliabilityProjection`, `None` if the field is not set or
     /// holds a different branch.
@@ -2221,23 +2134,6 @@ impl Impact {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [projection][crate::model::Impact::projection]
-    /// to hold a `ReliabilityProjection`.
-    ///
-    /// Note that all the setters affecting `projection` are
-    /// mutually exclusive.
-    pub fn set_reliability_projection<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReliabilityProjection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.projection = std::option::Option::Some(
-            crate::model::impact::Projection::ReliabilityProjection(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/redis/cluster/v1/src/builder.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builder.rs
@@ -1322,16 +1322,6 @@ pub mod cloud_redis_cluster {
             self.0.request.destination = v.into();
             self
         }
-
-        /// Sets the value of [destination][crate::model::ExportBackupRequest::destination]
-        /// to hold a `GcsBucket`.
-        ///
-        /// Note that all the setters affecting `destination` are
-        /// mutually exclusive.
-        pub fn set_gcs_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_gcs_bucket(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/redis/cluster/v1/src/model.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/model.rs
@@ -892,18 +892,6 @@ impl ExportBackupRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [destination][crate::model::ExportBackupRequest::destination]
-    /// to hold a `GcsBucket`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_bucket<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_backup_request::Destination::GcsBucket(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExportBackupRequest {
@@ -1432,22 +1420,6 @@ impl Cluster {
         })
     }
 
-    /// Sets the value of [import_sources][crate::model::Cluster::import_sources]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `import_sources` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::cluster::GcsBackupSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_sources =
-            std::option::Option::Some(crate::model::cluster::ImportSources::GcsSource(v.into()));
-        self
-    }
-
     /// The value of [import_sources][crate::model::Cluster::import_sources]
     /// if it holds a `ManagedBackupSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -1461,23 +1433,6 @@ impl Cluster {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [import_sources][crate::model::Cluster::import_sources]
-    /// to hold a `ManagedBackupSource`.
-    ///
-    /// Note that all the setters affecting `import_sources` are
-    /// mutually exclusive.
-    pub fn set_managed_backup_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::cluster::ManagedBackupSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.import_sources = std::option::Option::Some(
-            crate::model::cluster::ImportSources::ManagedBackupSource(v.into()),
-        );
-        self
     }
 }
 
@@ -1538,23 +1493,6 @@ pub mod cluster {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [info][crate::model::cluster::StateInfo::info]
-        /// to hold a `UpdateInfo`.
-        ///
-        /// Note that all the setters affecting `info` are
-        /// mutually exclusive.
-        pub fn set_update_info<
-            T: std::convert::Into<std::boxed::Box<crate::model::cluster::state_info::UpdateInfo>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.info = std::option::Option::Some(
-                crate::model::cluster::state_info::Info::UpdateInfo(v.into()),
-            );
-            self
         }
     }
 
@@ -1943,25 +1881,6 @@ impl AutomatedBackupConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [schedule][crate::model::AutomatedBackupConfig::schedule]
-    /// to hold a `FixedFrequencySchedule`.
-    ///
-    /// Note that all the setters affecting `schedule` are
-    /// mutually exclusive.
-    pub fn set_fixed_frequency_schedule<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::automated_backup_config::FixedFrequencySchedule>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule = std::option::Option::Some(
-            crate::model::automated_backup_config::Schedule::FixedFrequencySchedule(v.into()),
-        );
-        self
     }
 }
 
@@ -3650,23 +3569,6 @@ impl ConnectionDetail {
         })
     }
 
-    /// Sets the value of [connection][crate::model::ConnectionDetail::connection]
-    /// to hold a `PscAutoConnection`.
-    ///
-    /// Note that all the setters affecting `connection` are
-    /// mutually exclusive.
-    pub fn set_psc_auto_connection<
-        T: std::convert::Into<std::boxed::Box<crate::model::PscAutoConnection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection = std::option::Option::Some(
-            crate::model::connection_detail::Connection::PscAutoConnection(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection][crate::model::ConnectionDetail::connection]
     /// if it holds a `PscConnection`, `None` if the field is not set or
     /// holds a different branch.
@@ -3680,23 +3582,6 @@ impl ConnectionDetail {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connection][crate::model::ConnectionDetail::connection]
-    /// to hold a `PscConnection`.
-    ///
-    /// Note that all the setters affecting `connection` are
-    /// mutually exclusive.
-    pub fn set_psc_connection<
-        T: std::convert::Into<std::boxed::Box<crate::model::PscConnection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection = std::option::Option::Some(
-            crate::model::connection_detail::Connection::PscConnection(v.into()),
-        );
-        self
     }
 }
 
@@ -4016,25 +3901,6 @@ impl CertificateAuthority {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [server_ca][crate::model::CertificateAuthority::server_ca]
-    /// to hold a `ManagedServerCa`.
-    ///
-    /// Note that all the setters affecting `server_ca` are
-    /// mutually exclusive.
-    pub fn set_managed_server_ca<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::certificate_authority::ManagedCertificateAuthority>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.server_ca = std::option::Option::Some(
-            crate::model::certificate_authority::ServerCa::ManagedServerCa(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/redis/v1/src/model.rs
+++ b/src/generated/cloud/redis/v1/src/model.rs
@@ -2811,20 +2811,6 @@ impl InputConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::InputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::input_config::Source::GcsSource(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for InputConfig {
@@ -2979,23 +2965,6 @@ impl OutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::OutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::output_config::Destination::GcsDestination(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/resourcemanager/v3/src/model.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/model.rs
@@ -1137,21 +1137,6 @@ impl Organization {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [owner][crate::model::Organization::owner]
-    /// to hold a `DirectoryCustomerId`.
-    ///
-    /// Note that all the setters affecting `owner` are
-    /// mutually exclusive.
-    pub fn set_directory_customer_id<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.owner = std::option::Option::Some(
-            crate::model::organization::Owner::DirectoryCustomerId(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for Organization {

--- a/src/generated/cloud/retail/v2/src/builder.rs
+++ b/src/generated/cloud/retail/v2/src/builder.rs
@@ -7492,19 +7492,6 @@ pub mod user_event_service {
             self.0.request.conversion_rule = v.into();
             self
         }
-
-        /// Sets the value of [conversion_rule][crate::model::CollectUserEventRequest::conversion_rule]
-        /// to hold a `PrebuiltRule`.
-        ///
-        /// Note that all the setters affecting `conversion_rule` are
-        /// mutually exclusive.
-        pub fn set_prebuilt_rule<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_prebuilt_rule(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/retail/v2/src/model.rs
+++ b/src/generated/cloud/retail/v2/src/model.rs
@@ -2952,21 +2952,6 @@ impl Rule {
         })
     }
 
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `BoostAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_boost_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::BoostAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(crate::model::rule::Action::BoostAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Rule::action]
     /// if it holds a `RedirectAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -2978,22 +2963,6 @@ impl Rule {
             crate::model::rule::Action::RedirectAction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `RedirectAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_redirect_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::RedirectAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::rule::Action::RedirectAction(v.into()));
-        self
     }
 
     /// The value of [action][crate::model::Rule::action]
@@ -3009,22 +2978,6 @@ impl Rule {
         })
     }
 
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `OnewaySynonymsAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_oneway_synonyms_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::OnewaySynonymsAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::rule::Action::OnewaySynonymsAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Rule::action]
     /// if it holds a `DoNotAssociateAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3036,22 +2989,6 @@ impl Rule {
             crate::model::rule::Action::DoNotAssociateAction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `DoNotAssociateAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_do_not_associate_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::DoNotAssociateAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::rule::Action::DoNotAssociateAction(v.into()));
-        self
     }
 
     /// The value of [action][crate::model::Rule::action]
@@ -3067,22 +3004,6 @@ impl Rule {
         })
     }
 
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `ReplacementAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_replacement_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::ReplacementAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::rule::Action::ReplacementAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Rule::action]
     /// if it holds a `IgnoreAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3094,21 +3015,6 @@ impl Rule {
             crate::model::rule::Action::IgnoreAction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `IgnoreAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_ignore_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::IgnoreAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(crate::model::rule::Action::IgnoreAction(v.into()));
-        self
     }
 
     /// The value of [action][crate::model::Rule::action]
@@ -3124,21 +3030,6 @@ impl Rule {
         })
     }
 
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `FilterAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_filter_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::FilterAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(crate::model::rule::Action::FilterAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Rule::action]
     /// if it holds a `TwowaySynonymsAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3150,22 +3041,6 @@ impl Rule {
             crate::model::rule::Action::TwowaySynonymsAction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `TwowaySynonymsAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_twoway_synonyms_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::TwowaySynonymsAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::rule::Action::TwowaySynonymsAction(v.into()));
-        self
     }
 
     /// The value of [action][crate::model::Rule::action]
@@ -3181,22 +3056,6 @@ impl Rule {
         })
     }
 
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `ForceReturnFacetAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_force_return_facet_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::ForceReturnFacetAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::rule::Action::ForceReturnFacetAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Rule::action]
     /// if it holds a `RemoveFacetAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3210,22 +3069,6 @@ impl Rule {
         })
     }
 
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `RemoveFacetAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_remove_facet_action<
-        T: std::convert::Into<std::boxed::Box<crate::model::rule::RemoveFacetAction>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::rule::Action::RemoveFacetAction(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Rule::action]
     /// if it holds a `PinAction`, `None` if the field is not set or
     /// holds a different branch.
@@ -3237,19 +3080,6 @@ impl Rule {
             crate::model::rule::Action::PinAction(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Rule::action]
-    /// to hold a `PinAction`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_pin_action<T: std::convert::Into<std::boxed::Box<crate::model::rule::PinAction>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(crate::model::rule::Action::PinAction(v.into()));
-        self
     }
 }
 
@@ -4548,16 +4378,6 @@ impl Interval {
         })
     }
 
-    /// Sets the value of [min][crate::model::Interval::min]
-    /// to hold a `Minimum`.
-    ///
-    /// Note that all the setters affecting `min` are
-    /// mutually exclusive.
-    pub fn set_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.min = std::option::Option::Some(crate::model::interval::Min::Minimum(v.into()));
-        self
-    }
-
     /// The value of [min][crate::model::Interval::min]
     /// if it holds a `ExclusiveMinimum`, `None` if the field is not set or
     /// holds a different branch.
@@ -4567,17 +4387,6 @@ impl Interval {
             crate::model::interval::Min::ExclusiveMinimum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [min][crate::model::Interval::min]
-    /// to hold a `ExclusiveMinimum`.
-    ///
-    /// Note that all the setters affecting `min` are
-    /// mutually exclusive.
-    pub fn set_exclusive_minimum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.min =
-            std::option::Option::Some(crate::model::interval::Min::ExclusiveMinimum(v.into()));
-        self
     }
 
     /// Sets the value of [max][crate::model::Interval::max].
@@ -4603,16 +4412,6 @@ impl Interval {
         })
     }
 
-    /// Sets the value of [max][crate::model::Interval::max]
-    /// to hold a `Maximum`.
-    ///
-    /// Note that all the setters affecting `max` are
-    /// mutually exclusive.
-    pub fn set_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.max = std::option::Option::Some(crate::model::interval::Max::Maximum(v.into()));
-        self
-    }
-
     /// The value of [max][crate::model::Interval::max]
     /// if it holds a `ExclusiveMaximum`, `None` if the field is not set or
     /// holds a different branch.
@@ -4622,17 +4421,6 @@ impl Interval {
             crate::model::interval::Max::ExclusiveMaximum(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [max][crate::model::Interval::max]
-    /// to hold a `ExclusiveMaximum`.
-    ///
-    /// Note that all the setters affecting `max` are
-    /// mutually exclusive.
-    pub fn set_exclusive_maximum<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.max =
-            std::option::Option::Some(crate::model::interval::Max::ExclusiveMaximum(v.into()));
-        self
     }
 }
 
@@ -5965,19 +5753,6 @@ impl Control {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [control][crate::model::Control::control]
-    /// to hold a `Rule`.
-    ///
-    /// Note that all the setters affecting `control` are
-    /// mutually exclusive.
-    pub fn set_rule<T: std::convert::Into<std::boxed::Box<crate::model::Rule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.control = std::option::Option::Some(crate::model::control::Control::Rule(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Control {
@@ -6372,23 +6147,6 @@ impl OutputConfig {
         })
     }
 
-    /// Sets the value of [destination][crate::model::OutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::output_config::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::output_config::Destination::GcsDestination(v.into()),
-        );
-        self
-    }
-
     /// The value of [destination][crate::model::OutputConfig::destination]
     /// if it holds a `BigqueryDestination`, `None` if the field is not set or
     /// holds a different branch.
@@ -6403,23 +6161,6 @@ impl OutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::OutputConfig::destination]
-    /// to hold a `BigqueryDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_bigquery_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::output_config::BigQueryDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::output_config::Destination::BigqueryDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -6590,18 +6331,6 @@ impl ExportErrorsConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ExportErrorsConfig::destination]
-    /// to hold a `GcsPrefix`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::export_errors_config::Destination::GcsPrefix(v.into()),
-        );
-        self
     }
 }
 
@@ -7628,21 +7357,6 @@ impl BigQuerySource {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [partition][crate::model::BigQuerySource::partition]
-    /// to hold a `PartitionDate`.
-    ///
-    /// Note that all the setters affecting `partition` are
-    /// mutually exclusive.
-    pub fn set_partition_date<T: std::convert::Into<std::boxed::Box<gtype::model::Date>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.partition = std::option::Option::Some(
-            crate::model::big_query_source::Partition::PartitionDate(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BigQuerySource {
@@ -7790,18 +7504,6 @@ impl ImportErrorsConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::ImportErrorsConfig::destination]
-    /// to hold a `GcsPrefix`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_prefix<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::import_errors_config::Destination::GcsPrefix(v.into()),
-        );
-        self
     }
 }
 
@@ -8292,23 +7994,6 @@ impl ProductInputConfig {
         })
     }
 
-    /// Sets the value of [source][crate::model::ProductInputConfig::source]
-    /// to hold a `ProductInlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_product_inline_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ProductInlineSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::product_input_config::Source::ProductInlineSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ProductInputConfig::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -8320,21 +8005,6 @@ impl ProductInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ProductInputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::product_input_config::Source::GcsSource(v.into()),
-        );
-        self
     }
 
     /// The value of [source][crate::model::ProductInputConfig::source]
@@ -8350,23 +8020,6 @@ impl ProductInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ProductInputConfig::source]
-    /// to hold a `BigQuerySource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_big_query_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::product_input_config::Source::BigQuerySource(v.into()),
-        );
-        self
     }
 }
 
@@ -8444,23 +8097,6 @@ impl UserEventInputConfig {
         })
     }
 
-    /// Sets the value of [source][crate::model::UserEventInputConfig::source]
-    /// to hold a `UserEventInlineSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_user_event_inline_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::UserEventInlineSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::user_event_input_config::Source::UserEventInlineSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::UserEventInputConfig::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -8472,21 +8108,6 @@ impl UserEventInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::UserEventInputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::user_event_input_config::Source::GcsSource(v.into()),
-        );
-        self
     }
 
     /// The value of [source][crate::model::UserEventInputConfig::source]
@@ -8502,23 +8123,6 @@ impl UserEventInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::UserEventInputConfig::source]
-    /// to hold a `BigQuerySource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_big_query_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::user_event_input_config::Source::BigQuerySource(v.into()),
-        );
-        self
     }
 }
 
@@ -8604,23 +8208,6 @@ impl CompletionDataInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::CompletionDataInputConfig::source]
-    /// to hold a `BigQuerySource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_big_query_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQuerySource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::completion_data_input_config::Source::BigQuerySource(v.into()),
-        );
-        self
     }
 }
 
@@ -9406,27 +8993,6 @@ pub mod model {
                 crate::model::model::model_features_config::TypeDedicatedConfig::FrequentlyBoughtTogetherConfig(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [type_dedicated_config][crate::model::model::ModelFeaturesConfig::type_dedicated_config]
-        /// to hold a `FrequentlyBoughtTogetherConfig`.
-        ///
-        /// Note that all the setters affecting `type_dedicated_config` are
-        /// mutually exclusive.
-        pub fn set_frequently_bought_together_config<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::model::FrequentlyBoughtTogetherFeaturesConfig>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.type_dedicated_config = std::option::Option::Some(
-                crate::model::model::model_features_config::TypeDedicatedConfig::FrequentlyBoughtTogetherConfig(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -11904,20 +11470,6 @@ impl Product {
         })
     }
 
-    /// Sets the value of [expiration][crate::model::Product::expiration]
-    /// to hold a `ExpireTime`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.expiration =
-            std::option::Option::Some(crate::model::product::Expiration::ExpireTime(v.into()));
-        self
-    }
-
     /// The value of [expiration][crate::model::Product::expiration]
     /// if it holds a `Ttl`, `None` if the field is not set or
     /// holds a different branch.
@@ -11927,17 +11479,6 @@ impl Product {
             crate::model::product::Expiration::Ttl(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [expiration][crate::model::Product::expiration]
-    /// to hold a `Ttl`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
-        self.expiration =
-            std::option::Option::Some(crate::model::product::Expiration::Ttl(v.into()));
-        self
     }
 }
 
@@ -14340,23 +13881,6 @@ impl Tile {
         })
     }
 
-    /// Sets the value of [product_attribute][crate::model::Tile::product_attribute]
-    /// to hold a `ProductAttributeValue`.
-    ///
-    /// Note that all the setters affecting `product_attribute` are
-    /// mutually exclusive.
-    pub fn set_product_attribute_value<
-        T: std::convert::Into<std::boxed::Box<crate::model::ProductAttributeValue>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.product_attribute = std::option::Option::Some(
-            crate::model::tile::ProductAttribute::ProductAttributeValue(v.into()),
-        );
-        self
-    }
-
     /// The value of [product_attribute][crate::model::Tile::product_attribute]
     /// if it holds a `ProductAttributeInterval`, `None` if the field is not set or
     /// holds a different branch.
@@ -14370,23 +13894,6 @@ impl Tile {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [product_attribute][crate::model::Tile::product_attribute]
-    /// to hold a `ProductAttributeInterval`.
-    ///
-    /// Note that all the setters affecting `product_attribute` are
-    /// mutually exclusive.
-    pub fn set_product_attribute_interval<
-        T: std::convert::Into<std::boxed::Box<crate::model::ProductAttributeInterval>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.product_attribute = std::option::Option::Some(
-            crate::model::tile::ProductAttribute::ProductAttributeInterval(v.into()),
-        );
-        self
     }
 }
 
@@ -16478,23 +15985,6 @@ pub mod search_request {
                 })
             }
 
-            /// Sets the value of [r#type][crate::model::search_request::conversational_search_spec::UserAnswer::r#type]
-            /// to hold a `TextAnswer`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_text_answer<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::search_request::conversational_search_spec::user_answer::Type::TextAnswer(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [r#type][crate::model::search_request::conversational_search_spec::UserAnswer::r#type]
             /// if it holds a `SelectedAnswer`, `None` if the field is not set or
             /// holds a different branch.
@@ -16504,20 +15994,6 @@ pub mod search_request {
                     crate::model::search_request::conversational_search_spec::user_answer::Type::SelectedAnswer(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [r#type][crate::model::search_request::conversational_search_spec::UserAnswer::r#type]
-            /// to hold a `SelectedAnswer`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_selected_answer<T: std::convert::Into<std::boxed::Box<crate::model::search_request::conversational_search_spec::user_answer::SelectedAnswer>>>(mut self, v: T) -> Self{
-                self.r#type = std::option::Option::Some(
-                    crate::model::search_request::conversational_search_spec::user_answer::Type::SelectedAnswer(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -17476,18 +16952,6 @@ pub mod search_response {
                 })
             }
 
-            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
-            /// to hold a `Value`.
-            ///
-            /// Note that all the setters affecting `facet_value` are
-            /// mutually exclusive.
-            pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.facet_value = std::option::Option::Some(
-                    crate::model::search_response::facet::facet_value::FacetValue::Value(v.into()),
-                );
-                self
-            }
-
             /// The value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
             /// if it holds a `Interval`, `None` if the field is not set or
             /// holds a different branch.
@@ -17501,23 +16965,6 @@ pub mod search_response {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [facet_value][crate::model::search_response::facet::FacetValue::facet_value]
-            /// to hold a `Interval`.
-            ///
-            /// Note that all the setters affecting `facet_value` are
-            /// mutually exclusive.
-            pub fn set_interval<T: std::convert::Into<std::boxed::Box<crate::model::Interval>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.facet_value = std::option::Option::Some(
-                    crate::model::search_response::facet::facet_value::FacetValue::Interval(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -17914,23 +17361,6 @@ impl ExperimentInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [experiment_metadata][crate::model::ExperimentInfo::experiment_metadata]
-    /// to hold a `ServingConfigExperiment`.
-    ///
-    /// Note that all the setters affecting `experiment_metadata` are
-    /// mutually exclusive.
-    pub fn set_serving_config_experiment<
-        T: std::convert::Into<std::boxed::Box<crate::model::experiment_info::ServingConfigExperiment>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.experiment_metadata = std::option::Option::Some(
-            crate::model::experiment_info::ExperimentMetadata::ServingConfigExperiment(v.into()),
-        );
-        self
     }
 }
 
@@ -19926,18 +19356,6 @@ impl CollectUserEventRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [conversion_rule][crate::model::CollectUserEventRequest::conversion_rule]
-    /// to hold a `PrebuiltRule`.
-    ///
-    /// Note that all the setters affecting `conversion_rule` are
-    /// mutually exclusive.
-    pub fn set_prebuilt_rule<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.conversion_rule = std::option::Option::Some(
-            crate::model::collect_user_event_request::ConversionRule::PrebuiltRule(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/run/v2/src/builder.rs
+++ b/src/generated/cloud/run/v2/src/builder.rs
@@ -161,21 +161,6 @@ pub mod builds {
             self
         }
 
-        /// Sets the value of [source][crate::model::SubmitBuildRequest::source]
-        /// to hold a `StorageSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_storage_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::StorageSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_storage_source(v);
-            self
-        }
-
         /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type].
         ///
         /// Note that all the setters affecting `build_type` are
@@ -185,38 +170,6 @@ pub mod builds {
             v: T,
         ) -> Self {
             self.0.request.build_type = v.into();
-            self
-        }
-
-        /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
-        /// to hold a `BuildpackBuild`.
-        ///
-        /// Note that all the setters affecting `build_type` are
-        /// mutually exclusive.
-        pub fn set_buildpack_build<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::submit_build_request::BuildpacksBuild>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_buildpack_build(v);
-            self
-        }
-
-        /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
-        /// to hold a `DockerBuild`.
-        ///
-        /// Note that all the setters affecting `build_type` are
-        /// mutually exclusive.
-        pub fn set_docker_build<
-            T: std::convert::Into<std::boxed::Box<crate::model::submit_build_request::DockerBuild>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_docker_build(v);
             self
         }
     }

--- a/src/generated/cloud/run/v2/src/model.rs
+++ b/src/generated/cloud/run/v2/src/model.rs
@@ -151,23 +151,6 @@ impl SubmitBuildRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::SubmitBuildRequest::source]
-    /// to hold a `StorageSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_storage_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::StorageSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::submit_build_request::Source::StorageSource(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type].
     ///
     /// Note that all the setters affecting `build_type` are mutually
@@ -198,23 +181,6 @@ impl SubmitBuildRequest {
         })
     }
 
-    /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
-    /// to hold a `BuildpackBuild`.
-    ///
-    /// Note that all the setters affecting `build_type` are
-    /// mutually exclusive.
-    pub fn set_buildpack_build<
-        T: std::convert::Into<std::boxed::Box<crate::model::submit_build_request::BuildpacksBuild>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.build_type = std::option::Option::Some(
-            crate::model::submit_build_request::BuildType::BuildpackBuild(v.into()),
-        );
-        self
-    }
-
     /// The value of [build_type][crate::model::SubmitBuildRequest::build_type]
     /// if it holds a `DockerBuild`, `None` if the field is not set or
     /// holds a different branch.
@@ -229,23 +195,6 @@ impl SubmitBuildRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [build_type][crate::model::SubmitBuildRequest::build_type]
-    /// to hold a `DockerBuild`.
-    ///
-    /// Note that all the setters affecting `build_type` are
-    /// mutually exclusive.
-    pub fn set_docker_build<
-        T: std::convert::Into<std::boxed::Box<crate::model::submit_build_request::DockerBuild>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.build_type = std::option::Option::Some(
-            crate::model::submit_build_request::BuildType::DockerBuild(v.into()),
-        );
-        self
     }
 }
 
@@ -653,20 +602,6 @@ impl Condition {
         })
     }
 
-    /// Sets the value of [reasons][crate::model::Condition::reasons]
-    /// to hold a `Reason`.
-    ///
-    /// Note that all the setters affecting `reasons` are
-    /// mutually exclusive.
-    pub fn set_reason<T: std::convert::Into<crate::model::condition::CommonReason>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.reasons =
-            std::option::Option::Some(crate::model::condition::Reasons::Reason(v.into()));
-        self
-    }
-
     /// The value of [reasons][crate::model::Condition::reasons]
     /// if it holds a `RevisionReason`, `None` if the field is not set or
     /// holds a different branch.
@@ -676,20 +611,6 @@ impl Condition {
             crate::model::condition::Reasons::RevisionReason(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [reasons][crate::model::Condition::reasons]
-    /// to hold a `RevisionReason`.
-    ///
-    /// Note that all the setters affecting `reasons` are
-    /// mutually exclusive.
-    pub fn set_revision_reason<T: std::convert::Into<crate::model::condition::RevisionReason>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.reasons =
-            std::option::Option::Some(crate::model::condition::Reasons::RevisionReason(v.into()));
-        self
     }
 
     /// The value of [reasons][crate::model::Condition::reasons]
@@ -703,20 +624,6 @@ impl Condition {
             crate::model::condition::Reasons::ExecutionReason(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [reasons][crate::model::Condition::reasons]
-    /// to hold a `ExecutionReason`.
-    ///
-    /// Note that all the setters affecting `reasons` are
-    /// mutually exclusive.
-    pub fn set_execution_reason<T: std::convert::Into<crate::model::condition::ExecutionReason>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.reasons =
-            std::option::Option::Some(crate::model::condition::Reasons::ExecutionReason(v.into()));
-        self
     }
 }
 
@@ -3370,21 +3277,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [create_execution][crate::model::Job::create_execution]
-    /// to hold a `StartExecutionToken`.
-    ///
-    /// Note that all the setters affecting `create_execution` are
-    /// mutually exclusive.
-    pub fn set_start_execution_token<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_execution = std::option::Option::Some(
-            crate::model::job::CreateExecution::StartExecutionToken(v.into()),
-        );
-        self
-    }
-
     /// The value of [create_execution][crate::model::Job::create_execution]
     /// if it holds a `RunExecutionToken`, `None` if the field is not set or
     /// holds a different branch.
@@ -3396,21 +3288,6 @@ impl Job {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [create_execution][crate::model::Job::create_execution]
-    /// to hold a `RunExecutionToken`.
-    ///
-    /// Note that all the setters affecting `create_execution` are
-    /// mutually exclusive.
-    pub fn set_run_execution_token<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.create_execution = std::option::Option::Some(
-            crate::model::job::CreateExecution::RunExecutionToken(v.into()),
-        );
-        self
     }
 }
 
@@ -4027,16 +3904,6 @@ impl EnvVar {
         })
     }
 
-    /// Sets the value of [values][crate::model::EnvVar::values]
-    /// to hold a `Value`.
-    ///
-    /// Note that all the setters affecting `values` are
-    /// mutually exclusive.
-    pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.values = std::option::Option::Some(crate::model::env_var::Values::Value(v.into()));
-        self
-    }
-
     /// The value of [values][crate::model::EnvVar::values]
     /// if it holds a `ValueSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -4048,20 +3915,6 @@ impl EnvVar {
             crate::model::env_var::Values::ValueSource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [values][crate::model::EnvVar::values]
-    /// to hold a `ValueSource`.
-    ///
-    /// Note that all the setters affecting `values` are
-    /// mutually exclusive.
-    pub fn set_value_source<T: std::convert::Into<std::boxed::Box<crate::model::EnvVarSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.values =
-            std::option::Option::Some(crate::model::env_var::Values::ValueSource(v.into()));
-        self
     }
 }
 
@@ -4319,20 +4172,6 @@ impl Volume {
         })
     }
 
-    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
-    /// to hold a `Secret`.
-    ///
-    /// Note that all the setters affecting `volume_type` are
-    /// mutually exclusive.
-    pub fn set_secret<T: std::convert::Into<std::boxed::Box<crate::model::SecretVolumeSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volume_type =
-            std::option::Option::Some(crate::model::volume::VolumeType::Secret(v.into()));
-        self
-    }
-
     /// The value of [volume_type][crate::model::Volume::volume_type]
     /// if it holds a `CloudSqlInstance`, `None` if the field is not set or
     /// holds a different branch.
@@ -4344,22 +4183,6 @@ impl Volume {
             crate::model::volume::VolumeType::CloudSqlInstance(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
-    /// to hold a `CloudSqlInstance`.
-    ///
-    /// Note that all the setters affecting `volume_type` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql_instance<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlInstance>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volume_type =
-            std::option::Option::Some(crate::model::volume::VolumeType::CloudSqlInstance(v.into()));
-        self
     }
 
     /// The value of [volume_type][crate::model::Volume::volume_type]
@@ -4375,22 +4198,6 @@ impl Volume {
         })
     }
 
-    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
-    /// to hold a `EmptyDir`.
-    ///
-    /// Note that all the setters affecting `volume_type` are
-    /// mutually exclusive.
-    pub fn set_empty_dir<
-        T: std::convert::Into<std::boxed::Box<crate::model::EmptyDirVolumeSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volume_type =
-            std::option::Option::Some(crate::model::volume::VolumeType::EmptyDir(v.into()));
-        self
-    }
-
     /// The value of [volume_type][crate::model::Volume::volume_type]
     /// if it holds a `Nfs`, `None` if the field is not set or
     /// holds a different branch.
@@ -4402,20 +4209,6 @@ impl Volume {
         })
     }
 
-    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
-    /// to hold a `Nfs`.
-    ///
-    /// Note that all the setters affecting `volume_type` are
-    /// mutually exclusive.
-    pub fn set_nfs<T: std::convert::Into<std::boxed::Box<crate::model::NFSVolumeSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volume_type =
-            std::option::Option::Some(crate::model::volume::VolumeType::Nfs(v.into()));
-        self
-    }
-
     /// The value of [volume_type][crate::model::Volume::volume_type]
     /// if it holds a `Gcs`, `None` if the field is not set or
     /// holds a different branch.
@@ -4425,20 +4218,6 @@ impl Volume {
             crate::model::volume::VolumeType::Gcs(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [volume_type][crate::model::Volume::volume_type]
-    /// to hold a `Gcs`.
-    ///
-    /// Note that all the setters affecting `volume_type` are
-    /// mutually exclusive.
-    pub fn set_gcs<T: std::convert::Into<std::boxed::Box<crate::model::GCSVolumeSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.volume_type =
-            std::option::Option::Some(crate::model::volume::VolumeType::Gcs(v.into()));
-        self
     }
 }
 
@@ -5058,20 +4837,6 @@ impl Probe {
         })
     }
 
-    /// Sets the value of [probe_type][crate::model::Probe::probe_type]
-    /// to hold a `HttpGet`.
-    ///
-    /// Note that all the setters affecting `probe_type` are
-    /// mutually exclusive.
-    pub fn set_http_get<T: std::convert::Into<std::boxed::Box<crate::model::HTTPGetAction>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.probe_type =
-            std::option::Option::Some(crate::model::probe::ProbeType::HttpGet(v.into()));
-        self
-    }
-
     /// The value of [probe_type][crate::model::Probe::probe_type]
     /// if it holds a `TcpSocket`, `None` if the field is not set or
     /// holds a different branch.
@@ -5085,20 +4850,6 @@ impl Probe {
         })
     }
 
-    /// Sets the value of [probe_type][crate::model::Probe::probe_type]
-    /// to hold a `TcpSocket`.
-    ///
-    /// Note that all the setters affecting `probe_type` are
-    /// mutually exclusive.
-    pub fn set_tcp_socket<T: std::convert::Into<std::boxed::Box<crate::model::TCPSocketAction>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.probe_type =
-            std::option::Option::Some(crate::model::probe::ProbeType::TcpSocket(v.into()));
-        self
-    }
-
     /// The value of [probe_type][crate::model::Probe::probe_type]
     /// if it holds a `Grpc`, `None` if the field is not set or
     /// holds a different branch.
@@ -5108,19 +4859,6 @@ impl Probe {
             crate::model::probe::ProbeType::Grpc(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [probe_type][crate::model::Probe::probe_type]
-    /// to hold a `Grpc`.
-    ///
-    /// Note that all the setters affecting `probe_type` are
-    /// mutually exclusive.
-    pub fn set_grpc<T: std::convert::Into<std::boxed::Box<crate::model::GRPCAction>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.probe_type = std::option::Option::Some(crate::model::probe::ProbeType::Grpc(v.into()));
-        self
     }
 }
 
@@ -8122,17 +7860,6 @@ impl TaskTemplate {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [retries][crate::model::TaskTemplate::retries]
-    /// to hold a `MaxRetries`.
-    ///
-    /// Note that all the setters affecting `retries` are
-    /// mutually exclusive.
-    pub fn set_max_retries<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.retries =
-            std::option::Option::Some(crate::model::task_template::Retries::MaxRetries(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for TaskTemplate {
@@ -8631,18 +8358,6 @@ impl BinaryAuthorization {
         })
     }
 
-    /// Sets the value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
-    /// to hold a `UseDefault`.
-    ///
-    /// Note that all the setters affecting `binauthz_method` are
-    /// mutually exclusive.
-    pub fn set_use_default<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.binauthz_method = std::option::Option::Some(
-            crate::model::binary_authorization::BinauthzMethod::UseDefault(v.into()),
-        );
-        self
-    }
-
     /// The value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
     /// if it holds a `Policy`, `None` if the field is not set or
     /// holds a different branch.
@@ -8654,18 +8369,6 @@ impl BinaryAuthorization {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [binauthz_method][crate::model::BinaryAuthorization::binauthz_method]
-    /// to hold a `Policy`.
-    ///
-    /// Note that all the setters affecting `binauthz_method` are
-    /// mutually exclusive.
-    pub fn set_policy<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.binauthz_method = std::option::Option::Some(
-            crate::model::binary_authorization::BinauthzMethod::Policy(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/scheduler/v1/src/model.rs
+++ b/src/generated/cloud/scheduler/v1/src/model.rs
@@ -741,19 +741,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [target][crate::model::Job::target]
-    /// to hold a `PubsubTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_pubsub_target<T: std::convert::Into<std::boxed::Box<crate::model::PubsubTarget>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(crate::model::job::Target::PubsubTarget(v.into()));
-        self
-    }
-
     /// The value of [target][crate::model::Job::target]
     /// if it holds a `AppEngineHttpTarget`, `None` if the field is not set or
     /// holds a different branch.
@@ -767,22 +754,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [target][crate::model::Job::target]
-    /// to hold a `AppEngineHttpTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_app_engine_http_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::AppEngineHttpTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target =
-            std::option::Option::Some(crate::model::job::Target::AppEngineHttpTarget(v.into()));
-        self
-    }
-
     /// The value of [target][crate::model::Job::target]
     /// if it holds a `HttpTarget`, `None` if the field is not set or
     /// holds a different branch.
@@ -792,19 +763,6 @@ impl Job {
             crate::model::job::Target::HttpTarget(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::Job::target]
-    /// to hold a `HttpTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_http_target<T: std::convert::Into<std::boxed::Box<crate::model::HttpTarget>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(crate::model::job::Target::HttpTarget(v.into()));
-        self
     }
 }
 
@@ -1297,21 +1255,6 @@ impl HttpTarget {
         })
     }
 
-    /// Sets the value of [authorization_header][crate::model::HttpTarget::authorization_header]
-    /// to hold a `OauthToken`.
-    ///
-    /// Note that all the setters affecting `authorization_header` are
-    /// mutually exclusive.
-    pub fn set_oauth_token<T: std::convert::Into<std::boxed::Box<crate::model::OAuthToken>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorization_header = std::option::Option::Some(
-            crate::model::http_target::AuthorizationHeader::OauthToken(v.into()),
-        );
-        self
-    }
-
     /// The value of [authorization_header][crate::model::HttpTarget::authorization_header]
     /// if it holds a `OidcToken`, `None` if the field is not set or
     /// holds a different branch.
@@ -1323,21 +1266,6 @@ impl HttpTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authorization_header][crate::model::HttpTarget::authorization_header]
-    /// to hold a `OidcToken`.
-    ///
-    /// Note that all the setters affecting `authorization_header` are
-    /// mutually exclusive.
-    pub fn set_oidc_token<T: std::convert::Into<std::boxed::Box<crate::model::OidcToken>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorization_header = std::option::Option::Some(
-            crate::model::http_target::AuthorizationHeader::OidcToken(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/secretmanager/v1/src/model.rs
+++ b/src/generated/cloud/secretmanager/v1/src/model.rs
@@ -317,20 +317,6 @@ impl Secret {
         })
     }
 
-    /// Sets the value of [expiration][crate::model::Secret::expiration]
-    /// to hold a `ExpireTime`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.expiration =
-            std::option::Option::Some(crate::model::secret::Expiration::ExpireTime(v.into()));
-        self
-    }
-
     /// The value of [expiration][crate::model::Secret::expiration]
     /// if it holds a `Ttl`, `None` if the field is not set or
     /// holds a different branch.
@@ -340,17 +326,6 @@ impl Secret {
             crate::model::secret::Expiration::Ttl(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [expiration][crate::model::Secret::expiration]
-    /// to hold a `Ttl`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
-        self.expiration =
-            std::option::Option::Some(crate::model::secret::Expiration::Ttl(v.into()));
-        self
     }
 }
 
@@ -794,22 +769,6 @@ impl Replication {
         })
     }
 
-    /// Sets the value of [replication][crate::model::Replication::replication]
-    /// to hold a `Automatic`.
-    ///
-    /// Note that all the setters affecting `replication` are
-    /// mutually exclusive.
-    pub fn set_automatic<
-        T: std::convert::Into<std::boxed::Box<crate::model::replication::Automatic>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replication =
-            std::option::Option::Some(crate::model::replication::Replication::Automatic(v.into()));
-        self
-    }
-
     /// The value of [replication][crate::model::Replication::replication]
     /// if it holds a `UserManaged`, `None` if the field is not set or
     /// holds a different branch.
@@ -821,23 +780,6 @@ impl Replication {
             crate::model::replication::Replication::UserManaged(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [replication][crate::model::Replication::replication]
-    /// to hold a `UserManaged`.
-    ///
-    /// Note that all the setters affecting `replication` are
-    /// mutually exclusive.
-    pub fn set_user_managed<
-        T: std::convert::Into<std::boxed::Box<crate::model::replication::UserManaged>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replication = std::option::Option::Some(
-            crate::model::replication::Replication::UserManaged(v.into()),
-        );
-        self
     }
 }
 
@@ -1151,23 +1093,6 @@ impl ReplicationStatus {
         })
     }
 
-    /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
-    /// to hold a `Automatic`.
-    ///
-    /// Note that all the setters affecting `replication_status` are
-    /// mutually exclusive.
-    pub fn set_automatic<
-        T: std::convert::Into<std::boxed::Box<crate::model::replication_status::AutomaticStatus>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replication_status = std::option::Option::Some(
-            crate::model::replication_status::ReplicationStatus::Automatic(v.into()),
-        );
-        self
-    }
-
     /// The value of [replication_status][crate::model::ReplicationStatus::replication_status]
     /// if it holds a `UserManaged`, `None` if the field is not set or
     /// holds a different branch.
@@ -1182,23 +1107,6 @@ impl ReplicationStatus {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [replication_status][crate::model::ReplicationStatus::replication_status]
-    /// to hold a `UserManaged`.
-    ///
-    /// Note that all the setters affecting `replication_status` are
-    /// mutually exclusive.
-    pub fn set_user_managed<
-        T: std::convert::Into<std::boxed::Box<crate::model::replication_status::UserManagedStatus>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.replication_status = std::option::Option::Some(
-            crate::model::replication_status::ReplicationStatus::UserManaged(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/security/privateca/v1/src/model.rs
+++ b/src/generated/cloud/security/privateca/v1/src/model.rs
@@ -498,23 +498,6 @@ pub mod certificate_authority {
             })
         }
 
-        /// Sets the value of [key_version][crate::model::certificate_authority::KeyVersionSpec::key_version]
-        /// to hold a `CloudKmsKeyVersion`.
-        ///
-        /// Note that all the setters affecting `key_version` are
-        /// mutually exclusive.
-        pub fn set_cloud_kms_key_version<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.key_version = std::option::Option::Some(
-                crate::model::certificate_authority::key_version_spec::KeyVersion::CloudKmsKeyVersion(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [key_version][crate::model::certificate_authority::KeyVersionSpec::key_version]
         /// if it holds a `Algorithm`, `None` if the field is not set or
         /// holds a different branch.
@@ -528,25 +511,6 @@ pub mod certificate_authority {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [key_version][crate::model::certificate_authority::KeyVersionSpec::key_version]
-        /// to hold a `Algorithm`.
-        ///
-        /// Note that all the setters affecting `key_version` are
-        /// mutually exclusive.
-        pub fn set_algorithm<
-            T: std::convert::Into<crate::model::certificate_authority::SignHashAlgorithm>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.key_version = std::option::Option::Some(
-                crate::model::certificate_authority::key_version_spec::KeyVersion::Algorithm(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -1716,29 +1680,6 @@ pub mod ca_pool {
                 })
             }
 
-            /// Sets the value of [key_type][crate::model::ca_pool::issuance_policy::AllowedKeyType::key_type]
-            /// to hold a `Rsa`.
-            ///
-            /// Note that all the setters affecting `key_type` are
-            /// mutually exclusive.
-            pub fn set_rsa<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::ca_pool::issuance_policy::allowed_key_type::RsaKeyType,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.key_type = std::option::Option::Some(
-                    crate::model::ca_pool::issuance_policy::allowed_key_type::KeyType::Rsa(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [key_type][crate::model::ca_pool::issuance_policy::AllowedKeyType::key_type]
             /// if it holds a `EllipticCurve`, `None` if the field is not set or
             /// holds a different branch.
@@ -1754,29 +1695,6 @@ pub mod ca_pool {
                     crate::model::ca_pool::issuance_policy::allowed_key_type::KeyType::EllipticCurve(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [key_type][crate::model::ca_pool::issuance_policy::AllowedKeyType::key_type]
-            /// to hold a `EllipticCurve`.
-            ///
-            /// Note that all the setters affecting `key_type` are
-            /// mutually exclusive.
-            pub fn set_elliptic_curve<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::ca_pool::issuance_policy::allowed_key_type::EcKeyType,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.key_type = std::option::Option::Some(
-                    crate::model::ca_pool::issuance_policy::allowed_key_type::KeyType::EllipticCurve(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -2900,18 +2818,6 @@ impl Certificate {
         })
     }
 
-    /// Sets the value of [certificate_config][crate::model::Certificate::certificate_config]
-    /// to hold a `PemCsr`.
-    ///
-    /// Note that all the setters affecting `certificate_config` are
-    /// mutually exclusive.
-    pub fn set_pem_csr<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.certificate_config = std::option::Option::Some(
-            crate::model::certificate::CertificateConfig::PemCsr(v.into()),
-        );
-        self
-    }
-
     /// The value of [certificate_config][crate::model::Certificate::certificate_config]
     /// if it holds a `Config`, `None` if the field is not set or
     /// holds a different branch.
@@ -2921,21 +2827,6 @@ impl Certificate {
             crate::model::certificate::CertificateConfig::Config(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [certificate_config][crate::model::Certificate::certificate_config]
-    /// to hold a `Config`.
-    ///
-    /// Note that all the setters affecting `certificate_config` are
-    /// mutually exclusive.
-    pub fn set_config<T: std::convert::Into<std::boxed::Box<crate::model::CertificateConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.certificate_config = std::option::Option::Some(
-            crate::model::certificate::CertificateConfig::Config(v.into()),
-        );
-        self
     }
 }
 
@@ -3653,21 +3544,6 @@ impl SubordinateConfig {
         })
     }
 
-    /// Sets the value of [subordinate_config][crate::model::SubordinateConfig::subordinate_config]
-    /// to hold a `CertificateAuthority`.
-    ///
-    /// Note that all the setters affecting `subordinate_config` are
-    /// mutually exclusive.
-    pub fn set_certificate_authority<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.subordinate_config = std::option::Option::Some(
-            crate::model::subordinate_config::SubordinateConfig::CertificateAuthority(v.into()),
-        );
-        self
-    }
-
     /// The value of [subordinate_config][crate::model::SubordinateConfig::subordinate_config]
     /// if it holds a `PemIssuerChain`, `None` if the field is not set or
     /// holds a different branch.
@@ -3683,25 +3559,6 @@ impl SubordinateConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [subordinate_config][crate::model::SubordinateConfig::subordinate_config]
-    /// to hold a `PemIssuerChain`.
-    ///
-    /// Note that all the setters affecting `subordinate_config` are
-    /// mutually exclusive.
-    pub fn set_pem_issuer_chain<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::subordinate_config::SubordinateConfigChain>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.subordinate_config = std::option::Option::Some(
-            crate::model::subordinate_config::SubordinateConfig::PemIssuerChain(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/securitycenter/v2/src/model.rs
+++ b/src/generated/cloud/securitycenter/v2/src/model.rs
@@ -6078,29 +6078,6 @@ pub mod indicator {
             })
         }
 
-        /// Sets the value of [signature][crate::model::indicator::ProcessSignature::signature]
-        /// to hold a `MemoryHashSignature`.
-        ///
-        /// Note that all the setters affecting `signature` are
-        /// mutually exclusive.
-        pub fn set_memory_hash_signature<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::indicator::process_signature::MemoryHashSignature,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.signature = std::option::Option::Some(
-                crate::model::indicator::process_signature::Signature::MemoryHashSignature(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [signature][crate::model::indicator::ProcessSignature::signature]
         /// if it holds a `YaraRuleSignature`, `None` if the field is not set or
         /// holds a different branch.
@@ -6116,25 +6093,6 @@ pub mod indicator {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [signature][crate::model::indicator::ProcessSignature::signature]
-        /// to hold a `YaraRuleSignature`.
-        ///
-        /// Note that all the setters affecting `signature` are
-        /// mutually exclusive.
-        pub fn set_yara_rule_signature<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::indicator::process_signature::YaraRuleSignature>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.signature = std::option::Option::Some(
-                crate::model::indicator::process_signature::Signature::YaraRuleSignature(v.into()),
-            );
-            self
         }
     }
 
@@ -7640,23 +7598,6 @@ impl LogEntry {
             crate::model::log_entry::LogEntry::CloudLoggingEntry(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [log_entry][crate::model::LogEntry::log_entry]
-    /// to hold a `CloudLoggingEntry`.
-    ///
-    /// Note that all the setters affecting `log_entry` are
-    /// mutually exclusive.
-    pub fn set_cloud_logging_entry<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudLoggingEntry>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.log_entry = std::option::Option::Some(
-            crate::model::log_entry::LogEntry::CloudLoggingEntry(v.into()),
-        );
-        self
     }
 }
 
@@ -9183,23 +9124,6 @@ impl NotificationConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [notify_config][crate::model::NotificationConfig::notify_config]
-    /// to hold a `StreamingConfig`.
-    ///
-    /// Note that all the setters affecting `notify_config` are
-    /// mutually exclusive.
-    pub fn set_streaming_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::notification_config::StreamingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.notify_config = std::option::Option::Some(
-            crate::model::notification_config::NotifyConfig::StreamingConfig(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for NotificationConfig {
@@ -9345,20 +9269,6 @@ impl NotificationMessage {
             crate::model::notification_message::Event::Finding(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [event][crate::model::NotificationMessage::event]
-    /// to hold a `Finding`.
-    ///
-    /// Note that all the setters affecting `event` are
-    /// mutually exclusive.
-    pub fn set_finding<T: std::convert::Into<std::boxed::Box<crate::model::Finding>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.event =
-            std::option::Option::Some(crate::model::notification_message::Event::Finding(v.into()));
-        self
     }
 }
 
@@ -9757,21 +9667,6 @@ impl Resource {
         })
     }
 
-    /// Sets the value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
-    /// to hold a `GcpMetadata`.
-    ///
-    /// Note that all the setters affecting `cloud_provider_metadata` are
-    /// mutually exclusive.
-    pub fn set_gcp_metadata<T: std::convert::Into<std::boxed::Box<crate::model::GcpMetadata>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cloud_provider_metadata = std::option::Option::Some(
-            crate::model::resource::CloudProviderMetadata::GcpMetadata(v.into()),
-        );
-        self
-    }
-
     /// The value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
     /// if it holds a `AwsMetadata`, `None` if the field is not set or
     /// holds a different branch.
@@ -9783,21 +9678,6 @@ impl Resource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
-    /// to hold a `AwsMetadata`.
-    ///
-    /// Note that all the setters affecting `cloud_provider_metadata` are
-    /// mutually exclusive.
-    pub fn set_aws_metadata<T: std::convert::Into<std::boxed::Box<crate::model::AwsMetadata>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cloud_provider_metadata = std::option::Option::Some(
-            crate::model::resource::CloudProviderMetadata::AwsMetadata(v.into()),
-        );
-        self
     }
 
     /// The value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
@@ -9813,23 +9693,6 @@ impl Resource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cloud_provider_metadata][crate::model::Resource::cloud_provider_metadata]
-    /// to hold a `AzureMetadata`.
-    ///
-    /// Note that all the setters affecting `cloud_provider_metadata` are
-    /// mutually exclusive.
-    pub fn set_azure_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::AzureMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cloud_provider_metadata = std::option::Option::Some(
-            crate::model::resource::CloudProviderMetadata::AzureMetadata(v.into()),
-        );
-        self
     }
 }
 
@@ -13348,25 +13211,6 @@ pub mod list_findings_response {
                 })
             }
 
-            /// Sets the value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
-            /// to hold a `GcpMetadata`.
-            ///
-            /// Note that all the setters affecting `cloud_provider_metadata` are
-            /// mutually exclusive.
-            pub fn set_gcp_metadata<
-                T: std::convert::Into<std::boxed::Box<crate::model::GcpMetadata>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.cloud_provider_metadata = std::option::Option::Some(
-                    crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::GcpMetadata(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
             /// if it holds a `AwsMetadata`, `None` if the field is not set or
             /// holds a different branch.
@@ -13380,25 +13224,6 @@ pub mod list_findings_response {
                 })
             }
 
-            /// Sets the value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
-            /// to hold a `AwsMetadata`.
-            ///
-            /// Note that all the setters affecting `cloud_provider_metadata` are
-            /// mutually exclusive.
-            pub fn set_aws_metadata<
-                T: std::convert::Into<std::boxed::Box<crate::model::AwsMetadata>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.cloud_provider_metadata = std::option::Option::Some(
-                    crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::AwsMetadata(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
             /// if it holds a `AzureMetadata`, `None` if the field is not set or
             /// holds a different branch.
@@ -13410,25 +13235,6 @@ pub mod list_findings_response {
                     crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::AzureMetadata(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [cloud_provider_metadata][crate::model::list_findings_response::list_findings_result::Resource::cloud_provider_metadata]
-            /// to hold a `AzureMetadata`.
-            ///
-            /// Note that all the setters affecting `cloud_provider_metadata` are
-            /// mutually exclusive.
-            pub fn set_azure_metadata<
-                T: std::convert::Into<std::boxed::Box<crate::model::AzureMetadata>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.cloud_provider_metadata = std::option::Option::Some(
-                    crate::model::list_findings_response::list_findings_result::resource::CloudProviderMetadata::AzureMetadata(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 

--- a/src/generated/cloud/securityposture/v1/src/model.rs
+++ b/src/generated/cloud/securityposture/v1/src/model.rs
@@ -101,21 +101,6 @@ impl PolicyRule {
         })
     }
 
-    /// Sets the value of [kind][crate::model::PolicyRule::kind]
-    /// to hold a `Values`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_values<
-        T: std::convert::Into<std::boxed::Box<crate::model::policy_rule::StringValues>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::policy_rule::Kind::Values(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::PolicyRule::kind]
     /// if it holds a `AllowAll`, `None` if the field is not set or
     /// holds a different branch.
@@ -125,16 +110,6 @@ impl PolicyRule {
             crate::model::policy_rule::Kind::AllowAll(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::PolicyRule::kind]
-    /// to hold a `AllowAll`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_allow_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::policy_rule::Kind::AllowAll(v.into()));
-        self
     }
 
     /// The value of [kind][crate::model::PolicyRule::kind]
@@ -148,16 +123,6 @@ impl PolicyRule {
         })
     }
 
-    /// Sets the value of [kind][crate::model::PolicyRule::kind]
-    /// to hold a `DenyAll`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_deny_all<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::policy_rule::Kind::DenyAll(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::PolicyRule::kind]
     /// if it holds a `Enforce`, `None` if the field is not set or
     /// holds a different branch.
@@ -167,16 +132,6 @@ impl PolicyRule {
             crate::model::policy_rule::Kind::Enforce(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::PolicyRule::kind]
-    /// to hold a `Enforce`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_enforce<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.kind = std::option::Option::Some(crate::model::policy_rule::Kind::Enforce(v.into()));
-        self
     }
 }
 
@@ -1446,23 +1401,6 @@ impl Constraint {
         })
     }
 
-    /// Sets the value of [implementation][crate::model::Constraint::implementation]
-    /// to hold a `SecurityHealthAnalyticsModule`.
-    ///
-    /// Note that all the setters affecting `implementation` are
-    /// mutually exclusive.
-    pub fn set_security_health_analytics_module<
-        T: std::convert::Into<std::boxed::Box<crate::model::SecurityHealthAnalyticsModule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.implementation = std::option::Option::Some(
-            crate::model::constraint::Implementation::SecurityHealthAnalyticsModule(v.into()),
-        );
-        self
-    }
-
     /// The value of [implementation][crate::model::Constraint::implementation]
     /// if it holds a `SecurityHealthAnalyticsCustomModule`, `None` if the field is not set or
     /// holds a different branch.
@@ -1477,23 +1415,6 @@ impl Constraint {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [implementation][crate::model::Constraint::implementation]
-    /// to hold a `SecurityHealthAnalyticsCustomModule`.
-    ///
-    /// Note that all the setters affecting `implementation` are
-    /// mutually exclusive.
-    pub fn set_security_health_analytics_custom_module<
-        T: std::convert::Into<std::boxed::Box<crate::model::SecurityHealthAnalyticsCustomModule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.implementation = std::option::Option::Some(
-            crate::model::constraint::Implementation::SecurityHealthAnalyticsCustomModule(v.into()),
-        );
-        self
     }
 
     /// The value of [implementation][crate::model::Constraint::implementation]
@@ -1511,23 +1432,6 @@ impl Constraint {
         })
     }
 
-    /// Sets the value of [implementation][crate::model::Constraint::implementation]
-    /// to hold a `OrgPolicyConstraint`.
-    ///
-    /// Note that all the setters affecting `implementation` are
-    /// mutually exclusive.
-    pub fn set_org_policy_constraint<
-        T: std::convert::Into<std::boxed::Box<crate::model::OrgPolicyConstraint>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.implementation = std::option::Option::Some(
-            crate::model::constraint::Implementation::OrgPolicyConstraint(v.into()),
-        );
-        self
-    }
-
     /// The value of [implementation][crate::model::Constraint::implementation]
     /// if it holds a `OrgPolicyConstraintCustom`, `None` if the field is not set or
     /// holds a different branch.
@@ -1541,23 +1445,6 @@ impl Constraint {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [implementation][crate::model::Constraint::implementation]
-    /// to hold a `OrgPolicyConstraintCustom`.
-    ///
-    /// Note that all the setters affecting `implementation` are
-    /// mutually exclusive.
-    pub fn set_org_policy_constraint_custom<
-        T: std::convert::Into<std::boxed::Box<crate::model::OrgPolicyConstraintCustom>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.implementation = std::option::Option::Some(
-            crate::model::constraint::Implementation::OrgPolicyConstraintCustom(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/speech/v2/src/builder.rs
+++ b/src/generated/cloud/speech/v2/src/builder.rs
@@ -792,26 +792,6 @@ pub mod speech {
             self.0.request.audio_source = v.into();
             self
         }
-
-        /// Sets the value of [audio_source][crate::model::RecognizeRequest::audio_source]
-        /// to hold a `Content`.
-        ///
-        /// Note that all the setters affecting `audio_source` are
-        /// mutually exclusive.
-        pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_content(v);
-            self
-        }
-
-        /// Sets the value of [audio_source][crate::model::RecognizeRequest::audio_source]
-        /// to hold a `Uri`.
-        ///
-        /// Note that all the setters affecting `audio_source` are
-        /// mutually exclusive.
-        pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_uri(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/speech/v2/src/model.rs
+++ b/src/generated/cloud/speech/v2/src/model.rs
@@ -246,23 +246,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `BatchRecognizeRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_batch_recognize_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::BatchRecognizeRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::BatchRecognizeRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `CreateRecognizerRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -276,23 +259,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `CreateRecognizerRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_create_recognizer_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateRecognizerRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::CreateRecognizerRequest(v.into()),
-        );
-        self
     }
 
     /// The value of [request][crate::model::OperationMetadata::request]
@@ -310,23 +276,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `UpdateRecognizerRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_update_recognizer_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UpdateRecognizerRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::UpdateRecognizerRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `DeleteRecognizerRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -340,23 +289,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `DeleteRecognizerRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_delete_recognizer_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeleteRecognizerRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::DeleteRecognizerRequest(v.into()),
-        );
-        self
     }
 
     /// The value of [request][crate::model::OperationMetadata::request]
@@ -374,23 +306,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `UndeleteRecognizerRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_undelete_recognizer_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UndeleteRecognizerRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::UndeleteRecognizerRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `CreateCustomClassRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -404,23 +319,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `CreateCustomClassRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_create_custom_class_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateCustomClassRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::CreateCustomClassRequest(v.into()),
-        );
-        self
     }
 
     /// The value of [request][crate::model::OperationMetadata::request]
@@ -438,23 +336,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `UpdateCustomClassRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_update_custom_class_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UpdateCustomClassRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::UpdateCustomClassRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `DeleteCustomClassRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -468,23 +349,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `DeleteCustomClassRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_delete_custom_class_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeleteCustomClassRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::DeleteCustomClassRequest(v.into()),
-        );
-        self
     }
 
     /// The value of [request][crate::model::OperationMetadata::request]
@@ -502,23 +366,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `UndeleteCustomClassRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_undelete_custom_class_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UndeleteCustomClassRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::UndeleteCustomClassRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `CreatePhraseSetRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -532,23 +379,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `CreatePhraseSetRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_create_phrase_set_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreatePhraseSetRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::CreatePhraseSetRequest(v.into()),
-        );
-        self
     }
 
     /// The value of [request][crate::model::OperationMetadata::request]
@@ -566,23 +396,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `UpdatePhraseSetRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_update_phrase_set_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UpdatePhraseSetRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::UpdatePhraseSetRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `DeletePhraseSetRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -596,23 +409,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `DeletePhraseSetRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_delete_phrase_set_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeletePhraseSetRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::DeletePhraseSetRequest(v.into()),
-        );
-        self
     }
 
     /// The value of [request][crate::model::OperationMetadata::request]
@@ -630,23 +426,6 @@ impl OperationMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `UndeletePhraseSetRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_undelete_phrase_set_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UndeletePhraseSetRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::UndeletePhraseSetRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::OperationMetadata::request]
     /// if it holds a `UpdateConfigRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -661,24 +440,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::OperationMetadata::request]
-    /// to hold a `UpdateConfigRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    #[deprecated]
-    pub fn set_update_config_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UpdateConfigRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::operation_metadata::Request::UpdateConfigRequest(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [metadata][crate::model::OperationMetadata::metadata].
@@ -708,23 +469,6 @@ impl OperationMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [metadata][crate::model::OperationMetadata::metadata]
-    /// to hold a `BatchRecognizeMetadata`.
-    ///
-    /// Note that all the setters affecting `metadata` are
-    /// mutually exclusive.
-    pub fn set_batch_recognize_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::BatchRecognizeMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.metadata = std::option::Option::Some(
-            crate::model::operation_metadata::Metadata::BatchRecognizeMetadata(v.into()),
-        );
-        self
     }
 }
 
@@ -2475,18 +2219,6 @@ pub mod speech_adaptation {
             })
         }
 
-        /// Sets the value of [value][crate::model::speech_adaptation::AdaptationPhraseSet::value]
-        /// to hold a `PhraseSet`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_phrase_set<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::speech_adaptation::adaptation_phrase_set::Value::PhraseSet(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::speech_adaptation::AdaptationPhraseSet::value]
         /// if it holds a `InlinePhraseSet`, `None` if the field is not set or
         /// holds a different branch.
@@ -2500,25 +2232,6 @@ pub mod speech_adaptation {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::speech_adaptation::AdaptationPhraseSet::value]
-        /// to hold a `InlinePhraseSet`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_inline_phrase_set<
-            T: std::convert::Into<std::boxed::Box<crate::model::PhraseSet>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::speech_adaptation::adaptation_phrase_set::Value::InlinePhraseSet(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -2704,23 +2417,6 @@ impl RecognitionConfig {
         })
     }
 
-    /// Sets the value of [decoding_config][crate::model::RecognitionConfig::decoding_config]
-    /// to hold a `AutoDecodingConfig`.
-    ///
-    /// Note that all the setters affecting `decoding_config` are
-    /// mutually exclusive.
-    pub fn set_auto_decoding_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::AutoDetectDecodingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.decoding_config = std::option::Option::Some(
-            crate::model::recognition_config::DecodingConfig::AutoDecodingConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [decoding_config][crate::model::RecognitionConfig::decoding_config]
     /// if it holds a `ExplicitDecodingConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -2734,23 +2430,6 @@ impl RecognitionConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [decoding_config][crate::model::RecognitionConfig::decoding_config]
-    /// to hold a `ExplicitDecodingConfig`.
-    ///
-    /// Note that all the setters affecting `decoding_config` are
-    /// mutually exclusive.
-    pub fn set_explicit_decoding_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExplicitDecodingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.decoding_config = std::option::Option::Some(
-            crate::model::recognition_config::DecodingConfig::ExplicitDecodingConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -2897,18 +2576,6 @@ impl RecognizeRequest {
         })
     }
 
-    /// Sets the value of [audio_source][crate::model::RecognizeRequest::audio_source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `audio_source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.audio_source = std::option::Option::Some(
-            crate::model::recognize_request::AudioSource::Content(v.into()),
-        );
-        self
-    }
-
     /// The value of [audio_source][crate::model::RecognizeRequest::audio_source]
     /// if it holds a `Uri`, `None` if the field is not set or
     /// holds a different branch.
@@ -2918,17 +2585,6 @@ impl RecognizeRequest {
             crate::model::recognize_request::AudioSource::Uri(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [audio_source][crate::model::RecognizeRequest::audio_source]
-    /// to hold a `Uri`.
-    ///
-    /// Note that all the setters affecting `audio_source` are
-    /// mutually exclusive.
-    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.audio_source =
-            std::option::Option::Some(crate::model::recognize_request::AudioSource::Uri(v.into()));
-        self
     }
 }
 
@@ -3634,23 +3290,6 @@ impl StreamingRecognizeRequest {
         })
     }
 
-    /// Sets the value of [streaming_request][crate::model::StreamingRecognizeRequest::streaming_request]
-    /// to hold a `StreamingConfig`.
-    ///
-    /// Note that all the setters affecting `streaming_request` are
-    /// mutually exclusive.
-    pub fn set_streaming_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::StreamingRecognitionConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.streaming_request = std::option::Option::Some(
-            crate::model::streaming_recognize_request::StreamingRequest::StreamingConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [streaming_request][crate::model::StreamingRecognizeRequest::streaming_request]
     /// if it holds a `Audio`, `None` if the field is not set or
     /// holds a different branch.
@@ -3662,18 +3301,6 @@ impl StreamingRecognizeRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [streaming_request][crate::model::StreamingRecognizeRequest::streaming_request]
-    /// to hold a `Audio`.
-    ///
-    /// Note that all the setters affecting `streaming_request` are
-    /// mutually exclusive.
-    pub fn set_audio<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.streaming_request = std::option::Option::Some(
-            crate::model::streaming_recognize_request::StreamingRequest::Audio(v.into()),
-        );
-        self
     }
 }
 
@@ -4229,23 +3856,6 @@ impl RecognitionOutputConfig {
         })
     }
 
-    /// Sets the value of [output][crate::model::RecognitionOutputConfig::output]
-    /// to hold a `GcsOutputConfig`.
-    ///
-    /// Note that all the setters affecting `output` are
-    /// mutually exclusive.
-    pub fn set_gcs_output_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsOutputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output = std::option::Option::Some(
-            crate::model::recognition_output_config::Output::GcsOutputConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [output][crate::model::RecognitionOutputConfig::output]
     /// if it holds a `InlineResponseConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -4259,23 +3869,6 @@ impl RecognitionOutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [output][crate::model::RecognitionOutputConfig::output]
-    /// to hold a `InlineResponseConfig`.
-    ///
-    /// Note that all the setters affecting `output` are
-    /// mutually exclusive.
-    pub fn set_inline_response_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::InlineOutputConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output = std::option::Option::Some(
-            crate::model::recognition_output_config::Output::InlineResponseConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -4638,23 +4231,6 @@ impl BatchRecognizeFileResult {
         })
     }
 
-    /// Sets the value of [result][crate::model::BatchRecognizeFileResult::result]
-    /// to hold a `CloudStorageResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_result<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageResult>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::batch_recognize_file_result::Result::CloudStorageResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::BatchRecognizeFileResult::result]
     /// if it holds a `InlineResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -4668,21 +4244,6 @@ impl BatchRecognizeFileResult {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::BatchRecognizeFileResult::result]
-    /// to hold a `InlineResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_inline_result<T: std::convert::Into<std::boxed::Box<crate::model::InlineResult>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::batch_recognize_file_result::Result::InlineResult(v.into()),
-        );
-        self
     }
 }
 
@@ -4920,18 +4481,6 @@ impl BatchRecognizeFileMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [audio_source][crate::model::BatchRecognizeFileMetadata::audio_source]
-    /// to hold a `Uri`.
-    ///
-    /// Note that all the setters affecting `audio_source` are
-    /// mutually exclusive.
-    pub fn set_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.audio_source = std::option::Option::Some(
-            crate::model::batch_recognize_file_metadata::AudioSource::Uri(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/sql/v1/src/builder.rs
+++ b/src/generated/cloud/sql/v1/src/builder.rs
@@ -3439,21 +3439,6 @@ pub mod sql_instances_service {
             self.0.request.sync_config = v.into();
             self
         }
-
-        /// Sets the value of [sync_config][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_config]
-        /// to hold a `MysqlSyncConfig`.
-        ///
-        /// Note that all the setters affecting `sync_config` are
-        /// mutually exclusive.
-        pub fn set_mysql_sync_config<
-            T: std::convert::Into<std::boxed::Box<crate::model::MySqlSyncConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_mysql_sync_config(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -3576,21 +3561,6 @@ pub mod sql_instances_service {
             v: T,
         ) -> Self {
             self.0.request.sync_config = v.into();
-            self
-        }
-
-        /// Sets the value of [sync_config][crate::model::SqlInstancesStartExternalSyncRequest::sync_config]
-        /// to hold a `MysqlSyncConfig`.
-        ///
-        /// Note that all the setters affecting `sync_config` are
-        /// mutually exclusive.
-        pub fn set_mysql_sync_config<
-            T: std::convert::Into<std::boxed::Box<crate::model::MySqlSyncConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_mysql_sync_config(v);
             self
         }
     }

--- a/src/generated/cloud/sql/v1/src/model.rs
+++ b/src/generated/cloud/sql/v1/src/model.rs
@@ -3367,25 +3367,6 @@ impl SqlInstancesVerifyExternalSyncSettingsRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [sync_config][crate::model::SqlInstancesVerifyExternalSyncSettingsRequest::sync_config]
-    /// to hold a `MysqlSyncConfig`.
-    ///
-    /// Note that all the setters affecting `sync_config` are
-    /// mutually exclusive.
-    pub fn set_mysql_sync_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::MySqlSyncConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sync_config = std::option::Option::Some(
-            crate::model::sql_instances_verify_external_sync_settings_request::SyncConfig::MysqlSyncConfig(
-                v.into()
-            )
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for SqlInstancesVerifyExternalSyncSettingsRequest {
@@ -3803,25 +3784,6 @@ impl SqlInstancesStartExternalSyncRequest {
             crate::model::sql_instances_start_external_sync_request::SyncConfig::MysqlSyncConfig(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [sync_config][crate::model::SqlInstancesStartExternalSyncRequest::sync_config]
-    /// to hold a `MysqlSyncConfig`.
-    ///
-    /// Note that all the setters affecting `sync_config` are
-    /// mutually exclusive.
-    pub fn set_mysql_sync_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::MySqlSyncConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sync_config = std::option::Option::Some(
-            crate::model::sql_instances_start_external_sync_request::SyncConfig::MysqlSyncConfig(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -9233,23 +9195,6 @@ impl Database {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [database_details][crate::model::Database::database_details]
-    /// to hold a `SqlserverDatabaseDetails`.
-    ///
-    /// Note that all the setters affecting `database_details` are
-    /// mutually exclusive.
-    pub fn set_sqlserver_database_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerDatabaseDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.database_details = std::option::Option::Some(
-            crate::model::database::DatabaseDetails::SqlserverDatabaseDetails(v.into()),
-        );
-        self
     }
 }
 
@@ -15590,23 +15535,6 @@ impl User {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [user_details][crate::model::User::user_details]
-    /// to hold a `SqlserverUserDetails`.
-    ///
-    /// Note that all the setters affecting `user_details` are
-    /// mutually exclusive.
-    pub fn set_sqlserver_user_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::SqlServerUserDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.user_details = std::option::Option::Some(
-            crate::model::user::UserDetails::SqlserverUserDetails(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/storagebatchoperations/v1/src/model.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/model.rs
@@ -667,19 +667,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [source][crate::model::Job::source]
-    /// to hold a `BucketList`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_bucket_list<T: std::convert::Into<std::boxed::Box<crate::model::BucketList>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(crate::model::job::Source::BucketList(v.into()));
-        self
-    }
-
     /// Sets the value of [transformation][crate::model::Job::transformation].
     ///
     /// Note that all the setters affecting `transformation` are mutually
@@ -707,22 +694,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::Job::transformation]
-    /// to hold a `PutObjectHold`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_put_object_hold<
-        T: std::convert::Into<std::boxed::Box<crate::model::PutObjectHold>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation =
-            std::option::Option::Some(crate::model::job::Transformation::PutObjectHold(v.into()));
-        self
-    }
-
     /// The value of [transformation][crate::model::Job::transformation]
     /// if it holds a `DeleteObject`, `None` if the field is not set or
     /// holds a different branch.
@@ -736,20 +707,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::Job::transformation]
-    /// to hold a `DeleteObject`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_delete_object<T: std::convert::Into<std::boxed::Box<crate::model::DeleteObject>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation =
-            std::option::Option::Some(crate::model::job::Transformation::DeleteObject(v.into()));
-        self
-    }
-
     /// The value of [transformation][crate::model::Job::transformation]
     /// if it holds a `PutMetadata`, `None` if the field is not set or
     /// holds a different branch.
@@ -759,20 +716,6 @@ impl Job {
             crate::model::job::Transformation::PutMetadata(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::Job::transformation]
-    /// to hold a `PutMetadata`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_put_metadata<T: std::convert::Into<std::boxed::Box<crate::model::PutMetadata>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation =
-            std::option::Option::Some(crate::model::job::Transformation::PutMetadata(v.into()));
-        self
     }
 
     /// The value of [transformation][crate::model::Job::transformation]
@@ -786,22 +729,6 @@ impl Job {
             crate::model::job::Transformation::RewriteObject(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::Job::transformation]
-    /// to hold a `RewriteObject`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_rewrite_object<
-        T: std::convert::Into<std::boxed::Box<crate::model::RewriteObject>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation =
-            std::option::Option::Some(crate::model::job::Transformation::RewriteObject(v.into()));
-        self
     }
 }
 
@@ -1097,21 +1024,6 @@ pub mod bucket_list {
             })
         }
 
-        /// Sets the value of [object_configuration][crate::model::bucket_list::Bucket::object_configuration]
-        /// to hold a `PrefixList`.
-        ///
-        /// Note that all the setters affecting `object_configuration` are
-        /// mutually exclusive.
-        pub fn set_prefix_list<T: std::convert::Into<std::boxed::Box<crate::model::PrefixList>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.object_configuration = std::option::Option::Some(
-                crate::model::bucket_list::bucket::ObjectConfiguration::PrefixList(v.into()),
-            );
-            self
-        }
-
         /// The value of [object_configuration][crate::model::bucket_list::Bucket::object_configuration]
         /// if it holds a `Manifest`, `None` if the field is not set or
         /// holds a different branch.
@@ -1123,21 +1035,6 @@ pub mod bucket_list {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [object_configuration][crate::model::bucket_list::Bucket::object_configuration]
-        /// to hold a `Manifest`.
-        ///
-        /// Note that all the setters affecting `object_configuration` are
-        /// mutually exclusive.
-        pub fn set_manifest<T: std::convert::Into<std::boxed::Box<crate::model::Manifest>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.object_configuration = std::option::Option::Some(
-                crate::model::bucket_list::bucket::ObjectConfiguration::Manifest(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/storageinsights/v1/src/model.rs
+++ b/src/generated/cloud/storageinsights/v1/src/model.rs
@@ -1317,23 +1317,6 @@ impl ObjectMetadataReportOptions {
         })
     }
 
-    /// Sets the value of [filter][crate::model::ObjectMetadataReportOptions::filter]
-    /// to hold a `StorageFilters`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_storage_filters<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageFilters>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::object_metadata_report_options::Filter::StorageFilters(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [destination_options][crate::model::ObjectMetadataReportOptions::destination_options].
     ///
     /// Note that all the setters affecting `destination_options` are mutually
@@ -1363,25 +1346,6 @@ impl ObjectMetadataReportOptions {
             crate::model::object_metadata_report_options::DestinationOptions::StorageDestinationOptions(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination_options][crate::model::ObjectMetadataReportOptions::destination_options]
-    /// to hold a `StorageDestinationOptions`.
-    ///
-    /// Note that all the setters affecting `destination_options` are
-    /// mutually exclusive.
-    pub fn set_storage_destination_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageDestinationOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination_options = std::option::Option::Some(
-            crate::model::object_metadata_report_options::DestinationOptions::StorageDestinationOptions(
-                v.into()
-            )
-        );
-        self
     }
 }
 
@@ -1551,21 +1515,6 @@ impl ReportConfig {
         })
     }
 
-    /// Sets the value of [report_format][crate::model::ReportConfig::report_format]
-    /// to hold a `CsvOptions`.
-    ///
-    /// Note that all the setters affecting `report_format` are
-    /// mutually exclusive.
-    pub fn set_csv_options<T: std::convert::Into<std::boxed::Box<crate::model::CSVOptions>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.report_format = std::option::Option::Some(
-            crate::model::report_config::ReportFormat::CsvOptions(v.into()),
-        );
-        self
-    }
-
     /// The value of [report_format][crate::model::ReportConfig::report_format]
     /// if it holds a `ParquetOptions`, `None` if the field is not set or
     /// holds a different branch.
@@ -1579,23 +1528,6 @@ impl ReportConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [report_format][crate::model::ReportConfig::report_format]
-    /// to hold a `ParquetOptions`.
-    ///
-    /// Note that all the setters affecting `report_format` are
-    /// mutually exclusive.
-    pub fn set_parquet_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::ParquetOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.report_format = std::option::Option::Some(
-            crate::model::report_config::ReportFormat::ParquetOptions(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [report_kind][crate::model::ReportConfig::report_kind].
@@ -1625,23 +1557,6 @@ impl ReportConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [report_kind][crate::model::ReportConfig::report_kind]
-    /// to hold a `ObjectMetadataReportOptions`.
-    ///
-    /// Note that all the setters affecting `report_kind` are
-    /// mutually exclusive.
-    pub fn set_object_metadata_report_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::ObjectMetadataReportOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.report_kind = std::option::Option::Some(
-            crate::model::report_config::ReportKind::ObjectMetadataReportOptions(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/talent/v4/src/model.rs
+++ b/src/generated/cloud/talent/v4/src/model.rs
@@ -1184,23 +1184,6 @@ pub mod compensation_info {
             })
         }
 
-        /// Sets the value of [compensation_amount][crate::model::compensation_info::CompensationEntry::compensation_amount]
-        /// to hold a `Amount`.
-        ///
-        /// Note that all the setters affecting `compensation_amount` are
-        /// mutually exclusive.
-        pub fn set_amount<T: std::convert::Into<std::boxed::Box<gtype::model::Money>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.compensation_amount = std::option::Option::Some(
-                crate::model::compensation_info::compensation_entry::CompensationAmount::Amount(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [compensation_amount][crate::model::compensation_info::CompensationEntry::compensation_amount]
         /// if it holds a `Range`, `None` if the field is not set or
         /// holds a different branch.
@@ -1215,25 +1198,6 @@ pub mod compensation_info {
                 ) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [compensation_amount][crate::model::compensation_info::CompensationEntry::compensation_amount]
-        /// to hold a `Range`.
-        ///
-        /// Note that all the setters affecting `compensation_amount` are
-        /// mutually exclusive.
-        pub fn set_range<
-            T: std::convert::Into<std::boxed::Box<crate::model::compensation_info::CompensationRange>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.compensation_amount = std::option::Option::Some(
-                crate::model::compensation_info::compensation_entry::CompensationAmount::Range(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -3237,20 +3201,6 @@ impl ClientEvent {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [event][crate::model::ClientEvent::event]
-    /// to hold a `JobEvent`.
-    ///
-    /// Note that all the setters affecting `event` are
-    /// mutually exclusive.
-    pub fn set_job_event<T: std::convert::Into<std::boxed::Box<crate::model::JobEvent>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.event =
-            std::option::Option::Some(crate::model::client_event::Event::JobEvent(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for ClientEvent {
@@ -4711,21 +4661,6 @@ impl CommuteFilter {
         })
     }
 
-    /// Sets the value of [traffic_option][crate::model::CommuteFilter::traffic_option]
-    /// to hold a `RoadTraffic`.
-    ///
-    /// Note that all the setters affecting `traffic_option` are
-    /// mutually exclusive.
-    pub fn set_road_traffic<T: std::convert::Into<crate::model::commute_filter::RoadTraffic>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.traffic_option = std::option::Option::Some(
-            crate::model::commute_filter::TrafficOption::RoadTraffic(v.into()),
-        );
-        self
-    }
-
     /// The value of [traffic_option][crate::model::CommuteFilter::traffic_option]
     /// if it holds a `DepartureTime`, `None` if the field is not set or
     /// holds a different branch.
@@ -4737,21 +4672,6 @@ impl CommuteFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [traffic_option][crate::model::CommuteFilter::traffic_option]
-    /// to hold a `DepartureTime`.
-    ///
-    /// Note that all the setters affecting `traffic_option` are
-    /// mutually exclusive.
-    pub fn set_departure_time<T: std::convert::Into<std::boxed::Box<gtype::model::TimeOfDay>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.traffic_option = std::option::Option::Some(
-            crate::model::commute_filter::TrafficOption::DepartureTime(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/tasks/v2/src/model.rs
+++ b/src/generated/cloud/tasks/v2/src/model.rs
@@ -1859,21 +1859,6 @@ impl HttpRequest {
         })
     }
 
-    /// Sets the value of [authorization_header][crate::model::HttpRequest::authorization_header]
-    /// to hold a `OauthToken`.
-    ///
-    /// Note that all the setters affecting `authorization_header` are
-    /// mutually exclusive.
-    pub fn set_oauth_token<T: std::convert::Into<std::boxed::Box<crate::model::OAuthToken>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorization_header = std::option::Option::Some(
-            crate::model::http_request::AuthorizationHeader::OauthToken(v.into()),
-        );
-        self
-    }
-
     /// The value of [authorization_header][crate::model::HttpRequest::authorization_header]
     /// if it holds a `OidcToken`, `None` if the field is not set or
     /// holds a different branch.
@@ -1885,21 +1870,6 @@ impl HttpRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [authorization_header][crate::model::HttpRequest::authorization_header]
-    /// to hold a `OidcToken`.
-    ///
-    /// Note that all the setters affecting `authorization_header` are
-    /// mutually exclusive.
-    pub fn set_oidc_token<T: std::convert::Into<std::boxed::Box<crate::model::OidcToken>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.authorization_header = std::option::Option::Some(
-            crate::model::http_request::AuthorizationHeader::OidcToken(v.into()),
-        );
-        self
     }
 }
 
@@ -2666,23 +2636,6 @@ impl Task {
         })
     }
 
-    /// Sets the value of [message_type][crate::model::Task::message_type]
-    /// to hold a `AppEngineHttpRequest`.
-    ///
-    /// Note that all the setters affecting `message_type` are
-    /// mutually exclusive.
-    pub fn set_app_engine_http_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::AppEngineHttpRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message_type = std::option::Option::Some(
-            crate::model::task::MessageType::AppEngineHttpRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [message_type][crate::model::Task::message_type]
     /// if it holds a `HttpRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -2692,20 +2645,6 @@ impl Task {
             crate::model::task::MessageType::HttpRequest(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [message_type][crate::model::Task::message_type]
-    /// to hold a `HttpRequest`.
-    ///
-    /// Note that all the setters affecting `message_type` are
-    /// mutually exclusive.
-    pub fn set_http_request<T: std::convert::Into<std::boxed::Box<crate::model::HttpRequest>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.message_type =
-            std::option::Option::Some(crate::model::task::MessageType::HttpRequest(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/telcoautomation/v1/src/model.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/model.rs
@@ -4418,23 +4418,6 @@ impl ManagementConfig {
         })
     }
 
-    /// Sets the value of [oneof_config][crate::model::ManagementConfig::oneof_config]
-    /// to hold a `StandardManagementConfig`.
-    ///
-    /// Note that all the setters affecting `oneof_config` are
-    /// mutually exclusive.
-    pub fn set_standard_management_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::StandardManagementConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.oneof_config = std::option::Option::Some(
-            crate::model::management_config::OneofConfig::StandardManagementConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [oneof_config][crate::model::ManagementConfig::oneof_config]
     /// if it holds a `FullManagementConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -4448,23 +4431,6 @@ impl ManagementConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [oneof_config][crate::model::ManagementConfig::oneof_config]
-    /// to hold a `FullManagementConfig`.
-    ///
-    /// Note that all the setters affecting `oneof_config` are
-    /// mutually exclusive.
-    pub fn set_full_management_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::FullManagementConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.oneof_config = std::option::Option::Some(
-            crate::model::management_config::OneofConfig::FullManagementConfig(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/texttospeech/v1/src/model.rs
+++ b/src/generated/cloud/texttospeech/v1/src/model.rs
@@ -733,17 +733,6 @@ impl SynthesisInput {
         })
     }
 
-    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input_source =
-            std::option::Option::Some(crate::model::synthesis_input::InputSource::Text(v.into()));
-        self
-    }
-
     /// The value of [input_source][crate::model::SynthesisInput::input_source]
     /// if it holds a `Markup`, `None` if the field is not set or
     /// holds a different branch.
@@ -755,17 +744,6 @@ impl SynthesisInput {
         })
     }
 
-    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
-    /// to hold a `Markup`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_markup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input_source =
-            std::option::Option::Some(crate::model::synthesis_input::InputSource::Markup(v.into()));
-        self
-    }
-
     /// The value of [input_source][crate::model::SynthesisInput::input_source]
     /// if it holds a `Ssml`, `None` if the field is not set or
     /// holds a different branch.
@@ -775,17 +753,6 @@ impl SynthesisInput {
             crate::model::synthesis_input::InputSource::Ssml(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
-    /// to hold a `Ssml`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_ssml<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input_source =
-            std::option::Option::Some(crate::model::synthesis_input::InputSource::Ssml(v.into()));
-        self
     }
 
     /// The value of [input_source][crate::model::SynthesisInput::input_source]
@@ -801,23 +768,6 @@ impl SynthesisInput {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input_source][crate::model::SynthesisInput::input_source]
-    /// to hold a `MultiSpeakerMarkup`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_multi_speaker_markup<
-        T: std::convert::Into<std::boxed::Box<crate::model::MultiSpeakerMarkup>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.input_source = std::option::Option::Some(
-            crate::model::synthesis_input::InputSource::MultiSpeakerMarkup(v.into()),
-        );
-        self
     }
 }
 
@@ -1519,18 +1469,6 @@ impl StreamingSynthesisInput {
         })
     }
 
-    /// Sets the value of [input_source][crate::model::StreamingSynthesisInput::input_source]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input_source = std::option::Option::Some(
-            crate::model::streaming_synthesis_input::InputSource::Text(v.into()),
-        );
-        self
-    }
-
     /// The value of [input_source][crate::model::StreamingSynthesisInput::input_source]
     /// if it holds a `Markup`, `None` if the field is not set or
     /// holds a different branch.
@@ -1542,18 +1480,6 @@ impl StreamingSynthesisInput {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [input_source][crate::model::StreamingSynthesisInput::input_source]
-    /// to hold a `Markup`.
-    ///
-    /// Note that all the setters affecting `input_source` are
-    /// mutually exclusive.
-    pub fn set_markup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.input_source = std::option::Option::Some(
-            crate::model::streaming_synthesis_input::InputSource::Markup(v.into()),
-        );
-        self
     }
 }
 
@@ -1639,23 +1565,6 @@ impl StreamingSynthesizeRequest {
         })
     }
 
-    /// Sets the value of [streaming_request][crate::model::StreamingSynthesizeRequest::streaming_request]
-    /// to hold a `StreamingConfig`.
-    ///
-    /// Note that all the setters affecting `streaming_request` are
-    /// mutually exclusive.
-    pub fn set_streaming_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::StreamingSynthesizeConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.streaming_request = std::option::Option::Some(
-            crate::model::streaming_synthesize_request::StreamingRequest::StreamingConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [streaming_request][crate::model::StreamingSynthesizeRequest::streaming_request]
     /// if it holds a `Input`, `None` if the field is not set or
     /// holds a different branch.
@@ -1669,23 +1578,6 @@ impl StreamingSynthesizeRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [streaming_request][crate::model::StreamingSynthesizeRequest::streaming_request]
-    /// to hold a `Input`.
-    ///
-    /// Note that all the setters affecting `streaming_request` are
-    /// mutually exclusive.
-    pub fn set_input<
-        T: std::convert::Into<std::boxed::Box<crate::model::StreamingSynthesisInput>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.streaming_request = std::option::Option::Some(
-            crate::model::streaming_synthesize_request::StreamingRequest::Input(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/timeseriesinsights/v1/src/model.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/model.rs
@@ -497,17 +497,6 @@ impl EventDimension {
         })
     }
 
-    /// Sets the value of [value][crate::model::EventDimension::value]
-    /// to hold a `StringVal`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_val<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::event_dimension::Value::StringVal(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::EventDimension::value]
     /// if it holds a `LongVal`, `None` if the field is not set or
     /// holds a different branch.
@@ -517,17 +506,6 @@ impl EventDimension {
             crate::model::event_dimension::Value::LongVal(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::EventDimension::value]
-    /// to hold a `LongVal`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_long_val<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::event_dimension::Value::LongVal(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::EventDimension::value]
@@ -541,17 +519,6 @@ impl EventDimension {
         })
     }
 
-    /// Sets the value of [value][crate::model::EventDimension::value]
-    /// to hold a `BoolVal`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_val<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::event_dimension::Value::BoolVal(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::EventDimension::value]
     /// if it holds a `DoubleVal`, `None` if the field is not set or
     /// holds a different branch.
@@ -561,17 +528,6 @@ impl EventDimension {
             crate::model::event_dimension::Value::DoubleVal(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::EventDimension::value]
-    /// to hold a `DoubleVal`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_double_val<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::event_dimension::Value::DoubleVal(v.into()));
-        self
     }
 }
 
@@ -1047,17 +1003,6 @@ impl PinnedDimension {
         })
     }
 
-    /// Sets the value of [value][crate::model::PinnedDimension::value]
-    /// to hold a `StringVal`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_val<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::pinned_dimension::Value::StringVal(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::PinnedDimension::value]
     /// if it holds a `BoolVal`, `None` if the field is not set or
     /// holds a different branch.
@@ -1067,17 +1012,6 @@ impl PinnedDimension {
             crate::model::pinned_dimension::Value::BoolVal(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::PinnedDimension::value]
-    /// to hold a `BoolVal`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_val<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::pinned_dimension::Value::BoolVal(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/tpu/v2/src/model.rs
+++ b/src/generated/cloud/tpu/v2/src/model.rs
@@ -1636,20 +1636,6 @@ impl QueuedResource {
         })
     }
 
-    /// Sets the value of [resource][crate::model::QueuedResource::resource]
-    /// to hold a `Tpu`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_tpu<T: std::convert::Into<std::boxed::Box<crate::model::queued_resource::Tpu>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource =
-            std::option::Option::Some(crate::model::queued_resource::Resource::Tpu(v.into()));
-        self
-    }
-
     /// Sets the value of [tier][crate::model::QueuedResource::tier].
     ///
     /// Note that all the setters affecting `tier` are mutually
@@ -1677,19 +1663,6 @@ impl QueuedResource {
         })
     }
 
-    /// Sets the value of [tier][crate::model::QueuedResource::tier]
-    /// to hold a `Spot`.
-    ///
-    /// Note that all the setters affecting `tier` are
-    /// mutually exclusive.
-    pub fn set_spot<T: std::convert::Into<std::boxed::Box<crate::model::queued_resource::Spot>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tier = std::option::Option::Some(crate::model::queued_resource::Tier::Spot(v.into()));
-        self
-    }
-
     /// The value of [tier][crate::model::QueuedResource::tier]
     /// if it holds a `Guaranteed`, `None` if the field is not set or
     /// holds a different branch.
@@ -1701,22 +1674,6 @@ impl QueuedResource {
             crate::model::queued_resource::Tier::Guaranteed(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [tier][crate::model::QueuedResource::tier]
-    /// to hold a `Guaranteed`.
-    ///
-    /// Note that all the setters affecting `tier` are
-    /// mutually exclusive.
-    pub fn set_guaranteed<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource::Guaranteed>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tier =
-            std::option::Option::Some(crate::model::queued_resource::Tier::Guaranteed(v.into()));
-        self
     }
 }
 
@@ -1849,18 +1806,6 @@ pub mod queued_resource {
                 })
             }
 
-            /// Sets the value of [name_strategy][crate::model::queued_resource::tpu::NodeSpec::name_strategy]
-            /// to hold a `NodeId`.
-            ///
-            /// Note that all the setters affecting `name_strategy` are
-            /// mutually exclusive.
-            pub fn set_node_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-                self.name_strategy = std::option::Option::Some(
-                    crate::model::queued_resource::tpu::node_spec::NameStrategy::NodeId(v.into()),
-                );
-                self
-            }
-
             /// The value of [name_strategy][crate::model::queued_resource::tpu::NodeSpec::name_strategy]
             /// if it holds a `MultisliceParams`, `None` if the field is not set or
             /// holds a different branch.
@@ -1874,29 +1819,6 @@ pub mod queued_resource {
                     crate::model::queued_resource::tpu::node_spec::NameStrategy::MultisliceParams(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [name_strategy][crate::model::queued_resource::tpu::NodeSpec::name_strategy]
-            /// to hold a `MultisliceParams`.
-            ///
-            /// Note that all the setters affecting `name_strategy` are
-            /// mutually exclusive.
-            pub fn set_multislice_params<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::queued_resource::tpu::node_spec::MultisliceParams,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.name_strategy = std::option::Option::Some(
-                    crate::model::queued_resource::tpu::node_spec::NameStrategy::MultisliceParams(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -2094,23 +2016,6 @@ pub mod queued_resource {
             })
         }
 
-        /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// to hold a `ValidUntilDuration`.
-        ///
-        /// Note that all the setters affecting `start_timing_constraints` are
-        /// mutually exclusive.
-        pub fn set_valid_until_duration<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.start_timing_constraints = std::option::Option::Some(
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidUntilDuration(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
         /// if it holds a `ValidUntilTime`, `None` if the field is not set or
         /// holds a different branch.
@@ -2120,23 +2025,6 @@ pub mod queued_resource {
                 crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidUntilTime(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// to hold a `ValidUntilTime`.
-        ///
-        /// Note that all the setters affecting `start_timing_constraints` are
-        /// mutually exclusive.
-        pub fn set_valid_until_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.start_timing_constraints = std::option::Option::Some(
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidUntilTime(
-                    v.into()
-                )
-            );
-            self
         }
 
         /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
@@ -2150,23 +2038,6 @@ pub mod queued_resource {
             })
         }
 
-        /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// to hold a `ValidAfterDuration`.
-        ///
-        /// Note that all the setters affecting `start_timing_constraints` are
-        /// mutually exclusive.
-        pub fn set_valid_after_duration<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.start_timing_constraints = std::option::Option::Some(
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidAfterDuration(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
         /// if it holds a `ValidAfterTime`, `None` if the field is not set or
         /// holds a different branch.
@@ -2176,23 +2047,6 @@ pub mod queued_resource {
                 crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidAfterTime(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// to hold a `ValidAfterTime`.
-        ///
-        /// Note that all the setters affecting `start_timing_constraints` are
-        /// mutually exclusive.
-        pub fn set_valid_after_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.start_timing_constraints = std::option::Option::Some(
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidAfterTime(
-                    v.into()
-                )
-            );
-            self
         }
 
         /// The value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
@@ -2206,25 +2060,6 @@ pub mod queued_resource {
                 crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidInterval(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [start_timing_constraints][crate::model::queued_resource::QueueingPolicy::start_timing_constraints]
-        /// to hold a `ValidInterval`.
-        ///
-        /// Note that all the setters affecting `start_timing_constraints` are
-        /// mutually exclusive.
-        pub fn set_valid_interval<
-            T: std::convert::Into<std::boxed::Box<gtype::model::Interval>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.start_timing_constraints = std::option::Option::Some(
-                crate::model::queued_resource::queueing_policy::StartTimingConstraints::ValidInterval(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -2363,23 +2198,6 @@ impl QueuedResourceState {
         })
     }
 
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `CreatingData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_creating_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::CreatingData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::CreatingData(v.into()),
-        );
-        self
-    }
-
     /// The value of [state_data][crate::model::QueuedResourceState::state_data]
     /// if it holds a `AcceptedData`, `None` if the field is not set or
     /// holds a different branch.
@@ -2394,23 +2212,6 @@ impl QueuedResourceState {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `AcceptedData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_accepted_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::AcceptedData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::AcceptedData(v.into()),
-        );
-        self
     }
 
     /// The value of [state_data][crate::model::QueuedResourceState::state_data]
@@ -2429,23 +2230,6 @@ impl QueuedResourceState {
         })
     }
 
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `ProvisioningData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_provisioning_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::ProvisioningData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::ProvisioningData(v.into()),
-        );
-        self
-    }
-
     /// The value of [state_data][crate::model::QueuedResourceState::state_data]
     /// if it holds a `FailedData`, `None` if the field is not set or
     /// holds a different branch.
@@ -2460,23 +2244,6 @@ impl QueuedResourceState {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `FailedData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_failed_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::FailedData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::FailedData(v.into()),
-        );
-        self
     }
 
     /// The value of [state_data][crate::model::QueuedResourceState::state_data]
@@ -2495,23 +2262,6 @@ impl QueuedResourceState {
         })
     }
 
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `DeletingData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_deleting_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::DeletingData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::DeletingData(v.into()),
-        );
-        self
-    }
-
     /// The value of [state_data][crate::model::QueuedResourceState::state_data]
     /// if it holds a `ActiveData`, `None` if the field is not set or
     /// holds a different branch.
@@ -2526,23 +2276,6 @@ impl QueuedResourceState {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `ActiveData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_active_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::ActiveData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::ActiveData(v.into()),
-        );
-        self
     }
 
     /// The value of [state_data][crate::model::QueuedResourceState::state_data]
@@ -2561,23 +2294,6 @@ impl QueuedResourceState {
         })
     }
 
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `SuspendingData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_suspending_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::SuspendingData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::SuspendingData(v.into()),
-        );
-        self
-    }
-
     /// The value of [state_data][crate::model::QueuedResourceState::state_data]
     /// if it holds a `SuspendedData`, `None` if the field is not set or
     /// holds a different branch.
@@ -2592,23 +2308,6 @@ impl QueuedResourceState {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [state_data][crate::model::QueuedResourceState::state_data]
-    /// to hold a `SuspendedData`.
-    ///
-    /// Note that all the setters affecting `state_data` are
-    /// mutually exclusive.
-    pub fn set_suspended_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::queued_resource_state::SuspendedData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.state_data = std::option::Option::Some(
-            crate::model::queued_resource_state::StateData::SuspendedData(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/translate/v3/src/builder.rs
+++ b/src/generated/cloud/translate/v3/src/builder.rs
@@ -371,16 +371,6 @@ pub mod translation_service {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::DetectLanguageRequest::source]
-        /// to hold a `Content`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_content(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -2920,36 +2910,6 @@ pub mod translation_service {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
-        /// to hold a `FileInputSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_file_input_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::FileInputSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_file_input_source(v);
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
-        /// to hold a `GcsInputSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_input_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::GcsInputSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_input_source(v);
             self
         }
     }

--- a/src/generated/cloud/translate/v3/src/model.rs
+++ b/src/generated/cloud/translate/v3/src/model.rs
@@ -1016,23 +1016,6 @@ impl ImportAdaptiveMtFileRequest {
         })
     }
 
-    /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
-    /// to hold a `FileInputSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_file_input_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::FileInputSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_adaptive_mt_file_request::Source::FileInputSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
     /// if it holds a `GcsInputSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -1046,23 +1029,6 @@ impl ImportAdaptiveMtFileRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportAdaptiveMtFileRequest::source]
-    /// to hold a `GcsInputSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_input_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsInputSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_adaptive_mt_file_request::Source::GcsInputSource(v.into()),
-        );
-        self
     }
 }
 
@@ -1599,23 +1565,6 @@ pub mod dataset_input_config {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [source][crate::model::dataset_input_config::InputFile::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::GcsInputSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::dataset_input_config::input_file::Source::GcsSource(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for InputFile {
@@ -1807,23 +1756,6 @@ impl DatasetOutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::DatasetOutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsOutputDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::dataset_output_config::Destination::GcsDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -3435,22 +3367,6 @@ impl GlossaryEntry {
         })
     }
 
-    /// Sets the value of [data][crate::model::GlossaryEntry::data]
-    /// to hold a `TermsPair`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_terms_pair<
-        T: std::convert::Into<std::boxed::Box<crate::model::glossary_entry::GlossaryTermsPair>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data =
-            std::option::Option::Some(crate::model::glossary_entry::Data::TermsPair(v.into()));
-        self
-    }
-
     /// The value of [data][crate::model::GlossaryEntry::data]
     /// if it holds a `TermsSet`, `None` if the field is not set or
     /// holds a different branch.
@@ -3462,22 +3378,6 @@ impl GlossaryEntry {
             crate::model::glossary_entry::Data::TermsSet(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data][crate::model::GlossaryEntry::data]
-    /// to hold a `TermsSet`.
-    ///
-    /// Note that all the setters affecting `data` are
-    /// mutually exclusive.
-    pub fn set_terms_set<
-        T: std::convert::Into<std::boxed::Box<crate::model::glossary_entry::GlossaryTermsSet>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data =
-            std::option::Option::Some(crate::model::glossary_entry::Data::TermsSet(v.into()));
-        self
     }
 }
 
@@ -4284,18 +4184,6 @@ impl DetectLanguageRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::DetectLanguageRequest::source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::detect_language_request::Source::Content(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DetectLanguageRequest {
@@ -4676,20 +4564,6 @@ impl InputConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::InputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::input_config::Source::GcsSource(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for InputConfig {
@@ -4816,23 +4690,6 @@ impl OutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::OutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::output_config::Destination::GcsDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -4999,18 +4856,6 @@ impl DocumentInputConfig {
         })
     }
 
-    /// Sets the value of [source][crate::model::DocumentInputConfig::source]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::document_input_config::Source::Content(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::DocumentInputConfig::source]
     /// if it holds a `GcsSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -5022,21 +4867,6 @@ impl DocumentInputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::DocumentInputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::document_input_config::Source::GcsSource(v.into()),
-        );
-        self
     }
 }
 
@@ -5142,23 +4972,6 @@ impl DocumentOutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::DocumentOutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::document_output_config::Destination::GcsDestination(v.into()),
-        );
-        self
     }
 }
 
@@ -6167,21 +5980,6 @@ impl GlossaryInputConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::GlossaryInputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::glossary_input_config::Source::GcsSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for GlossaryInputConfig {
@@ -6346,22 +6144,6 @@ impl Glossary {
         })
     }
 
-    /// Sets the value of [languages][crate::model::Glossary::languages]
-    /// to hold a `LanguagePair`.
-    ///
-    /// Note that all the setters affecting `languages` are
-    /// mutually exclusive.
-    pub fn set_language_pair<
-        T: std::convert::Into<std::boxed::Box<crate::model::glossary::LanguageCodePair>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.languages =
-            std::option::Option::Some(crate::model::glossary::Languages::LanguagePair(v.into()));
-        self
-    }
-
     /// The value of [languages][crate::model::Glossary::languages]
     /// if it holds a `LanguageCodesSet`, `None` if the field is not set or
     /// holds a different branch.
@@ -6373,23 +6155,6 @@ impl Glossary {
             crate::model::glossary::Languages::LanguageCodesSet(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [languages][crate::model::Glossary::languages]
-    /// to hold a `LanguageCodesSet`.
-    ///
-    /// Note that all the setters affecting `languages` are
-    /// mutually exclusive.
-    pub fn set_language_codes_set<
-        T: std::convert::Into<std::boxed::Box<crate::model::glossary::LanguageCodesSet>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.languages = std::option::Option::Some(
-            crate::model::glossary::Languages::LanguageCodesSet(v.into()),
-        );
-        self
     }
 }
 
@@ -8074,21 +7839,6 @@ impl BatchDocumentInputConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::BatchDocumentInputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::batch_document_input_config::Source::GcsSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BatchDocumentInputConfig {
@@ -8181,23 +7931,6 @@ impl BatchDocumentOutputConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [destination][crate::model::BatchDocumentOutputConfig::destination]
-    /// to hold a `GcsDestination`.
-    ///
-    /// Note that all the setters affecting `destination` are
-    /// mutually exclusive.
-    pub fn set_gcs_destination<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsDestination>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.destination = std::option::Option::Some(
-            crate::model::batch_document_output_config::Destination::GcsDestination(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/video/livestream/v1/src/model.rs
+++ b/src/generated/cloud/video/livestream/v1/src/model.rs
@@ -95,21 +95,6 @@ impl ElementaryStream {
         })
     }
 
-    /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// to hold a `VideoStream`.
-    ///
-    /// Note that all the setters affecting `elementary_stream` are
-    /// mutually exclusive.
-    pub fn set_video_stream<T: std::convert::Into<std::boxed::Box<crate::model::VideoStream>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.elementary_stream = std::option::Option::Some(
-            crate::model::elementary_stream::ElementaryStream::VideoStream(v.into()),
-        );
-        self
-    }
-
     /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// if it holds a `AudioStream`, `None` if the field is not set or
     /// holds a different branch.
@@ -123,21 +108,6 @@ impl ElementaryStream {
         })
     }
 
-    /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// to hold a `AudioStream`.
-    ///
-    /// Note that all the setters affecting `elementary_stream` are
-    /// mutually exclusive.
-    pub fn set_audio_stream<T: std::convert::Into<std::boxed::Box<crate::model::AudioStream>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.elementary_stream = std::option::Option::Some(
-            crate::model::elementary_stream::ElementaryStream::AudioStream(v.into()),
-        );
-        self
-    }
-
     /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// if it holds a `TextStream`, `None` if the field is not set or
     /// holds a different branch.
@@ -149,21 +119,6 @@ impl ElementaryStream {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// to hold a `TextStream`.
-    ///
-    /// Note that all the setters affecting `elementary_stream` are
-    /// mutually exclusive.
-    pub fn set_text_stream<T: std::convert::Into<std::boxed::Box<crate::model::TextStream>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.elementary_stream = std::option::Option::Some(
-            crate::model::elementary_stream::ElementaryStream::TextStream(v.into()),
-        );
-        self
     }
 }
 
@@ -974,22 +929,6 @@ impl VideoStream {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [codec_settings][crate::model::VideoStream::codec_settings]
-    /// to hold a `H264`.
-    ///
-    /// Note that all the setters affecting `codec_settings` are
-    /// mutually exclusive.
-    pub fn set_h264<
-        T: std::convert::Into<std::boxed::Box<crate::model::video_stream::H264CodecSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.codec_settings =
-            std::option::Option::Some(crate::model::video_stream::CodecSettings::H264(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for VideoStream {
@@ -1242,18 +1181,6 @@ pub mod video_stream {
             })
         }
 
-        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_264_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
-        }
-
         /// The value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -1265,21 +1192,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
-        /// to hold a `GopDuration`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_duration<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_264_codec_settings::GopMode::GopDuration(v.into()),
-            );
-            self
         }
     }
 
@@ -1690,21 +1602,6 @@ impl TimecodeConfig {
         })
     }
 
-    /// Sets the value of [time_offset][crate::model::TimecodeConfig::time_offset]
-    /// to hold a `UtcOffset`.
-    ///
-    /// Note that all the setters affecting `time_offset` are
-    /// mutually exclusive.
-    pub fn set_utc_offset<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time_offset = std::option::Option::Some(
-            crate::model::timecode_config::TimeOffset::UtcOffset(v.into()),
-        );
-        self
-    }
-
     /// The value of [time_offset][crate::model::TimecodeConfig::time_offset]
     /// if it holds a `TimeZone`, `None` if the field is not set or
     /// holds a different branch.
@@ -1714,21 +1611,6 @@ impl TimecodeConfig {
             crate::model::timecode_config::TimeOffset::TimeZone(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [time_offset][crate::model::TimecodeConfig::time_offset]
-    /// to hold a `TimeZone`.
-    ///
-    /// Note that all the setters affecting `time_offset` are
-    /// mutually exclusive.
-    pub fn set_time_zone<T: std::convert::Into<std::boxed::Box<gtype::model::TimeZone>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time_offset = std::option::Option::Some(
-            crate::model::timecode_config::TimeOffset::TimeZone(v.into()),
-        );
-        self
     }
 }
 
@@ -4055,21 +3937,6 @@ impl Event {
         })
     }
 
-    /// Sets the value of [task][crate::model::Event::task]
-    /// to hold a `InputSwitch`.
-    ///
-    /// Note that all the setters affecting `task` are
-    /// mutually exclusive.
-    pub fn set_input_switch<
-        T: std::convert::Into<std::boxed::Box<crate::model::event::InputSwitchTask>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task = std::option::Option::Some(crate::model::event::Task::InputSwitch(v.into()));
-        self
-    }
-
     /// The value of [task][crate::model::Event::task]
     /// if it holds a `AdBreak`, `None` if the field is not set or
     /// holds a different branch.
@@ -4081,21 +3948,6 @@ impl Event {
             crate::model::event::Task::AdBreak(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [task][crate::model::Event::task]
-    /// to hold a `AdBreak`.
-    ///
-    /// Note that all the setters affecting `task` are
-    /// mutually exclusive.
-    pub fn set_ad_break<
-        T: std::convert::Into<std::boxed::Box<crate::model::event::AdBreakTask>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task = std::option::Option::Some(crate::model::event::Task::AdBreak(v.into()));
-        self
     }
 
     /// The value of [task][crate::model::Event::task]
@@ -4111,21 +3963,6 @@ impl Event {
         })
     }
 
-    /// Sets the value of [task][crate::model::Event::task]
-    /// to hold a `ReturnToProgram`.
-    ///
-    /// Note that all the setters affecting `task` are
-    /// mutually exclusive.
-    pub fn set_return_to_program<
-        T: std::convert::Into<std::boxed::Box<crate::model::event::ReturnToProgramTask>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task = std::option::Option::Some(crate::model::event::Task::ReturnToProgram(v.into()));
-        self
-    }
-
     /// The value of [task][crate::model::Event::task]
     /// if it holds a `Slate`, `None` if the field is not set or
     /// holds a different branch.
@@ -4135,19 +3972,6 @@ impl Event {
             crate::model::event::Task::Slate(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [task][crate::model::Event::task]
-    /// to hold a `Slate`.
-    ///
-    /// Note that all the setters affecting `task` are
-    /// mutually exclusive.
-    pub fn set_slate<T: std::convert::Into<std::boxed::Box<crate::model::event::SlateTask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task = std::option::Option::Some(crate::model::event::Task::Slate(v.into()));
-        self
     }
 
     /// The value of [task][crate::model::Event::task]
@@ -4161,19 +3985,6 @@ impl Event {
         })
     }
 
-    /// Sets the value of [task][crate::model::Event::task]
-    /// to hold a `Mute`.
-    ///
-    /// Note that all the setters affecting `task` are
-    /// mutually exclusive.
-    pub fn set_mute<T: std::convert::Into<std::boxed::Box<crate::model::event::MuteTask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task = std::option::Option::Some(crate::model::event::Task::Mute(v.into()));
-        self
-    }
-
     /// The value of [task][crate::model::Event::task]
     /// if it holds a `Unmute`, `None` if the field is not set or
     /// holds a different branch.
@@ -4183,19 +3994,6 @@ impl Event {
             crate::model::event::Task::Unmute(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [task][crate::model::Event::task]
-    /// to hold a `Unmute`.
-    ///
-    /// Note that all the setters affecting `task` are
-    /// mutually exclusive.
-    pub fn set_unmute<T: std::convert::Into<std::boxed::Box<crate::model::event::UnmuteTask>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.task = std::option::Option::Some(crate::model::event::Task::Unmute(v.into()));
-        self
     }
 }
 
@@ -4857,22 +4655,6 @@ pub mod clip {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [kind][crate::model::clip::Slice::kind]
-        /// to hold a `TimeSlice`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_time_slice<
-            T: std::convert::Into<std::boxed::Box<crate::model::clip::TimeSlice>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.kind =
-                std::option::Option::Some(crate::model::clip::slice::Kind::TimeSlice(v.into()));
-            self
-        }
     }
 
     impl wkt::message::Message for Slice {
@@ -5244,19 +5026,6 @@ impl Asset {
         })
     }
 
-    /// Sets the value of [resource][crate::model::Asset::resource]
-    /// to hold a `Video`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_video<T: std::convert::Into<std::boxed::Box<crate::model::asset::VideoAsset>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(crate::model::asset::Resource::Video(v.into()));
-        self
-    }
-
     /// The value of [resource][crate::model::Asset::resource]
     /// if it holds a `Image`, `None` if the field is not set or
     /// holds a different branch.
@@ -5266,19 +5035,6 @@ impl Asset {
             crate::model::asset::Resource::Image(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource][crate::model::Asset::resource]
-    /// to hold a `Image`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_image<T: std::convert::Into<std::boxed::Box<crate::model::asset::ImageAsset>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(crate::model::asset::Resource::Image(v.into()));
-        self
     }
 }
 
@@ -5599,23 +5355,6 @@ impl Encryption {
         })
     }
 
-    /// Sets the value of [secret_source][crate::model::Encryption::secret_source]
-    /// to hold a `SecretManagerKeySource`.
-    ///
-    /// Note that all the setters affecting `secret_source` are
-    /// mutually exclusive.
-    pub fn set_secret_manager_key_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::SecretManagerSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.secret_source = std::option::Option::Some(
-            crate::model::encryption::SecretSource::SecretManagerKeySource(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode].
     ///
     /// Note that all the setters affecting `encryption_mode` are mutually
@@ -5643,22 +5382,6 @@ impl Encryption {
         })
     }
 
-    /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// to hold a `Aes128`.
-    ///
-    /// Note that all the setters affecting `encryption_mode` are
-    /// mutually exclusive.
-    pub fn set_aes128<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::Aes128Encryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_mode =
-            std::option::Option::Some(crate::model::encryption::EncryptionMode::Aes128(v.into()));
-        self
-    }
-
     /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
     /// if it holds a `SampleAes`, `None` if the field is not set or
     /// holds a different branch.
@@ -5672,23 +5395,6 @@ impl Encryption {
         })
     }
 
-    /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// to hold a `SampleAes`.
-    ///
-    /// Note that all the setters affecting `encryption_mode` are
-    /// mutually exclusive.
-    pub fn set_sample_aes<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::SampleAesEncryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_mode = std::option::Option::Some(
-            crate::model::encryption::EncryptionMode::SampleAes(v.into()),
-        );
-        self
-    }
-
     /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
     /// if it holds a `MpegCenc`, `None` if the field is not set or
     /// holds a different branch.
@@ -5700,22 +5406,6 @@ impl Encryption {
             crate::model::encryption::EncryptionMode::MpegCenc(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// to hold a `MpegCenc`.
-    ///
-    /// Note that all the setters affecting `encryption_mode` are
-    /// mutually exclusive.
-    pub fn set_mpeg_cenc<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::MpegCommonEncryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_mode =
-            std::option::Option::Some(crate::model::encryption::EncryptionMode::MpegCenc(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/video/stitcher/v1/src/model.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/model.rs
@@ -387,22 +387,6 @@ impl CdnKey {
         })
     }
 
-    /// Sets the value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
-    /// to hold a `GoogleCdnKey`.
-    ///
-    /// Note that all the setters affecting `cdn_key_config` are
-    /// mutually exclusive.
-    pub fn set_google_cdn_key<
-        T: std::convert::Into<std::boxed::Box<crate::model::GoogleCdnKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdn_key_config =
-            std::option::Option::Some(crate::model::cdn_key::CdnKeyConfig::GoogleCdnKey(v.into()));
-        self
-    }
-
     /// The value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
     /// if it holds a `AkamaiCdnKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -416,22 +400,6 @@ impl CdnKey {
         })
     }
 
-    /// Sets the value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
-    /// to hold a `AkamaiCdnKey`.
-    ///
-    /// Note that all the setters affecting `cdn_key_config` are
-    /// mutually exclusive.
-    pub fn set_akamai_cdn_key<
-        T: std::convert::Into<std::boxed::Box<crate::model::AkamaiCdnKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdn_key_config =
-            std::option::Option::Some(crate::model::cdn_key::CdnKeyConfig::AkamaiCdnKey(v.into()));
-        self
-    }
-
     /// The value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
     /// if it holds a `MediaCdnKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -443,20 +411,6 @@ impl CdnKey {
             crate::model::cdn_key::CdnKeyConfig::MediaCdnKey(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cdn_key_config][crate::model::CdnKey::cdn_key_config]
-    /// to hold a `MediaCdnKey`.
-    ///
-    /// Note that all the setters affecting `cdn_key_config` are
-    /// mutually exclusive.
-    pub fn set_media_cdn_key<T: std::convert::Into<std::boxed::Box<crate::model::MediaCdnKey>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cdn_key_config =
-            std::option::Option::Some(crate::model::cdn_key::CdnKeyConfig::MediaCdnKey(v.into()));
-        self
     }
 }
 
@@ -1010,23 +964,6 @@ impl Companion {
         })
     }
 
-    /// Sets the value of [ad_resource][crate::model::Companion::ad_resource]
-    /// to hold a `IframeAdResource`.
-    ///
-    /// Note that all the setters affecting `ad_resource` are
-    /// mutually exclusive.
-    pub fn set_iframe_ad_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::IframeAdResource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ad_resource = std::option::Option::Some(
-            crate::model::companion::AdResource::IframeAdResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [ad_resource][crate::model::Companion::ad_resource]
     /// if it holds a `StaticAdResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -1042,23 +979,6 @@ impl Companion {
         })
     }
 
-    /// Sets the value of [ad_resource][crate::model::Companion::ad_resource]
-    /// to hold a `StaticAdResource`.
-    ///
-    /// Note that all the setters affecting `ad_resource` are
-    /// mutually exclusive.
-    pub fn set_static_ad_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::StaticAdResource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ad_resource = std::option::Option::Some(
-            crate::model::companion::AdResource::StaticAdResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [ad_resource][crate::model::Companion::ad_resource]
     /// if it holds a `HtmlAdResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -1070,23 +990,6 @@ impl Companion {
             crate::model::companion::AdResource::HtmlAdResource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [ad_resource][crate::model::Companion::ad_resource]
-    /// to hold a `HtmlAdResource`.
-    ///
-    /// Note that all the setters affecting `ad_resource` are
-    /// mutually exclusive.
-    pub fn set_html_ad_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::HtmlAdResource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.ad_resource = std::option::Option::Some(
-            crate::model::companion::AdResource::HtmlAdResource(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/video/transcoder/v1/src/model.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/model.rs
@@ -251,17 +251,6 @@ impl Job {
         })
     }
 
-    /// Sets the value of [job_config][crate::model::Job::job_config]
-    /// to hold a `TemplateId`.
-    ///
-    /// Note that all the setters affecting `job_config` are
-    /// mutually exclusive.
-    pub fn set_template_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.job_config =
-            std::option::Option::Some(crate::model::job::JobConfig::TemplateId(v.into()));
-        self
-    }
-
     /// The value of [job_config][crate::model::Job::job_config]
     /// if it holds a `Config`, `None` if the field is not set or
     /// holds a different branch.
@@ -271,19 +260,6 @@ impl Job {
             crate::model::job::JobConfig::Config(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job_config][crate::model::Job::job_config]
-    /// to hold a `Config`.
-    ///
-    /// Note that all the setters affecting `job_config` are
-    /// mutually exclusive.
-    pub fn set_config<T: std::convert::Into<std::boxed::Box<crate::model::JobConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job_config = std::option::Option::Some(crate::model::job::JobConfig::Config(v.into()));
-        self
     }
 }
 
@@ -1257,21 +1233,6 @@ impl ElementaryStream {
         })
     }
 
-    /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// to hold a `VideoStream`.
-    ///
-    /// Note that all the setters affecting `elementary_stream` are
-    /// mutually exclusive.
-    pub fn set_video_stream<T: std::convert::Into<std::boxed::Box<crate::model::VideoStream>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.elementary_stream = std::option::Option::Some(
-            crate::model::elementary_stream::ElementaryStream::VideoStream(v.into()),
-        );
-        self
-    }
-
     /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// if it holds a `AudioStream`, `None` if the field is not set or
     /// holds a different branch.
@@ -1285,21 +1246,6 @@ impl ElementaryStream {
         })
     }
 
-    /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// to hold a `AudioStream`.
-    ///
-    /// Note that all the setters affecting `elementary_stream` are
-    /// mutually exclusive.
-    pub fn set_audio_stream<T: std::convert::Into<std::boxed::Box<crate::model::AudioStream>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.elementary_stream = std::option::Option::Some(
-            crate::model::elementary_stream::ElementaryStream::AudioStream(v.into()),
-        );
-        self
-    }
-
     /// The value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
     /// if it holds a `TextStream`, `None` if the field is not set or
     /// holds a different branch.
@@ -1311,21 +1257,6 @@ impl ElementaryStream {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [elementary_stream][crate::model::ElementaryStream::elementary_stream]
-    /// to hold a `TextStream`.
-    ///
-    /// Note that all the setters affecting `elementary_stream` are
-    /// mutually exclusive.
-    pub fn set_text_stream<T: std::convert::Into<std::boxed::Box<crate::model::TextStream>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.elementary_stream = std::option::Option::Some(
-            crate::model::elementary_stream::ElementaryStream::TextStream(v.into()),
-        );
-        self
     }
 }
 
@@ -1552,20 +1483,6 @@ impl Manifest {
             crate::model::manifest::ManifestConfig::Dash(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [manifest_config][crate::model::Manifest::manifest_config]
-    /// to hold a `Dash`.
-    ///
-    /// Note that all the setters affecting `manifest_config` are
-    /// mutually exclusive.
-    pub fn set_dash<T: std::convert::Into<std::boxed::Box<crate::model::manifest::DashConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.manifest_config =
-            std::option::Option::Some(crate::model::manifest::ManifestConfig::Dash(v.into()));
-        self
     }
 }
 
@@ -2123,18 +2040,6 @@ impl SpriteSheet {
         })
     }
 
-    /// Sets the value of [extraction_strategy][crate::model::SpriteSheet::extraction_strategy]
-    /// to hold a `TotalCount`.
-    ///
-    /// Note that all the setters affecting `extraction_strategy` are
-    /// mutually exclusive.
-    pub fn set_total_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.extraction_strategy = std::option::Option::Some(
-            crate::model::sprite_sheet::ExtractionStrategy::TotalCount(v.into()),
-        );
-        self
-    }
-
     /// The value of [extraction_strategy][crate::model::SpriteSheet::extraction_strategy]
     /// if it holds a `Interval`, `None` if the field is not set or
     /// holds a different branch.
@@ -2146,21 +2051,6 @@ impl SpriteSheet {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [extraction_strategy][crate::model::SpriteSheet::extraction_strategy]
-    /// to hold a `Interval`.
-    ///
-    /// Note that all the setters affecting `extraction_strategy` are
-    /// mutually exclusive.
-    pub fn set_interval<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.extraction_strategy = std::option::Option::Some(
-            crate::model::sprite_sheet::ExtractionStrategy::Interval(v.into()),
-        );
-        self
     }
 }
 
@@ -2575,23 +2465,6 @@ pub mod overlay {
             })
         }
 
-        /// Sets the value of [animation_type][crate::model::overlay::Animation::animation_type]
-        /// to hold a `AnimationStatic`.
-        ///
-        /// Note that all the setters affecting `animation_type` are
-        /// mutually exclusive.
-        pub fn set_animation_static<
-            T: std::convert::Into<std::boxed::Box<crate::model::overlay::AnimationStatic>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.animation_type = std::option::Option::Some(
-                crate::model::overlay::animation::AnimationType::AnimationStatic(v.into()),
-            );
-            self
-        }
-
         /// The value of [animation_type][crate::model::overlay::Animation::animation_type]
         /// if it holds a `AnimationFade`, `None` if the field is not set or
         /// holds a different branch.
@@ -2607,23 +2480,6 @@ pub mod overlay {
             })
         }
 
-        /// Sets the value of [animation_type][crate::model::overlay::Animation::animation_type]
-        /// to hold a `AnimationFade`.
-        ///
-        /// Note that all the setters affecting `animation_type` are
-        /// mutually exclusive.
-        pub fn set_animation_fade<
-            T: std::convert::Into<std::boxed::Box<crate::model::overlay::AnimationFade>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.animation_type = std::option::Option::Some(
-                crate::model::overlay::animation::AnimationType::AnimationFade(v.into()),
-            );
-            self
-        }
-
         /// The value of [animation_type][crate::model::overlay::Animation::animation_type]
         /// if it holds a `AnimationEnd`, `None` if the field is not set or
         /// holds a different branch.
@@ -2637,23 +2493,6 @@ pub mod overlay {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [animation_type][crate::model::overlay::Animation::animation_type]
-        /// to hold a `AnimationEnd`.
-        ///
-        /// Note that all the setters affecting `animation_type` are
-        /// mutually exclusive.
-        pub fn set_animation_end<
-            T: std::convert::Into<std::boxed::Box<crate::model::overlay::AnimationEnd>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.animation_type = std::option::Option::Some(
-                crate::model::overlay::animation::AnimationType::AnimationEnd(v.into()),
-            );
-            self
         }
     }
 
@@ -3358,27 +3197,6 @@ pub mod preprocessing_config {
             })
         }
 
-        /// Sets the value of [deinterlacing_filter][crate::model::preprocessing_config::Deinterlace::deinterlacing_filter]
-        /// to hold a `Yadif`.
-        ///
-        /// Note that all the setters affecting `deinterlacing_filter` are
-        /// mutually exclusive.
-        pub fn set_yadif<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::preprocessing_config::deinterlace::YadifConfig>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.deinterlacing_filter = std::option::Option::Some(
-                crate::model::preprocessing_config::deinterlace::DeinterlacingFilter::Yadif(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [deinterlacing_filter][crate::model::preprocessing_config::Deinterlace::deinterlacing_filter]
         /// if it holds a `Bwdif`, `None` if the field is not set or
         /// holds a different branch.
@@ -3394,27 +3212,6 @@ pub mod preprocessing_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [deinterlacing_filter][crate::model::preprocessing_config::Deinterlace::deinterlacing_filter]
-        /// to hold a `Bwdif`.
-        ///
-        /// Note that all the setters affecting `deinterlacing_filter` are
-        /// mutually exclusive.
-        pub fn set_bwdif<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::preprocessing_config::deinterlace::BwdifConfig>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.deinterlacing_filter = std::option::Option::Some(
-                crate::model::preprocessing_config::deinterlace::DeinterlacingFilter::Bwdif(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -3631,22 +3428,6 @@ impl VideoStream {
         })
     }
 
-    /// Sets the value of [codec_settings][crate::model::VideoStream::codec_settings]
-    /// to hold a `H264`.
-    ///
-    /// Note that all the setters affecting `codec_settings` are
-    /// mutually exclusive.
-    pub fn set_h264<
-        T: std::convert::Into<std::boxed::Box<crate::model::video_stream::H264CodecSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.codec_settings =
-            std::option::Option::Some(crate::model::video_stream::CodecSettings::H264(v.into()));
-        self
-    }
-
     /// The value of [codec_settings][crate::model::VideoStream::codec_settings]
     /// if it holds a `H265`, `None` if the field is not set or
     /// holds a different branch.
@@ -3660,22 +3441,6 @@ impl VideoStream {
         })
     }
 
-    /// Sets the value of [codec_settings][crate::model::VideoStream::codec_settings]
-    /// to hold a `H265`.
-    ///
-    /// Note that all the setters affecting `codec_settings` are
-    /// mutually exclusive.
-    pub fn set_h265<
-        T: std::convert::Into<std::boxed::Box<crate::model::video_stream::H265CodecSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.codec_settings =
-            std::option::Option::Some(crate::model::video_stream::CodecSettings::H265(v.into()));
-        self
-    }
-
     /// The value of [codec_settings][crate::model::VideoStream::codec_settings]
     /// if it holds a `Vp9`, `None` if the field is not set or
     /// holds a different branch.
@@ -3687,22 +3452,6 @@ impl VideoStream {
             crate::model::video_stream::CodecSettings::Vp9(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [codec_settings][crate::model::VideoStream::codec_settings]
-    /// to hold a `Vp9`.
-    ///
-    /// Note that all the setters affecting `codec_settings` are
-    /// mutually exclusive.
-    pub fn set_vp9<
-        T: std::convert::Into<std::boxed::Box<crate::model::video_stream::Vp9CodecSettings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.codec_settings =
-            std::option::Option::Some(crate::model::video_stream::CodecSettings::Vp9(v.into()));
-        self
     }
 }
 
@@ -4031,18 +3780,6 @@ pub mod video_stream {
             })
         }
 
-        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_264_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
-        }
-
         /// The value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -4054,21 +3791,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::H264CodecSettings::gop_mode]
-        /// to hold a `GopDuration`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_duration<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_264_codec_settings::GopMode::GopDuration(v.into()),
-            );
-            self
         }
     }
 
@@ -4412,18 +4134,6 @@ pub mod video_stream {
             })
         }
 
-        /// Sets the value of [gop_mode][crate::model::video_stream::H265CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_265_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
-        }
-
         /// The value of [gop_mode][crate::model::video_stream::H265CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -4435,21 +4145,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::H265CodecSettings::gop_mode]
-        /// to hold a `GopDuration`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_duration<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::h_265_codec_settings::GopMode::GopDuration(v.into()),
-            );
-            self
         }
     }
 
@@ -4669,18 +4364,6 @@ pub mod video_stream {
             })
         }
 
-        /// Sets the value of [gop_mode][crate::model::video_stream::Vp9CodecSettings::gop_mode]
-        /// to hold a `GopFrameCount`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_frame_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::vp_9_codec_settings::GopMode::GopFrameCount(v.into()),
-            );
-            self
-        }
-
         /// The value of [gop_mode][crate::model::video_stream::Vp9CodecSettings::gop_mode]
         /// if it holds a `GopDuration`, `None` if the field is not set or
         /// holds a different branch.
@@ -4692,21 +4375,6 @@ pub mod video_stream {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [gop_mode][crate::model::video_stream::Vp9CodecSettings::gop_mode]
-        /// to hold a `GopDuration`.
-        ///
-        /// Note that all the setters affecting `gop_mode` are
-        /// mutually exclusive.
-        pub fn set_gop_duration<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.gop_mode = std::option::Option::Some(
-                crate::model::video_stream::vp_9_codec_settings::GopMode::GopDuration(v.into()),
-            );
-            self
         }
     }
 
@@ -5244,22 +4912,6 @@ impl Encryption {
         })
     }
 
-    /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// to hold a `Aes128`.
-    ///
-    /// Note that all the setters affecting `encryption_mode` are
-    /// mutually exclusive.
-    pub fn set_aes_128<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::Aes128Encryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_mode =
-            std::option::Option::Some(crate::model::encryption::EncryptionMode::Aes128(v.into()));
-        self
-    }
-
     /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
     /// if it holds a `SampleAes`, `None` if the field is not set or
     /// holds a different branch.
@@ -5273,23 +4925,6 @@ impl Encryption {
         })
     }
 
-    /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// to hold a `SampleAes`.
-    ///
-    /// Note that all the setters affecting `encryption_mode` are
-    /// mutually exclusive.
-    pub fn set_sample_aes<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::SampleAesEncryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_mode = std::option::Option::Some(
-            crate::model::encryption::EncryptionMode::SampleAes(v.into()),
-        );
-        self
-    }
-
     /// The value of [encryption_mode][crate::model::Encryption::encryption_mode]
     /// if it holds a `MpegCenc`, `None` if the field is not set or
     /// holds a different branch.
@@ -5301,22 +4936,6 @@ impl Encryption {
             crate::model::encryption::EncryptionMode::MpegCenc(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [encryption_mode][crate::model::Encryption::encryption_mode]
-    /// to hold a `MpegCenc`.
-    ///
-    /// Note that all the setters affecting `encryption_mode` are
-    /// mutually exclusive.
-    pub fn set_mpeg_cenc<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::MpegCommonEncryption>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.encryption_mode =
-            std::option::Option::Some(crate::model::encryption::EncryptionMode::MpegCenc(v.into()));
-        self
     }
 
     /// Sets the value of [secret_source][crate::model::Encryption::secret_source].
@@ -5346,23 +4965,6 @@ impl Encryption {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [secret_source][crate::model::Encryption::secret_source]
-    /// to hold a `SecretManagerKeySource`.
-    ///
-    /// Note that all the setters affecting `secret_source` are
-    /// mutually exclusive.
-    pub fn set_secret_manager_key_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::encryption::SecretManagerSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.secret_source = std::option::Option::Some(
-            crate::model::encryption::SecretSource::SecretManagerKeySource(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/videointelligence/v1/src/model.rs
+++ b/src/generated/cloud/videointelligence/v1/src/model.rs
@@ -2937,21 +2937,6 @@ impl ObjectTrackingAnnotation {
         })
     }
 
-    /// Sets the value of [track_info][crate::model::ObjectTrackingAnnotation::track_info]
-    /// to hold a `Segment`.
-    ///
-    /// Note that all the setters affecting `track_info` are
-    /// mutually exclusive.
-    pub fn set_segment<T: std::convert::Into<std::boxed::Box<crate::model::VideoSegment>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.track_info = std::option::Option::Some(
-            crate::model::object_tracking_annotation::TrackInfo::Segment(v.into()),
-        );
-        self
-    }
-
     /// The value of [track_info][crate::model::ObjectTrackingAnnotation::track_info]
     /// if it holds a `TrackId`, `None` if the field is not set or
     /// holds a different branch.
@@ -2963,18 +2948,6 @@ impl ObjectTrackingAnnotation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [track_info][crate::model::ObjectTrackingAnnotation::track_info]
-    /// to hold a `TrackId`.
-    ///
-    /// Note that all the setters affecting `track_info` are
-    /// mutually exclusive.
-    pub fn set_track_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.track_info = std::option::Option::Some(
-            crate::model::object_tracking_annotation::TrackInfo::TrackId(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/vision/v1/src/builder.rs
+++ b/src/generated/cloud/vision/v1/src/builder.rs
@@ -2217,31 +2217,6 @@ pub mod product_search {
             self.0.request.target = v.into();
             self
         }
-
-        /// Sets the value of [target][crate::model::PurgeProductsRequest::target]
-        /// to hold a `ProductSetPurgeConfig`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_product_set_purge_config<
-            T: std::convert::Into<std::boxed::Box<crate::model::ProductSetPurgeConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_product_set_purge_config(v);
-            self
-        }
-
-        /// Sets the value of [target][crate::model::PurgeProductsRequest::target]
-        /// to hold a `DeleteOrphanProducts`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_delete_orphan_products<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_delete_orphan_products(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/vision/v1/src/model.rs
+++ b/src/generated/cloud/vision/v1/src/model.rs
@@ -5666,23 +5666,6 @@ impl ImportProductSetsInputConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::ImportProductSetsInputConfig::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ImportProductSetsGcsSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_product_sets_input_config::Source::GcsSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ImportProductSetsInputConfig {
@@ -6149,23 +6132,6 @@ impl PurgeProductsRequest {
         })
     }
 
-    /// Sets the value of [target][crate::model::PurgeProductsRequest::target]
-    /// to hold a `ProductSetPurgeConfig`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_product_set_purge_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::ProductSetPurgeConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::purge_products_request::Target::ProductSetPurgeConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::PurgeProductsRequest::target]
     /// if it holds a `DeleteOrphanProducts`, `None` if the field is not set or
     /// holds a different branch.
@@ -6177,18 +6143,6 @@ impl PurgeProductsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::PurgeProductsRequest::target]
-    /// to hold a `DeleteOrphanProducts`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_delete_orphan_products<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::purge_products_request::Target::DeleteOrphanProducts(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/vmmigration/v1/src/model.rs
+++ b/src/generated/cloud/vmmigration/v1/src/model.rs
@@ -394,23 +394,6 @@ impl CycleStep {
         })
     }
 
-    /// Sets the value of [step][crate::model::CycleStep::step]
-    /// to hold a `InitializingReplication`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_initializing_replication<
-        T: std::convert::Into<std::boxed::Box<crate::model::InitializingReplicationStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step = std::option::Option::Some(
-            crate::model::cycle_step::Step::InitializingReplication(v.into()),
-        );
-        self
-    }
-
     /// The value of [step][crate::model::CycleStep::step]
     /// if it holds a `Replicating`, `None` if the field is not set or
     /// holds a different branch.
@@ -424,22 +407,6 @@ impl CycleStep {
         })
     }
 
-    /// Sets the value of [step][crate::model::CycleStep::step]
-    /// to hold a `Replicating`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_replicating<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReplicatingStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step =
-            std::option::Option::Some(crate::model::cycle_step::Step::Replicating(v.into()));
-        self
-    }
-
     /// The value of [step][crate::model::CycleStep::step]
     /// if it holds a `PostProcessing`, `None` if the field is not set or
     /// holds a different branch.
@@ -451,22 +418,6 @@ impl CycleStep {
             crate::model::cycle_step::Step::PostProcessing(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step][crate::model::CycleStep::step]
-    /// to hold a `PostProcessing`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_post_processing<
-        T: std::convert::Into<std::boxed::Box<crate::model::PostProcessingStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step =
-            std::option::Option::Some(crate::model::cycle_step::Step::PostProcessing(v.into()));
-        self
     }
 }
 
@@ -926,23 +877,6 @@ impl MigratingVm {
         })
     }
 
-    /// Sets the value of [target_vm_defaults][crate::model::MigratingVm::target_vm_defaults]
-    /// to hold a `ComputeEngineTargetDefaults`.
-    ///
-    /// Note that all the setters affecting `target_vm_defaults` are
-    /// mutually exclusive.
-    pub fn set_compute_engine_target_defaults<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeEngineTargetDefaults>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_vm_defaults = std::option::Option::Some(
-            crate::model::migrating_vm::TargetVmDefaults::ComputeEngineTargetDefaults(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [source_vm_details][crate::model::MigratingVm::source_vm_details].
     ///
     /// Note that all the setters affecting `source_vm_details` are mutually
@@ -970,23 +904,6 @@ impl MigratingVm {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_vm_details][crate::model::MigratingVm::source_vm_details]
-    /// to hold a `AwsSourceVmDetails`.
-    ///
-    /// Note that all the setters affecting `source_vm_details` are
-    /// mutually exclusive.
-    pub fn set_aws_source_vm_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::AwsSourceVmDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_vm_details = std::option::Option::Some(
-            crate::model::migrating_vm::SourceVmDetails::AwsSourceVmDetails(v.into()),
-        );
-        self
     }
 }
 
@@ -1373,23 +1290,6 @@ impl CloneJob {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [target_vm_details][crate::model::CloneJob::target_vm_details]
-    /// to hold a `ComputeEngineTargetDetails`.
-    ///
-    /// Note that all the setters affecting `target_vm_details` are
-    /// mutually exclusive.
-    pub fn set_compute_engine_target_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeEngineTargetDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_vm_details = std::option::Option::Some(
-            crate::model::clone_job::TargetVmDetails::ComputeEngineTargetDetails(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for CloneJob {
@@ -1651,19 +1551,6 @@ impl CloneStep {
         })
     }
 
-    /// Sets the value of [step][crate::model::CloneStep::step]
-    /// to hold a `AdaptingOs`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_adapting_os<T: std::convert::Into<std::boxed::Box<crate::model::AdaptingOSStep>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step = std::option::Option::Some(crate::model::clone_step::Step::AdaptingOs(v.into()));
-        self
-    }
-
     /// The value of [step][crate::model::CloneStep::step]
     /// if it holds a `PreparingVmDisks`, `None` if the field is not set or
     /// holds a different branch.
@@ -1675,22 +1562,6 @@ impl CloneStep {
             crate::model::clone_step::Step::PreparingVmDisks(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step][crate::model::CloneStep::step]
-    /// to hold a `PreparingVmDisks`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_preparing_vm_disks<
-        T: std::convert::Into<std::boxed::Box<crate::model::PreparingVMDisksStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step =
-            std::option::Option::Some(crate::model::clone_step::Step::PreparingVmDisks(v.into()));
-        self
     }
 
     /// The value of [step][crate::model::CloneStep::step]
@@ -1706,23 +1577,6 @@ impl CloneStep {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step][crate::model::CloneStep::step]
-    /// to hold a `InstantiatingMigratedVm`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_instantiating_migrated_vm<
-        T: std::convert::Into<std::boxed::Box<crate::model::InstantiatingMigratedVMStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step = std::option::Option::Some(
-            crate::model::clone_step::Step::InstantiatingMigratedVm(v.into()),
-        );
-        self
     }
 }
 
@@ -1977,23 +1831,6 @@ impl CutoverJob {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target_vm_details][crate::model::CutoverJob::target_vm_details]
-    /// to hold a `ComputeEngineTargetDetails`.
-    ///
-    /// Note that all the setters affecting `target_vm_details` are
-    /// mutually exclusive.
-    pub fn set_compute_engine_target_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComputeEngineTargetDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target_vm_details = std::option::Option::Some(
-            crate::model::cutover_job::TargetVmDetails::ComputeEngineTargetDetails(v.into()),
-        );
-        self
     }
 }
 
@@ -2260,23 +2097,6 @@ impl CutoverStep {
         })
     }
 
-    /// Sets the value of [step][crate::model::CutoverStep::step]
-    /// to hold a `PreviousReplicationCycle`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_previous_replication_cycle<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReplicationCycle>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step = std::option::Option::Some(
-            crate::model::cutover_step::Step::PreviousReplicationCycle(v.into()),
-        );
-        self
-    }
-
     /// The value of [step][crate::model::CutoverStep::step]
     /// if it holds a `ShuttingDownSourceVm`, `None` if the field is not set or
     /// holds a different branch.
@@ -2292,23 +2112,6 @@ impl CutoverStep {
         })
     }
 
-    /// Sets the value of [step][crate::model::CutoverStep::step]
-    /// to hold a `ShuttingDownSourceVm`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_shutting_down_source_vm<
-        T: std::convert::Into<std::boxed::Box<crate::model::ShuttingDownSourceVMStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step = std::option::Option::Some(
-            crate::model::cutover_step::Step::ShuttingDownSourceVm(v.into()),
-        );
-        self
-    }
-
     /// The value of [step][crate::model::CutoverStep::step]
     /// if it holds a `FinalSync`, `None` if the field is not set or
     /// holds a different branch.
@@ -2320,22 +2123,6 @@ impl CutoverStep {
             crate::model::cutover_step::Step::FinalSync(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step][crate::model::CutoverStep::step]
-    /// to hold a `FinalSync`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_final_sync<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReplicationCycle>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step =
-            std::option::Option::Some(crate::model::cutover_step::Step::FinalSync(v.into()));
-        self
     }
 
     /// The value of [step][crate::model::CutoverStep::step]
@@ -2351,22 +2138,6 @@ impl CutoverStep {
         })
     }
 
-    /// Sets the value of [step][crate::model::CutoverStep::step]
-    /// to hold a `PreparingVmDisks`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_preparing_vm_disks<
-        T: std::convert::Into<std::boxed::Box<crate::model::PreparingVMDisksStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step =
-            std::option::Option::Some(crate::model::cutover_step::Step::PreparingVmDisks(v.into()));
-        self
-    }
-
     /// The value of [step][crate::model::CutoverStep::step]
     /// if it holds a `InstantiatingMigratedVm`, `None` if the field is not set or
     /// holds a different branch.
@@ -2380,23 +2151,6 @@ impl CutoverStep {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step][crate::model::CutoverStep::step]
-    /// to hold a `InstantiatingMigratedVm`.
-    ///
-    /// Note that all the setters affecting `step` are
-    /// mutually exclusive.
-    pub fn set_instantiating_migrated_vm<
-        T: std::convert::Into<std::boxed::Box<crate::model::InstantiatingMigratedVMStep>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step = std::option::Option::Some(
-            crate::model::cutover_step::Step::InstantiatingMigratedVm(v.into()),
-        );
-        self
     }
 }
 
@@ -2878,20 +2632,6 @@ impl Source {
         })
     }
 
-    /// Sets the value of [source_details][crate::model::Source::source_details]
-    /// to hold a `Vmware`.
-    ///
-    /// Note that all the setters affecting `source_details` are
-    /// mutually exclusive.
-    pub fn set_vmware<T: std::convert::Into<std::boxed::Box<crate::model::VmwareSourceDetails>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_details =
-            std::option::Option::Some(crate::model::source::SourceDetails::Vmware(v.into()));
-        self
-    }
-
     /// The value of [source_details][crate::model::Source::source_details]
     /// if it holds a `Aws`, `None` if the field is not set or
     /// holds a different branch.
@@ -2901,20 +2641,6 @@ impl Source {
             crate::model::source::SourceDetails::Aws(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_details][crate::model::Source::source_details]
-    /// to hold a `Aws`.
-    ///
-    /// Note that all the setters affecting `source_details` are
-    /// mutually exclusive.
-    pub fn set_aws<T: std::convert::Into<std::boxed::Box<crate::model::AwsSourceDetails>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_details =
-            std::option::Option::Some(crate::model::source::SourceDetails::Aws(v.into()));
-        self
     }
 }
 
@@ -3151,23 +2877,6 @@ impl AwsSourceDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [credentials_type][crate::model::AwsSourceDetails::credentials_type]
-    /// to hold a `AccessKeyCreds`.
-    ///
-    /// Note that all the setters affecting `credentials_type` are
-    /// mutually exclusive.
-    pub fn set_access_key_creds<
-        T: std::convert::Into<std::boxed::Box<crate::model::aws_source_details::AccessKeyCredentials>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.credentials_type = std::option::Option::Some(
-            crate::model::aws_source_details::CredentialsType::AccessKeyCreds(v.into()),
-        );
-        self
     }
 }
 
@@ -5979,23 +5688,6 @@ impl FetchInventoryResponse {
         })
     }
 
-    /// Sets the value of [source_vms][crate::model::FetchInventoryResponse::source_vms]
-    /// to hold a `VmwareVms`.
-    ///
-    /// Note that all the setters affecting `source_vms` are
-    /// mutually exclusive.
-    pub fn set_vmware_vms<
-        T: std::convert::Into<std::boxed::Box<crate::model::VmwareVmsDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_vms = std::option::Option::Some(
-            crate::model::fetch_inventory_response::SourceVms::VmwareVms(v.into()),
-        );
-        self
-    }
-
     /// The value of [source_vms][crate::model::FetchInventoryResponse::source_vms]
     /// if it holds a `AwsVms`, `None` if the field is not set or
     /// holds a different branch.
@@ -6007,21 +5699,6 @@ impl FetchInventoryResponse {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_vms][crate::model::FetchInventoryResponse::source_vms]
-    /// to hold a `AwsVms`.
-    ///
-    /// Note that all the setters affecting `source_vms` are
-    /// mutually exclusive.
-    pub fn set_aws_vms<T: std::convert::Into<std::boxed::Box<crate::model::AwsVmsDetails>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_vms = std::option::Option::Some(
-            crate::model::fetch_inventory_response::SourceVms::AwsVms(v.into()),
-        );
-        self
     }
 }
 
@@ -6554,23 +6231,6 @@ impl VmUtilizationInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [vm_details][crate::model::VmUtilizationInfo::vm_details]
-    /// to hold a `VmwareVmDetails`.
-    ///
-    /// Note that all the setters affecting `vm_details` are
-    /// mutually exclusive.
-    pub fn set_vmware_vm_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::VmwareVmDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.vm_details = std::option::Option::Some(
-            crate::model::vm_utilization_info::VmDetails::VmwareVmDetails(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/cloud/vmwareengine/v1/src/model.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/model.rs
@@ -9042,18 +9042,6 @@ pub mod external_access_rule {
             })
         }
 
-        /// Sets the value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
-        /// to hold a `IpAddress`.
-        ///
-        /// Note that all the setters affecting `ip_range` are
-        /// mutually exclusive.
-        pub fn set_ip_address<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.ip_range = std::option::Option::Some(
-                crate::model::external_access_rule::ip_range::IpRange::IpAddress(v.into()),
-            );
-            self
-        }
-
         /// The value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
         /// if it holds a `IpAddressRange`, `None` if the field is not set or
         /// holds a different branch.
@@ -9067,21 +9055,6 @@ pub mod external_access_rule {
             })
         }
 
-        /// Sets the value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
-        /// to hold a `IpAddressRange`.
-        ///
-        /// Note that all the setters affecting `ip_range` are
-        /// mutually exclusive.
-        pub fn set_ip_address_range<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.ip_range = std::option::Option::Some(
-                crate::model::external_access_rule::ip_range::IpRange::IpAddressRange(v.into()),
-            );
-            self
-        }
-
         /// The value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
         /// if it holds a `ExternalAddress`, `None` if the field is not set or
         /// holds a different branch.
@@ -9093,21 +9066,6 @@ pub mod external_access_rule {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [ip_range][crate::model::external_access_rule::IpRange::ip_range]
-        /// to hold a `ExternalAddress`.
-        ///
-        /// Note that all the setters affecting `ip_range` are
-        /// mutually exclusive.
-        pub fn set_external_address<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.ip_range = std::option::Option::Some(
-                crate::model::external_access_rule::ip_range::IpRange::ExternalAddress(v.into()),
-            );
-            self
         }
     }
 
@@ -12971,18 +12929,6 @@ impl ManagementDnsZoneBinding {
         })
     }
 
-    /// Sets the value of [bind_network][crate::model::ManagementDnsZoneBinding::bind_network]
-    /// to hold a `VpcNetwork`.
-    ///
-    /// Note that all the setters affecting `bind_network` are
-    /// mutually exclusive.
-    pub fn set_vpc_network<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.bind_network = std::option::Option::Some(
-            crate::model::management_dns_zone_binding::BindNetwork::VpcNetwork(v.into()),
-        );
-        self
-    }
-
     /// The value of [bind_network][crate::model::ManagementDnsZoneBinding::bind_network]
     /// if it holds a `VmwareEngineNetwork`, `None` if the field is not set or
     /// holds a different branch.
@@ -12994,21 +12940,6 @@ impl ManagementDnsZoneBinding {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [bind_network][crate::model::ManagementDnsZoneBinding::bind_network]
-    /// to hold a `VmwareEngineNetwork`.
-    ///
-    /// Note that all the setters affecting `bind_network` are
-    /// mutually exclusive.
-    pub fn set_vmware_engine_network<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.bind_network = std::option::Option::Some(
-            crate::model::management_dns_zone_binding::BindNetwork::VmwareEngineNetwork(v.into()),
-        );
-        self
     }
 }
 
@@ -14886,17 +14817,6 @@ impl Principal {
         })
     }
 
-    /// Sets the value of [principal][crate::model::Principal::principal]
-    /// to hold a `User`.
-    ///
-    /// Note that all the setters affecting `principal` are
-    /// mutually exclusive.
-    pub fn set_user<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.principal =
-            std::option::Option::Some(crate::model::principal::Principal::User(v.into()));
-        self
-    }
-
     /// The value of [principal][crate::model::Principal::principal]
     /// if it holds a `ServiceAccount`, `None` if the field is not set or
     /// holds a different branch.
@@ -14906,17 +14826,6 @@ impl Principal {
             crate::model::principal::Principal::ServiceAccount(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [principal][crate::model::Principal::principal]
-    /// to hold a `ServiceAccount`.
-    ///
-    /// Note that all the setters affecting `principal` are
-    /// mutually exclusive.
-    pub fn set_service_account<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.principal =
-            std::option::Option::Some(crate::model::principal::Principal::ServiceAccount(v.into()));
-        self
     }
 }
 

--- a/src/generated/cloud/webrisk/v1/src/model.rs
+++ b/src/generated/cloud/webrisk/v1/src/model.rs
@@ -1207,18 +1207,6 @@ pub mod threat_info {
             })
         }
 
-        /// Sets the value of [value][crate::model::threat_info::Confidence::value]
-        /// to hold a `Score`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_score<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::threat_info::confidence::Value::Score(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::threat_info::Confidence::value]
         /// if it holds a `Level`, `None` if the field is not set or
         /// holds a different branch.
@@ -1232,23 +1220,6 @@ pub mod threat_info {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::threat_info::Confidence::value]
-        /// to hold a `Level`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_level<
-            T: std::convert::Into<crate::model::threat_info::confidence::ConfidenceLevel>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::threat_info::confidence::Value::Level(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/cloud/websecurityscanner/v1/src/model.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/model.rs
@@ -1541,26 +1541,6 @@ pub mod scan_config {
             })
         }
 
-        /// Sets the value of [authentication][crate::model::scan_config::Authentication::authentication]
-        /// to hold a `GoogleAccount`.
-        ///
-        /// Note that all the setters affecting `authentication` are
-        /// mutually exclusive.
-        #[deprecated]
-        pub fn set_google_account<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::scan_config::authentication::GoogleAccount>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.authentication = std::option::Option::Some(
-                crate::model::scan_config::authentication::Authentication::GoogleAccount(v.into()),
-            );
-            self
-        }
-
         /// The value of [authentication][crate::model::scan_config::Authentication::authentication]
         /// if it holds a `CustomAccount`, `None` if the field is not set or
         /// holds a different branch.
@@ -1578,25 +1558,6 @@ pub mod scan_config {
             })
         }
 
-        /// Sets the value of [authentication][crate::model::scan_config::Authentication::authentication]
-        /// to hold a `CustomAccount`.
-        ///
-        /// Note that all the setters affecting `authentication` are
-        /// mutually exclusive.
-        pub fn set_custom_account<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::scan_config::authentication::CustomAccount>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.authentication = std::option::Option::Some(
-                crate::model::scan_config::authentication::Authentication::CustomAccount(v.into()),
-            );
-            self
-        }
-
         /// The value of [authentication][crate::model::scan_config::Authentication::authentication]
         /// if it holds a `IapCredential`, `None` if the field is not set or
         /// holds a different branch.
@@ -1612,25 +1573,6 @@ pub mod scan_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [authentication][crate::model::scan_config::Authentication::authentication]
-        /// to hold a `IapCredential`.
-        ///
-        /// Note that all the setters affecting `authentication` are
-        /// mutually exclusive.
-        pub fn set_iap_credential<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::scan_config::authentication::IapCredential>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.authentication = std::option::Option::Some(
-                crate::model::scan_config::authentication::Authentication::IapCredential(v.into()),
-            );
-            self
         }
     }
 
@@ -1797,20 +1739,6 @@ pub mod scan_config {
                     crate::model::scan_config::authentication::iap_credential::IapCredentials::IapTestServiceAccountInfo(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [iap_credentials][crate::model::scan_config::authentication::IapCredential::iap_credentials]
-            /// to hold a `IapTestServiceAccountInfo`.
-            ///
-            /// Note that all the setters affecting `iap_credentials` are
-            /// mutually exclusive.
-            pub fn set_iap_test_service_account_info<T: std::convert::Into<std::boxed::Box<crate::model::scan_config::authentication::iap_credential::IapTestServiceAccountInfo>>>(mut self, v: T) -> Self{
-                self.iap_credentials = std::option::Option::Some(
-                    crate::model::scan_config::authentication::iap_credential::IapCredentials::IapTestServiceAccountInfo(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 

--- a/src/generated/cloud/workflows/v1/src/model.rs
+++ b/src/generated/cloud/workflows/v1/src/model.rs
@@ -370,17 +370,6 @@ impl Workflow {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source_code][crate::model::Workflow::source_code]
-    /// to hold a `SourceContents`.
-    ///
-    /// Note that all the setters affecting `source_code` are
-    /// mutually exclusive.
-    pub fn set_source_contents<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source_code =
-            std::option::Option::Some(crate::model::workflow::SourceCode::SourceContents(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Workflow {

--- a/src/generated/cloud/workstations/v1/src/builder.rs
+++ b/src/generated/cloud/workstations/v1/src/builder.rs
@@ -2289,32 +2289,6 @@ pub mod workstations {
             self.0.request.expiration = v.into();
             self
         }
-
-        /// Sets the value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
-        /// to hold a `ExpireTime`.
-        ///
-        /// Note that all the setters affecting `expiration` are
-        /// mutually exclusive.
-        pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_expire_time(v);
-            self
-        }
-
-        /// Sets the value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
-        /// to hold a `Ttl`.
-        ///
-        /// Note that all the setters affecting `expiration` are
-        /// mutually exclusive.
-        pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_ttl(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/cloud/workstations/v1/src/model.rs
+++ b/src/generated/cloud/workstations/v1/src/model.rs
@@ -786,25 +786,6 @@ pub mod workstation_config {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [config][crate::model::workstation_config::Host::config]
-        /// to hold a `GceInstance`.
-        ///
-        /// Note that all the setters affecting `config` are
-        /// mutually exclusive.
-        pub fn set_gce_instance<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::workstation_config::host::GceInstance>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.config = std::option::Option::Some(
-                crate::model::workstation_config::host::Config::GceInstance(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for Host {
@@ -1226,20 +1207,6 @@ pub mod workstation_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [directory_type][crate::model::workstation_config::PersistentDirectory::directory_type]
-        /// to hold a `GcePd`.
-        ///
-        /// Note that all the setters affecting `directory_type` are
-        /// mutually exclusive.
-        pub fn set_gce_pd<T: std::convert::Into<std::boxed::Box<crate::model::workstation_config::persistent_directory::GceRegionalPersistentDisk>>>(mut self, v: T) -> Self{
-            self.directory_type = std::option::Option::Some(
-                crate::model::workstation_config::persistent_directory::DirectoryType::GcePd(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -3614,21 +3581,6 @@ impl GenerateAccessTokenRequest {
         })
     }
 
-    /// Sets the value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
-    /// to hold a `ExpireTime`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_expire_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.expiration = std::option::Option::Some(
-            crate::model::generate_access_token_request::Expiration::ExpireTime(v.into()),
-        );
-        self
-    }
-
     /// The value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
     /// if it holds a `Ttl`, `None` if the field is not set or
     /// holds a different branch.
@@ -3640,18 +3592,6 @@ impl GenerateAccessTokenRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [expiration][crate::model::GenerateAccessTokenRequest::expiration]
-    /// to hold a `Ttl`.
-    ///
-    /// Note that all the setters affecting `expiration` are
-    /// mutually exclusive.
-    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
-        self.expiration = std::option::Option::Some(
-            crate::model::generate_access_token_request::Expiration::Ttl(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/container/v1/src/model.rs
+++ b/src/generated/container/v1/src/model.rs
@@ -2995,20 +2995,6 @@ pub mod containerd_config {
                     _ => std::option::Option::None,
                 })
             }
-
-            /// Sets the value of [certificate_config][crate::model::containerd_config::private_registry_access_config::CertificateAuthorityDomainConfig::certificate_config]
-            /// to hold a `GcpSecretManagerCertificateConfig`.
-            ///
-            /// Note that all the setters affecting `certificate_config` are
-            /// mutually exclusive.
-            pub fn set_gcp_secret_manager_certificate_config<T: std::convert::Into<std::boxed::Box<crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::GCPSecretManagerCertificateConfig>>>(mut self, v: T) -> Self{
-                self.certificate_config = std::option::Option::Some(
-                    crate::model::containerd_config::private_registry_access_config::certificate_authority_domain_config::CertificateConfig::GcpSecretManagerCertificateConfig(
-                        v.into()
-                    )
-                );
-                self
-            }
         }
 
         impl wkt::message::Message for CertificateAuthorityDomainConfig {
@@ -10066,18 +10052,6 @@ pub mod operation_progress {
             })
         }
 
-        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
-        /// to hold a `IntValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::operation_progress::metric::Value::IntValue(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::operation_progress::Metric::value]
         /// if it holds a `DoubleValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -10091,18 +10065,6 @@ pub mod operation_progress {
             })
         }
 
-        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
-        /// to hold a `DoubleValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::operation_progress::metric::Value::DoubleValue(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::operation_progress::Metric::value]
         /// if it holds a `StringValue`, `None` if the field is not set or
         /// holds a different branch.
@@ -10114,21 +10076,6 @@ pub mod operation_progress {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::operation_progress::Metric::value]
-        /// to hold a `StringValue`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_string_value<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::operation_progress::metric::Value::StringValue(v.into()),
-            );
-            self
         }
     }
 
@@ -12835,25 +12782,6 @@ impl BlueGreenSettings {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [rollout_policy][crate::model::BlueGreenSettings::rollout_policy]
-    /// to hold a `StandardRolloutPolicy`.
-    ///
-    /// Note that all the setters affecting `rollout_policy` are
-    /// mutually exclusive.
-    pub fn set_standard_rollout_policy<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::blue_green_settings::StandardRolloutPolicy>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.rollout_policy = std::option::Option::Some(
-            crate::model::blue_green_settings::RolloutPolicy::StandardRolloutPolicy(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BlueGreenSettings {
@@ -12932,20 +12860,6 @@ pub mod blue_green_settings {
             })
         }
 
-        /// Sets the value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
-        /// to hold a `BatchPercentage`.
-        ///
-        /// Note that all the setters affecting `update_batch_size` are
-        /// mutually exclusive.
-        pub fn set_batch_percentage<T: std::convert::Into<f32>>(mut self, v: T) -> Self {
-            self.update_batch_size = std::option::Option::Some(
-                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchPercentage(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
         /// if it holds a `BatchNodeCount`, `None` if the field is not set or
         /// holds a different branch.
@@ -12955,20 +12869,6 @@ pub mod blue_green_settings {
                 crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchNodeCount(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [update_batch_size][crate::model::blue_green_settings::StandardRolloutPolicy::update_batch_size]
-        /// to hold a `BatchNodeCount`.
-        ///
-        /// Note that all the setters affecting `update_batch_size` are
-        /// mutually exclusive.
-        pub fn set_batch_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.update_batch_size = std::option::Option::Some(
-                crate::model::blue_green_settings::standard_rollout_policy::UpdateBatchSize::BatchNodeCount(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -14463,23 +14363,6 @@ impl MaintenanceWindow {
         })
     }
 
-    /// Sets the value of [policy][crate::model::MaintenanceWindow::policy]
-    /// to hold a `DailyMaintenanceWindow`.
-    ///
-    /// Note that all the setters affecting `policy` are
-    /// mutually exclusive.
-    pub fn set_daily_maintenance_window<
-        T: std::convert::Into<std::boxed::Box<crate::model::DailyMaintenanceWindow>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.policy = std::option::Option::Some(
-            crate::model::maintenance_window::Policy::DailyMaintenanceWindow(v.into()),
-        );
-        self
-    }
-
     /// The value of [policy][crate::model::MaintenanceWindow::policy]
     /// if it holds a `RecurringWindow`, `None` if the field is not set or
     /// holds a different branch.
@@ -14493,23 +14376,6 @@ impl MaintenanceWindow {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [policy][crate::model::MaintenanceWindow::policy]
-    /// to hold a `RecurringWindow`.
-    ///
-    /// Note that all the setters affecting `policy` are
-    /// mutually exclusive.
-    pub fn set_recurring_window<
-        T: std::convert::Into<std::boxed::Box<crate::model::RecurringTimeWindow>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.policy = std::option::Option::Some(
-            crate::model::maintenance_window::Policy::RecurringWindow(v.into()),
-        );
-        self
     }
 }
 
@@ -14610,23 +14476,6 @@ impl TimeWindow {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [options][crate::model::TimeWindow::options]
-    /// to hold a `MaintenanceExclusionOptions`.
-    ///
-    /// Note that all the setters affecting `options` are
-    /// mutually exclusive.
-    pub fn set_maintenance_exclusion_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::MaintenanceExclusionOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options = std::option::Option::Some(
-            crate::model::time_window::Options::MaintenanceExclusionOptions(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/datastore/admin/v1/src/model.rs
+++ b/src/generated/datastore/admin/v1/src/model.rs
@@ -1898,25 +1898,6 @@ impl MigrationProgressEvent {
         })
     }
 
-    /// Sets the value of [step_details][crate::model::MigrationProgressEvent::step_details]
-    /// to hold a `PrepareStepDetails`.
-    ///
-    /// Note that all the setters affecting `step_details` are
-    /// mutually exclusive.
-    pub fn set_prepare_step_details<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::migration_progress_event::PrepareStepDetails>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_details = std::option::Option::Some(
-            crate::model::migration_progress_event::StepDetails::PrepareStepDetails(v.into()),
-        );
-        self
-    }
-
     /// The value of [step_details][crate::model::MigrationProgressEvent::step_details]
     /// if it holds a `RedirectWritesStepDetails`, `None` if the field is not set or
     /// holds a different branch.
@@ -1932,27 +1913,6 @@ impl MigrationProgressEvent {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [step_details][crate::model::MigrationProgressEvent::step_details]
-    /// to hold a `RedirectWritesStepDetails`.
-    ///
-    /// Note that all the setters affecting `step_details` are
-    /// mutually exclusive.
-    pub fn set_redirect_writes_step_details<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::migration_progress_event::RedirectWritesStepDetails>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.step_details = std::option::Option::Some(
-            crate::model::migration_progress_event::StepDetails::RedirectWritesStepDetails(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 

--- a/src/generated/devtools/artifactregistry/v1/src/builder.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builder.rs
@@ -859,21 +859,6 @@ pub mod artifact_registry {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::ImportAptArtifactsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::ImportAptArtifactsGcsSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -991,21 +976,6 @@ pub mod artifact_registry {
             v: T,
         ) -> Self {
             self.0.request.source = v.into();
-            self
-        }
-
-        /// Sets the value of [source][crate::model::ImportYumArtifactsRequest::source]
-        /// to hold a `GcsSource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_gcs_source<
-            T: std::convert::Into<std::boxed::Box<crate::model::ImportYumArtifactsGcsSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_gcs_source(v);
             self
         }
     }

--- a/src/generated/devtools/artifactregistry/v1/src/model.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/model.rs
@@ -365,23 +365,6 @@ impl ImportAptArtifactsRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::ImportAptArtifactsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ImportAptArtifactsGcsSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_apt_artifacts_request::Source::GcsSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ImportAptArtifactsRequest {
@@ -467,23 +450,6 @@ impl ImportAptArtifactsErrorInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportAptArtifactsErrorInfo::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ImportAptArtifactsGcsSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_apt_artifacts_error_info::Source::GcsSource(v.into()),
-        );
-        self
     }
 }
 
@@ -3625,23 +3591,6 @@ impl CleanupPolicy {
         })
     }
 
-    /// Sets the value of [condition_type][crate::model::CleanupPolicy::condition_type]
-    /// to hold a `Condition`.
-    ///
-    /// Note that all the setters affecting `condition_type` are
-    /// mutually exclusive.
-    pub fn set_condition<
-        T: std::convert::Into<std::boxed::Box<crate::model::CleanupPolicyCondition>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition_type = std::option::Option::Some(
-            crate::model::cleanup_policy::ConditionType::Condition(v.into()),
-        );
-        self
-    }
-
     /// The value of [condition_type][crate::model::CleanupPolicy::condition_type]
     /// if it holds a `MostRecentVersions`, `None` if the field is not set or
     /// holds a different branch.
@@ -3655,23 +3604,6 @@ impl CleanupPolicy {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [condition_type][crate::model::CleanupPolicy::condition_type]
-    /// to hold a `MostRecentVersions`.
-    ///
-    /// Note that all the setters affecting `condition_type` are
-    /// mutually exclusive.
-    pub fn set_most_recent_versions<
-        T: std::convert::Into<std::boxed::Box<crate::model::CleanupPolicyMostRecentVersions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.condition_type = std::option::Option::Some(
-            crate::model::cleanup_policy::ConditionType::MostRecentVersions(v.into()),
-        );
-        self
     }
 }
 
@@ -3960,25 +3892,6 @@ impl RemoteRepositoryConfig {
         })
     }
 
-    /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// to hold a `DockerRepository`.
-    ///
-    /// Note that all the setters affecting `remote_source` are
-    /// mutually exclusive.
-    pub fn set_docker_repository<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::remote_repository_config::DockerRepository>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_source = std::option::Option::Some(
-            crate::model::remote_repository_config::RemoteSource::DockerRepository(v.into()),
-        );
-        self
-    }
-
     /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// if it holds a `MavenRepository`, `None` if the field is not set or
     /// holds a different branch.
@@ -3996,25 +3909,6 @@ impl RemoteRepositoryConfig {
         })
     }
 
-    /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// to hold a `MavenRepository`.
-    ///
-    /// Note that all the setters affecting `remote_source` are
-    /// mutually exclusive.
-    pub fn set_maven_repository<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::remote_repository_config::MavenRepository>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_source = std::option::Option::Some(
-            crate::model::remote_repository_config::RemoteSource::MavenRepository(v.into()),
-        );
-        self
-    }
-
     /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// if it holds a `NpmRepository`, `None` if the field is not set or
     /// holds a different branch.
@@ -4029,23 +3923,6 @@ impl RemoteRepositoryConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// to hold a `NpmRepository`.
-    ///
-    /// Note that all the setters affecting `remote_source` are
-    /// mutually exclusive.
-    pub fn set_npm_repository<
-        T: std::convert::Into<std::boxed::Box<crate::model::remote_repository_config::NpmRepository>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_source = std::option::Option::Some(
-            crate::model::remote_repository_config::RemoteSource::NpmRepository(v.into()),
-        );
-        self
     }
 
     /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
@@ -4065,25 +3942,6 @@ impl RemoteRepositoryConfig {
         })
     }
 
-    /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// to hold a `PythonRepository`.
-    ///
-    /// Note that all the setters affecting `remote_source` are
-    /// mutually exclusive.
-    pub fn set_python_repository<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::remote_repository_config::PythonRepository>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_source = std::option::Option::Some(
-            crate::model::remote_repository_config::RemoteSource::PythonRepository(v.into()),
-        );
-        self
-    }
-
     /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// if it holds a `AptRepository`, `None` if the field is not set or
     /// holds a different branch.
@@ -4098,23 +3956,6 @@ impl RemoteRepositoryConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// to hold a `AptRepository`.
-    ///
-    /// Note that all the setters affecting `remote_source` are
-    /// mutually exclusive.
-    pub fn set_apt_repository<
-        T: std::convert::Into<std::boxed::Box<crate::model::remote_repository_config::AptRepository>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_source = std::option::Option::Some(
-            crate::model::remote_repository_config::RemoteSource::AptRepository(v.into()),
-        );
-        self
     }
 
     /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
@@ -4133,23 +3974,6 @@ impl RemoteRepositoryConfig {
         })
     }
 
-    /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// to hold a `YumRepository`.
-    ///
-    /// Note that all the setters affecting `remote_source` are
-    /// mutually exclusive.
-    pub fn set_yum_repository<
-        T: std::convert::Into<std::boxed::Box<crate::model::remote_repository_config::YumRepository>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_source = std::option::Option::Some(
-            crate::model::remote_repository_config::RemoteSource::YumRepository(v.into()),
-        );
-        self
-    }
-
     /// The value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
     /// if it holds a `CommonRepository`, `None` if the field is not set or
     /// holds a different branch.
@@ -4165,25 +3989,6 @@ impl RemoteRepositoryConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [remote_source][crate::model::RemoteRepositoryConfig::remote_source]
-    /// to hold a `CommonRepository`.
-    ///
-    /// Note that all the setters affecting `remote_source` are
-    /// mutually exclusive.
-    pub fn set_common_repository<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::remote_repository_config::CommonRemoteRepository>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.remote_source = std::option::Option::Some(
-            crate::model::remote_repository_config::RemoteSource::CommonRepository(v.into()),
-        );
-        self
     }
 }
 
@@ -4245,20 +4050,6 @@ pub mod remote_repository_config {
                 crate::model::remote_repository_config::upstream_credentials::Credentials::UsernamePasswordCredentials(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [credentials][crate::model::remote_repository_config::UpstreamCredentials::credentials]
-        /// to hold a `UsernamePasswordCredentials`.
-        ///
-        /// Note that all the setters affecting `credentials` are
-        /// mutually exclusive.
-        pub fn set_username_password_credentials<T: std::convert::Into<std::boxed::Box<crate::model::remote_repository_config::upstream_credentials::UsernamePasswordCredentials>>>(mut self, v: T) -> Self{
-            self.credentials = std::option::Option::Some(
-                crate::model::remote_repository_config::upstream_credentials::Credentials::UsernamePasswordCredentials(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -4387,27 +4178,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// Sets the value of [upstream][crate::model::remote_repository_config::DockerRepository::upstream]
-        /// to hold a `PublicRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_public_repository<
-            T: std::convert::Into<
-                    crate::model::remote_repository_config::docker_repository::PublicRepository,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::docker_repository::Upstream::PublicRepository(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [upstream][crate::model::remote_repository_config::DockerRepository::upstream]
         /// if it holds a `CustomRepository`, `None` if the field is not set or
         /// holds a different branch.
@@ -4423,29 +4193,6 @@ pub mod remote_repository_config {
                 crate::model::remote_repository_config::docker_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [upstream][crate::model::remote_repository_config::DockerRepository::upstream]
-        /// to hold a `CustomRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_custom_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::docker_repository::CustomRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::docker_repository::Upstream::CustomRepository(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -4694,27 +4441,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// Sets the value of [upstream][crate::model::remote_repository_config::MavenRepository::upstream]
-        /// to hold a `PublicRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_public_repository<
-            T: std::convert::Into<
-                    crate::model::remote_repository_config::maven_repository::PublicRepository,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::maven_repository::Upstream::PublicRepository(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [upstream][crate::model::remote_repository_config::MavenRepository::upstream]
         /// if it holds a `CustomRepository`, `None` if the field is not set or
         /// holds a different branch.
@@ -4730,29 +4456,6 @@ pub mod remote_repository_config {
                 crate::model::remote_repository_config::maven_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [upstream][crate::model::remote_repository_config::MavenRepository::upstream]
-        /// to hold a `CustomRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_custom_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::maven_repository::CustomRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::maven_repository::Upstream::CustomRepository(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -5001,27 +4704,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// Sets the value of [upstream][crate::model::remote_repository_config::NpmRepository::upstream]
-        /// to hold a `PublicRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_public_repository<
-            T: std::convert::Into<
-                    crate::model::remote_repository_config::npm_repository::PublicRepository,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::npm_repository::Upstream::PublicRepository(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [upstream][crate::model::remote_repository_config::NpmRepository::upstream]
         /// if it holds a `CustomRepository`, `None` if the field is not set or
         /// holds a different branch.
@@ -5037,29 +4719,6 @@ pub mod remote_repository_config {
                 crate::model::remote_repository_config::npm_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [upstream][crate::model::remote_repository_config::NpmRepository::upstream]
-        /// to hold a `CustomRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_custom_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::npm_repository::CustomRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::npm_repository::Upstream::CustomRepository(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -5308,27 +4967,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// Sets the value of [upstream][crate::model::remote_repository_config::PythonRepository::upstream]
-        /// to hold a `PublicRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_public_repository<
-            T: std::convert::Into<
-                    crate::model::remote_repository_config::python_repository::PublicRepository,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::python_repository::Upstream::PublicRepository(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [upstream][crate::model::remote_repository_config::PythonRepository::upstream]
         /// if it holds a `CustomRepository`, `None` if the field is not set or
         /// holds a different branch.
@@ -5344,29 +4982,6 @@ pub mod remote_repository_config {
                 crate::model::remote_repository_config::python_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [upstream][crate::model::remote_repository_config::PythonRepository::upstream]
-        /// to hold a `CustomRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_custom_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::python_repository::CustomRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::python_repository::Upstream::CustomRepository(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -5616,29 +5231,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// Sets the value of [upstream][crate::model::remote_repository_config::AptRepository::upstream]
-        /// to hold a `PublicRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_public_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::apt_repository::PublicRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::apt_repository::Upstream::PublicRepository(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [upstream][crate::model::remote_repository_config::AptRepository::upstream]
         /// if it holds a `CustomRepository`, `None` if the field is not set or
         /// holds a different branch.
@@ -5654,29 +5246,6 @@ pub mod remote_repository_config {
                 crate::model::remote_repository_config::apt_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [upstream][crate::model::remote_repository_config::AptRepository::upstream]
-        /// to hold a `CustomRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_custom_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::apt_repository::CustomRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::apt_repository::Upstream::CustomRepository(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -5996,29 +5565,6 @@ pub mod remote_repository_config {
             })
         }
 
-        /// Sets the value of [upstream][crate::model::remote_repository_config::YumRepository::upstream]
-        /// to hold a `PublicRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_public_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::yum_repository::PublicRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::yum_repository::Upstream::PublicRepository(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [upstream][crate::model::remote_repository_config::YumRepository::upstream]
         /// if it holds a `CustomRepository`, `None` if the field is not set or
         /// holds a different branch.
@@ -6034,29 +5580,6 @@ pub mod remote_repository_config {
                 crate::model::remote_repository_config::yum_repository::Upstream::CustomRepository(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [upstream][crate::model::remote_repository_config::YumRepository::upstream]
-        /// to hold a `CustomRepository`.
-        ///
-        /// Note that all the setters affecting `upstream` are
-        /// mutually exclusive.
-        pub fn set_custom_repository<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::remote_repository_config::yum_repository::CustomRepository,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.upstream = std::option::Option::Some(
-                crate::model::remote_repository_config::yum_repository::Upstream::CustomRepository(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -6659,23 +6182,6 @@ impl Repository {
         })
     }
 
-    /// Sets the value of [format_config][crate::model::Repository::format_config]
-    /// to hold a `MavenConfig`.
-    ///
-    /// Note that all the setters affecting `format_config` are
-    /// mutually exclusive.
-    pub fn set_maven_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::repository::MavenRepositoryConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.format_config = std::option::Option::Some(
-            crate::model::repository::FormatConfig::MavenConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [format_config][crate::model::Repository::format_config]
     /// if it holds a `DockerConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -6688,23 +6194,6 @@ impl Repository {
             crate::model::repository::FormatConfig::DockerConfig(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [format_config][crate::model::Repository::format_config]
-    /// to hold a `DockerConfig`.
-    ///
-    /// Note that all the setters affecting `format_config` are
-    /// mutually exclusive.
-    pub fn set_docker_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::repository::DockerRepositoryConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.format_config = std::option::Option::Some(
-            crate::model::repository::FormatConfig::DockerConfig(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [mode_config][crate::model::Repository::mode_config].
@@ -6736,23 +6225,6 @@ impl Repository {
         })
     }
 
-    /// Sets the value of [mode_config][crate::model::Repository::mode_config]
-    /// to hold a `VirtualRepositoryConfig`.
-    ///
-    /// Note that all the setters affecting `mode_config` are
-    /// mutually exclusive.
-    pub fn set_virtual_repository_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::VirtualRepositoryConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode_config = std::option::Option::Some(
-            crate::model::repository::ModeConfig::VirtualRepositoryConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [mode_config][crate::model::Repository::mode_config]
     /// if it holds a `RemoteRepositoryConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -6766,23 +6238,6 @@ impl Repository {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [mode_config][crate::model::Repository::mode_config]
-    /// to hold a `RemoteRepositoryConfig`.
-    ///
-    /// Note that all the setters affecting `mode_config` are
-    /// mutually exclusive.
-    pub fn set_remote_repository_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::RemoteRepositoryConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode_config = std::option::Option::Some(
-            crate::model::repository::ModeConfig::RemoteRepositoryConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -10527,23 +9982,6 @@ impl ImportYumArtifactsRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::ImportYumArtifactsRequest::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ImportYumArtifactsGcsSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_yum_artifacts_request::Source::GcsSource(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ImportYumArtifactsRequest {
@@ -10629,23 +10067,6 @@ impl ImportYumArtifactsErrorInfo {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::ImportYumArtifactsErrorInfo::source]
-    /// to hold a `GcsSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_gcs_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::ImportYumArtifactsGcsSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::import_yum_artifacts_error_info::Source::GcsSource(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/devtools/cloudbuild/v1/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/model.rs
@@ -537,17 +537,6 @@ impl RepoSource {
         })
     }
 
-    /// Sets the value of [revision][crate::model::RepoSource::revision]
-    /// to hold a `BranchName`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_branch_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision =
-            std::option::Option::Some(crate::model::repo_source::Revision::BranchName(v.into()));
-        self
-    }
-
     /// The value of [revision][crate::model::RepoSource::revision]
     /// if it holds a `TagName`, `None` if the field is not set or
     /// holds a different branch.
@@ -559,17 +548,6 @@ impl RepoSource {
         })
     }
 
-    /// Sets the value of [revision][crate::model::RepoSource::revision]
-    /// to hold a `TagName`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_tag_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision =
-            std::option::Option::Some(crate::model::repo_source::Revision::TagName(v.into()));
-        self
-    }
-
     /// The value of [revision][crate::model::RepoSource::revision]
     /// if it holds a `CommitSha`, `None` if the field is not set or
     /// holds a different branch.
@@ -579,17 +557,6 @@ impl RepoSource {
             crate::model::repo_source::Revision::CommitSha(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [revision][crate::model::RepoSource::revision]
-    /// to hold a `CommitSha`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_commit_sha<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision =
-            std::option::Option::Some(crate::model::repo_source::Revision::CommitSha(v.into()));
-        self
     }
 }
 
@@ -730,22 +697,6 @@ impl Source {
         })
     }
 
-    /// Sets the value of [source][crate::model::Source::source]
-    /// to hold a `StorageSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_storage_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::StorageSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::source::Source::StorageSource(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Source::source]
     /// if it holds a `RepoSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -755,19 +706,6 @@ impl Source {
             crate::model::source::Source::RepoSource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Source::source]
-    /// to hold a `RepoSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_repo_source<T: std::convert::Into<std::boxed::Box<crate::model::RepoSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(crate::model::source::Source::RepoSource(v.into()));
-        self
     }
 
     /// The value of [source][crate::model::Source::source]
@@ -781,19 +719,6 @@ impl Source {
         })
     }
 
-    /// Sets the value of [source][crate::model::Source::source]
-    /// to hold a `GitSource`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_git_source<T: std::convert::Into<std::boxed::Box<crate::model::GitSource>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(crate::model::source::Source::GitSource(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::Source::source]
     /// if it holds a `StorageSourceManifest`, `None` if the field is not set or
     /// holds a different branch.
@@ -805,23 +730,6 @@ impl Source {
             crate::model::source::Source::StorageSourceManifest(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::Source::source]
-    /// to hold a `StorageSourceManifest`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_storage_source_manifest<
-        T: std::convert::Into<std::boxed::Box<crate::model::StorageSourceManifest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::source::Source::StorageSourceManifest(v.into()),
-        );
-        self
     }
 }
 
@@ -2856,16 +2764,6 @@ impl Dependency {
         })
     }
 
-    /// Sets the value of [dep][crate::model::Dependency::dep]
-    /// to hold a `Empty`.
-    ///
-    /// Note that all the setters affecting `dep` are
-    /// mutually exclusive.
-    pub fn set_empty<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.dep = std::option::Option::Some(crate::model::dependency::Dep::Empty(v.into()));
-        self
-    }
-
     /// The value of [dep][crate::model::Dependency::dep]
     /// if it holds a `GitSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -2877,21 +2775,6 @@ impl Dependency {
             crate::model::dependency::Dep::GitSource(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [dep][crate::model::Dependency::dep]
-    /// to hold a `GitSource`.
-    ///
-    /// Note that all the setters affecting `dep` are
-    /// mutually exclusive.
-    pub fn set_git_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::dependency::GitSourceDependency>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.dep = std::option::Option::Some(crate::model::dependency::Dep::GitSource(v.into()));
-        self
     }
 }
 
@@ -3034,18 +2917,6 @@ pub mod dependency {
             })
         }
 
-        /// Sets the value of [repotype][crate::model::dependency::GitSourceRepository::repotype]
-        /// to hold a `Url`.
-        ///
-        /// Note that all the setters affecting `repotype` are
-        /// mutually exclusive.
-        pub fn set_url<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.repotype = std::option::Option::Some(
-                crate::model::dependency::git_source_repository::Repotype::Url(v.into()),
-            );
-            self
-        }
-
         /// The value of [repotype][crate::model::dependency::GitSourceRepository::repotype]
         /// if it holds a `DeveloperConnect`, `None` if the field is not set or
         /// holds a different branch.
@@ -3057,23 +2928,6 @@ pub mod dependency {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [repotype][crate::model::dependency::GitSourceRepository::repotype]
-        /// to hold a `DeveloperConnect`.
-        ///
-        /// Note that all the setters affecting `repotype` are
-        /// mutually exclusive.
-        pub fn set_developer_connect<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.repotype = std::option::Option::Some(
-                crate::model::dependency::git_source_repository::Repotype::DeveloperConnect(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -5254,17 +5108,6 @@ impl GitRepoSource {
         })
     }
 
-    /// Sets the value of [source][crate::model::GitRepoSource::source]
-    /// to hold a `Repository`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_repository<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::git_repo_source::Source::Repository(v.into()));
-        self
-    }
-
     /// Sets the value of [enterprise_config][crate::model::GitRepoSource::enterprise_config].
     ///
     /// Note that all the setters affecting `enterprise_config` are mutually
@@ -5290,21 +5133,6 @@ impl GitRepoSource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [enterprise_config][crate::model::GitRepoSource::enterprise_config]
-    /// to hold a `GithubEnterpriseConfig`.
-    ///
-    /// Note that all the setters affecting `enterprise_config` are
-    /// mutually exclusive.
-    pub fn set_github_enterprise_config<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enterprise_config = std::option::Option::Some(
-            crate::model::git_repo_source::EnterpriseConfig::GithubEnterpriseConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -5445,17 +5273,6 @@ impl GitFileSource {
         })
     }
 
-    /// Sets the value of [source][crate::model::GitFileSource::source]
-    /// to hold a `Repository`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_repository<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::git_file_source::Source::Repository(v.into()));
-        self
-    }
-
     /// Sets the value of [enterprise_config][crate::model::GitFileSource::enterprise_config].
     ///
     /// Note that all the setters affecting `enterprise_config` are mutually
@@ -5481,21 +5298,6 @@ impl GitFileSource {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [enterprise_config][crate::model::GitFileSource::enterprise_config]
-    /// to hold a `GithubEnterpriseConfig`.
-    ///
-    /// Note that all the setters affecting `enterprise_config` are
-    /// mutually exclusive.
-    pub fn set_github_enterprise_config<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.enterprise_config = std::option::Option::Some(
-            crate::model::git_file_source::EnterpriseConfig::GithubEnterpriseConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -6016,18 +5818,6 @@ impl BuildTrigger {
         })
     }
 
-    /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
-    /// to hold a `Autodetect`.
-    ///
-    /// Note that all the setters affecting `build_template` are
-    /// mutually exclusive.
-    pub fn set_autodetect<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.build_template = std::option::Option::Some(
-            crate::model::build_trigger::BuildTemplate::Autodetect(v.into()),
-        );
-        self
-    }
-
     /// The value of [build_template][crate::model::BuildTrigger::build_template]
     /// if it holds a `Build`, `None` if the field is not set or
     /// holds a different branch.
@@ -6039,20 +5829,6 @@ impl BuildTrigger {
         })
     }
 
-    /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
-    /// to hold a `Build`.
-    ///
-    /// Note that all the setters affecting `build_template` are
-    /// mutually exclusive.
-    pub fn set_build<T: std::convert::Into<std::boxed::Box<crate::model::Build>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.build_template =
-            std::option::Option::Some(crate::model::build_trigger::BuildTemplate::Build(v.into()));
-        self
-    }
-
     /// The value of [build_template][crate::model::BuildTrigger::build_template]
     /// if it holds a `Filename`, `None` if the field is not set or
     /// holds a different branch.
@@ -6062,18 +5838,6 @@ impl BuildTrigger {
             crate::model::build_trigger::BuildTemplate::Filename(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
-    /// to hold a `Filename`.
-    ///
-    /// Note that all the setters affecting `build_template` are
-    /// mutually exclusive.
-    pub fn set_filename<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.build_template = std::option::Option::Some(
-            crate::model::build_trigger::BuildTemplate::Filename(v.into()),
-        );
-        self
     }
 
     /// The value of [build_template][crate::model::BuildTrigger::build_template]
@@ -6089,23 +5853,6 @@ impl BuildTrigger {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [build_template][crate::model::BuildTrigger::build_template]
-    /// to hold a `GitFileSource`.
-    ///
-    /// Note that all the setters affecting `build_template` are
-    /// mutually exclusive.
-    pub fn set_git_file_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::GitFileSource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.build_template = std::option::Option::Some(
-            crate::model::build_trigger::BuildTemplate::GitFileSource(v.into()),
-        );
-        self
     }
 }
 
@@ -6220,23 +5967,6 @@ impl RepositoryEventConfig {
         })
     }
 
-    /// Sets the value of [filter][crate::model::RepositoryEventConfig::filter]
-    /// to hold a `PullRequest`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_pull_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::PullRequestFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::repository_event_config::Filter::PullRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::RepositoryEventConfig::filter]
     /// if it holds a `Push`, `None` if the field is not set or
     /// holds a different branch.
@@ -6246,21 +5976,6 @@ impl RepositoryEventConfig {
             crate::model::repository_event_config::Filter::Push(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::RepositoryEventConfig::filter]
-    /// to hold a `Push`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_push<T: std::convert::Into<std::boxed::Box<crate::model::PushFilter>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::repository_event_config::Filter::Push(v.into()),
-        );
-        self
     }
 }
 
@@ -6513,23 +6228,6 @@ impl GitHubEventsConfig {
         })
     }
 
-    /// Sets the value of [event][crate::model::GitHubEventsConfig::event]
-    /// to hold a `PullRequest`.
-    ///
-    /// Note that all the setters affecting `event` are
-    /// mutually exclusive.
-    pub fn set_pull_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::PullRequestFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.event = std::option::Option::Some(
-            crate::model::git_hub_events_config::Event::PullRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [event][crate::model::GitHubEventsConfig::event]
     /// if it holds a `Push`, `None` if the field is not set or
     /// holds a different branch.
@@ -6539,20 +6237,6 @@ impl GitHubEventsConfig {
             crate::model::git_hub_events_config::Event::Push(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [event][crate::model::GitHubEventsConfig::event]
-    /// to hold a `Push`.
-    ///
-    /// Note that all the setters affecting `event` are
-    /// mutually exclusive.
-    pub fn set_push<T: std::convert::Into<std::boxed::Box<crate::model::PushFilter>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.event =
-            std::option::Option::Some(crate::model::git_hub_events_config::Event::Push(v.into()));
-        self
     }
 }
 
@@ -6864,17 +6548,6 @@ impl WebhookConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [auth_method][crate::model::WebhookConfig::auth_method]
-    /// to hold a `Secret`.
-    ///
-    /// Note that all the setters affecting `auth_method` are
-    /// mutually exclusive.
-    pub fn set_secret<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.auth_method =
-            std::option::Option::Some(crate::model::webhook_config::AuthMethod::Secret(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for WebhookConfig {
@@ -7107,17 +6780,6 @@ impl PullRequestFilter {
             crate::model::pull_request_filter::GitRef::Branch(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [git_ref][crate::model::PullRequestFilter::git_ref]
-    /// to hold a `Branch`.
-    ///
-    /// Note that all the setters affecting `git_ref` are
-    /// mutually exclusive.
-    pub fn set_branch<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.git_ref =
-            std::option::Option::Some(crate::model::pull_request_filter::GitRef::Branch(v.into()));
-        self
     }
 }
 
@@ -7359,17 +7021,6 @@ impl PushFilter {
         })
     }
 
-    /// Sets the value of [git_ref][crate::model::PushFilter::git_ref]
-    /// to hold a `Branch`.
-    ///
-    /// Note that all the setters affecting `git_ref` are
-    /// mutually exclusive.
-    pub fn set_branch<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.git_ref =
-            std::option::Option::Some(crate::model::push_filter::GitRef::Branch(v.into()));
-        self
-    }
-
     /// The value of [git_ref][crate::model::PushFilter::git_ref]
     /// if it holds a `Tag`, `None` if the field is not set or
     /// holds a different branch.
@@ -7379,16 +7030,6 @@ impl PushFilter {
             crate::model::push_filter::GitRef::Tag(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [git_ref][crate::model::PushFilter::git_ref]
-    /// to hold a `Tag`.
-    ///
-    /// Note that all the setters affecting `git_ref` are
-    /// mutually exclusive.
-    pub fn set_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.git_ref = std::option::Option::Some(crate::model::push_filter::GitRef::Tag(v.into()));
-        self
     }
 }
 
@@ -9425,23 +9066,6 @@ impl WorkerPool {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [config][crate::model::WorkerPool::config]
-    /// to hold a `PrivatePoolV1Config`.
-    ///
-    /// Note that all the setters affecting `config` are
-    /// mutually exclusive.
-    pub fn set_private_pool_v1_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::PrivatePoolV1Config>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.config = std::option::Option::Some(
-            crate::model::worker_pool::Config::PrivatePoolV1Config(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/devtools/cloudbuild/v2/src/model.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/model.rs
@@ -394,21 +394,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `GithubConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_github_config<T: std::convert::Into<std::boxed::Box<crate::model::GitHubConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::GithubConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_config][crate::model::Connection::connection_config]
     /// if it holds a `GithubEnterpriseConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -422,23 +407,6 @@ impl Connection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `GithubEnterpriseConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_github_enterprise_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::GitHubEnterpriseConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::GithubEnterpriseConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [connection_config][crate::model::Connection::connection_config]
@@ -456,21 +424,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `GitlabConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_gitlab_config<T: std::convert::Into<std::boxed::Box<crate::model::GitLabConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::GitlabConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_config][crate::model::Connection::connection_config]
     /// if it holds a `BitbucketDataCenterConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -486,23 +439,6 @@ impl Connection {
         })
     }
 
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `BitbucketDataCenterConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_bitbucket_data_center_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::BitbucketDataCenterConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::BitbucketDataCenterConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [connection_config][crate::model::Connection::connection_config]
     /// if it holds a `BitbucketCloudConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -516,23 +452,6 @@ impl Connection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [connection_config][crate::model::Connection::connection_config]
-    /// to hold a `BitbucketCloudConfig`.
-    ///
-    /// Note that all the setters affecting `connection_config` are
-    /// mutually exclusive.
-    pub fn set_bitbucket_cloud_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::BitbucketCloudConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.connection_config = std::option::Option::Some(
-            crate::model::connection::ConnectionConfig::BitbucketCloudConfig(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/devtools/cloudtrace/v2/src/model.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/model.rs
@@ -397,23 +397,6 @@ pub mod span {
             })
         }
 
-        /// Sets the value of [value][crate::model::span::TimeEvent::value]
-        /// to hold a `Annotation`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_annotation<
-            T: std::convert::Into<std::boxed::Box<crate::model::span::time_event::Annotation>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::span::time_event::Value::Annotation(v.into()),
-            );
-            self
-        }
-
         /// The value of [value][crate::model::span::TimeEvent::value]
         /// if it holds a `MessageEvent`, `None` if the field is not set or
         /// holds a different branch.
@@ -428,23 +411,6 @@ pub mod span {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::span::TimeEvent::value]
-        /// to hold a `MessageEvent`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_message_event<
-            T: std::convert::Into<std::boxed::Box<crate::model::span::time_event::MessageEvent>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::span::time_event::Value::MessageEvent(v.into()),
-            );
-            self
         }
     }
 
@@ -1281,22 +1247,6 @@ impl AttributeValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::AttributeValue::value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_value<
-        T: std::convert::Into<std::boxed::Box<crate::model::TruncatableString>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::attribute_value::Value::StringValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::AttributeValue::value]
     /// if it holds a `IntValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -1308,17 +1258,6 @@ impl AttributeValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::AttributeValue::value]
-    /// to hold a `IntValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::attribute_value::Value::IntValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::AttributeValue::value]
     /// if it holds a `BoolValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -1328,17 +1267,6 @@ impl AttributeValue {
             crate::model::attribute_value::Value::BoolValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::AttributeValue::value]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::attribute_value::Value::BoolValue(v.into()));
-        self
     }
 }
 

--- a/src/generated/devtools/containeranalysis/v1/src/builder.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/builder.rs
@@ -437,23 +437,6 @@ pub mod container_analysis {
             self.0.request.target = v.into();
             self
         }
-
-        /// Sets the value of [target][crate::model::ExportSBOMRequest::target]
-        /// to hold a `CloudStorageLocation`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_cloud_storage_location<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::export_sbom_request::CloudStorageLocation>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_cloud_storage_location(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/devtools/containeranalysis/v1/src/model.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/model.rs
@@ -93,25 +93,6 @@ impl ExportSBOMRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [target][crate::model::ExportSBOMRequest::target]
-    /// to hold a `CloudStorageLocation`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_location<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::export_sbom_request::CloudStorageLocation>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::export_sbom_request::Target::CloudStorageLocation(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ExportSBOMRequest {

--- a/src/generated/firestore/admin/v1/src/model.rs
+++ b/src/generated/firestore/admin/v1/src/model.rs
@@ -790,23 +790,6 @@ pub mod database {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [source][crate::model::database::SourceInfo::source]
-        /// to hold a `Backup`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_backup<
-            T: std::convert::Into<std::boxed::Box<crate::model::database::source_info::BackupSource>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::database::source_info::Source::Backup(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for SourceInfo {
@@ -924,29 +907,6 @@ pub mod database {
             })
         }
 
-        /// Sets the value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
-        /// to hold a `GoogleDefaultEncryption`.
-        ///
-        /// Note that all the setters affecting `encryption_type` are
-        /// mutually exclusive.
-        pub fn set_google_default_encryption<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::database::encryption_config::GoogleDefaultEncryptionOptions,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.encryption_type = std::option::Option::Some(
-                crate::model::database::encryption_config::EncryptionType::GoogleDefaultEncryption(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
         /// if it holds a `UseSourceEncryption`, `None` if the field is not set or
         /// holds a different branch.
@@ -964,29 +924,6 @@ pub mod database {
             })
         }
 
-        /// Sets the value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
-        /// to hold a `UseSourceEncryption`.
-        ///
-        /// Note that all the setters affecting `encryption_type` are
-        /// mutually exclusive.
-        pub fn set_use_source_encryption<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::database::encryption_config::SourceEncryptionOptions,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.encryption_type = std::option::Option::Some(
-                crate::model::database::encryption_config::EncryptionType::UseSourceEncryption(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
         /// if it holds a `CustomerManagedEncryption`, `None` if the field is not set or
         /// holds a different branch.
@@ -1002,29 +939,6 @@ pub mod database {
                 crate::model::database::encryption_config::EncryptionType::CustomerManagedEncryption(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [encryption_type][crate::model::database::EncryptionConfig::encryption_type]
-        /// to hold a `CustomerManagedEncryption`.
-        ///
-        /// Note that all the setters affecting `encryption_type` are
-        /// mutually exclusive.
-        pub fn set_customer_managed_encryption<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::database::encryption_config::CustomerManagedEncryptionOptions,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.encryption_type = std::option::Option::Some(
-                crate::model::database::encryption_config::EncryptionType::CustomerManagedEncryption(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -4617,21 +4531,6 @@ pub mod index {
             })
         }
 
-        /// Sets the value of [value_mode][crate::model::index::IndexField::value_mode]
-        /// to hold a `Order`.
-        ///
-        /// Note that all the setters affecting `value_mode` are
-        /// mutually exclusive.
-        pub fn set_order<T: std::convert::Into<crate::model::index::index_field::Order>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value_mode = std::option::Option::Some(
-                crate::model::index::index_field::ValueMode::Order(v.into()),
-            );
-            self
-        }
-
         /// The value of [value_mode][crate::model::index::IndexField::value_mode]
         /// if it holds a `ArrayConfig`, `None` if the field is not set or
         /// holds a different branch.
@@ -4645,23 +4544,6 @@ pub mod index {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value_mode][crate::model::index::IndexField::value_mode]
-        /// to hold a `ArrayConfig`.
-        ///
-        /// Note that all the setters affecting `value_mode` are
-        /// mutually exclusive.
-        pub fn set_array_config<
-            T: std::convert::Into<crate::model::index::index_field::ArrayConfig>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value_mode = std::option::Option::Some(
-                crate::model::index::index_field::ValueMode::ArrayConfig(v.into()),
-            );
-            self
         }
 
         /// The value of [value_mode][crate::model::index::IndexField::value_mode]
@@ -4678,23 +4560,6 @@ pub mod index {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value_mode][crate::model::index::IndexField::value_mode]
-        /// to hold a `VectorConfig`.
-        ///
-        /// Note that all the setters affecting `value_mode` are
-        /// mutually exclusive.
-        pub fn set_vector_config<
-            T: std::convert::Into<std::boxed::Box<crate::model::index::index_field::VectorConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value_mode = std::option::Option::Some(
-                crate::model::index::index_field::ValueMode::VectorConfig(v.into()),
-            );
-            self
         }
     }
 
@@ -4772,25 +4637,6 @@ pub mod index {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [r#type][crate::model::index::index_field::VectorConfig::r#type]
-            /// to hold a `Flat`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_flat<
-                T: std::convert::Into<
-                        std::boxed::Box<crate::model::index::index_field::vector_config::FlatIndex>,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::index::index_field::vector_config::Type::Flat(v.into()),
-                );
-                self
             }
         }
 
@@ -7086,23 +6932,6 @@ impl BackupSchedule {
         })
     }
 
-    /// Sets the value of [recurrence][crate::model::BackupSchedule::recurrence]
-    /// to hold a `DailyRecurrence`.
-    ///
-    /// Note that all the setters affecting `recurrence` are
-    /// mutually exclusive.
-    pub fn set_daily_recurrence<
-        T: std::convert::Into<std::boxed::Box<crate::model::DailyRecurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recurrence = std::option::Option::Some(
-            crate::model::backup_schedule::Recurrence::DailyRecurrence(v.into()),
-        );
-        self
-    }
-
     /// The value of [recurrence][crate::model::BackupSchedule::recurrence]
     /// if it holds a `WeeklyRecurrence`, `None` if the field is not set or
     /// holds a different branch.
@@ -7116,23 +6945,6 @@ impl BackupSchedule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [recurrence][crate::model::BackupSchedule::recurrence]
-    /// to hold a `WeeklyRecurrence`.
-    ///
-    /// Note that all the setters affecting `recurrence` are
-    /// mutually exclusive.
-    pub fn set_weekly_recurrence<
-        T: std::convert::Into<std::boxed::Box<crate::model::WeeklyRecurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.recurrence = std::option::Option::Some(
-            crate::model::backup_schedule::Recurrence::WeeklyRecurrence(v.into()),
-        );
-        self
     }
 }
 
@@ -7327,23 +7139,6 @@ impl UserCreds {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [user_creds_identity][crate::model::UserCreds::user_creds_identity]
-    /// to hold a `ResourceIdentity`.
-    ///
-    /// Note that all the setters affecting `user_creds_identity` are
-    /// mutually exclusive.
-    pub fn set_resource_identity<
-        T: std::convert::Into<std::boxed::Box<crate::model::user_creds::ResourceIdentity>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.user_creds_identity = std::option::Option::Some(
-            crate::model::user_creds::UserCredsIdentity::ResourceIdentity(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/grafeas/v1/src/model.rs
+++ b/src/generated/grafeas/v1/src/model.rs
@@ -996,23 +996,6 @@ impl ComplianceNote {
         })
     }
 
-    /// Sets the value of [compliance_type][crate::model::ComplianceNote::compliance_type]
-    /// to hold a `CisBenchmark`.
-    ///
-    /// Note that all the setters affecting `compliance_type` are
-    /// mutually exclusive.
-    pub fn set_cis_benchmark<
-        T: std::convert::Into<std::boxed::Box<crate::model::compliance_note::CisBenchmark>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.compliance_type = std::option::Option::Some(
-            crate::model::compliance_note::ComplianceType::CisBenchmark(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [potential_impact][crate::model::ComplianceNote::potential_impact].
     ///
     /// Note that all the setters affecting `potential_impact` are mutually
@@ -1038,18 +1021,6 @@ impl ComplianceNote {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [potential_impact][crate::model::ComplianceNote::potential_impact]
-    /// to hold a `Impact`.
-    ///
-    /// Note that all the setters affecting `potential_impact` are
-    /// mutually exclusive.
-    pub fn set_impact<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.potential_impact = std::option::Option::Some(
-            crate::model::compliance_note::PotentialImpact::Impact(v.into()),
-        );
-        self
     }
 }
 
@@ -4710,21 +4681,6 @@ impl DSSEAttestationOccurrence {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [decoded_payload][crate::model::DSSEAttestationOccurrence::decoded_payload]
-    /// to hold a `Statement`.
-    ///
-    /// Note that all the setters affecting `decoded_payload` are
-    /// mutually exclusive.
-    pub fn set_statement<T: std::convert::Into<std::boxed::Box<crate::model::InTotoStatement>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.decoded_payload = std::option::Option::Some(
-            crate::model::dsse_attestation_occurrence::DecodedPayload::Statement(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DSSEAttestationOccurrence {
@@ -4888,22 +4844,6 @@ impl Occurrence {
         })
     }
 
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Vulnerability`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_vulnerability<
-        T: std::convert::Into<std::boxed::Box<crate::model::VulnerabilityOccurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Vulnerability(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Occurrence::details]
     /// if it holds a `Build`, `None` if the field is not set or
     /// holds a different branch.
@@ -4915,20 +4855,6 @@ impl Occurrence {
         })
     }
 
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Build`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_build<T: std::convert::Into<std::boxed::Box<crate::model::BuildOccurrence>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Build(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Occurrence::details]
     /// if it holds a `Image`, `None` if the field is not set or
     /// holds a different branch.
@@ -4938,20 +4864,6 @@ impl Occurrence {
             crate::model::occurrence::Details::Image(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Image`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_image<T: std::convert::Into<std::boxed::Box<crate::model::ImageOccurrence>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Image(v.into()));
-        self
     }
 
     /// The value of [details][crate::model::Occurrence::details]
@@ -4967,20 +4879,6 @@ impl Occurrence {
         })
     }
 
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Package`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_package<T: std::convert::Into<std::boxed::Box<crate::model::PackageOccurrence>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Package(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Occurrence::details]
     /// if it holds a `Deployment`, `None` if the field is not set or
     /// holds a different branch.
@@ -4992,22 +4890,6 @@ impl Occurrence {
             crate::model::occurrence::Details::Deployment(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Deployment`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_deployment<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeploymentOccurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Deployment(v.into()));
-        self
     }
 
     /// The value of [details][crate::model::Occurrence::details]
@@ -5023,22 +4905,6 @@ impl Occurrence {
         })
     }
 
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Discovery`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_discovery<
-        T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryOccurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Discovery(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Occurrence::details]
     /// if it holds a `Attestation`, `None` if the field is not set or
     /// holds a different branch.
@@ -5050,22 +4916,6 @@ impl Occurrence {
             crate::model::occurrence::Details::Attestation(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Attestation`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_attestation<
-        T: std::convert::Into<std::boxed::Box<crate::model::AttestationOccurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Attestation(v.into()));
-        self
     }
 
     /// The value of [details][crate::model::Occurrence::details]
@@ -5081,20 +4931,6 @@ impl Occurrence {
         })
     }
 
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Upgrade`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_upgrade<T: std::convert::Into<std::boxed::Box<crate::model::UpgradeOccurrence>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Upgrade(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Occurrence::details]
     /// if it holds a `Compliance`, `None` if the field is not set or
     /// holds a different branch.
@@ -5106,22 +4942,6 @@ impl Occurrence {
             crate::model::occurrence::Details::Compliance(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Compliance`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_compliance<
-        T: std::convert::Into<std::boxed::Box<crate::model::ComplianceOccurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Compliance(v.into()));
-        self
     }
 
     /// The value of [details][crate::model::Occurrence::details]
@@ -5137,22 +4957,6 @@ impl Occurrence {
         })
     }
 
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `DsseAttestation`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_dsse_attestation<
-        T: std::convert::Into<std::boxed::Box<crate::model::DSSEAttestationOccurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::DsseAttestation(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Occurrence::details]
     /// if it holds a `SbomReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -5166,22 +4970,6 @@ impl Occurrence {
         })
     }
 
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `SbomReference`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_sbom_reference<
-        T: std::convert::Into<std::boxed::Box<crate::model::SBOMReferenceOccurrence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::SbomReference(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::Occurrence::details]
     /// if it holds a `Secret`, `None` if the field is not set or
     /// holds a different branch.
@@ -5191,20 +4979,6 @@ impl Occurrence {
             crate::model::occurrence::Details::Secret(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::Occurrence::details]
-    /// to hold a `Secret`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_secret<T: std::convert::Into<std::boxed::Box<crate::model::SecretOccurrence>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::occurrence::Details::Secret(v.into()));
-        self
     }
 }
 
@@ -5416,21 +5190,6 @@ impl Note {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Vulnerability`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_vulnerability<
-        T: std::convert::Into<std::boxed::Box<crate::model::VulnerabilityNote>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Vulnerability(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Note::r#type]
     /// if it holds a `Build`, `None` if the field is not set or
     /// holds a different branch.
@@ -5440,19 +5199,6 @@ impl Note {
             crate::model::note::Type::Build(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Build`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_build<T: std::convert::Into<std::boxed::Box<crate::model::BuildNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Build(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Note::r#type]
@@ -5466,19 +5212,6 @@ impl Note {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Image`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_image<T: std::convert::Into<std::boxed::Box<crate::model::ImageNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Image(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Note::r#type]
     /// if it holds a `Package`, `None` if the field is not set or
     /// holds a different branch.
@@ -5488,19 +5221,6 @@ impl Note {
             crate::model::note::Type::Package(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Package`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_package<T: std::convert::Into<std::boxed::Box<crate::model::PackageNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Package(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Note::r#type]
@@ -5516,19 +5236,6 @@ impl Note {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Deployment`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_deployment<T: std::convert::Into<std::boxed::Box<crate::model::DeploymentNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Deployment(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Note::r#type]
     /// if it holds a `Discovery`, `None` if the field is not set or
     /// holds a different branch.
@@ -5538,19 +5245,6 @@ impl Note {
             crate::model::note::Type::Discovery(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Discovery`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_discovery<T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Discovery(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Note::r#type]
@@ -5566,21 +5260,6 @@ impl Note {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Attestation`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_attestation<
-        T: std::convert::Into<std::boxed::Box<crate::model::AttestationNote>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Attestation(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Note::r#type]
     /// if it holds a `Upgrade`, `None` if the field is not set or
     /// holds a different branch.
@@ -5590,19 +5269,6 @@ impl Note {
             crate::model::note::Type::Upgrade(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Upgrade`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_upgrade<T: std::convert::Into<std::boxed::Box<crate::model::UpgradeNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Upgrade(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Note::r#type]
@@ -5618,19 +5284,6 @@ impl Note {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Compliance`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_compliance<T: std::convert::Into<std::boxed::Box<crate::model::ComplianceNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Compliance(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Note::r#type]
     /// if it holds a `DsseAttestation`, `None` if the field is not set or
     /// holds a different branch.
@@ -5642,22 +5295,6 @@ impl Note {
             crate::model::note::Type::DsseAttestation(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `DsseAttestation`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_dsse_attestation<
-        T: std::convert::Into<std::boxed::Box<crate::model::DSSEAttestationNote>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::note::Type::DsseAttestation(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Note::r#type]
@@ -5673,22 +5310,6 @@ impl Note {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `VulnerabilityAssessment`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_vulnerability_assessment<
-        T: std::convert::Into<std::boxed::Box<crate::model::VulnerabilityAssessmentNote>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::note::Type::VulnerabilityAssessment(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Note::r#type]
     /// if it holds a `SbomReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -5702,21 +5323,6 @@ impl Note {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `SbomReference`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_sbom_reference<
-        T: std::convert::Into<std::boxed::Box<crate::model::SBOMReferenceNote>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::SbomReference(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Note::r#type]
     /// if it holds a `Secret`, `None` if the field is not set or
     /// holds a different branch.
@@ -5726,19 +5332,6 @@ impl Note {
             crate::model::note::Type::Secret(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Note::r#type]
-    /// to hold a `Secret`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_secret<T: std::convert::Into<std::boxed::Box<crate::model::SecretNote>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::note::Type::Secret(v.into()));
-        self
     }
 }
 
@@ -7404,23 +6997,6 @@ impl InTotoStatement {
         })
     }
 
-    /// Sets the value of [predicate][crate::model::InTotoStatement::predicate]
-    /// to hold a `Provenance`.
-    ///
-    /// Note that all the setters affecting `predicate` are
-    /// mutually exclusive.
-    pub fn set_provenance<
-        T: std::convert::Into<std::boxed::Box<crate::model::InTotoProvenance>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.predicate = std::option::Option::Some(
-            crate::model::in_toto_statement::Predicate::Provenance(v.into()),
-        );
-        self
-    }
-
     /// The value of [predicate][crate::model::InTotoStatement::predicate]
     /// if it holds a `SlsaProvenance`, `None` if the field is not set or
     /// holds a different branch.
@@ -7436,23 +7012,6 @@ impl InTotoStatement {
         })
     }
 
-    /// Sets the value of [predicate][crate::model::InTotoStatement::predicate]
-    /// to hold a `SlsaProvenance`.
-    ///
-    /// Note that all the setters affecting `predicate` are
-    /// mutually exclusive.
-    pub fn set_slsa_provenance<
-        T: std::convert::Into<std::boxed::Box<crate::model::SlsaProvenance>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.predicate = std::option::Option::Some(
-            crate::model::in_toto_statement::Predicate::SlsaProvenance(v.into()),
-        );
-        self
-    }
-
     /// The value of [predicate][crate::model::InTotoStatement::predicate]
     /// if it holds a `SlsaProvenanceZeroTwo`, `None` if the field is not set or
     /// holds a different branch.
@@ -7466,23 +7025,6 @@ impl InTotoStatement {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [predicate][crate::model::InTotoStatement::predicate]
-    /// to hold a `SlsaProvenanceZeroTwo`.
-    ///
-    /// Note that all the setters affecting `predicate` are
-    /// mutually exclusive.
-    pub fn set_slsa_provenance_zero_two<
-        T: std::convert::Into<std::boxed::Box<crate::model::SlsaProvenanceZeroTwo>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.predicate = std::option::Option::Some(
-            crate::model::in_toto_statement::Predicate::SlsaProvenanceZeroTwo(v.into()),
-        );
-        self
     }
 }
 
@@ -9284,22 +8826,6 @@ impl SourceContext {
         })
     }
 
-    /// Sets the value of [context][crate::model::SourceContext::context]
-    /// to hold a `CloudRepo`.
-    ///
-    /// Note that all the setters affecting `context` are
-    /// mutually exclusive.
-    pub fn set_cloud_repo<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudRepoSourceContext>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.context =
-            std::option::Option::Some(crate::model::source_context::Context::CloudRepo(v.into()));
-        self
-    }
-
     /// The value of [context][crate::model::SourceContext::context]
     /// if it holds a `Gerrit`, `None` if the field is not set or
     /// holds a different branch.
@@ -9313,20 +8839,6 @@ impl SourceContext {
         })
     }
 
-    /// Sets the value of [context][crate::model::SourceContext::context]
-    /// to hold a `Gerrit`.
-    ///
-    /// Note that all the setters affecting `context` are
-    /// mutually exclusive.
-    pub fn set_gerrit<T: std::convert::Into<std::boxed::Box<crate::model::GerritSourceContext>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.context =
-            std::option::Option::Some(crate::model::source_context::Context::Gerrit(v.into()));
-        self
-    }
-
     /// The value of [context][crate::model::SourceContext::context]
     /// if it holds a `Git`, `None` if the field is not set or
     /// holds a different branch.
@@ -9336,20 +8848,6 @@ impl SourceContext {
             crate::model::source_context::Context::Git(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [context][crate::model::SourceContext::context]
-    /// to hold a `Git`.
-    ///
-    /// Note that all the setters affecting `context` are
-    /// mutually exclusive.
-    pub fn set_git<T: std::convert::Into<std::boxed::Box<crate::model::GitSourceContext>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.context =
-            std::option::Option::Some(crate::model::source_context::Context::Git(v.into()));
-        self
     }
 }
 
@@ -9630,18 +9128,6 @@ impl CloudRepoSourceContext {
         })
     }
 
-    /// Sets the value of [revision][crate::model::CloudRepoSourceContext::revision]
-    /// to hold a `RevisionId`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision = std::option::Option::Some(
-            crate::model::cloud_repo_source_context::Revision::RevisionId(v.into()),
-        );
-        self
-    }
-
     /// The value of [revision][crate::model::CloudRepoSourceContext::revision]
     /// if it holds a `AliasContext`, `None` if the field is not set or
     /// holds a different branch.
@@ -9655,21 +9141,6 @@ impl CloudRepoSourceContext {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [revision][crate::model::CloudRepoSourceContext::revision]
-    /// to hold a `AliasContext`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_alias_context<T: std::convert::Into<std::boxed::Box<crate::model::AliasContext>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.revision = std::option::Option::Some(
-            crate::model::cloud_repo_source_context::Revision::AliasContext(v.into()),
-        );
-        self
     }
 }
 
@@ -9767,18 +9238,6 @@ impl GerritSourceContext {
         })
     }
 
-    /// Sets the value of [revision][crate::model::GerritSourceContext::revision]
-    /// to hold a `RevisionId`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_revision_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.revision = std::option::Option::Some(
-            crate::model::gerrit_source_context::Revision::RevisionId(v.into()),
-        );
-        self
-    }
-
     /// The value of [revision][crate::model::GerritSourceContext::revision]
     /// if it holds a `AliasContext`, `None` if the field is not set or
     /// holds a different branch.
@@ -9792,21 +9251,6 @@ impl GerritSourceContext {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [revision][crate::model::GerritSourceContext::revision]
-    /// to hold a `AliasContext`.
-    ///
-    /// Note that all the setters affecting `revision` are
-    /// mutually exclusive.
-    pub fn set_alias_context<T: std::convert::Into<std::boxed::Box<crate::model::AliasContext>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.revision = std::option::Option::Some(
-            crate::model::gerrit_source_context::Revision::AliasContext(v.into()),
-        );
-        self
     }
 }
 
@@ -9923,21 +9367,6 @@ impl RepoId {
         })
     }
 
-    /// Sets the value of [id][crate::model::RepoId::id]
-    /// to hold a `ProjectRepoId`.
-    ///
-    /// Note that all the setters affecting `id` are
-    /// mutually exclusive.
-    pub fn set_project_repo_id<
-        T: std::convert::Into<std::boxed::Box<crate::model::ProjectRepoId>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.id = std::option::Option::Some(crate::model::repo_id::Id::ProjectRepoId(v.into()));
-        self
-    }
-
     /// The value of [id][crate::model::RepoId::id]
     /// if it holds a `Uid`, `None` if the field is not set or
     /// holds a different branch.
@@ -9947,16 +9376,6 @@ impl RepoId {
             crate::model::repo_id::Id::Uid(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [id][crate::model::RepoId::id]
-    /// to hold a `Uid`.
-    ///
-    /// Note that all the setters affecting `id` are
-    /// mutually exclusive.
-    pub fn set_uid<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.id = std::option::Option::Some(crate::model::repo_id::Id::Uid(v.into()));
-        self
     }
 }
 
@@ -10413,21 +9832,6 @@ impl SecretLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location][crate::model::SecretLocation::location]
-    /// to hold a `FileLocation`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_file_location<T: std::convert::Into<std::boxed::Box<crate::model::FileLocation>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::secret_location::Location::FileLocation(v.into()),
-        );
-        self
     }
 }
 
@@ -12216,20 +11620,6 @@ pub mod vulnerability_assessment_note {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [identifier][crate::model::vulnerability_assessment_note::Product::identifier]
-        /// to hold a `GenericUri`.
-        ///
-        /// Note that all the setters affecting `identifier` are
-        /// mutually exclusive.
-        pub fn set_generic_uri<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.identifier = std::option::Option::Some(
-                crate::model::vulnerability_assessment_note::product::Identifier::GenericUri(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 

--- a/src/generated/iam/admin/v1/src/builder.rs
+++ b/src/generated/iam/admin/v1/src/builder.rs
@@ -2377,19 +2377,6 @@ pub mod iam {
             self.0.request.lint_object = v.into();
             self
         }
-
-        /// Sets the value of [lint_object][crate::model::LintPolicyRequest::lint_object]
-        /// to hold a `Condition`.
-        ///
-        /// Note that all the setters affecting `lint_object` are
-        /// mutually exclusive.
-        pub fn set_condition<T: std::convert::Into<std::boxed::Box<gtype::model::Expr>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_condition(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/iam/admin/v1/src/model.rs
+++ b/src/generated/iam/admin/v1/src/model.rs
@@ -3301,21 +3301,6 @@ impl LintPolicyRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [lint_object][crate::model::LintPolicyRequest::lint_object]
-    /// to hold a `Condition`.
-    ///
-    /// Note that all the setters affecting `lint_object` are
-    /// mutually exclusive.
-    pub fn set_condition<T: std::convert::Into<std::boxed::Box<gtype::model::Expr>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.lint_object = std::option::Option::Some(
-            crate::model::lint_policy_request::LintObject::Condition(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for LintPolicyRequest {

--- a/src/generated/iam/v2/src/model.rs
+++ b/src/generated/iam/v2/src/model.rs
@@ -420,19 +420,6 @@ impl PolicyRule {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [kind][crate::model::PolicyRule::kind]
-    /// to hold a `DenyRule`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_deny_rule<T: std::convert::Into<std::boxed::Box<crate::model::DenyRule>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind = std::option::Option::Some(crate::model::policy_rule::Kind::DenyRule(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for PolicyRule {

--- a/src/generated/iam/v3/src/model.rs
+++ b/src/generated/iam/v3/src/model.rs
@@ -408,21 +408,6 @@ pub mod policy_binding {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [target][crate::model::policy_binding::Target::target]
-        /// to hold a `PrincipalSet`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_principal_set<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.target = std::option::Option::Some(
-                crate::model::policy_binding::target::Target::PrincipalSet(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for Target {

--- a/src/generated/identity/accesscontextmanager/v1/src/model.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/model.rs
@@ -1672,19 +1672,6 @@ impl AccessLevel {
         })
     }
 
-    /// Sets the value of [level][crate::model::AccessLevel::level]
-    /// to hold a `Basic`.
-    ///
-    /// Note that all the setters affecting `level` are
-    /// mutually exclusive.
-    pub fn set_basic<T: std::convert::Into<std::boxed::Box<crate::model::BasicLevel>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.level = std::option::Option::Some(crate::model::access_level::Level::Basic(v.into()));
-        self
-    }
-
     /// The value of [level][crate::model::AccessLevel::level]
     /// if it holds a `Custom`, `None` if the field is not set or
     /// holds a different branch.
@@ -1694,19 +1681,6 @@ impl AccessLevel {
             crate::model::access_level::Level::Custom(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [level][crate::model::AccessLevel::level]
-    /// to hold a `Custom`.
-    ///
-    /// Note that all the setters affecting `level` are
-    /// mutually exclusive.
-    pub fn set_custom<T: std::convert::Into<std::boxed::Box<crate::model::CustomLevel>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.level = std::option::Option::Some(crate::model::access_level::Level::Custom(v.into()));
-        self
     }
 }
 
@@ -3013,18 +2987,6 @@ pub mod service_perimeter_config {
             })
         }
 
-        /// Sets the value of [kind][crate::model::service_perimeter_config::MethodSelector::kind]
-        /// to hold a `Method`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_method<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::service_perimeter_config::method_selector::Kind::Method(v.into()),
-            );
-            self
-        }
-
         /// The value of [kind][crate::model::service_perimeter_config::MethodSelector::kind]
         /// if it holds a `Permission`, `None` if the field is not set or
         /// holds a different branch.
@@ -3036,18 +2998,6 @@ pub mod service_perimeter_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [kind][crate::model::service_perimeter_config::MethodSelector::kind]
-        /// to hold a `Permission`.
-        ///
-        /// Note that all the setters affecting `kind` are
-        /// mutually exclusive.
-        pub fn set_permission<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.kind = std::option::Option::Some(
-                crate::model::service_perimeter_config::method_selector::Kind::Permission(v.into()),
-            );
-            self
         }
     }
 
@@ -3197,23 +3147,6 @@ pub mod service_perimeter_config {
             })
         }
 
-        /// Sets the value of [source][crate::model::service_perimeter_config::IngressSource::source]
-        /// to hold a `AccessLevel`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_access_level<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::service_perimeter_config::ingress_source::Source::AccessLevel(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [source][crate::model::service_perimeter_config::IngressSource::source]
         /// if it holds a `Resource`, `None` if the field is not set or
         /// holds a different branch.
@@ -3225,18 +3158,6 @@ pub mod service_perimeter_config {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::service_perimeter_config::IngressSource::source]
-        /// to hold a `Resource`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_resource<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::service_perimeter_config::ingress_source::Source::Resource(v.into()),
-            );
-            self
         }
     }
 

--- a/src/generated/logging/v2/src/model.rs
+++ b/src/generated/logging/v2/src/model.rs
@@ -366,20 +366,6 @@ impl LogEntry {
         })
     }
 
-    /// Sets the value of [payload][crate::model::LogEntry::payload]
-    /// to hold a `ProtoPayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_proto_payload<T: std::convert::Into<std::boxed::Box<wkt::Any>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.payload =
-            std::option::Option::Some(crate::model::log_entry::Payload::ProtoPayload(v.into()));
-        self
-    }
-
     /// The value of [payload][crate::model::LogEntry::payload]
     /// if it holds a `TextPayload`, `None` if the field is not set or
     /// holds a different branch.
@@ -391,17 +377,6 @@ impl LogEntry {
         })
     }
 
-    /// Sets the value of [payload][crate::model::LogEntry::payload]
-    /// to hold a `TextPayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_text_payload<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.payload =
-            std::option::Option::Some(crate::model::log_entry::Payload::TextPayload(v.into()));
-        self
-    }
-
     /// The value of [payload][crate::model::LogEntry::payload]
     /// if it holds a `JsonPayload`, `None` if the field is not set or
     /// holds a different branch.
@@ -411,20 +386,6 @@ impl LogEntry {
             crate::model::log_entry::Payload::JsonPayload(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [payload][crate::model::LogEntry::payload]
-    /// to hold a `JsonPayload`.
-    ///
-    /// Note that all the setters affecting `payload` are
-    /// mutually exclusive.
-    pub fn set_json_payload<T: std::convert::Into<std::boxed::Box<wkt::Struct>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.payload =
-            std::option::Option::Some(crate::model::log_entry::Payload::JsonPayload(v.into()));
-        self
     }
 }
 
@@ -2281,22 +2242,6 @@ impl LogSink {
             crate::model::log_sink::Options::BigqueryOptions(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [options][crate::model::LogSink::options]
-    /// to hold a `BigqueryOptions`.
-    ///
-    /// Note that all the setters affecting `options` are
-    /// mutually exclusive.
-    pub fn set_bigquery_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.options =
-            std::option::Option::Some(crate::model::log_sink::Options::BigqueryOptions(v.into()));
-        self
     }
 }
 
@@ -5353,23 +5298,6 @@ impl BucketMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::BucketMetadata::request]
-    /// to hold a `CreateBucketRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_create_bucket_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateBucketRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::bucket_metadata::Request::CreateBucketRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::BucketMetadata::request]
     /// if it holds a `UpdateBucketRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -5383,23 +5311,6 @@ impl BucketMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::BucketMetadata::request]
-    /// to hold a `UpdateBucketRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_update_bucket_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::UpdateBucketRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::bucket_metadata::Request::UpdateBucketRequest(v.into()),
-        );
-        self
     }
 }
 
@@ -5508,23 +5419,6 @@ impl LinkMetadata {
         })
     }
 
-    /// Sets the value of [request][crate::model::LinkMetadata::request]
-    /// to hold a `CreateLinkRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_create_link_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::CreateLinkRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::link_metadata::Request::CreateLinkRequest(v.into()),
-        );
-        self
-    }
-
     /// The value of [request][crate::model::LinkMetadata::request]
     /// if it holds a `DeleteLinkRequest`, `None` if the field is not set or
     /// holds a different branch.
@@ -5538,23 +5432,6 @@ impl LinkMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::LinkMetadata::request]
-    /// to hold a `DeleteLinkRequest`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_delete_link_request<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeleteLinkRequest>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request = std::option::Option::Some(
-            crate::model::link_metadata::Request::DeleteLinkRequest(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/longrunning/src/model.rs
+++ b/src/generated/longrunning/src/model.rs
@@ -119,19 +119,6 @@ impl Operation {
         })
     }
 
-    /// Sets the value of [result][crate::model::Operation::result]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(crate::model::operation::Result::Error(v.into()));
-        self
-    }
-
     /// The value of [result][crate::model::Operation::result]
     /// if it holds a `Response`, `None` if the field is not set or
     /// holds a different branch.
@@ -141,17 +128,6 @@ impl Operation {
             crate::model::operation::Result::Response(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::Operation::result]
-    /// to hold a `Response`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_response<T: std::convert::Into<std::boxed::Box<wkt::Any>>>(mut self, v: T) -> Self {
-        self.result =
-            std::option::Option::Some(crate::model::operation::Result::Response(v.into()));
-        self
     }
 }
 

--- a/src/generated/monitoring/dashboard/v1/src/model.rs
+++ b/src/generated/monitoring/dashboard/v1/src/model.rs
@@ -1529,20 +1529,6 @@ impl Dashboard {
         })
     }
 
-    /// Sets the value of [layout][crate::model::Dashboard::layout]
-    /// to hold a `GridLayout`.
-    ///
-    /// Note that all the setters affecting `layout` are
-    /// mutually exclusive.
-    pub fn set_grid_layout<T: std::convert::Into<std::boxed::Box<crate::model::GridLayout>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.layout =
-            std::option::Option::Some(crate::model::dashboard::Layout::GridLayout(v.into()));
-        self
-    }
-
     /// The value of [layout][crate::model::Dashboard::layout]
     /// if it holds a `MosaicLayout`, `None` if the field is not set or
     /// holds a different branch.
@@ -1556,20 +1542,6 @@ impl Dashboard {
         })
     }
 
-    /// Sets the value of [layout][crate::model::Dashboard::layout]
-    /// to hold a `MosaicLayout`.
-    ///
-    /// Note that all the setters affecting `layout` are
-    /// mutually exclusive.
-    pub fn set_mosaic_layout<T: std::convert::Into<std::boxed::Box<crate::model::MosaicLayout>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.layout =
-            std::option::Option::Some(crate::model::dashboard::Layout::MosaicLayout(v.into()));
-        self
-    }
-
     /// The value of [layout][crate::model::Dashboard::layout]
     /// if it holds a `RowLayout`, `None` if the field is not set or
     /// holds a different branch.
@@ -1579,20 +1551,6 @@ impl Dashboard {
             crate::model::dashboard::Layout::RowLayout(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [layout][crate::model::Dashboard::layout]
-    /// to hold a `RowLayout`.
-    ///
-    /// Note that all the setters affecting `layout` are
-    /// mutually exclusive.
-    pub fn set_row_layout<T: std::convert::Into<std::boxed::Box<crate::model::RowLayout>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.layout =
-            std::option::Option::Some(crate::model::dashboard::Layout::RowLayout(v.into()));
-        self
     }
 
     /// The value of [layout][crate::model::Dashboard::layout]
@@ -1606,20 +1564,6 @@ impl Dashboard {
             crate::model::dashboard::Layout::ColumnLayout(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [layout][crate::model::Dashboard::layout]
-    /// to hold a `ColumnLayout`.
-    ///
-    /// Note that all the setters affecting `layout` are
-    /// mutually exclusive.
-    pub fn set_column_layout<T: std::convert::Into<std::boxed::Box<crate::model::ColumnLayout>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.layout =
-            std::option::Option::Some(crate::model::dashboard::Layout::ColumnLayout(v.into()));
-        self
     }
 }
 
@@ -1736,18 +1680,6 @@ impl DashboardFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [default_value][crate::model::DashboardFilter::default_value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `default_value` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.default_value = std::option::Option::Some(
-            crate::model::dashboard_filter::DefaultValue::StringValue(v.into()),
-        );
-        self
     }
 }
 
@@ -2875,23 +2807,6 @@ impl TimeSeriesQuery {
         })
     }
 
-    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
-    /// to hold a `TimeSeriesFilter`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_time_series_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimeSeriesFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::time_series_query::Source::TimeSeriesFilter(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::TimeSeriesQuery::source]
     /// if it holds a `TimeSeriesFilterRatio`, `None` if the field is not set or
     /// holds a different branch.
@@ -2907,23 +2822,6 @@ impl TimeSeriesQuery {
         })
     }
 
-    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
-    /// to hold a `TimeSeriesFilterRatio`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_time_series_filter_ratio<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimeSeriesFilterRatio>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::time_series_query::Source::TimeSeriesFilterRatio(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::TimeSeriesQuery::source]
     /// if it holds a `TimeSeriesQueryLanguage`, `None` if the field is not set or
     /// holds a different branch.
@@ -2937,21 +2835,6 @@ impl TimeSeriesQuery {
         })
     }
 
-    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
-    /// to hold a `TimeSeriesQueryLanguage`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_time_series_query_language<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::time_series_query::Source::TimeSeriesQueryLanguage(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::TimeSeriesQuery::source]
     /// if it holds a `PrometheusQuery`, `None` if the field is not set or
     /// holds a different branch.
@@ -2963,21 +2846,6 @@ impl TimeSeriesQuery {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::TimeSeriesQuery::source]
-    /// to hold a `PrometheusQuery`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_prometheus_query<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::time_series_query::Source::PrometheusQuery(v.into()),
-        );
-        self
     }
 }
 
@@ -3104,23 +2972,6 @@ impl TimeSeriesFilter {
         })
     }
 
-    /// Sets the value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
-    /// to hold a `PickTimeSeriesFilter`.
-    ///
-    /// Note that all the setters affecting `output_filter` are
-    /// mutually exclusive.
-    pub fn set_pick_time_series_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::PickTimeSeriesFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_filter = std::option::Option::Some(
-            crate::model::time_series_filter::OutputFilter::PickTimeSeriesFilter(v.into()),
-        );
-        self
-    }
-
     /// The value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
     /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
     /// holds a different branch.
@@ -3135,24 +2986,6 @@ impl TimeSeriesFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [output_filter][crate::model::TimeSeriesFilter::output_filter]
-    /// to hold a `StatisticalTimeSeriesFilter`.
-    ///
-    /// Note that all the setters affecting `output_filter` are
-    /// mutually exclusive.
-    #[deprecated]
-    pub fn set_statistical_time_series_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_filter = std::option::Option::Some(
-            crate::model::time_series_filter::OutputFilter::StatisticalTimeSeriesFilter(v.into()),
-        );
-        self
     }
 }
 
@@ -3280,23 +3113,6 @@ impl TimeSeriesFilterRatio {
         })
     }
 
-    /// Sets the value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
-    /// to hold a `PickTimeSeriesFilter`.
-    ///
-    /// Note that all the setters affecting `output_filter` are
-    /// mutually exclusive.
-    pub fn set_pick_time_series_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::PickTimeSeriesFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_filter = std::option::Option::Some(
-            crate::model::time_series_filter_ratio::OutputFilter::PickTimeSeriesFilter(v.into()),
-        );
-        self
-    }
-
     /// The value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
     /// if it holds a `StatisticalTimeSeriesFilter`, `None` if the field is not set or
     /// holds a different branch.
@@ -3311,26 +3127,6 @@ impl TimeSeriesFilterRatio {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [output_filter][crate::model::TimeSeriesFilterRatio::output_filter]
-    /// to hold a `StatisticalTimeSeriesFilter`.
-    ///
-    /// Note that all the setters affecting `output_filter` are
-    /// mutually exclusive.
-    #[deprecated]
-    pub fn set_statistical_time_series_filter<
-        T: std::convert::Into<std::boxed::Box<crate::model::StatisticalTimeSeriesFilter>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.output_filter = std::option::Option::Some(
-            crate::model::time_series_filter_ratio::OutputFilter::StatisticalTimeSeriesFilter(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -4290,22 +4086,6 @@ impl Scorecard {
         })
     }
 
-    /// Sets the value of [data_view][crate::model::Scorecard::data_view]
-    /// to hold a `GaugeView`.
-    ///
-    /// Note that all the setters affecting `data_view` are
-    /// mutually exclusive.
-    pub fn set_gauge_view<
-        T: std::convert::Into<std::boxed::Box<crate::model::scorecard::GaugeView>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_view =
-            std::option::Option::Some(crate::model::scorecard::DataView::GaugeView(v.into()));
-        self
-    }
-
     /// The value of [data_view][crate::model::Scorecard::data_view]
     /// if it holds a `SparkChartView`, `None` if the field is not set or
     /// holds a different branch.
@@ -4319,22 +4099,6 @@ impl Scorecard {
         })
     }
 
-    /// Sets the value of [data_view][crate::model::Scorecard::data_view]
-    /// to hold a `SparkChartView`.
-    ///
-    /// Note that all the setters affecting `data_view` are
-    /// mutually exclusive.
-    pub fn set_spark_chart_view<
-        T: std::convert::Into<std::boxed::Box<crate::model::scorecard::SparkChartView>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_view =
-            std::option::Option::Some(crate::model::scorecard::DataView::SparkChartView(v.into()));
-        self
-    }
-
     /// The value of [data_view][crate::model::Scorecard::data_view]
     /// if it holds a `BlankView`, `None` if the field is not set or
     /// holds a different branch.
@@ -4344,20 +4108,6 @@ impl Scorecard {
             crate::model::scorecard::DataView::BlankView(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_view][crate::model::Scorecard::data_view]
-    /// to hold a `BlankView`.
-    ///
-    /// Note that all the setters affecting `data_view` are
-    /// mutually exclusive.
-    pub fn set_blank_view<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_view =
-            std::option::Option::Some(crate::model::scorecard::DataView::BlankView(v.into()));
-        self
     }
 }
 
@@ -6119,19 +5869,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `XyChart`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_xy_chart<T: std::convert::Into<std::boxed::Box<crate::model::XyChart>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content = std::option::Option::Some(crate::model::widget::Content::XyChart(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `Scorecard`, `None` if the field is not set or
     /// holds a different branch.
@@ -6141,20 +5878,6 @@ impl Widget {
             crate::model::widget::Content::Scorecard(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `Scorecard`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_scorecard<T: std::convert::Into<std::boxed::Box<crate::model::Scorecard>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::Scorecard(v.into()));
-        self
     }
 
     /// The value of [content][crate::model::Widget::content]
@@ -6168,19 +5891,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::boxed::Box<crate::model::Text>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content = std::option::Option::Some(crate::model::widget::Content::Text(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `Blank`, `None` if the field is not set or
     /// holds a different branch.
@@ -6192,16 +5902,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `Blank`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_blank<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(mut self, v: T) -> Self {
-        self.content = std::option::Option::Some(crate::model::widget::Content::Blank(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `AlertChart`, `None` if the field is not set or
     /// holds a different branch.
@@ -6211,20 +5911,6 @@ impl Widget {
             crate::model::widget::Content::AlertChart(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `AlertChart`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_alert_chart<T: std::convert::Into<std::boxed::Box<crate::model::AlertChart>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::AlertChart(v.into()));
-        self
     }
 
     /// The value of [content][crate::model::Widget::content]
@@ -6240,22 +5926,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `TimeSeriesTable`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_time_series_table<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimeSeriesTable>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::TimeSeriesTable(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `CollapsibleGroup`, `None` if the field is not set or
     /// holds a different branch.
@@ -6269,22 +5939,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `CollapsibleGroup`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_collapsible_group<
-        T: std::convert::Into<std::boxed::Box<crate::model::CollapsibleGroup>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::CollapsibleGroup(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `LogsPanel`, `None` if the field is not set or
     /// holds a different branch.
@@ -6294,20 +5948,6 @@ impl Widget {
             crate::model::widget::Content::LogsPanel(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `LogsPanel`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_logs_panel<T: std::convert::Into<std::boxed::Box<crate::model::LogsPanel>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::LogsPanel(v.into()));
-        self
     }
 
     /// The value of [content][crate::model::Widget::content]
@@ -6323,20 +5963,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `IncidentList`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_incident_list<T: std::convert::Into<std::boxed::Box<crate::model::IncidentList>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::IncidentList(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `PieChart`, `None` if the field is not set or
     /// holds a different branch.
@@ -6346,19 +5972,6 @@ impl Widget {
             crate::model::widget::Content::PieChart(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `PieChart`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_pie_chart<T: std::convert::Into<std::boxed::Box<crate::model::PieChart>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content = std::option::Option::Some(crate::model::widget::Content::PieChart(v.into()));
-        self
     }
 
     /// The value of [content][crate::model::Widget::content]
@@ -6374,22 +5987,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `ErrorReportingPanel`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_error_reporting_panel<
-        T: std::convert::Into<std::boxed::Box<crate::model::ErrorReportingPanel>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::ErrorReportingPanel(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `SectionHeader`, `None` if the field is not set or
     /// holds a different branch.
@@ -6403,22 +6000,6 @@ impl Widget {
         })
     }
 
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `SectionHeader`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_section_header<
-        T: std::convert::Into<std::boxed::Box<crate::model::SectionHeader>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::SectionHeader(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Widget::content]
     /// if it holds a `SingleViewGroup`, `None` if the field is not set or
     /// holds a different branch.
@@ -6430,22 +6011,6 @@ impl Widget {
             crate::model::widget::Content::SingleViewGroup(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Widget::content]
-    /// to hold a `SingleViewGroup`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_single_view_group<
-        T: std::convert::Into<std::boxed::Box<crate::model::SingleViewGroup>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.content =
-            std::option::Option::Some(crate::model::widget::Content::SingleViewGroup(v.into()));
-        self
     }
 }
 

--- a/src/generated/monitoring/v3/src/builder.rs
+++ b/src/generated/monitoring/v3/src/builder.rs
@@ -625,45 +625,6 @@ pub mod group_service {
             self.0.request.filter = v.into();
             self
         }
-
-        /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
-        /// to hold a `ChildrenOfGroup`.
-        ///
-        /// Note that all the setters affecting `filter` are
-        /// mutually exclusive.
-        pub fn set_children_of_group<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_children_of_group(v);
-            self
-        }
-
-        /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
-        /// to hold a `AncestorsOfGroup`.
-        ///
-        /// Note that all the setters affecting `filter` are
-        /// mutually exclusive.
-        pub fn set_ancestors_of_group<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_ancestors_of_group(v);
-            self
-        }
-
-        /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
-        /// to hold a `DescendantsOfGroup`.
-        ///
-        /// Note that all the setters affecting `filter` are
-        /// mutually exclusive.
-        pub fn set_descendants_of_group<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_descendants_of_group(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/monitoring/v3/src/model.rs
+++ b/src/generated/monitoring/v3/src/model.rs
@@ -564,25 +564,6 @@ pub mod alert_policy {
             })
         }
 
-        /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
-        /// to hold a `ConditionThreshold`.
-        ///
-        /// Note that all the setters affecting `condition` are
-        /// mutually exclusive.
-        pub fn set_condition_threshold<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::alert_policy::condition::MetricThreshold>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.condition = std::option::Option::Some(
-                crate::model::alert_policy::condition::Condition::ConditionThreshold(v.into()),
-            );
-            self
-        }
-
         /// The value of [condition][crate::model::alert_policy::Condition::condition]
         /// if it holds a `ConditionAbsent`, `None` if the field is not set or
         /// holds a different branch.
@@ -600,25 +581,6 @@ pub mod alert_policy {
             })
         }
 
-        /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
-        /// to hold a `ConditionAbsent`.
-        ///
-        /// Note that all the setters affecting `condition` are
-        /// mutually exclusive.
-        pub fn set_condition_absent<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::alert_policy::condition::MetricAbsence>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.condition = std::option::Option::Some(
-                crate::model::alert_policy::condition::Condition::ConditionAbsent(v.into()),
-            );
-            self
-        }
-
         /// The value of [condition][crate::model::alert_policy::Condition::condition]
         /// if it holds a `ConditionMatchedLog`, `None` if the field is not set or
         /// holds a different branch.
@@ -633,23 +595,6 @@ pub mod alert_policy {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
-        /// to hold a `ConditionMatchedLog`.
-        ///
-        /// Note that all the setters affecting `condition` are
-        /// mutually exclusive.
-        pub fn set_condition_matched_log<
-            T: std::convert::Into<std::boxed::Box<crate::model::alert_policy::condition::LogMatch>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.condition = std::option::Option::Some(
-                crate::model::alert_policy::condition::Condition::ConditionMatchedLog(v.into()),
-            );
-            self
         }
 
         /// The value of [condition][crate::model::alert_policy::Condition::condition]
@@ -669,29 +614,6 @@ pub mod alert_policy {
             })
         }
 
-        /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
-        /// to hold a `ConditionMonitoringQueryLanguage`.
-        ///
-        /// Note that all the setters affecting `condition` are
-        /// mutually exclusive.
-        pub fn set_condition_monitoring_query_language<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::alert_policy::condition::MonitoringQueryLanguageCondition,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.condition = std::option::Option::Some(
-                crate::model::alert_policy::condition::Condition::ConditionMonitoringQueryLanguage(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [condition][crate::model::alert_policy::Condition::condition]
         /// if it holds a `ConditionPrometheusQueryLanguage`, `None` if the field is not set or
         /// holds a different branch.
@@ -709,29 +631,6 @@ pub mod alert_policy {
             })
         }
 
-        /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
-        /// to hold a `ConditionPrometheusQueryLanguage`.
-        ///
-        /// Note that all the setters affecting `condition` are
-        /// mutually exclusive.
-        pub fn set_condition_prometheus_query_language<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::alert_policy::condition::PrometheusQueryLanguageCondition,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.condition = std::option::Option::Some(
-                crate::model::alert_policy::condition::Condition::ConditionPrometheusQueryLanguage(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [condition][crate::model::alert_policy::Condition::condition]
         /// if it holds a `ConditionSql`, `None` if the field is not set or
         /// holds a different branch.
@@ -747,25 +646,6 @@ pub mod alert_policy {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [condition][crate::model::alert_policy::Condition::condition]
-        /// to hold a `ConditionSql`.
-        ///
-        /// Note that all the setters affecting `condition` are
-        /// mutually exclusive.
-        pub fn set_condition_sql<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::alert_policy::condition::SqlCondition>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.condition = std::option::Option::Some(
-                crate::model::alert_policy::condition::Condition::ConditionSql(v.into()),
-            );
-            self
         }
     }
 
@@ -829,18 +709,6 @@ pub mod alert_policy {
                 })
             }
 
-            /// Sets the value of [r#type][crate::model::alert_policy::condition::Trigger::r#type]
-            /// to hold a `Count`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::alert_policy::condition::trigger::Type::Count(v.into()),
-                );
-                self
-            }
-
             /// The value of [r#type][crate::model::alert_policy::condition::Trigger::r#type]
             /// if it holds a `Percent`, `None` if the field is not set or
             /// holds a different branch.
@@ -852,18 +720,6 @@ pub mod alert_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [r#type][crate::model::alert_policy::condition::Trigger::r#type]
-            /// to hold a `Percent`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_percent<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::alert_policy::condition::trigger::Type::Percent(v.into()),
-                );
-                self
             }
         }
 
@@ -1710,29 +1566,6 @@ pub mod alert_policy {
                 })
             }
 
-            /// Sets the value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
-            /// to hold a `Minutes`.
-            ///
-            /// Note that all the setters affecting `schedule` are
-            /// mutually exclusive.
-            pub fn set_minutes<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::alert_policy::condition::sql_condition::Minutes,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.schedule = std::option::Option::Some(
-                    crate::model::alert_policy::condition::sql_condition::Schedule::Minutes(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
             /// if it holds a `Hourly`, `None` if the field is not set or
             /// holds a different branch.
@@ -1750,29 +1583,6 @@ pub mod alert_policy {
                 })
             }
 
-            /// Sets the value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
-            /// to hold a `Hourly`.
-            ///
-            /// Note that all the setters affecting `schedule` are
-            /// mutually exclusive.
-            pub fn set_hourly<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::alert_policy::condition::sql_condition::Hourly,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.schedule = std::option::Option::Some(
-                    crate::model::alert_policy::condition::sql_condition::Schedule::Hourly(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
             /// if it holds a `Daily`, `None` if the field is not set or
             /// holds a different branch.
@@ -1788,27 +1598,6 @@ pub mod alert_policy {
                     }
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [schedule][crate::model::alert_policy::condition::SqlCondition::schedule]
-            /// to hold a `Daily`.
-            ///
-            /// Note that all the setters affecting `schedule` are
-            /// mutually exclusive.
-            pub fn set_daily<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::alert_policy::condition::sql_condition::Daily,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.schedule = std::option::Option::Some(
-                    crate::model::alert_policy::condition::sql_condition::Schedule::Daily(v.into()),
-                );
-                self
             }
 
             /// Sets the value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate].
@@ -1846,29 +1635,6 @@ pub mod alert_policy {
                 })
             }
 
-            /// Sets the value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate]
-            /// to hold a `RowCountTest`.
-            ///
-            /// Note that all the setters affecting `evaluate` are
-            /// mutually exclusive.
-            pub fn set_row_count_test<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::alert_policy::condition::sql_condition::RowCountTest,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.evaluate = std::option::Option::Some(
-                    crate::model::alert_policy::condition::sql_condition::Evaluate::RowCountTest(
-                        v.into(),
-                    ),
-                );
-                self
-            }
-
             /// The value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate]
             /// if it holds a `BooleanTest`, `None` if the field is not set or
             /// holds a different branch.
@@ -1884,29 +1650,6 @@ pub mod alert_policy {
                     ) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [evaluate][crate::model::alert_policy::condition::SqlCondition::evaluate]
-            /// to hold a `BooleanTest`.
-            ///
-            /// Note that all the setters affecting `evaluate` are
-            /// mutually exclusive.
-            pub fn set_boolean_test<
-                T: std::convert::Into<
-                        std::boxed::Box<
-                            crate::model::alert_policy::condition::sql_condition::BooleanTest,
-                        >,
-                    >,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.evaluate = std::option::Option::Some(
-                    crate::model::alert_policy::condition::sql_condition::Evaluate::BooleanTest(
-                        v.into(),
-                    ),
-                );
-                self
             }
         }
 
@@ -3419,17 +3162,6 @@ impl TypedValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::BoolValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::TypedValue::value]
     /// if it holds a `Int64Value`, `None` if the field is not set or
     /// holds a different branch.
@@ -3439,17 +3171,6 @@ impl TypedValue {
             crate::model::typed_value::Value::Int64Value(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `Int64Value`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::Int64Value(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::TypedValue::value]
@@ -3463,17 +3184,6 @@ impl TypedValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `DoubleValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_double_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::DoubleValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::TypedValue::value]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -3483,17 +3193,6 @@ impl TypedValue {
             crate::model::typed_value::Value::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::typed_value::Value::StringValue(v.into()));
-        self
     }
 
     /// The value of [value][crate::model::TypedValue::value]
@@ -3507,23 +3206,6 @@ impl TypedValue {
             crate::model::typed_value::Value::DistributionValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::TypedValue::value]
-    /// to hold a `DistributionValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_distribution_value<
-        T: std::convert::Into<std::boxed::Box<api::model::Distribution>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.value = std::option::Option::Some(
-            crate::model::typed_value::Value::DistributionValue(v.into()),
-        );
-        self
     }
 }
 
@@ -4667,21 +4349,6 @@ impl ListGroupsRequest {
         })
     }
 
-    /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
-    /// to hold a `ChildrenOfGroup`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_children_of_group<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::list_groups_request::Filter::ChildrenOfGroup(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::ListGroupsRequest::filter]
     /// if it holds a `AncestorsOfGroup`, `None` if the field is not set or
     /// holds a different branch.
@@ -4695,21 +4362,6 @@ impl ListGroupsRequest {
         })
     }
 
-    /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
-    /// to hold a `AncestorsOfGroup`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_ancestors_of_group<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::list_groups_request::Filter::AncestorsOfGroup(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::ListGroupsRequest::filter]
     /// if it holds a `DescendantsOfGroup`, `None` if the field is not set or
     /// holds a different branch.
@@ -4721,21 +4373,6 @@ impl ListGroupsRequest {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::ListGroupsRequest::filter]
-    /// to hold a `DescendantsOfGroup`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_descendants_of_group<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::list_groups_request::Filter::DescendantsOfGroup(v.into()),
-        );
-        self
     }
 }
 
@@ -5718,17 +5355,6 @@ impl LabelValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::LabelValue::value]
-    /// to hold a `BoolValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_bool_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::label_value::Value::BoolValue(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::LabelValue::value]
     /// if it holds a `Int64Value`, `None` if the field is not set or
     /// holds a different branch.
@@ -5740,17 +5366,6 @@ impl LabelValue {
         })
     }
 
-    /// Sets the value of [value][crate::model::LabelValue::value]
-    /// to hold a `Int64Value`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_int64_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::label_value::Value::Int64Value(v.into()));
-        self
-    }
-
     /// The value of [value][crate::model::LabelValue::value]
     /// if it holds a `StringValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -5760,17 +5375,6 @@ impl LabelValue {
             crate::model::label_value::Value::StringValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [value][crate::model::LabelValue::value]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `value` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.value =
-            std::option::Option::Some(crate::model::label_value::Value::StringValue(v.into()));
-        self
     }
 }
 
@@ -8709,20 +8313,6 @@ impl Service {
         })
     }
 
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `Custom`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_custom<T: std::convert::Into<std::boxed::Box<crate::model::service::Custom>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::Custom(v.into()));
-        self
-    }
-
     /// The value of [identifier][crate::model::Service::identifier]
     /// if it holds a `AppEngine`, `None` if the field is not set or
     /// holds a different branch.
@@ -8734,22 +8324,6 @@ impl Service {
             crate::model::service::Identifier::AppEngine(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `AppEngine`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_app_engine<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::AppEngine>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::AppEngine(v.into()));
-        self
     }
 
     /// The value of [identifier][crate::model::Service::identifier]
@@ -8765,22 +8339,6 @@ impl Service {
         })
     }
 
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `CloudEndpoints`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_cloud_endpoints<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::CloudEndpoints>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::CloudEndpoints(v.into()));
-        self
-    }
-
     /// The value of [identifier][crate::model::Service::identifier]
     /// if it holds a `ClusterIstio`, `None` if the field is not set or
     /// holds a different branch.
@@ -8794,22 +8352,6 @@ impl Service {
         })
     }
 
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `ClusterIstio`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_cluster_istio<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::ClusterIstio>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::ClusterIstio(v.into()));
-        self
-    }
-
     /// The value of [identifier][crate::model::Service::identifier]
     /// if it holds a `MeshIstio`, `None` if the field is not set or
     /// holds a different branch.
@@ -8821,22 +8363,6 @@ impl Service {
             crate::model::service::Identifier::MeshIstio(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `MeshIstio`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_mesh_istio<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::MeshIstio>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::MeshIstio(v.into()));
-        self
     }
 
     /// The value of [identifier][crate::model::Service::identifier]
@@ -8854,23 +8380,6 @@ impl Service {
         })
     }
 
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `IstioCanonicalService`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_istio_canonical_service<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::IstioCanonicalService>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier = std::option::Option::Some(
-            crate::model::service::Identifier::IstioCanonicalService(v.into()),
-        );
-        self
-    }
-
     /// The value of [identifier][crate::model::Service::identifier]
     /// if it holds a `CloudRun`, `None` if the field is not set or
     /// holds a different branch.
@@ -8882,22 +8391,6 @@ impl Service {
             crate::model::service::Identifier::CloudRun(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `CloudRun`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_cloud_run<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::CloudRun>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::CloudRun(v.into()));
-        self
     }
 
     /// The value of [identifier][crate::model::Service::identifier]
@@ -8913,22 +8406,6 @@ impl Service {
         })
     }
 
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `GkeNamespace`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_gke_namespace<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::GkeNamespace>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::GkeNamespace(v.into()));
-        self
-    }
-
     /// The value of [identifier][crate::model::Service::identifier]
     /// if it holds a `GkeWorkload`, `None` if the field is not set or
     /// holds a different branch.
@@ -8942,22 +8419,6 @@ impl Service {
         })
     }
 
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `GkeWorkload`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_gke_workload<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::GkeWorkload>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::GkeWorkload(v.into()));
-        self
-    }
-
     /// The value of [identifier][crate::model::Service::identifier]
     /// if it holds a `GkeService`, `None` if the field is not set or
     /// holds a different branch.
@@ -8969,22 +8430,6 @@ impl Service {
             crate::model::service::Identifier::GkeService(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [identifier][crate::model::Service::identifier]
-    /// to hold a `GkeService`.
-    ///
-    /// Note that all the setters affecting `identifier` are
-    /// mutually exclusive.
-    pub fn set_gke_service<
-        T: std::convert::Into<std::boxed::Box<crate::model::service::GkeService>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.identifier =
-            std::option::Option::Some(crate::model::service::Identifier::GkeService(v.into()));
-        self
     }
 }
 
@@ -9857,21 +9302,6 @@ impl ServiceLevelObjective {
         })
     }
 
-    /// Sets the value of [period][crate::model::ServiceLevelObjective::period]
-    /// to hold a `RollingPeriod`.
-    ///
-    /// Note that all the setters affecting `period` are
-    /// mutually exclusive.
-    pub fn set_rolling_period<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.period = std::option::Option::Some(
-            crate::model::service_level_objective::Period::RollingPeriod(v.into()),
-        );
-        self
-    }
-
     /// The value of [period][crate::model::ServiceLevelObjective::period]
     /// if it holds a `CalendarPeriod`, `None` if the field is not set or
     /// holds a different branch.
@@ -9883,21 +9313,6 @@ impl ServiceLevelObjective {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [period][crate::model::ServiceLevelObjective::period]
-    /// to hold a `CalendarPeriod`.
-    ///
-    /// Note that all the setters affecting `period` are
-    /// mutually exclusive.
-    pub fn set_calendar_period<T: std::convert::Into<gtype::model::CalendarPeriod>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.period = std::option::Option::Some(
-            crate::model::service_level_objective::Period::CalendarPeriod(v.into()),
-        );
-        self
     }
 }
 
@@ -10127,21 +9542,6 @@ impl ServiceLevelIndicator {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::ServiceLevelIndicator::r#type]
-    /// to hold a `BasicSli`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_basic_sli<T: std::convert::Into<std::boxed::Box<crate::model::BasicSli>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::service_level_indicator::Type::BasicSli(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::ServiceLevelIndicator::r#type]
     /// if it holds a `RequestBased`, `None` if the field is not set or
     /// holds a different branch.
@@ -10157,23 +9557,6 @@ impl ServiceLevelIndicator {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::ServiceLevelIndicator::r#type]
-    /// to hold a `RequestBased`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_request_based<
-        T: std::convert::Into<std::boxed::Box<crate::model::RequestBasedSli>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::service_level_indicator::Type::RequestBased(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::ServiceLevelIndicator::r#type]
     /// if it holds a `WindowsBased`, `None` if the field is not set or
     /// holds a different branch.
@@ -10187,23 +9570,6 @@ impl ServiceLevelIndicator {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::ServiceLevelIndicator::r#type]
-    /// to hold a `WindowsBased`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_windows_based<
-        T: std::convert::Into<std::boxed::Box<crate::model::WindowsBasedSli>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::service_level_indicator::Type::WindowsBased(v.into()),
-        );
-        self
     }
 }
 
@@ -10343,22 +9709,6 @@ impl BasicSli {
         })
     }
 
-    /// Sets the value of [sli_criteria][crate::model::BasicSli::sli_criteria]
-    /// to hold a `Availability`.
-    ///
-    /// Note that all the setters affecting `sli_criteria` are
-    /// mutually exclusive.
-    pub fn set_availability<
-        T: std::convert::Into<std::boxed::Box<crate::model::basic_sli::AvailabilityCriteria>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sli_criteria =
-            std::option::Option::Some(crate::model::basic_sli::SliCriteria::Availability(v.into()));
-        self
-    }
-
     /// The value of [sli_criteria][crate::model::BasicSli::sli_criteria]
     /// if it holds a `Latency`, `None` if the field is not set or
     /// holds a different branch.
@@ -10370,22 +9720,6 @@ impl BasicSli {
             crate::model::basic_sli::SliCriteria::Latency(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [sli_criteria][crate::model::BasicSli::sli_criteria]
-    /// to hold a `Latency`.
-    ///
-    /// Note that all the setters affecting `sli_criteria` are
-    /// mutually exclusive.
-    pub fn set_latency<
-        T: std::convert::Into<std::boxed::Box<crate::model::basic_sli::LatencyCriteria>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.sli_criteria =
-            std::option::Option::Some(crate::model::basic_sli::SliCriteria::Latency(v.into()));
-        self
     }
 }
 
@@ -10566,23 +9900,6 @@ impl RequestBasedSli {
         })
     }
 
-    /// Sets the value of [method][crate::model::RequestBasedSli::method]
-    /// to hold a `GoodTotalRatio`.
-    ///
-    /// Note that all the setters affecting `method` are
-    /// mutually exclusive.
-    pub fn set_good_total_ratio<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimeSeriesRatio>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method = std::option::Option::Some(
-            crate::model::request_based_sli::Method::GoodTotalRatio(v.into()),
-        );
-        self
-    }
-
     /// The value of [method][crate::model::RequestBasedSli::method]
     /// if it holds a `DistributionCut`, `None` if the field is not set or
     /// holds a different branch.
@@ -10596,23 +9913,6 @@ impl RequestBasedSli {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [method][crate::model::RequestBasedSli::method]
-    /// to hold a `DistributionCut`.
-    ///
-    /// Note that all the setters affecting `method` are
-    /// mutually exclusive.
-    pub fn set_distribution_cut<
-        T: std::convert::Into<std::boxed::Box<crate::model::DistributionCut>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method = std::option::Option::Some(
-            crate::model::request_based_sli::Method::DistributionCut(v.into()),
-        );
-        self
     }
 }
 
@@ -10837,21 +10137,6 @@ impl WindowsBasedSli {
         })
     }
 
-    /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
-    /// to hold a `GoodBadMetricFilter`.
-    ///
-    /// Note that all the setters affecting `window_criterion` are
-    /// mutually exclusive.
-    pub fn set_good_bad_metric_filter<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.window_criterion = std::option::Option::Some(
-            crate::model::windows_based_sli::WindowCriterion::GoodBadMetricFilter(v.into()),
-        );
-        self
-    }
-
     /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
     /// if it holds a `GoodTotalRatioThreshold`, `None` if the field is not set or
     /// holds a different branch.
@@ -10866,23 +10151,6 @@ impl WindowsBasedSli {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
-    /// to hold a `GoodTotalRatioThreshold`.
-    ///
-    /// Note that all the setters affecting `window_criterion` are
-    /// mutually exclusive.
-    pub fn set_good_total_ratio_threshold<
-        T: std::convert::Into<std::boxed::Box<crate::model::windows_based_sli::PerformanceThreshold>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.window_criterion = std::option::Option::Some(
-            crate::model::windows_based_sli::WindowCriterion::GoodTotalRatioThreshold(v.into()),
-        );
-        self
     }
 
     /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
@@ -10900,23 +10168,6 @@ impl WindowsBasedSli {
         })
     }
 
-    /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
-    /// to hold a `MetricMeanInRange`.
-    ///
-    /// Note that all the setters affecting `window_criterion` are
-    /// mutually exclusive.
-    pub fn set_metric_mean_in_range<
-        T: std::convert::Into<std::boxed::Box<crate::model::windows_based_sli::MetricRange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.window_criterion = std::option::Option::Some(
-            crate::model::windows_based_sli::WindowCriterion::MetricMeanInRange(v.into()),
-        );
-        self
-    }
-
     /// The value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
     /// if it holds a `MetricSumInRange`, `None` if the field is not set or
     /// holds a different branch.
@@ -10930,23 +10181,6 @@ impl WindowsBasedSli {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [window_criterion][crate::model::WindowsBasedSli::window_criterion]
-    /// to hold a `MetricSumInRange`.
-    ///
-    /// Note that all the setters affecting `window_criterion` are
-    /// mutually exclusive.
-    pub fn set_metric_sum_in_range<
-        T: std::convert::Into<std::boxed::Box<crate::model::windows_based_sli::MetricRange>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.window_criterion = std::option::Option::Some(
-            crate::model::windows_based_sli::WindowCriterion::MetricSumInRange(v.into()),
-        );
-        self
     }
 }
 
@@ -11027,23 +10261,6 @@ pub mod windows_based_sli {
             })
         }
 
-        /// Sets the value of [r#type][crate::model::windows_based_sli::PerformanceThreshold::r#type]
-        /// to hold a `Performance`.
-        ///
-        /// Note that all the setters affecting `r#type` are
-        /// mutually exclusive.
-        pub fn set_performance<
-            T: std::convert::Into<std::boxed::Box<crate::model::RequestBasedSli>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#type = std::option::Option::Some(
-                crate::model::windows_based_sli::performance_threshold::Type::Performance(v.into()),
-            );
-            self
-        }
-
         /// The value of [r#type][crate::model::windows_based_sli::PerformanceThreshold::r#type]
         /// if it holds a `BasicSliPerformance`, `None` if the field is not set or
         /// holds a different branch.
@@ -11055,25 +10272,6 @@ pub mod windows_based_sli {
                 crate::model::windows_based_sli::performance_threshold::Type::BasicSliPerformance(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [r#type][crate::model::windows_based_sli::PerformanceThreshold::r#type]
-        /// to hold a `BasicSliPerformance`.
-        ///
-        /// Note that all the setters affecting `r#type` are
-        /// mutually exclusive.
-        pub fn set_basic_sli_performance<
-            T: std::convert::Into<std::boxed::Box<crate::model::BasicSli>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#type = std::option::Option::Some(
-                crate::model::windows_based_sli::performance_threshold::Type::BasicSliPerformance(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -12699,25 +11897,6 @@ impl SyntheticMonitorTarget {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [target][crate::model::SyntheticMonitorTarget::target]
-    /// to hold a `CloudFunctionV2`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_cloud_function_v2<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::synthetic_monitor_target::CloudFunctionV2Target>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::synthetic_monitor_target::Target::CloudFunctionV2(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for SyntheticMonitorTarget {
@@ -13023,23 +12202,6 @@ impl UptimeCheckConfig {
         })
     }
 
-    /// Sets the value of [resource][crate::model::UptimeCheckConfig::resource]
-    /// to hold a `MonitoredResource`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_monitored_resource<
-        T: std::convert::Into<std::boxed::Box<api::model::MonitoredResource>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(
-            crate::model::uptime_check_config::Resource::MonitoredResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [resource][crate::model::UptimeCheckConfig::resource]
     /// if it holds a `ResourceGroup`, `None` if the field is not set or
     /// holds a different branch.
@@ -13056,23 +12218,6 @@ impl UptimeCheckConfig {
         })
     }
 
-    /// Sets the value of [resource][crate::model::UptimeCheckConfig::resource]
-    /// to hold a `ResourceGroup`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_resource_group<
-        T: std::convert::Into<std::boxed::Box<crate::model::uptime_check_config::ResourceGroup>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(
-            crate::model::uptime_check_config::Resource::ResourceGroup(v.into()),
-        );
-        self
-    }
-
     /// The value of [resource][crate::model::UptimeCheckConfig::resource]
     /// if it holds a `SyntheticMonitor`, `None` if the field is not set or
     /// holds a different branch.
@@ -13086,23 +12231,6 @@ impl UptimeCheckConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource][crate::model::UptimeCheckConfig::resource]
-    /// to hold a `SyntheticMonitor`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_synthetic_monitor<
-        T: std::convert::Into<std::boxed::Box<crate::model::SyntheticMonitorTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(
-            crate::model::uptime_check_config::Resource::SyntheticMonitor(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type].
@@ -13136,23 +12264,6 @@ impl UptimeCheckConfig {
         })
     }
 
-    /// Sets the value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type]
-    /// to hold a `HttpCheck`.
-    ///
-    /// Note that all the setters affecting `check_request_type` are
-    /// mutually exclusive.
-    pub fn set_http_check<
-        T: std::convert::Into<std::boxed::Box<crate::model::uptime_check_config::HttpCheck>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.check_request_type = std::option::Option::Some(
-            crate::model::uptime_check_config::CheckRequestType::HttpCheck(v.into()),
-        );
-        self
-    }
-
     /// The value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type]
     /// if it holds a `TcpCheck`, `None` if the field is not set or
     /// holds a different branch.
@@ -13166,23 +12277,6 @@ impl UptimeCheckConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [check_request_type][crate::model::UptimeCheckConfig::check_request_type]
-    /// to hold a `TcpCheck`.
-    ///
-    /// Note that all the setters affecting `check_request_type` are
-    /// mutually exclusive.
-    pub fn set_tcp_check<
-        T: std::convert::Into<std::boxed::Box<crate::model::uptime_check_config::TcpCheck>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.check_request_type = std::option::Option::Some(
-            crate::model::uptime_check_config::CheckRequestType::TcpCheck(v.into()),
-        );
-        self
     }
 }
 
@@ -13552,29 +12646,6 @@ pub mod uptime_check_config {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [auth_method][crate::model::uptime_check_config::HttpCheck::auth_method]
-        /// to hold a `ServiceAgentAuthentication`.
-        ///
-        /// Note that all the setters affecting `auth_method` are
-        /// mutually exclusive.
-        pub fn set_service_agent_authentication<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::uptime_check_config::http_check::ServiceAgentAuthentication,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.auth_method = std::option::Option::Some(
-                crate::model::uptime_check_config::http_check::AuthMethod::ServiceAgentAuthentication(
-                    v.into()
-                )
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for HttpCheck {
@@ -13682,20 +12753,6 @@ pub mod uptime_check_config {
                 })
             }
 
-            /// Sets the value of [status_code][crate::model::uptime_check_config::http_check::ResponseStatusCode::status_code]
-            /// to hold a `StatusValue`.
-            ///
-            /// Note that all the setters affecting `status_code` are
-            /// mutually exclusive.
-            pub fn set_status_value<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                self.status_code = std::option::Option::Some(
-                    crate::model::uptime_check_config::http_check::response_status_code::StatusCode::StatusValue(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [status_code][crate::model::uptime_check_config::http_check::ResponseStatusCode::status_code]
             /// if it holds a `StatusClass`, `None` if the field is not set or
             /// holds a different branch.
@@ -13709,20 +12766,6 @@ pub mod uptime_check_config {
                     crate::model::uptime_check_config::http_check::response_status_code::StatusCode::StatusClass(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [status_code][crate::model::uptime_check_config::http_check::ResponseStatusCode::status_code]
-            /// to hold a `StatusClass`.
-            ///
-            /// Note that all the setters affecting `status_code` are
-            /// mutually exclusive.
-            pub fn set_status_class<T: std::convert::Into<crate::model::uptime_check_config::http_check::response_status_code::StatusClass>>(mut self, v: T) -> Self{
-                self.status_code = std::option::Option::Some(
-                    crate::model::uptime_check_config::http_check::response_status_code::StatusCode::StatusClass(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -14512,29 +13555,6 @@ pub mod uptime_check_config {
                 crate::model::uptime_check_config::content_matcher::AdditionalMatcherInfo::JsonPathMatcher(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [additional_matcher_info][crate::model::uptime_check_config::ContentMatcher::additional_matcher_info]
-        /// to hold a `JsonPathMatcher`.
-        ///
-        /// Note that all the setters affecting `additional_matcher_info` are
-        /// mutually exclusive.
-        pub fn set_json_path_matcher<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::uptime_check_config::content_matcher::JsonPathMatcher,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.additional_matcher_info = std::option::Option::Some(
-                crate::model::uptime_check_config::content_matcher::AdditionalMatcherInfo::JsonPathMatcher(
-                    v.into()
-                )
-            );
-            self
         }
     }
 

--- a/src/generated/privacy/dlp/v2/src/builder.rs
+++ b/src/generated/privacy/dlp/v2/src/builder.rs
@@ -2465,36 +2465,6 @@ pub mod dlp_service {
             self.0.request.job = v.into();
             self
         }
-
-        /// Sets the value of [job][crate::model::CreateDlpJobRequest::job]
-        /// to hold a `InspectJob`.
-        ///
-        /// Note that all the setters affecting `job` are
-        /// mutually exclusive.
-        pub fn set_inspect_job<
-            T: std::convert::Into<std::boxed::Box<crate::model::InspectJobConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_inspect_job(v);
-            self
-        }
-
-        /// Sets the value of [job][crate::model::CreateDlpJobRequest::job]
-        /// to hold a `RiskJob`.
-        ///
-        /// Note that all the setters affecting `job` are
-        /// mutually exclusive.
-        pub fn set_risk_job<
-            T: std::convert::Into<std::boxed::Box<crate::model::RiskAnalysisJobConfig>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_risk_job(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/privacy/dlp/v2/src/model.rs
+++ b/src/generated/privacy/dlp/v2/src/model.rs
@@ -195,22 +195,6 @@ impl ExclusionRule {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
-    /// to hold a `Dictionary`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_dictionary<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::Dictionary>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::exclusion_rule::Type::Dictionary(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::ExclusionRule::r#type]
     /// if it holds a `Regex`, `None` if the field is not set or
     /// holds a different branch.
@@ -222,22 +206,6 @@ impl ExclusionRule {
             crate::model::exclusion_rule::Type::Regex(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
-    /// to hold a `Regex`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_regex<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::Regex>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::exclusion_rule::Type::Regex(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::ExclusionRule::r#type]
@@ -253,23 +221,6 @@ impl ExclusionRule {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
-    /// to hold a `ExcludeInfoTypes`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_exclude_info_types<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExcludeInfoTypes>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::exclusion_rule::Type::ExcludeInfoTypes(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::ExclusionRule::r#type]
     /// if it holds a `ExcludeByHotword`, `None` if the field is not set or
     /// holds a different branch.
@@ -281,23 +232,6 @@ impl ExclusionRule {
             crate::model::exclusion_rule::Type::ExcludeByHotword(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::ExclusionRule::r#type]
-    /// to hold a `ExcludeByHotword`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_exclude_by_hotword<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExcludeByHotword>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::exclusion_rule::Type::ExcludeByHotword(v.into()),
-        );
-        self
     }
 }
 
@@ -379,24 +313,6 @@ impl InspectionRule {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::InspectionRule::r#type]
-    /// to hold a `HotwordRule`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_hotword_rule<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::custom_info_type::detection_rule::HotwordRule>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::inspection_rule::Type::HotwordRule(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::InspectionRule::r#type]
     /// if it holds a `ExclusionRule`, `None` if the field is not set or
     /// holds a different branch.
@@ -408,22 +324,6 @@ impl InspectionRule {
             crate::model::inspection_rule::Type::ExclusionRule(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::InspectionRule::r#type]
-    /// to hold a `ExclusionRule`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_exclusion_rule<
-        T: std::convert::Into<std::boxed::Box<crate::model::ExclusionRule>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::inspection_rule::Type::ExclusionRule(v.into()));
-        self
     }
 }
 
@@ -1242,17 +1142,6 @@ impl ContentItem {
         })
     }
 
-    /// Sets the value of [data_item][crate::model::ContentItem::data_item]
-    /// to hold a `Value`.
-    ///
-    /// Note that all the setters affecting `data_item` are
-    /// mutually exclusive.
-    pub fn set_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.data_item =
-            std::option::Option::Some(crate::model::content_item::DataItem::Value(v.into()));
-        self
-    }
-
     /// The value of [data_item][crate::model::ContentItem::data_item]
     /// if it holds a `Table`, `None` if the field is not set or
     /// holds a different branch.
@@ -1262,20 +1151,6 @@ impl ContentItem {
             crate::model::content_item::DataItem::Table(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_item][crate::model::ContentItem::data_item]
-    /// to hold a `Table`.
-    ///
-    /// Note that all the setters affecting `data_item` are
-    /// mutually exclusive.
-    pub fn set_table<T: std::convert::Into<std::boxed::Box<crate::model::Table>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_item =
-            std::option::Option::Some(crate::model::content_item::DataItem::Table(v.into()));
-        self
     }
 
     /// The value of [data_item][crate::model::ContentItem::data_item]
@@ -1289,20 +1164,6 @@ impl ContentItem {
             crate::model::content_item::DataItem::ByteItem(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_item][crate::model::ContentItem::data_item]
-    /// to hold a `ByteItem`.
-    ///
-    /// Note that all the setters affecting `data_item` are
-    /// mutually exclusive.
-    pub fn set_byte_item<T: std::convert::Into<std::boxed::Box<crate::model::ByteContentItem>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_item =
-            std::option::Option::Some(crate::model::content_item::DataItem::ByteItem(v.into()));
-        self
     }
 }
 
@@ -1858,23 +1719,6 @@ impl ContentLocation {
         })
     }
 
-    /// Sets the value of [location][crate::model::ContentLocation::location]
-    /// to hold a `RecordLocation`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_record_location<
-        T: std::convert::Into<std::boxed::Box<crate::model::RecordLocation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::content_location::Location::RecordLocation(v.into()),
-        );
-        self
-    }
-
     /// The value of [location][crate::model::ContentLocation::location]
     /// if it holds a `ImageLocation`, `None` if the field is not set or
     /// holds a different branch.
@@ -1888,23 +1732,6 @@ impl ContentLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location][crate::model::ContentLocation::location]
-    /// to hold a `ImageLocation`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_image_location<
-        T: std::convert::Into<std::boxed::Box<crate::model::ImageLocation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::content_location::Location::ImageLocation(v.into()),
-        );
-        self
     }
 
     /// The value of [location][crate::model::ContentLocation::location]
@@ -1922,23 +1749,6 @@ impl ContentLocation {
         })
     }
 
-    /// Sets the value of [location][crate::model::ContentLocation::location]
-    /// to hold a `DocumentLocation`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_document_location<
-        T: std::convert::Into<std::boxed::Box<crate::model::DocumentLocation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::content_location::Location::DocumentLocation(v.into()),
-        );
-        self
-    }
-
     /// The value of [location][crate::model::ContentLocation::location]
     /// if it holds a `MetadataLocation`, `None` if the field is not set or
     /// holds a different branch.
@@ -1952,23 +1762,6 @@ impl ContentLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location][crate::model::ContentLocation::location]
-    /// to hold a `MetadataLocation`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_metadata_location<
-        T: std::convert::Into<std::boxed::Box<crate::model::MetadataLocation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::content_location::Location::MetadataLocation(v.into()),
-        );
-        self
     }
 }
 
@@ -2055,23 +1848,6 @@ impl MetadataLocation {
             crate::model::metadata_location::Label::StorageLabel(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [label][crate::model::MetadataLocation::label]
-    /// to hold a `StorageLabel`.
-    ///
-    /// Note that all the setters affecting `label` are
-    /// mutually exclusive.
-    pub fn set_storage_label<
-        T: std::convert::Into<std::boxed::Box<crate::model::StorageMetadataLabel>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.label = std::option::Option::Some(
-            crate::model::metadata_location::Label::StorageLabel(v.into()),
-        );
-        self
     }
 }
 
@@ -2715,23 +2491,6 @@ pub mod redact_image_request {
             })
         }
 
-        /// Sets the value of [target][crate::model::redact_image_request::ImageRedactionConfig::target]
-        /// to hold a `InfoType`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_info_type<T: std::convert::Into<std::boxed::Box<crate::model::InfoType>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.target = std::option::Option::Some(
-                crate::model::redact_image_request::image_redaction_config::Target::InfoType(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [target][crate::model::redact_image_request::ImageRedactionConfig::target]
         /// if it holds a `RedactAllText`, `None` if the field is not set or
         /// holds a different branch.
@@ -2741,20 +2500,6 @@ pub mod redact_image_request {
                 crate::model::redact_image_request::image_redaction_config::Target::RedactAllText(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [target][crate::model::redact_image_request::ImageRedactionConfig::target]
-        /// to hold a `RedactAllText`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_redact_all_text<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.target = std::option::Option::Some(
-                crate::model::redact_image_request::image_redaction_config::Target::RedactAllText(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -3506,20 +3251,6 @@ impl OutputStorageConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [r#type][crate::model::OutputStorageConfig::r#type]
-    /// to hold a `Table`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_table<T: std::convert::Into<std::boxed::Box<crate::model::BigQueryTable>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::output_storage_config::Type::Table(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for OutputStorageConfig {
@@ -4011,23 +3742,6 @@ impl DataProfileBigQueryRowSchema {
         })
     }
 
-    /// Sets the value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
-    /// to hold a `TableProfile`.
-    ///
-    /// Note that all the setters affecting `data_profile` are
-    /// mutually exclusive.
-    pub fn set_table_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::TableDataProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_profile = std::option::Option::Some(
-            crate::model::data_profile_big_query_row_schema::DataProfile::TableProfile(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
     /// if it holds a `ColumnProfile`, `None` if the field is not set or
     /// holds a different branch.
@@ -4043,23 +3757,6 @@ impl DataProfileBigQueryRowSchema {
         })
     }
 
-    /// Sets the value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
-    /// to hold a `ColumnProfile`.
-    ///
-    /// Note that all the setters affecting `data_profile` are
-    /// mutually exclusive.
-    pub fn set_column_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::ColumnDataProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_profile = std::option::Option::Some(
-            crate::model::data_profile_big_query_row_schema::DataProfile::ColumnProfile(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
     /// if it holds a `FileStoreProfile`, `None` if the field is not set or
     /// holds a different branch.
@@ -4073,25 +3770,6 @@ impl DataProfileBigQueryRowSchema {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_profile][crate::model::DataProfileBigQueryRowSchema::data_profile]
-    /// to hold a `FileStoreProfile`.
-    ///
-    /// Note that all the setters affecting `data_profile` are
-    /// mutually exclusive.
-    pub fn set_file_store_profile<
-        T: std::convert::Into<std::boxed::Box<crate::model::FileStoreDataProfile>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_profile = std::option::Option::Some(
-            crate::model::data_profile_big_query_row_schema::DataProfile::FileStoreProfile(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -4229,23 +3907,6 @@ impl ActionDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::ActionDetails::details]
-    /// to hold a `DeidentifyDetails`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_deidentify_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::DeidentifyDataSourceDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details = std::option::Option::Some(
-            crate::model::action_details::Details::DeidentifyDetails(v.into()),
-        );
-        self
     }
 }
 
@@ -4658,23 +4319,6 @@ impl InfoTypeCategory {
         })
     }
 
-    /// Sets the value of [category][crate::model::InfoTypeCategory::category]
-    /// to hold a `LocationCategory`.
-    ///
-    /// Note that all the setters affecting `category` are
-    /// mutually exclusive.
-    pub fn set_location_category<
-        T: std::convert::Into<crate::model::info_type_category::LocationCategory>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.category = std::option::Option::Some(
-            crate::model::info_type_category::Category::LocationCategory(v.into()),
-        );
-        self
-    }
-
     /// The value of [category][crate::model::InfoTypeCategory::category]
     /// if it holds a `IndustryCategory`, `None` if the field is not set or
     /// holds a different branch.
@@ -4690,23 +4334,6 @@ impl InfoTypeCategory {
         })
     }
 
-    /// Sets the value of [category][crate::model::InfoTypeCategory::category]
-    /// to hold a `IndustryCategory`.
-    ///
-    /// Note that all the setters affecting `category` are
-    /// mutually exclusive.
-    pub fn set_industry_category<
-        T: std::convert::Into<crate::model::info_type_category::IndustryCategory>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.category = std::option::Option::Some(
-            crate::model::info_type_category::Category::IndustryCategory(v.into()),
-        );
-        self
-    }
-
     /// The value of [category][crate::model::InfoTypeCategory::category]
     /// if it holds a `TypeCategory`, `None` if the field is not set or
     /// holds a different branch.
@@ -4720,23 +4347,6 @@ impl InfoTypeCategory {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [category][crate::model::InfoTypeCategory::category]
-    /// to hold a `TypeCategory`.
-    ///
-    /// Note that all the setters affecting `category` are
-    /// mutually exclusive.
-    pub fn set_type_category<
-        T: std::convert::Into<crate::model::info_type_category::TypeCategory>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.category = std::option::Option::Some(
-            crate::model::info_type_category::Category::TypeCategory(v.into()),
-        );
-        self
     }
 }
 
@@ -5840,19 +5450,6 @@ impl QuasiId {
         })
     }
 
-    /// Sets the value of [tag][crate::model::QuasiId::tag]
-    /// to hold a `InfoType`.
-    ///
-    /// Note that all the setters affecting `tag` are
-    /// mutually exclusive.
-    pub fn set_info_type<T: std::convert::Into<std::boxed::Box<crate::model::InfoType>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tag = std::option::Option::Some(crate::model::quasi_id::Tag::InfoType(v.into()));
-        self
-    }
-
     /// The value of [tag][crate::model::QuasiId::tag]
     /// if it holds a `CustomTag`, `None` if the field is not set or
     /// holds a different branch.
@@ -5864,16 +5461,6 @@ impl QuasiId {
         })
     }
 
-    /// Sets the value of [tag][crate::model::QuasiId::tag]
-    /// to hold a `CustomTag`.
-    ///
-    /// Note that all the setters affecting `tag` are
-    /// mutually exclusive.
-    pub fn set_custom_tag<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.tag = std::option::Option::Some(crate::model::quasi_id::Tag::CustomTag(v.into()));
-        self
-    }
-
     /// The value of [tag][crate::model::QuasiId::tag]
     /// if it holds a `Inferred`, `None` if the field is not set or
     /// holds a different branch.
@@ -5883,19 +5470,6 @@ impl QuasiId {
             crate::model::quasi_id::Tag::Inferred(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [tag][crate::model::QuasiId::tag]
-    /// to hold a `Inferred`.
-    ///
-    /// Note that all the setters affecting `tag` are
-    /// mutually exclusive.
-    pub fn set_inferred<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.tag = std::option::Option::Some(crate::model::quasi_id::Tag::Inferred(v.into()));
-        self
     }
 }
 
@@ -6109,23 +5683,6 @@ impl PrivacyMetric {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// to hold a `NumericalStatsConfig`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_numerical_stats_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::privacy_metric::NumericalStatsConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::privacy_metric::Type::NumericalStatsConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::PrivacyMetric::r#type]
     /// if it holds a `CategoricalStatsConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -6142,23 +5699,6 @@ impl PrivacyMetric {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// to hold a `CategoricalStatsConfig`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_categorical_stats_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::privacy_metric::CategoricalStatsConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::privacy_metric::Type::CategoricalStatsConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::PrivacyMetric::r#type]
     /// if it holds a `KAnonymityConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -6172,23 +5712,6 @@ impl PrivacyMetric {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// to hold a `KAnonymityConfig`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_k_anonymity_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::privacy_metric::KAnonymityConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::privacy_metric::Type::KAnonymityConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::PrivacyMetric::r#type]
     /// if it holds a `LDiversityConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -6200,23 +5723,6 @@ impl PrivacyMetric {
             crate::model::privacy_metric::Type::LDiversityConfig(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// to hold a `LDiversityConfig`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_l_diversity_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::privacy_metric::LDiversityConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::privacy_metric::Type::LDiversityConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [r#type][crate::model::PrivacyMetric::r#type]
@@ -6235,23 +5741,6 @@ impl PrivacyMetric {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// to hold a `KMapEstimationConfig`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_k_map_estimation_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::privacy_metric::KMapEstimationConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::privacy_metric::Type::KMapEstimationConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::PrivacyMetric::r#type]
     /// if it holds a `DeltaPresenceEstimationConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -6267,25 +5756,6 @@ impl PrivacyMetric {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::PrivacyMetric::r#type]
-    /// to hold a `DeltaPresenceEstimationConfig`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_delta_presence_estimation_config<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::privacy_metric::DeltaPresenceEstimationConfig>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::privacy_metric::Type::DeltaPresenceEstimationConfig(v.into()),
-        );
-        self
     }
 }
 
@@ -6635,23 +6105,6 @@ pub mod privacy_metric {
                 })
             }
 
-            /// Sets the value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
-            /// to hold a `InfoType`.
-            ///
-            /// Note that all the setters affecting `tag` are
-            /// mutually exclusive.
-            pub fn set_info_type<T: std::convert::Into<std::boxed::Box<crate::model::InfoType>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.tag = std::option::Option::Some(
-                    crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::InfoType(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
             /// if it holds a `CustomTag`, `None` if the field is not set or
             /// holds a different branch.
@@ -6663,23 +6116,6 @@ pub mod privacy_metric {
                 })
             }
 
-            /// Sets the value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
-            /// to hold a `CustomTag`.
-            ///
-            /// Note that all the setters affecting `tag` are
-            /// mutually exclusive.
-            pub fn set_custom_tag<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.tag = std::option::Option::Some(
-                    crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::CustomTag(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
             /// if it holds a `Inferred`, `None` if the field is not set or
             /// holds a different branch.
@@ -6689,23 +6125,6 @@ pub mod privacy_metric {
                     crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::Inferred(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [tag][crate::model::privacy_metric::k_map_estimation_config::TaggedField::tag]
-            /// to hold a `Inferred`.
-            ///
-            /// Note that all the setters affecting `tag` are
-            /// mutually exclusive.
-            pub fn set_inferred<T: std::convert::Into<std::boxed::Box<wkt::Empty>>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.tag = std::option::Option::Some(
-                    crate::model::privacy_metric::k_map_estimation_config::tagged_field::Tag::Inferred(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -7075,27 +6494,6 @@ impl AnalyzeDataSourceRiskDetails {
         })
     }
 
-    /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// to hold a `NumericalStatsResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_numerical_stats_result<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::analyze_data_source_risk_details::NumericalStatsResult,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::analyze_data_source_risk_details::Result::NumericalStatsResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
     /// if it holds a `CategoricalStatsResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -7111,29 +6509,6 @@ impl AnalyzeDataSourceRiskDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// to hold a `CategoricalStatsResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_categorical_stats_result<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::analyze_data_source_risk_details::CategoricalStatsResult,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::analyze_data_source_risk_details::Result::CategoricalStatsResult(
-                v.into(),
-            ),
-        );
-        self
     }
 
     /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
@@ -7153,25 +6528,6 @@ impl AnalyzeDataSourceRiskDetails {
         })
     }
 
-    /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// to hold a `KAnonymityResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_k_anonymity_result<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::analyze_data_source_risk_details::KAnonymityResult>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::analyze_data_source_risk_details::Result::KAnonymityResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
     /// if it holds a `LDiversityResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -7187,25 +6543,6 @@ impl AnalyzeDataSourceRiskDetails {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// to hold a `LDiversityResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_l_diversity_result<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::analyze_data_source_risk_details::LDiversityResult>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::analyze_data_source_risk_details::Result::LDiversityResult(v.into()),
-        );
-        self
     }
 
     /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
@@ -7225,27 +6562,6 @@ impl AnalyzeDataSourceRiskDetails {
         })
     }
 
-    /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// to hold a `KMapEstimationResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_k_map_estimation_result<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::analyze_data_source_risk_details::KMapEstimationResult,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::analyze_data_source_risk_details::Result::KMapEstimationResult(v.into()),
-        );
-        self
-    }
-
     /// The value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
     /// if it holds a `DeltaPresenceEstimationResult`, `None` if the field is not set or
     /// holds a different branch.
@@ -7261,29 +6577,6 @@ impl AnalyzeDataSourceRiskDetails {
             crate::model::analyze_data_source_risk_details::Result::DeltaPresenceEstimationResult(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [result][crate::model::AnalyzeDataSourceRiskDetails::result]
-    /// to hold a `DeltaPresenceEstimationResult`.
-    ///
-    /// Note that all the setters affecting `result` are
-    /// mutually exclusive.
-    pub fn set_delta_presence_estimation_result<
-        T: std::convert::Into<
-                std::boxed::Box<
-                    crate::model::analyze_data_source_risk_details::DeltaPresenceEstimationResult,
-                >,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.result = std::option::Option::Some(
-            crate::model::analyze_data_source_risk_details::Result::DeltaPresenceEstimationResult(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -8445,16 +7738,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `IntegerValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_integer_value<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::IntegerValue(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Value::r#type]
     /// if it holds a `FloatValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -8464,16 +7747,6 @@ impl Value {
             crate::model::value::Type::FloatValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `FloatValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_float_value<T: std::convert::Into<f64>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::FloatValue(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Value::r#type]
@@ -8487,16 +7760,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `StringValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_string_value<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::StringValue(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Value::r#type]
     /// if it holds a `BooleanValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -8506,16 +7769,6 @@ impl Value {
             crate::model::value::Type::BooleanValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `BooleanValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_boolean_value<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::BooleanValue(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Value::r#type]
@@ -8529,20 +7782,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `TimestampValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_timestamp_value<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::value::Type::TimestampValue(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Value::r#type]
     /// if it holds a `TimeValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -8552,19 +7791,6 @@ impl Value {
             crate::model::value::Type::TimeValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `TimeValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_time_value<T: std::convert::Into<std::boxed::Box<gtype::model::TimeOfDay>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::TimeValue(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::Value::r#type]
@@ -8578,19 +7804,6 @@ impl Value {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `DateValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_date_value<T: std::convert::Into<std::boxed::Box<gtype::model::Date>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(crate::model::value::Type::DateValue(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::Value::r#type]
     /// if it holds a `DayOfWeekValue`, `None` if the field is not set or
     /// holds a different branch.
@@ -8600,20 +7813,6 @@ impl Value {
             crate::model::value::Type::DayOfWeekValue(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::Value::r#type]
-    /// to hold a `DayOfWeekValue`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_day_of_week_value<T: std::convert::Into<gtype::model::DayOfWeek>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::value::Type::DayOfWeekValue(v.into()));
-        self
     }
 }
 
@@ -8695,20 +7894,6 @@ impl QuoteInfo {
             crate::model::quote_info::ParsedQuote::DateTime(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [parsed_quote][crate::model::QuoteInfo::parsed_quote]
-    /// to hold a `DateTime`.
-    ///
-    /// Note that all the setters affecting `parsed_quote` are
-    /// mutually exclusive.
-    pub fn set_date_time<T: std::convert::Into<std::boxed::Box<crate::model::DateTime>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.parsed_quote =
-            std::option::Option::Some(crate::model::quote_info::ParsedQuote::DateTime(v.into()));
-        self
     }
 }
 
@@ -8912,23 +8097,6 @@ impl DeidentifyConfig {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::DeidentifyConfig::transformation]
-    /// to hold a `InfoTypeTransformations`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_info_type_transformations<
-        T: std::convert::Into<std::boxed::Box<crate::model::InfoTypeTransformations>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::deidentify_config::Transformation::InfoTypeTransformations(v.into()),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::DeidentifyConfig::transformation]
     /// if it holds a `RecordTransformations`, `None` if the field is not set or
     /// holds a different branch.
@@ -8944,23 +8112,6 @@ impl DeidentifyConfig {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::DeidentifyConfig::transformation]
-    /// to hold a `RecordTransformations`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_record_transformations<
-        T: std::convert::Into<std::boxed::Box<crate::model::RecordTransformations>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::deidentify_config::Transformation::RecordTransformations(v.into()),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::DeidentifyConfig::transformation]
     /// if it holds a `ImageTransformations`, `None` if the field is not set or
     /// holds a different branch.
@@ -8974,23 +8125,6 @@ impl DeidentifyConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::DeidentifyConfig::transformation]
-    /// to hold a `ImageTransformations`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_image_transformations<
-        T: std::convert::Into<std::boxed::Box<crate::model::ImageTransformations>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::deidentify_config::Transformation::ImageTransformations(v.into()),
-        );
-        self
     }
 }
 
@@ -9136,20 +8270,6 @@ pub mod image_transformations {
             })
         }
 
-        /// Sets the value of [target][crate::model::image_transformations::ImageTransformation::target]
-        /// to hold a `SelectedInfoTypes`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_selected_info_types<T: std::convert::Into<std::boxed::Box<crate::model::image_transformations::image_transformation::SelectedInfoTypes>>>(mut self, v: T) -> Self{
-            self.target = std::option::Option::Some(
-                crate::model::image_transformations::image_transformation::Target::SelectedInfoTypes(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [target][crate::model::image_transformations::ImageTransformation::target]
         /// if it holds a `AllInfoTypes`, `None` if the field is not set or
         /// holds a different branch.
@@ -9169,29 +8289,6 @@ pub mod image_transformations {
             })
         }
 
-        /// Sets the value of [target][crate::model::image_transformations::ImageTransformation::target]
-        /// to hold a `AllInfoTypes`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_all_info_types<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::image_transformations::image_transformation::AllInfoTypes,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.target = std::option::Option::Some(
-                crate::model::image_transformations::image_transformation::Target::AllInfoTypes(
-                    v.into(),
-                ),
-            );
-            self
-        }
-
         /// The value of [target][crate::model::image_transformations::ImageTransformation::target]
         /// if it holds a `AllText`, `None` if the field is not set or
         /// holds a different branch.
@@ -9207,29 +8304,6 @@ pub mod image_transformations {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [target][crate::model::image_transformations::ImageTransformation::target]
-        /// to hold a `AllText`.
-        ///
-        /// Note that all the setters affecting `target` are
-        /// mutually exclusive.
-        pub fn set_all_text<
-            T: std::convert::Into<
-                    std::boxed::Box<
-                        crate::model::image_transformations::image_transformation::AllText,
-                    >,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.target = std::option::Option::Some(
-                crate::model::image_transformations::image_transformation::Target::AllText(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -9412,25 +8486,6 @@ impl TransformationErrorHandling {
         })
     }
 
-    /// Sets the value of [mode][crate::model::TransformationErrorHandling::mode]
-    /// to hold a `ThrowError`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_throw_error<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::transformation_error_handling::ThrowError>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode = std::option::Option::Some(
-            crate::model::transformation_error_handling::Mode::ThrowError(v.into()),
-        );
-        self
-    }
-
     /// The value of [mode][crate::model::TransformationErrorHandling::mode]
     /// if it holds a `LeaveUntransformed`, `None` if the field is not set or
     /// holds a different branch.
@@ -9446,25 +8501,6 @@ impl TransformationErrorHandling {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [mode][crate::model::TransformationErrorHandling::mode]
-    /// to hold a `LeaveUntransformed`.
-    ///
-    /// Note that all the setters affecting `mode` are
-    /// mutually exclusive.
-    pub fn set_leave_untransformed<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::transformation_error_handling::LeaveUntransformed>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.mode = std::option::Option::Some(
-            crate::model::transformation_error_handling::Mode::LeaveUntransformed(v.into()),
-        );
-        self
     }
 }
 
@@ -9591,23 +8627,6 @@ impl PrimitiveTransformation {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `ReplaceConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_replace_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReplaceValueConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::ReplaceConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// if it holds a `RedactConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9621,21 +8640,6 @@ impl PrimitiveTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `RedactConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_redact_config<T: std::convert::Into<std::boxed::Box<crate::model::RedactConfig>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::RedactConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9653,23 +8657,6 @@ impl PrimitiveTransformation {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `CharacterMaskConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_character_mask_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::CharacterMaskConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::CharacterMaskConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// if it holds a `CryptoReplaceFfxFpeConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9683,25 +8670,6 @@ impl PrimitiveTransformation {
             ) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `CryptoReplaceFfxFpeConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_crypto_replace_ffx_fpe_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::CryptoReplaceFfxFpeConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::CryptoReplaceFfxFpeConfig(
-                v.into(),
-            ),
-        );
-        self
     }
 
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9719,25 +8687,6 @@ impl PrimitiveTransformation {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `FixedSizeBucketingConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_fixed_size_bucketing_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::FixedSizeBucketingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::FixedSizeBucketingConfig(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// if it holds a `BucketingConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9751,23 +8700,6 @@ impl PrimitiveTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `BucketingConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_bucketing_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::BucketingConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::BucketingConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9785,25 +8717,6 @@ impl PrimitiveTransformation {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `ReplaceWithInfoTypeConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_replace_with_info_type_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReplaceWithInfoTypeConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::ReplaceWithInfoTypeConfig(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// if it holds a `TimePartConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9817,23 +8730,6 @@ impl PrimitiveTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `TimePartConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_time_part_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::TimePartConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::TimePartConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9851,23 +8747,6 @@ impl PrimitiveTransformation {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `CryptoHashConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_crypto_hash_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::CryptoHashConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::CryptoHashConfig(v.into()),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// if it holds a `DateShiftConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9881,23 +8760,6 @@ impl PrimitiveTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `DateShiftConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_date_shift_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::DateShiftConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::DateShiftConfig(v.into()),
-        );
-        self
     }
 
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
@@ -9915,25 +8777,6 @@ impl PrimitiveTransformation {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `CryptoDeterministicConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_crypto_deterministic_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::CryptoDeterministicConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::CryptoDeterministicConfig(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::PrimitiveTransformation::transformation]
     /// if it holds a `ReplaceDictionaryConfig`, `None` if the field is not set or
     /// holds a different branch.
@@ -9947,25 +8790,6 @@ impl PrimitiveTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::PrimitiveTransformation::transformation]
-    /// to hold a `ReplaceDictionaryConfig`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_replace_dictionary_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::ReplaceDictionaryConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::primitive_transformation::Transformation::ReplaceDictionaryConfig(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -10455,23 +9279,6 @@ impl ReplaceDictionaryConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [r#type][crate::model::ReplaceDictionaryConfig::r#type]
-    /// to hold a `WordList`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_word_list<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::dictionary::WordList>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::replace_dictionary_config::Type::WordList(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for ReplaceDictionaryConfig {
@@ -10591,21 +9398,6 @@ impl CharsToIgnore {
         })
     }
 
-    /// Sets the value of [characters][crate::model::CharsToIgnore::characters]
-    /// to hold a `CharactersToSkip`.
-    ///
-    /// Note that all the setters affecting `characters` are
-    /// mutually exclusive.
-    pub fn set_characters_to_skip<T: std::convert::Into<std::string::String>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.characters = std::option::Option::Some(
-            crate::model::chars_to_ignore::Characters::CharactersToSkip(v.into()),
-        );
-        self
-    }
-
     /// The value of [characters][crate::model::CharsToIgnore::characters]
     /// if it holds a `CommonCharactersToIgnore`, `None` if the field is not set or
     /// holds a different branch.
@@ -10619,23 +9411,6 @@ impl CharsToIgnore {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [characters][crate::model::CharsToIgnore::characters]
-    /// to hold a `CommonCharactersToIgnore`.
-    ///
-    /// Note that all the setters affecting `characters` are
-    /// mutually exclusive.
-    pub fn set_common_characters_to_ignore<
-        T: std::convert::Into<crate::model::chars_to_ignore::CommonCharsToIgnore>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.characters = std::option::Option::Some(
-            crate::model::chars_to_ignore::Characters::CommonCharactersToIgnore(v.into()),
-        );
-        self
     }
 }
 
@@ -11269,23 +10044,6 @@ impl CryptoReplaceFfxFpeConfig {
         })
     }
 
-    /// Sets the value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
-    /// to hold a `CommonAlphabet`.
-    ///
-    /// Note that all the setters affecting `alphabet` are
-    /// mutually exclusive.
-    pub fn set_common_alphabet<
-        T: std::convert::Into<crate::model::crypto_replace_ffx_fpe_config::FfxCommonNativeAlphabet>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.alphabet = std::option::Option::Some(
-            crate::model::crypto_replace_ffx_fpe_config::Alphabet::CommonAlphabet(v.into()),
-        );
-        self
-    }
-
     /// The value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
     /// if it holds a `CustomAlphabet`, `None` if the field is not set or
     /// holds a different branch.
@@ -11299,18 +10057,6 @@ impl CryptoReplaceFfxFpeConfig {
         })
     }
 
-    /// Sets the value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
-    /// to hold a `CustomAlphabet`.
-    ///
-    /// Note that all the setters affecting `alphabet` are
-    /// mutually exclusive.
-    pub fn set_custom_alphabet<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.alphabet = std::option::Option::Some(
-            crate::model::crypto_replace_ffx_fpe_config::Alphabet::CustomAlphabet(v.into()),
-        );
-        self
-    }
-
     /// The value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
     /// if it holds a `Radix`, `None` if the field is not set or
     /// holds a different branch.
@@ -11322,18 +10068,6 @@ impl CryptoReplaceFfxFpeConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [alphabet][crate::model::CryptoReplaceFfxFpeConfig::alphabet]
-    /// to hold a `Radix`.
-    ///
-    /// Note that all the setters affecting `alphabet` are
-    /// mutually exclusive.
-    pub fn set_radix<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.alphabet = std::option::Option::Some(
-            crate::model::crypto_replace_ffx_fpe_config::Alphabet::Radix(v.into()),
-        );
-        self
     }
 }
 
@@ -11576,22 +10310,6 @@ impl CryptoKey {
         })
     }
 
-    /// Sets the value of [source][crate::model::CryptoKey::source]
-    /// to hold a `Transient`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_transient<
-        T: std::convert::Into<std::boxed::Box<crate::model::TransientCryptoKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::crypto_key::Source::Transient(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::CryptoKey::source]
     /// if it holds a `Unwrapped`, `None` if the field is not set or
     /// holds a different branch.
@@ -11605,22 +10323,6 @@ impl CryptoKey {
         })
     }
 
-    /// Sets the value of [source][crate::model::CryptoKey::source]
-    /// to hold a `Unwrapped`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_unwrapped<
-        T: std::convert::Into<std::boxed::Box<crate::model::UnwrappedCryptoKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::crypto_key::Source::Unwrapped(v.into()));
-        self
-    }
-
     /// The value of [source][crate::model::CryptoKey::source]
     /// if it holds a `KmsWrapped`, `None` if the field is not set or
     /// holds a different branch.
@@ -11632,22 +10334,6 @@ impl CryptoKey {
             crate::model::crypto_key::Source::KmsWrapped(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::CryptoKey::source]
-    /// to hold a `KmsWrapped`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_kms_wrapped<
-        T: std::convert::Into<std::boxed::Box<crate::model::KmsWrappedCryptoKey>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source =
-            std::option::Option::Some(crate::model::crypto_key::Source::KmsWrapped(v.into()));
-        self
     }
 }
 
@@ -11889,20 +10575,6 @@ impl DateShiftConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [method][crate::model::DateShiftConfig::method]
-    /// to hold a `CryptoKey`.
-    ///
-    /// Note that all the setters affecting `method` are
-    /// mutually exclusive.
-    pub fn set_crypto_key<T: std::convert::Into<std::boxed::Box<crate::model::CryptoKey>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.method =
-            std::option::Option::Some(crate::model::date_shift_config::Method::CryptoKey(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for DateShiftConfig {
@@ -12122,23 +10794,6 @@ impl FieldTransformation {
         })
     }
 
-    /// Sets the value of [transformation][crate::model::FieldTransformation::transformation]
-    /// to hold a `PrimitiveTransformation`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_primitive_transformation<
-        T: std::convert::Into<std::boxed::Box<crate::model::PrimitiveTransformation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::field_transformation::Transformation::PrimitiveTransformation(v.into()),
-        );
-        self
-    }
-
     /// The value of [transformation][crate::model::FieldTransformation::transformation]
     /// if it holds a `InfoTypeTransformations`, `None` if the field is not set or
     /// holds a different branch.
@@ -12152,23 +10807,6 @@ impl FieldTransformation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [transformation][crate::model::FieldTransformation::transformation]
-    /// to hold a `InfoTypeTransformations`.
-    ///
-    /// Note that all the setters affecting `transformation` are
-    /// mutually exclusive.
-    pub fn set_info_type_transformations<
-        T: std::convert::Into<std::boxed::Box<crate::model::InfoTypeTransformations>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.transformation = std::option::Option::Some(
-            crate::model::field_transformation::Transformation::InfoTypeTransformations(v.into()),
-        );
-        self
     }
 }
 
@@ -12512,23 +11150,6 @@ pub mod record_condition {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [r#type][crate::model::record_condition::Expressions::r#type]
-        /// to hold a `Conditions`.
-        ///
-        /// Note that all the setters affecting `r#type` are
-        /// mutually exclusive.
-        pub fn set_conditions<
-            T: std::convert::Into<std::boxed::Box<crate::model::record_condition::Conditions>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#type = std::option::Option::Some(
-                crate::model::record_condition::expressions::Type::Conditions(v.into()),
-            );
-            self
         }
     }
 
@@ -13307,18 +11928,6 @@ impl TransformationLocation {
         })
     }
 
-    /// Sets the value of [location_type][crate::model::TransformationLocation::location_type]
-    /// to hold a `FindingId`.
-    ///
-    /// Note that all the setters affecting `location_type` are
-    /// mutually exclusive.
-    pub fn set_finding_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.location_type = std::option::Option::Some(
-            crate::model::transformation_location::LocationType::FindingId(v.into()),
-        );
-        self
-    }
-
     /// The value of [location_type][crate::model::TransformationLocation::location_type]
     /// if it holds a `RecordTransformation`, `None` if the field is not set or
     /// holds a different branch.
@@ -13332,23 +11941,6 @@ impl TransformationLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location_type][crate::model::TransformationLocation::location_type]
-    /// to hold a `RecordTransformation`.
-    ///
-    /// Note that all the setters affecting `location_type` are
-    /// mutually exclusive.
-    pub fn set_record_transformation<
-        T: std::convert::Into<std::boxed::Box<crate::model::RecordTransformation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location_type = std::option::Option::Some(
-            crate::model::transformation_location::LocationType::RecordTransformation(v.into()),
-        );
-        self
     }
 }
 
@@ -13538,21 +12130,6 @@ impl TransformationDetailsStorageConfig {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [r#type][crate::model::TransformationDetailsStorageConfig::r#type]
-    /// to hold a `Table`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_table<T: std::convert::Into<std::boxed::Box<crate::model::BigQueryTable>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::transformation_details_storage_config::Type::Table(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for TransformationDetailsStorageConfig {
@@ -13628,21 +12205,6 @@ impl Schedule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [option][crate::model::Schedule::option]
-    /// to hold a `RecurrencePeriodDuration`.
-    ///
-    /// Note that all the setters affecting `option` are
-    /// mutually exclusive.
-    pub fn set_recurrence_period_duration<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.option = std::option::Option::Some(
-            crate::model::schedule::Option::RecurrencePeriodDuration(v.into()),
-        );
-        self
     }
 }
 
@@ -14269,21 +12831,6 @@ impl JobTrigger {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [job][crate::model::JobTrigger::job]
-    /// to hold a `InspectJob`.
-    ///
-    /// Note that all the setters affecting `job` are
-    /// mutually exclusive.
-    pub fn set_inspect_job<
-        T: std::convert::Into<std::boxed::Box<crate::model::InspectJobConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job = std::option::Option::Some(crate::model::job_trigger::Job::InspectJob(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for JobTrigger {
@@ -14343,21 +12890,6 @@ pub mod job_trigger {
             })
         }
 
-        /// Sets the value of [trigger][crate::model::job_trigger::Trigger::trigger]
-        /// to hold a `Schedule`.
-        ///
-        /// Note that all the setters affecting `trigger` are
-        /// mutually exclusive.
-        pub fn set_schedule<T: std::convert::Into<std::boxed::Box<crate::model::Schedule>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.trigger = std::option::Option::Some(
-                crate::model::job_trigger::trigger::Trigger::Schedule(v.into()),
-            );
-            self
-        }
-
         /// The value of [trigger][crate::model::job_trigger::Trigger::trigger]
         /// if it holds a `Manual`, `None` if the field is not set or
         /// holds a different branch.
@@ -14369,21 +12901,6 @@ pub mod job_trigger {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [trigger][crate::model::job_trigger::Trigger::trigger]
-        /// to hold a `Manual`.
-        ///
-        /// Note that all the setters affecting `trigger` are
-        /// mutually exclusive.
-        pub fn set_manual<T: std::convert::Into<std::boxed::Box<crate::model::Manual>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.trigger = std::option::Option::Some(
-                crate::model::job_trigger::trigger::Trigger::Manual(v.into()),
-            );
-            self
         }
     }
 
@@ -14610,22 +13127,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [action][crate::model::Action::action]
-    /// to hold a `SaveFindings`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_save_findings<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::SaveFindings>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::action::Action::SaveFindings(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Action::action]
     /// if it holds a `PubSub`, `None` if the field is not set or
     /// holds a different branch.
@@ -14639,21 +13140,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [action][crate::model::Action::action]
-    /// to hold a `PubSub`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_pub_sub<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::PublishToPubSub>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(crate::model::action::Action::PubSub(v.into()));
-        self
-    }
-
     /// The value of [action][crate::model::Action::action]
     /// if it holds a `PublishSummaryToCscc`, `None` if the field is not set or
     /// holds a different branch.
@@ -14665,22 +13151,6 @@ impl Action {
             crate::model::action::Action::PublishSummaryToCscc(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Action::action]
-    /// to hold a `PublishSummaryToCscc`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_publish_summary_to_cscc<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::PublishSummaryToCscc>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::action::Action::PublishSummaryToCscc(v.into()));
-        self
     }
 
     /// The value of [action][crate::model::Action::action]
@@ -14700,25 +13170,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [action][crate::model::Action::action]
-    /// to hold a `PublishFindingsToCloudDataCatalog`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_publish_findings_to_cloud_data_catalog<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::action::PublishFindingsToCloudDataCatalog>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::action::Action::PublishFindingsToCloudDataCatalog(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::Action::action]
     /// if it holds a `Deidentify`, `None` if the field is not set or
     /// holds a different branch.
@@ -14730,21 +13181,6 @@ impl Action {
             crate::model::action::Action::Deidentify(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Action::action]
-    /// to hold a `Deidentify`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_deidentify<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::Deidentify>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(crate::model::action::Action::Deidentify(v.into()));
-        self
     }
 
     /// The value of [action][crate::model::Action::action]
@@ -14760,23 +13196,6 @@ impl Action {
         })
     }
 
-    /// Sets the value of [action][crate::model::Action::action]
-    /// to hold a `JobNotificationEmails`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_job_notification_emails<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::JobNotificationEmails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::action::Action::JobNotificationEmails(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::Action::action]
     /// if it holds a `PublishToStackdriver`, `None` if the field is not set or
     /// holds a different branch.
@@ -14788,22 +13207,6 @@ impl Action {
             crate::model::action::Action::PublishToStackdriver(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::Action::action]
-    /// to hold a `PublishToStackdriver`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_publish_to_stackdriver<
-        T: std::convert::Into<std::boxed::Box<crate::model::action::PublishToStackdriver>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action =
-            std::option::Option::Some(crate::model::action::Action::PublishToStackdriver(v.into()));
-        self
     }
 }
 
@@ -15087,21 +13490,6 @@ pub mod action {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [output][crate::model::action::Deidentify::output]
-        /// to hold a `CloudStorageOutput`.
-        ///
-        /// Note that all the setters affecting `output` are
-        /// mutually exclusive.
-        pub fn set_cloud_storage_output<T: std::convert::Into<std::string::String>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.output = std::option::Option::Some(
-                crate::model::action::deidentify::Output::CloudStorageOutput(v.into()),
-            );
-            self
         }
     }
 
@@ -16337,23 +14725,6 @@ impl CreateDlpJobRequest {
         })
     }
 
-    /// Sets the value of [job][crate::model::CreateDlpJobRequest::job]
-    /// to hold a `InspectJob`.
-    ///
-    /// Note that all the setters affecting `job` are
-    /// mutually exclusive.
-    pub fn set_inspect_job<
-        T: std::convert::Into<std::boxed::Box<crate::model::InspectJobConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job = std::option::Option::Some(
-            crate::model::create_dlp_job_request::Job::InspectJob(v.into()),
-        );
-        self
-    }
-
     /// The value of [job][crate::model::CreateDlpJobRequest::job]
     /// if it holds a `RiskJob`, `None` if the field is not set or
     /// holds a different branch.
@@ -16365,22 +14736,6 @@ impl CreateDlpJobRequest {
             crate::model::create_dlp_job_request::Job::RiskJob(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [job][crate::model::CreateDlpJobRequest::job]
-    /// to hold a `RiskJob`.
-    ///
-    /// Note that all the setters affecting `job` are
-    /// mutually exclusive.
-    pub fn set_risk_job<
-        T: std::convert::Into<std::boxed::Box<crate::model::RiskAnalysisJobConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.job =
-            std::option::Option::Some(crate::model::create_dlp_job_request::Job::RiskJob(v.into()));
-        self
     }
 }
 
@@ -16782,23 +15137,6 @@ impl DataProfileAction {
         })
     }
 
-    /// Sets the value of [action][crate::model::DataProfileAction::action]
-    /// to hold a `ExportData`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_export_data<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_profile_action::Export>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::data_profile_action::Action::ExportData(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::DataProfileAction::action]
     /// if it holds a `PubSubNotification`, `None` if the field is not set or
     /// holds a different branch.
@@ -16815,23 +15153,6 @@ impl DataProfileAction {
         })
     }
 
-    /// Sets the value of [action][crate::model::DataProfileAction::action]
-    /// to hold a `PubSubNotification`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_pub_sub_notification<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_profile_action::PubSubNotification>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::data_profile_action::Action::PubSubNotification(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::DataProfileAction::action]
     /// if it holds a `PublishToChronicle`, `None` if the field is not set or
     /// holds a different branch.
@@ -16846,23 +15167,6 @@ impl DataProfileAction {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::DataProfileAction::action]
-    /// to hold a `PublishToChronicle`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_publish_to_chronicle<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_profile_action::PublishToChronicle>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::data_profile_action::Action::PublishToChronicle(v.into()),
-        );
-        self
     }
 
     /// The value of [action][crate::model::DataProfileAction::action]
@@ -16882,25 +15186,6 @@ impl DataProfileAction {
         })
     }
 
-    /// Sets the value of [action][crate::model::DataProfileAction::action]
-    /// to hold a `PublishToScc`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_publish_to_scc<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::data_profile_action::PublishToSecurityCommandCenter>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::data_profile_action::Action::PublishToScc(v.into()),
-        );
-        self
-    }
-
     /// The value of [action][crate::model::DataProfileAction::action]
     /// if it holds a `TagResources`, `None` if the field is not set or
     /// holds a different branch.
@@ -16915,23 +15200,6 @@ impl DataProfileAction {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [action][crate::model::DataProfileAction::action]
-    /// to hold a `TagResources`.
-    ///
-    /// Note that all the setters affecting `action` are
-    /// mutually exclusive.
-    pub fn set_tag_resources<
-        T: std::convert::Into<std::boxed::Box<crate::model::data_profile_action::TagResources>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.action = std::option::Option::Some(
-            crate::model::data_profile_action::Action::TagResources(v.into()),
-        );
-        self
     }
 }
 
@@ -17464,25 +15732,6 @@ pub mod data_profile_action {
                     _ => std::option::Option::None,
                 })
             }
-
-            /// Sets the value of [r#type][crate::model::data_profile_action::tag_resources::TagCondition::r#type]
-            /// to hold a `SensitivityScore`.
-            ///
-            /// Note that all the setters affecting `r#type` are
-            /// mutually exclusive.
-            pub fn set_sensitivity_score<
-                T: std::convert::Into<std::boxed::Box<crate::model::SensitivityScore>>,
-            >(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.r#type = std::option::Option::Some(
-                    crate::model::data_profile_action::tag_resources::tag_condition::Type::SensitivityScore(
-                        v.into()
-                    )
-                );
-                self
-            }
         }
 
         impl wkt::message::Message for TagCondition {
@@ -17556,23 +15805,6 @@ pub mod data_profile_action {
                     crate::model::data_profile_action::tag_resources::tag_value::Format::NamespacedValue(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [format][crate::model::data_profile_action::tag_resources::TagValue::format]
-            /// to hold a `NamespacedValue`.
-            ///
-            /// Note that all the setters affecting `format` are
-            /// mutually exclusive.
-            pub fn set_namespaced_value<T: std::convert::Into<std::string::String>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.format = std::option::Option::Some(
-                    crate::model::data_profile_action::tag_resources::tag_value::Format::NamespacedValue(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -17967,25 +16199,6 @@ impl DataProfileFindingLocation {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [location_extra_details][crate::model::DataProfileFindingLocation::location_extra_details]
-    /// to hold a `DataProfileFindingRecordLocation`.
-    ///
-    /// Note that all the setters affecting `location_extra_details` are
-    /// mutually exclusive.
-    pub fn set_data_profile_finding_record_location<
-        T: std::convert::Into<std::boxed::Box<crate::model::DataProfileFindingRecordLocation>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.location_extra_details = std::option::Option::Some(
-            crate::model::data_profile_finding_location::LocationExtraDetails::DataProfileFindingRecordLocation(
-                v.into()
-            )
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DataProfileFindingLocation {
@@ -18373,18 +16586,6 @@ impl DataProfileLocation {
         })
     }
 
-    /// Sets the value of [location][crate::model::DataProfileLocation::location]
-    /// to hold a `OrganizationId`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_organization_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::data_profile_location::Location::OrganizationId(v.into()),
-        );
-        self
-    }
-
     /// The value of [location][crate::model::DataProfileLocation::location]
     /// if it holds a `FolderId`, `None` if the field is not set or
     /// holds a different branch.
@@ -18396,18 +16597,6 @@ impl DataProfileLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location][crate::model::DataProfileLocation::location]
-    /// to hold a `FolderId`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_folder_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::data_profile_location::Location::FolderId(v.into()),
-        );
-        self
     }
 }
 
@@ -18898,23 +17087,6 @@ impl DiscoveryTarget {
         })
     }
 
-    /// Sets the value of [target][crate::model::DiscoveryTarget::target]
-    /// to hold a `BigQueryTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_big_query_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryDiscoveryTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discovery_target::Target::BigQueryTarget(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::DiscoveryTarget::target]
     /// if it holds a `CloudSqlTarget`, `None` if the field is not set or
     /// holds a different branch.
@@ -18928,23 +17100,6 @@ impl DiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::DiscoveryTarget::target]
-    /// to hold a `CloudSqlTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlDiscoveryTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discovery_target::Target::CloudSqlTarget(v.into()),
-        );
-        self
     }
 
     /// The value of [target][crate::model::DiscoveryTarget::target]
@@ -18962,23 +17117,6 @@ impl DiscoveryTarget {
         })
     }
 
-    /// Sets the value of [target][crate::model::DiscoveryTarget::target]
-    /// to hold a `SecretsTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_secrets_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::SecretsDiscoveryTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discovery_target::Target::SecretsTarget(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::DiscoveryTarget::target]
     /// if it holds a `CloudStorageTarget`, `None` if the field is not set or
     /// holds a different branch.
@@ -18992,23 +17130,6 @@ impl DiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::DiscoveryTarget::target]
-    /// to hold a `CloudStorageTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageDiscoveryTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discovery_target::Target::CloudStorageTarget(v.into()),
-        );
-        self
     }
 
     /// The value of [target][crate::model::DiscoveryTarget::target]
@@ -19026,23 +17147,6 @@ impl DiscoveryTarget {
         })
     }
 
-    /// Sets the value of [target][crate::model::DiscoveryTarget::target]
-    /// to hold a `OtherCloudTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_other_cloud_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::OtherCloudDiscoveryTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discovery_target::Target::OtherCloudTarget(v.into()),
-        );
-        self
-    }
-
     /// The value of [target][crate::model::DiscoveryTarget::target]
     /// if it holds a `VertexDatasetTarget`, `None` if the field is not set or
     /// holds a different branch.
@@ -19056,23 +17160,6 @@ impl DiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [target][crate::model::DiscoveryTarget::target]
-    /// to hold a `VertexDatasetTarget`.
-    ///
-    /// Note that all the setters affecting `target` are
-    /// mutually exclusive.
-    pub fn set_vertex_dataset_target<
-        T: std::convert::Into<std::boxed::Box<crate::model::VertexDatasetDiscoveryTarget>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.target = std::option::Option::Some(
-            crate::model::discovery_target::Target::VertexDatasetTarget(v.into()),
-        );
-        self
     }
 }
 
@@ -19205,23 +17292,6 @@ impl BigQueryDiscoveryTarget {
         })
     }
 
-    /// Sets the value of [frequency][crate::model::BigQueryDiscoveryTarget::frequency]
-    /// to hold a `Cadence`.
-    ///
-    /// Note that all the setters affecting `frequency` are
-    /// mutually exclusive.
-    pub fn set_cadence<
-        T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryGenerationCadence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.frequency = std::option::Option::Some(
-            crate::model::big_query_discovery_target::Frequency::Cadence(v.into()),
-        );
-        self
-    }
-
     /// The value of [frequency][crate::model::BigQueryDiscoveryTarget::frequency]
     /// if it holds a `Disabled`, `None` if the field is not set or
     /// holds a different branch.
@@ -19233,21 +17303,6 @@ impl BigQueryDiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [frequency][crate::model::BigQueryDiscoveryTarget::frequency]
-    /// to hold a `Disabled`.
-    ///
-    /// Note that all the setters affecting `frequency` are
-    /// mutually exclusive.
-    pub fn set_disabled<T: std::convert::Into<std::boxed::Box<crate::model::Disabled>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.frequency = std::option::Option::Some(
-            crate::model::big_query_discovery_target::Frequency::Disabled(v.into()),
-        );
-        self
     }
 }
 
@@ -19332,23 +17387,6 @@ impl DiscoveryBigQueryFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
-    /// to hold a `Tables`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_tables<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryTableCollection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_big_query_filter::Filter::Tables(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
     /// if it holds a `OtherTables`, `None` if the field is not set or
     /// holds a different branch.
@@ -19366,25 +17404,6 @@ impl DiscoveryBigQueryFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
-    /// to hold a `OtherTables`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_other_tables<
-        T: std::convert::Into<
-                std::boxed::Box<crate::model::discovery_big_query_filter::AllOtherBigQueryTables>,
-            >,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_big_query_filter::Filter::OtherTables(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
     /// if it holds a `TableReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -19398,23 +17417,6 @@ impl DiscoveryBigQueryFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::DiscoveryBigQueryFilter::filter]
-    /// to hold a `TableReference`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_table_reference<
-        T: std::convert::Into<std::boxed::Box<crate::model::TableReference>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_big_query_filter::Filter::TableReference(v.into()),
-        );
-        self
     }
 }
 
@@ -19529,23 +17531,6 @@ impl BigQueryTableCollection {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [pattern][crate::model::BigQueryTableCollection::pattern]
-    /// to hold a `IncludeRegexes`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_include_regexes<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryRegexes>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pattern = std::option::Option::Some(
-            crate::model::big_query_table_collection::Pattern::IncludeRegexes(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BigQueryTableCollection {
@@ -19658,21 +17643,6 @@ impl DiscoveryBigQueryConditions {
         })
     }
 
-    /// Sets the value of [included_types][crate::model::DiscoveryBigQueryConditions::included_types]
-    /// to hold a `Types`.
-    ///
-    /// Note that all the setters affecting `included_types` are
-    /// mutually exclusive.
-    pub fn set_types<T: std::convert::Into<std::boxed::Box<crate::model::BigQueryTableTypes>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.included_types = std::option::Option::Some(
-            crate::model::discovery_big_query_conditions::IncludedTypes::Types(v.into()),
-        );
-        self
-    }
-
     /// The value of [included_types][crate::model::DiscoveryBigQueryConditions::included_types]
     /// if it holds a `TypeCollection`, `None` if the field is not set or
     /// holds a different branch.
@@ -19686,21 +17656,6 @@ impl DiscoveryBigQueryConditions {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [included_types][crate::model::DiscoveryBigQueryConditions::included_types]
-    /// to hold a `TypeCollection`.
-    ///
-    /// Note that all the setters affecting `included_types` are
-    /// mutually exclusive.
-    pub fn set_type_collection<T: std::convert::Into<crate::model::BigQueryTableTypeCollection>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.included_types = std::option::Option::Some(
-            crate::model::discovery_big_query_conditions::IncludedTypes::TypeCollection(v.into()),
-        );
-        self
     }
 }
 
@@ -20089,23 +18044,6 @@ impl CloudSqlDiscoveryTarget {
         })
     }
 
-    /// Sets the value of [cadence][crate::model::CloudSqlDiscoveryTarget::cadence]
-    /// to hold a `GenerationCadence`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_generation_cadence<
-        T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryCloudSqlGenerationCadence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::cloud_sql_discovery_target::Cadence::GenerationCadence(v.into()),
-        );
-        self
-    }
-
     /// The value of [cadence][crate::model::CloudSqlDiscoveryTarget::cadence]
     /// if it holds a `Disabled`, `None` if the field is not set or
     /// holds a different branch.
@@ -20117,21 +18055,6 @@ impl CloudSqlDiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cadence][crate::model::CloudSqlDiscoveryTarget::cadence]
-    /// to hold a `Disabled`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_disabled<T: std::convert::Into<std::boxed::Box<crate::model::Disabled>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::cloud_sql_discovery_target::Cadence::Disabled(v.into()),
-        );
-        self
     }
 }
 
@@ -20214,23 +18137,6 @@ impl DiscoveryCloudSqlFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
-    /// to hold a `Collection`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_collection<
-        T: std::convert::Into<std::boxed::Box<crate::model::DatabaseResourceCollection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_cloud_sql_filter::Filter::Collection(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
     /// if it holds a `Others`, `None` if the field is not set or
     /// holds a different branch.
@@ -20246,23 +18152,6 @@ impl DiscoveryCloudSqlFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
-    /// to hold a `Others`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_others<
-        T: std::convert::Into<std::boxed::Box<crate::model::AllOtherDatabaseResources>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_cloud_sql_filter::Filter::Others(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
     /// if it holds a `DatabaseResourceReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -20276,23 +18165,6 @@ impl DiscoveryCloudSqlFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::DiscoveryCloudSqlFilter::filter]
-    /// to hold a `DatabaseResourceReference`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_database_resource_reference<
-        T: std::convert::Into<std::boxed::Box<crate::model::DatabaseResourceReference>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_cloud_sql_filter::Filter::DatabaseResourceReference(v.into()),
-        );
-        self
     }
 }
 
@@ -20379,23 +18251,6 @@ impl DatabaseResourceCollection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [pattern][crate::model::DatabaseResourceCollection::pattern]
-    /// to hold a `IncludeRegexes`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_include_regexes<
-        T: std::convert::Into<std::boxed::Box<crate::model::DatabaseResourceRegexes>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pattern = std::option::Option::Some(
-            crate::model::database_resource_collection::Pattern::IncludeRegexes(v.into()),
-        );
-        self
     }
 }
 
@@ -21366,23 +19221,6 @@ impl CloudStorageDiscoveryTarget {
         })
     }
 
-    /// Sets the value of [cadence][crate::model::CloudStorageDiscoveryTarget::cadence]
-    /// to hold a `GenerationCadence`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_generation_cadence<
-        T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryCloudStorageGenerationCadence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::cloud_storage_discovery_target::Cadence::GenerationCadence(v.into()),
-        );
-        self
-    }
-
     /// The value of [cadence][crate::model::CloudStorageDiscoveryTarget::cadence]
     /// if it holds a `Disabled`, `None` if the field is not set or
     /// holds a different branch.
@@ -21394,21 +19232,6 @@ impl CloudStorageDiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cadence][crate::model::CloudStorageDiscoveryTarget::cadence]
-    /// to hold a `Disabled`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_disabled<T: std::convert::Into<std::boxed::Box<crate::model::Disabled>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::cloud_storage_discovery_target::Cadence::Disabled(v.into()),
-        );
-        self
     }
 }
 
@@ -21493,23 +19316,6 @@ impl DiscoveryCloudStorageFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
-    /// to hold a `Collection`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_collection<
-        T: std::convert::Into<std::boxed::Box<crate::model::FileStoreCollection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_cloud_storage_filter::Filter::Collection(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
     /// if it holds a `CloudStorageResourceReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -21525,25 +19331,6 @@ impl DiscoveryCloudStorageFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
-    /// to hold a `CloudStorageResourceReference`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_resource_reference<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageResourceReference>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_cloud_storage_filter::Filter::CloudStorageResourceReference(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
     /// if it holds a `Others`, `None` if the field is not set or
     /// holds a different branch.
@@ -21555,21 +19342,6 @@ impl DiscoveryCloudStorageFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::DiscoveryCloudStorageFilter::filter]
-    /// to hold a `Others`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_others<T: std::convert::Into<std::boxed::Box<crate::model::AllOtherResources>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_cloud_storage_filter::Filter::Others(v.into()),
-        );
-        self
     }
 }
 
@@ -21655,23 +19427,6 @@ impl FileStoreCollection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [pattern][crate::model::FileStoreCollection::pattern]
-    /// to hold a `IncludeRegexes`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_include_regexes<
-        T: std::convert::Into<std::boxed::Box<crate::model::FileStoreRegexes>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pattern = std::option::Option::Some(
-            crate::model::file_store_collection::Pattern::IncludeRegexes(v.into()),
-        );
-        self
     }
 }
 
@@ -21785,23 +19540,6 @@ impl FileStoreRegex {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource_regex][crate::model::FileStoreRegex::resource_regex]
-    /// to hold a `CloudStorageRegex`.
-    ///
-    /// Note that all the setters affecting `resource_regex` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_regex<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageRegex>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource_regex = std::option::Option::Some(
-            crate::model::file_store_regex::ResourceRegex::CloudStorageRegex(v.into()),
-        );
-        self
     }
 }
 
@@ -22463,25 +20201,6 @@ impl DiscoveryFileStoreConditions {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [conditions][crate::model::DiscoveryFileStoreConditions::conditions]
-    /// to hold a `CloudStorageConditions`.
-    ///
-    /// Note that all the setters affecting `conditions` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_conditions<
-        T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryCloudStorageConditions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conditions = std::option::Option::Some(
-            crate::model::discovery_file_store_conditions::Conditions::CloudStorageConditions(
-                v.into(),
-            ),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for DiscoveryFileStoreConditions {
@@ -22610,23 +20329,6 @@ impl OtherCloudDiscoveryTarget {
         })
     }
 
-    /// Sets the value of [cadence][crate::model::OtherCloudDiscoveryTarget::cadence]
-    /// to hold a `GenerationCadence`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_generation_cadence<
-        T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryOtherCloudGenerationCadence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::other_cloud_discovery_target::Cadence::GenerationCadence(v.into()),
-        );
-        self
-    }
-
     /// The value of [cadence][crate::model::OtherCloudDiscoveryTarget::cadence]
     /// if it holds a `Disabled`, `None` if the field is not set or
     /// holds a different branch.
@@ -22638,21 +20340,6 @@ impl OtherCloudDiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cadence][crate::model::OtherCloudDiscoveryTarget::cadence]
-    /// to hold a `Disabled`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_disabled<T: std::convert::Into<std::boxed::Box<crate::model::Disabled>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::other_cloud_discovery_target::Cadence::Disabled(v.into()),
-        );
-        self
     }
 }
 
@@ -22733,23 +20420,6 @@ impl DiscoveryOtherCloudFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
-    /// to hold a `Collection`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_collection<
-        T: std::convert::Into<std::boxed::Box<crate::model::OtherCloudResourceCollection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_other_cloud_filter::Filter::Collection(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
     /// if it holds a `SingleResource`, `None` if the field is not set or
     /// holds a different branch.
@@ -22766,23 +20436,6 @@ impl DiscoveryOtherCloudFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
-    /// to hold a `SingleResource`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_single_resource<
-        T: std::convert::Into<std::boxed::Box<crate::model::OtherCloudSingleResourceReference>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_other_cloud_filter::Filter::SingleResource(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
     /// if it holds a `Others`, `None` if the field is not set or
     /// holds a different branch.
@@ -22794,21 +20447,6 @@ impl DiscoveryOtherCloudFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::DiscoveryOtherCloudFilter::filter]
-    /// to hold a `Others`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_others<T: std::convert::Into<std::boxed::Box<crate::model::AllOtherResources>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_other_cloud_filter::Filter::Others(v.into()),
-        );
-        self
     }
 }
 
@@ -22892,23 +20530,6 @@ impl OtherCloudResourceCollection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [pattern][crate::model::OtherCloudResourceCollection::pattern]
-    /// to hold a `IncludeRegexes`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_include_regexes<
-        T: std::convert::Into<std::boxed::Box<crate::model::OtherCloudResourceRegexes>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pattern = std::option::Option::Some(
-            crate::model::other_cloud_resource_collection::Pattern::IncludeRegexes(v.into()),
-        );
-        self
     }
 }
 
@@ -23027,23 +20648,6 @@ impl OtherCloudResourceRegex {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource_regex][crate::model::OtherCloudResourceRegex::resource_regex]
-    /// to hold a `AmazonS3BucketRegex`.
-    ///
-    /// Note that all the setters affecting `resource_regex` are
-    /// mutually exclusive.
-    pub fn set_amazon_s3_bucket_regex<
-        T: std::convert::Into<std::boxed::Box<crate::model::AmazonS3BucketRegex>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource_regex = std::option::Option::Some(
-            crate::model::other_cloud_resource_regex::ResourceRegex::AmazonS3BucketRegex(v.into()),
-        );
-        self
     }
 }
 
@@ -23205,23 +20809,6 @@ impl OtherCloudSingleResourceReference {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [resource][crate::model::OtherCloudSingleResourceReference::resource]
-    /// to hold a `AmazonS3Bucket`.
-    ///
-    /// Note that all the setters affecting `resource` are
-    /// mutually exclusive.
-    pub fn set_amazon_s3_bucket<
-        T: std::convert::Into<std::boxed::Box<crate::model::AmazonS3Bucket>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.resource = std::option::Option::Some(
-            crate::model::other_cloud_single_resource_reference::Resource::AmazonS3Bucket(v.into()),
-        );
-        self
     }
 }
 
@@ -23385,25 +20972,6 @@ impl DiscoveryOtherCloudConditions {
             crate::model::discovery_other_cloud_conditions::Conditions::AmazonS3BucketConditions(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [conditions][crate::model::DiscoveryOtherCloudConditions::conditions]
-    /// to hold a `AmazonS3BucketConditions`.
-    ///
-    /// Note that all the setters affecting `conditions` are
-    /// mutually exclusive.
-    pub fn set_amazon_s3_bucket_conditions<
-        T: std::convert::Into<std::boxed::Box<crate::model::AmazonS3BucketConditions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.conditions = std::option::Option::Some(
-            crate::model::discovery_other_cloud_conditions::Conditions::AmazonS3BucketConditions(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -23889,18 +21457,6 @@ impl DiscoveryStartingLocation {
         })
     }
 
-    /// Sets the value of [location][crate::model::DiscoveryStartingLocation::location]
-    /// to hold a `OrganizationId`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_organization_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::discovery_starting_location::Location::OrganizationId(v.into()),
-        );
-        self
-    }
-
     /// The value of [location][crate::model::DiscoveryStartingLocation::location]
     /// if it holds a `FolderId`, `None` if the field is not set or
     /// holds a different branch.
@@ -23912,18 +21468,6 @@ impl DiscoveryStartingLocation {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [location][crate::model::DiscoveryStartingLocation::location]
-    /// to hold a `FolderId`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_folder_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-        self.location = std::option::Option::Some(
-            crate::model::discovery_starting_location::Location::FolderId(v.into()),
-        );
-        self
     }
 }
 
@@ -24007,18 +21551,6 @@ impl OtherCloudDiscoveryStartingLocation {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [location][crate::model::OtherCloudDiscoveryStartingLocation::location]
-    /// to hold a `AwsLocation`.
-    ///
-    /// Note that all the setters affecting `location` are
-    /// mutually exclusive.
-    pub fn set_aws_location<T: std::convert::Into<std::boxed::Box<crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation>>>(mut self, v: T) -> Self{
-        self.location = std::option::Option::Some(
-            crate::model::other_cloud_discovery_starting_location::Location::AwsLocation(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for OtherCloudDiscoveryStartingLocation {
@@ -24073,20 +21605,6 @@ pub mod other_cloud_discovery_starting_location {
             })
         }
 
-        /// Sets the value of [scope][crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation::scope]
-        /// to hold a `AccountId`.
-        ///
-        /// Note that all the setters affecting `scope` are
-        /// mutually exclusive.
-        pub fn set_account_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.scope = std::option::Option::Some(
-                crate::model::other_cloud_discovery_starting_location::aws_discovery_starting_location::Scope::AccountId(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [scope][crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation::scope]
         /// if it holds a `AllAssetInventoryAssets`, `None` if the field is not set or
         /// holds a different branch.
@@ -24096,20 +21614,6 @@ pub mod other_cloud_discovery_starting_location {
                 crate::model::other_cloud_discovery_starting_location::aws_discovery_starting_location::Scope::AllAssetInventoryAssets(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [scope][crate::model::other_cloud_discovery_starting_location::AwsDiscoveryStartingLocation::scope]
-        /// to hold a `AllAssetInventoryAssets`.
-        ///
-        /// Note that all the setters affecting `scope` are
-        /// mutually exclusive.
-        pub fn set_all_asset_inventory_assets<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-            self.scope = std::option::Option::Some(
-                crate::model::other_cloud_discovery_starting_location::aws_discovery_starting_location::Scope::AllAssetInventoryAssets(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -24261,23 +21765,6 @@ impl VertexDatasetDiscoveryTarget {
         })
     }
 
-    /// Sets the value of [cadence][crate::model::VertexDatasetDiscoveryTarget::cadence]
-    /// to hold a `GenerationCadence`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_generation_cadence<
-        T: std::convert::Into<std::boxed::Box<crate::model::DiscoveryVertexDatasetGenerationCadence>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::vertex_dataset_discovery_target::Cadence::GenerationCadence(v.into()),
-        );
-        self
-    }
-
     /// The value of [cadence][crate::model::VertexDatasetDiscoveryTarget::cadence]
     /// if it holds a `Disabled`, `None` if the field is not set or
     /// holds a different branch.
@@ -24289,21 +21776,6 @@ impl VertexDatasetDiscoveryTarget {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [cadence][crate::model::VertexDatasetDiscoveryTarget::cadence]
-    /// to hold a `Disabled`.
-    ///
-    /// Note that all the setters affecting `cadence` are
-    /// mutually exclusive.
-    pub fn set_disabled<T: std::convert::Into<std::boxed::Box<crate::model::Disabled>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.cadence = std::option::Option::Some(
-            crate::model::vertex_dataset_discovery_target::Cadence::Disabled(v.into()),
-        );
-        self
     }
 }
 
@@ -24388,23 +21860,6 @@ impl DiscoveryVertexDatasetFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
-    /// to hold a `Collection`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_collection<
-        T: std::convert::Into<std::boxed::Box<crate::model::VertexDatasetCollection>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_vertex_dataset_filter::Filter::Collection(v.into()),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
     /// if it holds a `VertexDatasetResourceReference`, `None` if the field is not set or
     /// holds a different branch.
@@ -24418,25 +21873,6 @@ impl DiscoveryVertexDatasetFilter {
         })
     }
 
-    /// Sets the value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
-    /// to hold a `VertexDatasetResourceReference`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_vertex_dataset_resource_reference<
-        T: std::convert::Into<std::boxed::Box<crate::model::VertexDatasetResourceReference>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_vertex_dataset_filter::Filter::VertexDatasetResourceReference(
-                v.into(),
-            ),
-        );
-        self
-    }
-
     /// The value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
     /// if it holds a `Others`, `None` if the field is not set or
     /// holds a different branch.
@@ -24448,21 +21884,6 @@ impl DiscoveryVertexDatasetFilter {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [filter][crate::model::DiscoveryVertexDatasetFilter::filter]
-    /// to hold a `Others`.
-    ///
-    /// Note that all the setters affecting `filter` are
-    /// mutually exclusive.
-    pub fn set_others<T: std::convert::Into<std::boxed::Box<crate::model::AllOtherResources>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.filter = std::option::Option::Some(
-            crate::model::discovery_vertex_dataset_filter::Filter::Others(v.into()),
-        );
-        self
     }
 }
 
@@ -24547,23 +21968,6 @@ impl VertexDatasetCollection {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [pattern][crate::model::VertexDatasetCollection::pattern]
-    /// to hold a `VertexDatasetRegexes`.
-    ///
-    /// Note that all the setters affecting `pattern` are
-    /// mutually exclusive.
-    pub fn set_vertex_dataset_regexes<
-        T: std::convert::Into<std::boxed::Box<crate::model::VertexDatasetRegexes>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.pattern = std::option::Option::Some(
-            crate::model::vertex_dataset_collection::Pattern::VertexDatasetRegexes(v.into()),
-        );
-        self
     }
 }
 
@@ -24987,22 +22391,6 @@ impl DlpJob {
         })
     }
 
-    /// Sets the value of [details][crate::model::DlpJob::details]
-    /// to hold a `RiskDetails`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_risk_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::AnalyzeDataSourceRiskDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::dlp_job::Details::RiskDetails(v.into()));
-        self
-    }
-
     /// The value of [details][crate::model::DlpJob::details]
     /// if it holds a `InspectDetails`, `None` if the field is not set or
     /// holds a different branch.
@@ -25014,22 +22402,6 @@ impl DlpJob {
             crate::model::dlp_job::Details::InspectDetails(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [details][crate::model::DlpJob::details]
-    /// to hold a `InspectDetails`.
-    ///
-    /// Note that all the setters affecting `details` are
-    /// mutually exclusive.
-    pub fn set_inspect_details<
-        T: std::convert::Into<std::boxed::Box<crate::model::InspectDataSourceDetails>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.details =
-            std::option::Option::Some(crate::model::dlp_job::Details::InspectDetails(v.into()));
-        self
     }
 }
 
@@ -26027,23 +23399,6 @@ impl LargeCustomDictionaryConfig {
         })
     }
 
-    /// Sets the value of [source][crate::model::LargeCustomDictionaryConfig::source]
-    /// to hold a `CloudStorageFileSet`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_file_set<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageFileSet>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::large_custom_dictionary_config::Source::CloudStorageFileSet(v.into()),
-        );
-        self
-    }
-
     /// The value of [source][crate::model::LargeCustomDictionaryConfig::source]
     /// if it holds a `BigQueryField`, `None` if the field is not set or
     /// holds a different branch.
@@ -26057,23 +23412,6 @@ impl LargeCustomDictionaryConfig {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source][crate::model::LargeCustomDictionaryConfig::source]
-    /// to hold a `BigQueryField`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_big_query_field<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryField>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::large_custom_dictionary_config::Source::BigQueryField(v.into()),
-        );
-        self
     }
 }
 
@@ -26204,23 +23542,6 @@ impl StoredInfoTypeConfig {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
-    /// to hold a `LargeCustomDictionary`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_large_custom_dictionary<
-        T: std::convert::Into<std::boxed::Box<crate::model::LargeCustomDictionaryConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::stored_info_type_config::Type::LargeCustomDictionary(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
     /// if it holds a `Dictionary`, `None` if the field is not set or
     /// holds a different branch.
@@ -26236,23 +23557,6 @@ impl StoredInfoTypeConfig {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
-    /// to hold a `Dictionary`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_dictionary<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::Dictionary>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::stored_info_type_config::Type::Dictionary(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
     /// if it holds a `Regex`, `None` if the field is not set or
     /// holds a different branch.
@@ -26264,22 +23568,6 @@ impl StoredInfoTypeConfig {
             crate::model::stored_info_type_config::Type::Regex(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::StoredInfoTypeConfig::r#type]
-    /// to hold a `Regex`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_regex<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::Regex>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::stored_info_type_config::Type::Regex(v.into()));
-        self
     }
 }
 
@@ -26355,23 +23643,6 @@ impl StoredInfoTypeStats {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::StoredInfoTypeStats::r#type]
-    /// to hold a `LargeCustomDictionary`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_large_custom_dictionary<
-        T: std::convert::Into<std::boxed::Box<crate::model::LargeCustomDictionaryStats>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::stored_info_type_stats::Type::LargeCustomDictionary(v.into()),
-        );
-        self
     }
 }
 
@@ -31009,25 +28280,6 @@ pub mod data_profile_pub_sub_condition {
             })
         }
 
-        /// Sets the value of [value][crate::model::data_profile_pub_sub_condition::PubSubCondition::value]
-        /// to hold a `MinimumRiskScore`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_minimum_risk_score<
-            T: std::convert::Into<crate::model::data_profile_pub_sub_condition::ProfileScoreBucket>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::data_profile_pub_sub_condition::pub_sub_condition::Value::MinimumRiskScore(
-                    v.into()
-                )
-            );
-            self
-        }
-
         /// The value of [value][crate::model::data_profile_pub_sub_condition::PubSubCondition::value]
         /// if it holds a `MinimumSensitivityScore`, `None` if the field is not set or
         /// holds a different branch.
@@ -31040,25 +28292,6 @@ pub mod data_profile_pub_sub_condition {
                 crate::model::data_profile_pub_sub_condition::pub_sub_condition::Value::MinimumSensitivityScore(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [value][crate::model::data_profile_pub_sub_condition::PubSubCondition::value]
-        /// to hold a `MinimumSensitivityScore`.
-        ///
-        /// Note that all the setters affecting `value` are
-        /// mutually exclusive.
-        pub fn set_minimum_sensitivity_score<
-            T: std::convert::Into<crate::model::data_profile_pub_sub_condition::ProfileScoreBucket>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.value = std::option::Option::Some(
-                crate::model::data_profile_pub_sub_condition::pub_sub_condition::Value::MinimumSensitivityScore(
-                    v.into()
-                )
-            );
-            self
         }
     }
 
@@ -31996,22 +29229,6 @@ impl Connection {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [properties][crate::model::Connection::properties]
-    /// to hold a `CloudSql`.
-    ///
-    /// Note that all the setters affecting `properties` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlProperties>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.properties =
-            std::option::Option::Some(crate::model::connection::Properties::CloudSql(v.into()));
-        self
-    }
 }
 
 impl wkt::message::Message for Connection {
@@ -32203,23 +29420,6 @@ impl CloudSqlProperties {
         })
     }
 
-    /// Sets the value of [credential][crate::model::CloudSqlProperties::credential]
-    /// to hold a `UsernamePassword`.
-    ///
-    /// Note that all the setters affecting `credential` are
-    /// mutually exclusive.
-    pub fn set_username_password<
-        T: std::convert::Into<std::boxed::Box<crate::model::SecretManagerCredential>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.credential = std::option::Option::Some(
-            crate::model::cloud_sql_properties::Credential::UsernamePassword(v.into()),
-        );
-        self
-    }
-
     /// The value of [credential][crate::model::CloudSqlProperties::credential]
     /// if it holds a `CloudSqlIam`, `None` if the field is not set or
     /// holds a different branch.
@@ -32233,23 +29433,6 @@ impl CloudSqlProperties {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [credential][crate::model::CloudSqlProperties::credential]
-    /// to hold a `CloudSqlIam`.
-    ///
-    /// Note that all the setters affecting `credential` are
-    /// mutually exclusive.
-    pub fn set_cloud_sql_iam<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudSqlIamCredential>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.credential = std::option::Option::Some(
-            crate::model::cloud_sql_properties::Credential::CloudSqlIam(v.into()),
-        );
-        self
     }
 }
 
@@ -32524,21 +29707,6 @@ impl FileClusterType {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [file_cluster_type][crate::model::FileClusterType::file_cluster_type]
-    /// to hold a `Cluster`.
-    ///
-    /// Note that all the setters affecting `file_cluster_type` are
-    /// mutually exclusive.
-    pub fn set_cluster<T: std::convert::Into<crate::model::file_cluster_type::Cluster>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.file_cluster_type = std::option::Option::Some(
-            crate::model::file_cluster_type::FileClusterType::Cluster(v.into()),
-        );
-        self
     }
 }
 
@@ -33343,22 +30511,6 @@ impl CustomInfoType {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
-    /// to hold a `Dictionary`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_dictionary<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::Dictionary>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::custom_info_type::Type::Dictionary(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::CustomInfoType::r#type]
     /// if it holds a `Regex`, `None` if the field is not set or
     /// holds a different branch.
@@ -33370,22 +30522,6 @@ impl CustomInfoType {
             crate::model::custom_info_type::Type::Regex(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
-    /// to hold a `Regex`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_regex<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::Regex>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::custom_info_type::Type::Regex(v.into()));
-        self
     }
 
     /// The value of [r#type][crate::model::CustomInfoType::r#type]
@@ -33401,23 +30537,6 @@ impl CustomInfoType {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
-    /// to hold a `SurrogateType`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_surrogate_type<
-        T: std::convert::Into<std::boxed::Box<crate::model::custom_info_type::SurrogateType>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::custom_info_type::Type::SurrogateType(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::CustomInfoType::r#type]
     /// if it holds a `StoredType`, `None` if the field is not set or
     /// holds a different branch.
@@ -33427,20 +30546,6 @@ impl CustomInfoType {
             crate::model::custom_info_type::Type::StoredType(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::CustomInfoType::r#type]
-    /// to hold a `StoredType`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_stored_type<T: std::convert::Into<std::boxed::Box<crate::model::StoredType>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::custom_info_type::Type::StoredType(v.into()));
-        self
     }
 }
 
@@ -33529,25 +30634,6 @@ pub mod custom_info_type {
             })
         }
 
-        /// Sets the value of [source][crate::model::custom_info_type::Dictionary::source]
-        /// to hold a `WordList`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_word_list<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::custom_info_type::dictionary::WordList>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::custom_info_type::dictionary::Source::WordList(v.into()),
-            );
-            self
-        }
-
         /// The value of [source][crate::model::custom_info_type::Dictionary::source]
         /// if it holds a `CloudStoragePath`, `None` if the field is not set or
         /// holds a different branch.
@@ -33561,23 +30647,6 @@ pub mod custom_info_type {
                 }
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [source][crate::model::custom_info_type::Dictionary::source]
-        /// to hold a `CloudStoragePath`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_cloud_storage_path<
-            T: std::convert::Into<std::boxed::Box<crate::model::CloudStoragePath>>,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.source = std::option::Option::Some(
-                crate::model::custom_info_type::dictionary::Source::CloudStoragePath(v.into()),
-            );
-            self
         }
     }
 
@@ -33778,25 +30847,6 @@ pub mod custom_info_type {
                 _ => std::option::Option::None,
             })
         }
-
-        /// Sets the value of [r#type][crate::model::custom_info_type::DetectionRule::r#type]
-        /// to hold a `HotwordRule`.
-        ///
-        /// Note that all the setters affecting `r#type` are
-        /// mutually exclusive.
-        pub fn set_hotword_rule<
-            T: std::convert::Into<
-                    std::boxed::Box<crate::model::custom_info_type::detection_rule::HotwordRule>,
-                >,
-        >(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.r#type = std::option::Option::Some(
-                crate::model::custom_info_type::detection_rule::Type::HotwordRule(v.into()),
-            );
-            self
-        }
     }
 
     impl wkt::message::Message for DetectionRule {
@@ -33900,23 +30950,6 @@ pub mod custom_info_type {
                 })
             }
 
-            /// Sets the value of [adjustment][crate::model::custom_info_type::detection_rule::LikelihoodAdjustment::adjustment]
-            /// to hold a `FixedLikelihood`.
-            ///
-            /// Note that all the setters affecting `adjustment` are
-            /// mutually exclusive.
-            pub fn set_fixed_likelihood<T: std::convert::Into<crate::model::Likelihood>>(
-                mut self,
-                v: T,
-            ) -> Self {
-                self.adjustment = std::option::Option::Some(
-                    crate::model::custom_info_type::detection_rule::likelihood_adjustment::Adjustment::FixedLikelihood(
-                        v.into()
-                    )
-                );
-                self
-            }
-
             /// The value of [adjustment][crate::model::custom_info_type::detection_rule::LikelihoodAdjustment::adjustment]
             /// if it holds a `RelativeLikelihood`, `None` if the field is not set or
             /// holds a different branch.
@@ -33926,20 +30959,6 @@ pub mod custom_info_type {
                     crate::model::custom_info_type::detection_rule::likelihood_adjustment::Adjustment::RelativeLikelihood(v) => std::option::Option::Some(v),
                     _ => std::option::Option::None,
                 })
-            }
-
-            /// Sets the value of [adjustment][crate::model::custom_info_type::detection_rule::LikelihoodAdjustment::adjustment]
-            /// to hold a `RelativeLikelihood`.
-            ///
-            /// Note that all the setters affecting `adjustment` are
-            /// mutually exclusive.
-            pub fn set_relative_likelihood<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-                self.adjustment = std::option::Option::Some(
-                    crate::model::custom_info_type::detection_rule::likelihood_adjustment::Adjustment::RelativeLikelihood(
-                        v.into()
-                    )
-                );
-                self
             }
         }
 
@@ -35218,23 +32237,6 @@ impl StorageConfig {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
-    /// to hold a `DatastoreOptions`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_datastore_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::DatastoreOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::storage_config::Type::DatastoreOptions(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::StorageConfig::r#type]
     /// if it holds a `CloudStorageOptions`, `None` if the field is not set or
     /// holds a different branch.
@@ -35250,23 +32252,6 @@ impl StorageConfig {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
-    /// to hold a `CloudStorageOptions`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_cloud_storage_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::CloudStorageOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::storage_config::Type::CloudStorageOptions(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::StorageConfig::r#type]
     /// if it holds a `BigQueryOptions`, `None` if the field is not set or
     /// holds a different branch.
@@ -35280,23 +32265,6 @@ impl StorageConfig {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
-    /// to hold a `BigQueryOptions`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_big_query_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::BigQueryOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type = std::option::Option::Some(
-            crate::model::storage_config::Type::BigQueryOptions(v.into()),
-        );
-        self
-    }
-
     /// The value of [r#type][crate::model::StorageConfig::r#type]
     /// if it holds a `HybridOptions`, `None` if the field is not set or
     /// holds a different branch.
@@ -35308,22 +32276,6 @@ impl StorageConfig {
             crate::model::storage_config::Type::HybridOptions(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::StorageConfig::r#type]
-    /// to hold a `HybridOptions`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_hybrid_options<
-        T: std::convert::Into<std::boxed::Box<crate::model::HybridOptions>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::storage_config::Type::HybridOptions(v.into()));
-        self
     }
 }
 
@@ -35799,17 +32751,6 @@ pub mod key {
             })
         }
 
-        /// Sets the value of [id_type][crate::model::key::PathElement::id_type]
-        /// to hold a `Id`.
-        ///
-        /// Note that all the setters affecting `id_type` are
-        /// mutually exclusive.
-        pub fn set_id<T: std::convert::Into<i64>>(mut self, v: T) -> Self {
-            self.id_type =
-                std::option::Option::Some(crate::model::key::path_element::IdType::Id(v.into()));
-            self
-        }
-
         /// The value of [id_type][crate::model::key::PathElement::id_type]
         /// if it holds a `Name`, `None` if the field is not set or
         /// holds a different branch.
@@ -35819,17 +32760,6 @@ pub mod key {
                 crate::model::key::path_element::IdType::Name(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [id_type][crate::model::key::PathElement::id_type]
-        /// to hold a `Name`.
-        ///
-        /// Note that all the setters affecting `id_type` are
-        /// mutually exclusive.
-        pub fn set_name<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.id_type =
-                std::option::Option::Some(crate::model::key::path_element::IdType::Name(v.into()));
-            self
         }
     }
 
@@ -35923,20 +32853,6 @@ impl RecordKey {
         })
     }
 
-    /// Sets the value of [r#type][crate::model::RecordKey::r#type]
-    /// to hold a `DatastoreKey`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_datastore_key<T: std::convert::Into<std::boxed::Box<crate::model::DatastoreKey>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::record_key::Type::DatastoreKey(v.into()));
-        self
-    }
-
     /// The value of [r#type][crate::model::RecordKey::r#type]
     /// if it holds a `BigQueryKey`, `None` if the field is not set or
     /// holds a different branch.
@@ -35948,20 +32864,6 @@ impl RecordKey {
             crate::model::record_key::Type::BigQueryKey(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [r#type][crate::model::RecordKey::r#type]
-    /// to hold a `BigQueryKey`.
-    ///
-    /// Note that all the setters affecting `r#type` are
-    /// mutually exclusive.
-    pub fn set_big_query_key<T: std::convert::Into<std::boxed::Box<crate::model::BigQueryKey>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.r#type =
-            std::option::Option::Some(crate::model::record_key::Type::BigQueryKey(v.into()));
-        self
     }
 }
 

--- a/src/generated/showcase/src/builder.rs
+++ b/src/generated/showcase/src/builder.rs
@@ -1998,29 +1998,6 @@ pub mod echo {
             self.0.request.response = v.into();
             self
         }
-
-        /// Sets the value of [response][crate::model::EchoRequest::response]
-        /// to hold a `Content`.
-        ///
-        /// Note that all the setters affecting `response` are
-        /// mutually exclusive.
-        pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_content(v);
-            self
-        }
-
-        /// Sets the value of [response][crate::model::EchoRequest::response]
-        /// to hold a `Error`.
-        ///
-        /// Note that all the setters affecting `response` are
-        /// mutually exclusive.
-        pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_error(v);
-            self
-        }
     }
 
     #[doc(hidden)]
@@ -2530,32 +2507,6 @@ pub mod echo {
             self
         }
 
-        /// Sets the value of [end][crate::model::WaitRequest::end]
-        /// to hold a `EndTime`.
-        ///
-        /// Note that all the setters affecting `end` are
-        /// mutually exclusive.
-        pub fn set_end_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_end_time(v);
-            self
-        }
-
-        /// Sets the value of [end][crate::model::WaitRequest::end]
-        /// to hold a `Ttl`.
-        ///
-        /// Note that all the setters affecting `end` are
-        /// mutually exclusive.
-        pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_ttl(v);
-            self
-        }
-
         /// Sets the value of [response][crate::model::WaitRequest::response].
         ///
         /// Note that all the setters affecting `response` are
@@ -2565,32 +2516,6 @@ pub mod echo {
             v: T,
         ) -> Self {
             self.0.request.response = v.into();
-            self
-        }
-
-        /// Sets the value of [response][crate::model::WaitRequest::response]
-        /// to hold a `Error`.
-        ///
-        /// Note that all the setters affecting `response` are
-        /// mutually exclusive.
-        pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_error(v);
-            self
-        }
-
-        /// Sets the value of [response][crate::model::WaitRequest::response]
-        /// to hold a `Success`.
-        ///
-        /// Note that all the setters affecting `response` are
-        /// mutually exclusive.
-        pub fn set_success<T: std::convert::Into<std::boxed::Box<crate::model::WaitResponse>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_success(v);
             self
         }
     }
@@ -2664,32 +2589,6 @@ pub mod echo {
             v: T,
         ) -> Self {
             self.0.request.response = v.into();
-            self
-        }
-
-        /// Sets the value of [response][crate::model::BlockRequest::response]
-        /// to hold a `Error`.
-        ///
-        /// Note that all the setters affecting `response` are
-        /// mutually exclusive.
-        pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_error(v);
-            self
-        }
-
-        /// Sets the value of [response][crate::model::BlockRequest::response]
-        /// to hold a `Success`.
-        ///
-        /// Note that all the setters affecting `response` are
-        /// mutually exclusive.
-        pub fn set_success<T: std::convert::Into<std::boxed::Box<crate::model::BlockResponse>>>(
-            mut self,
-            v: T,
-        ) -> Self {
-            self.0.request = self.0.request.set_success(v);
             self
         }
     }

--- a/src/generated/showcase/src/model.rs
+++ b/src/generated/showcase/src/model.rs
@@ -1087,17 +1087,6 @@ impl EchoRequest {
         })
     }
 
-    /// Sets the value of [response][crate::model::EchoRequest::response]
-    /// to hold a `Content`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_content<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.response =
-            std::option::Option::Some(crate::model::echo_request::Response::Content(v.into()));
-        self
-    }
-
     /// The value of [response][crate::model::EchoRequest::response]
     /// if it holds a `Error`, `None` if the field is not set or
     /// holds a different branch.
@@ -1107,20 +1096,6 @@ impl EchoRequest {
             crate::model::echo_request::Response::Error(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response][crate::model::EchoRequest::response]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response =
-            std::option::Option::Some(crate::model::echo_request::Response::Error(v.into()));
-        self
     }
 }
 
@@ -1908,19 +1883,6 @@ impl WaitRequest {
         })
     }
 
-    /// Sets the value of [end][crate::model::WaitRequest::end]
-    /// to hold a `EndTime`.
-    ///
-    /// Note that all the setters affecting `end` are
-    /// mutually exclusive.
-    pub fn set_end_time<T: std::convert::Into<std::boxed::Box<wkt::Timestamp>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.end = std::option::Option::Some(crate::model::wait_request::End::EndTime(v.into()));
-        self
-    }
-
     /// The value of [end][crate::model::WaitRequest::end]
     /// if it holds a `Ttl`, `None` if the field is not set or
     /// holds a different branch.
@@ -1930,16 +1892,6 @@ impl WaitRequest {
             crate::model::wait_request::End::Ttl(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [end][crate::model::WaitRequest::end]
-    /// to hold a `Ttl`.
-    ///
-    /// Note that all the setters affecting `end` are
-    /// mutually exclusive.
-    pub fn set_ttl<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(mut self, v: T) -> Self {
-        self.end = std::option::Option::Some(crate::model::wait_request::End::Ttl(v.into()));
-        self
     }
 
     /// Sets the value of [response][crate::model::WaitRequest::response].
@@ -1967,20 +1919,6 @@ impl WaitRequest {
         })
     }
 
-    /// Sets the value of [response][crate::model::WaitRequest::response]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response =
-            std::option::Option::Some(crate::model::wait_request::Response::Error(v.into()));
-        self
-    }
-
     /// The value of [response][crate::model::WaitRequest::response]
     /// if it holds a `Success`, `None` if the field is not set or
     /// holds a different branch.
@@ -1990,20 +1928,6 @@ impl WaitRequest {
             crate::model::wait_request::Response::Success(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response][crate::model::WaitRequest::response]
-    /// to hold a `Success`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_success<T: std::convert::Into<std::boxed::Box<crate::model::WaitResponse>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response =
-            std::option::Option::Some(crate::model::wait_request::Response::Success(v.into()));
-        self
     }
 }
 
@@ -2165,20 +2089,6 @@ impl BlockRequest {
         })
     }
 
-    /// Sets the value of [response][crate::model::BlockRequest::response]
-    /// to hold a `Error`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_error<T: std::convert::Into<std::boxed::Box<rpc::model::Status>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response =
-            std::option::Option::Some(crate::model::block_request::Response::Error(v.into()));
-        self
-    }
-
     /// The value of [response][crate::model::BlockRequest::response]
     /// if it holds a `Success`, `None` if the field is not set or
     /// holds a different branch.
@@ -2188,20 +2098,6 @@ impl BlockRequest {
             crate::model::block_request::Response::Success(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [response][crate::model::BlockRequest::response]
-    /// to hold a `Success`.
-    ///
-    /// Note that all the setters affecting `response` are
-    /// mutually exclusive.
-    pub fn set_success<T: std::convert::Into<std::boxed::Box<crate::model::BlockResponse>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.response =
-            std::option::Option::Some(crate::model::block_request::Response::Success(v.into()));
-        self
     }
 }
 
@@ -3094,16 +2990,6 @@ impl Blurb {
         })
     }
 
-    /// Sets the value of [content][crate::model::Blurb::content]
-    /// to hold a `Text`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_text<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.content = std::option::Option::Some(crate::model::blurb::Content::Text(v.into()));
-        self
-    }
-
     /// The value of [content][crate::model::Blurb::content]
     /// if it holds a `Image`, `None` if the field is not set or
     /// holds a different branch.
@@ -3113,16 +2999,6 @@ impl Blurb {
             crate::model::blurb::Content::Image(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [content][crate::model::Blurb::content]
-    /// to hold a `Image`.
-    ///
-    /// Note that all the setters affecting `content` are
-    /// mutually exclusive.
-    pub fn set_image<T: std::convert::Into<::bytes::Bytes>>(mut self, v: T) -> Self {
-        self.content = std::option::Option::Some(crate::model::blurb::Content::Image(v.into()));
-        self
     }
 
     /// Sets the value of [legacy_id][crate::model::Blurb::legacy_id].
@@ -3150,17 +3026,6 @@ impl Blurb {
         })
     }
 
-    /// Sets the value of [legacy_id][crate::model::Blurb::legacy_id]
-    /// to hold a `LegacyRoomId`.
-    ///
-    /// Note that all the setters affecting `legacy_id` are
-    /// mutually exclusive.
-    pub fn set_legacy_room_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.legacy_id =
-            std::option::Option::Some(crate::model::blurb::LegacyId::LegacyRoomId(v.into()));
-        self
-    }
-
     /// The value of [legacy_id][crate::model::Blurb::legacy_id]
     /// if it holds a `LegacyUserId`, `None` if the field is not set or
     /// holds a different branch.
@@ -3170,17 +3035,6 @@ impl Blurb {
             crate::model::blurb::LegacyId::LegacyUserId(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [legacy_id][crate::model::Blurb::legacy_id]
-    /// to hold a `LegacyUserId`.
-    ///
-    /// Note that all the setters affecting `legacy_id` are
-    /// mutually exclusive.
-    pub fn set_legacy_user_id<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.legacy_id =
-            std::option::Option::Some(crate::model::blurb::LegacyId::LegacyUserId(v.into()));
-        self
     }
 }
 
@@ -3989,22 +3843,6 @@ impl ConnectRequest {
         })
     }
 
-    /// Sets the value of [request][crate::model::ConnectRequest::request]
-    /// to hold a `Config`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_config<
-        T: std::convert::Into<std::boxed::Box<crate::model::connect_request::ConnectConfig>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request =
-            std::option::Option::Some(crate::model::connect_request::Request::Config(v.into()));
-        self
-    }
-
     /// The value of [request][crate::model::ConnectRequest::request]
     /// if it holds a `Blurb`, `None` if the field is not set or
     /// holds a different branch.
@@ -4014,20 +3852,6 @@ impl ConnectRequest {
             crate::model::connect_request::Request::Blurb(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [request][crate::model::ConnectRequest::request]
-    /// to hold a `Blurb`.
-    ///
-    /// Note that all the setters affecting `request` are
-    /// mutually exclusive.
-    pub fn set_blurb<T: std::convert::Into<std::boxed::Box<crate::model::Blurb>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.request =
-            std::option::Option::Some(crate::model::connect_request::Request::Blurb(v.into()));
-        self
     }
 }
 

--- a/src/generated/spanner/admin/database/v1/src/builder.rs
+++ b/src/generated/spanner/admin/database/v1/src/builder.rs
@@ -1690,16 +1690,6 @@ pub mod database_admin {
             self.0.request.source = v.into();
             self
         }
-
-        /// Sets the value of [source][crate::model::RestoreDatabaseRequest::source]
-        /// to hold a `Backup`.
-        ///
-        /// Note that all the setters affecting `source` are
-        /// mutually exclusive.
-        pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-            self.0.request = self.0.request.set_backup(v);
-            self
-        }
     }
 
     #[doc(hidden)]

--- a/src/generated/spanner/admin/database/v1/src/model.rs
+++ b/src/generated/spanner/admin/database/v1/src/model.rs
@@ -2141,21 +2141,6 @@ impl BackupScheduleSpec {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [schedule_spec][crate::model::BackupScheduleSpec::schedule_spec]
-    /// to hold a `CronSpec`.
-    ///
-    /// Note that all the setters affecting `schedule_spec` are
-    /// mutually exclusive.
-    pub fn set_cron_spec<T: std::convert::Into<std::boxed::Box<crate::model::CrontabSpec>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.schedule_spec = std::option::Option::Some(
-            crate::model::backup_schedule_spec::ScheduleSpec::CronSpec(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for BackupScheduleSpec {
@@ -2314,23 +2299,6 @@ impl BackupSchedule {
         })
     }
 
-    /// Sets the value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
-    /// to hold a `FullBackupSpec`.
-    ///
-    /// Note that all the setters affecting `backup_type_spec` are
-    /// mutually exclusive.
-    pub fn set_full_backup_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::FullBackupSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_type_spec = std::option::Option::Some(
-            crate::model::backup_schedule::BackupTypeSpec::FullBackupSpec(v.into()),
-        );
-        self
-    }
-
     /// The value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
     /// if it holds a `IncrementalBackupSpec`, `None` if the field is not set or
     /// holds a different branch.
@@ -2344,23 +2312,6 @@ impl BackupSchedule {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [backup_type_spec][crate::model::BackupSchedule::backup_type_spec]
-    /// to hold a `IncrementalBackupSpec`.
-    ///
-    /// Note that all the setters affecting `backup_type_spec` are
-    /// mutually exclusive.
-    pub fn set_incremental_backup_spec<
-        T: std::convert::Into<std::boxed::Box<crate::model::IncrementalBackupSpec>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.backup_type_spec = std::option::Option::Some(
-            crate::model::backup_schedule::BackupTypeSpec::IncrementalBackupSpec(v.into()),
-        );
-        self
     }
 }
 
@@ -3180,20 +3131,6 @@ impl RestoreInfo {
             crate::model::restore_info::SourceInfo::BackupInfo(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_info][crate::model::RestoreInfo::source_info]
-    /// to hold a `BackupInfo`.
-    ///
-    /// Note that all the setters affecting `source_info` are
-    /// mutually exclusive.
-    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_info =
-            std::option::Option::Some(crate::model::restore_info::SourceInfo::BackupInfo(v.into()));
-        self
     }
 }
 
@@ -4770,18 +4707,6 @@ impl RestoreDatabaseRequest {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [source][crate::model::RestoreDatabaseRequest::source]
-    /// to hold a `Backup`.
-    ///
-    /// Note that all the setters affecting `source` are
-    /// mutually exclusive.
-    pub fn set_backup<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.source = std::option::Option::Some(
-            crate::model::restore_database_request::Source::Backup(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for RestoreDatabaseRequest {
@@ -5193,21 +5118,6 @@ impl RestoreDatabaseMetadata {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [source_info][crate::model::RestoreDatabaseMetadata::source_info]
-    /// to hold a `BackupInfo`.
-    ///
-    /// Note that all the setters affecting `source_info` are
-    /// mutually exclusive.
-    pub fn set_backup_info<T: std::convert::Into<std::boxed::Box<crate::model::BackupInfo>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.source_info = std::option::Option::Some(
-            crate::model::restore_database_metadata::SourceInfo::BackupInfo(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/spanner/admin/instance/v1/src/model.rs
+++ b/src/generated/spanner/admin/instance/v1/src/model.rs
@@ -1239,18 +1239,6 @@ impl ReplicaComputeCapacity {
         })
     }
 
-    /// Sets the value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
-    /// to hold a `NodeCount`.
-    ///
-    /// Note that all the setters affecting `compute_capacity` are
-    /// mutually exclusive.
-    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.compute_capacity = std::option::Option::Some(
-            crate::model::replica_compute_capacity::ComputeCapacity::NodeCount(v.into()),
-        );
-        self
-    }
-
     /// The value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
     /// if it holds a `ProcessingUnits`, `None` if the field is not set or
     /// holds a different branch.
@@ -1262,18 +1250,6 @@ impl ReplicaComputeCapacity {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [compute_capacity][crate::model::ReplicaComputeCapacity::compute_capacity]
-    /// to hold a `ProcessingUnits`.
-    ///
-    /// Note that all the setters affecting `compute_capacity` are
-    /// mutually exclusive.
-    pub fn set_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.compute_capacity = std::option::Option::Some(
-            crate::model::replica_compute_capacity::ComputeCapacity::ProcessingUnits(v.into()),
-        );
-        self
     }
 }
 
@@ -1460,18 +1436,6 @@ pub mod autoscaling_config {
             })
         }
 
-        /// Sets the value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
-        /// to hold a `MinNodes`.
-        ///
-        /// Note that all the setters affecting `min_limit` are
-        /// mutually exclusive.
-        pub fn set_min_nodes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.min_limit = std::option::Option::Some(
-                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinNodes(v.into()),
-            );
-            self
-        }
-
         /// The value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
         /// if it holds a `MinProcessingUnits`, `None` if the field is not set or
         /// holds a different branch.
@@ -1481,20 +1445,6 @@ pub mod autoscaling_config {
                 crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinProcessingUnits(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [min_limit][crate::model::autoscaling_config::AutoscalingLimits::min_limit]
-        /// to hold a `MinProcessingUnits`.
-        ///
-        /// Note that all the setters affecting `min_limit` are
-        /// mutually exclusive.
-        pub fn set_min_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.min_limit = std::option::Option::Some(
-                crate::model::autoscaling_config::autoscaling_limits::MinLimit::MinProcessingUnits(
-                    v.into(),
-                ),
-            );
-            self
         }
 
         /// Sets the value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit].
@@ -1528,18 +1478,6 @@ pub mod autoscaling_config {
             })
         }
 
-        /// Sets the value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
-        /// to hold a `MaxNodes`.
-        ///
-        /// Note that all the setters affecting `max_limit` are
-        /// mutually exclusive.
-        pub fn set_max_nodes<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.max_limit = std::option::Option::Some(
-                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxNodes(v.into()),
-            );
-            self
-        }
-
         /// The value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
         /// if it holds a `MaxProcessingUnits`, `None` if the field is not set or
         /// holds a different branch.
@@ -1549,20 +1487,6 @@ pub mod autoscaling_config {
                 crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxProcessingUnits(v) => std::option::Option::Some(v),
                 _ => std::option::Option::None,
             })
-        }
-
-        /// Sets the value of [max_limit][crate::model::autoscaling_config::AutoscalingLimits::max_limit]
-        /// to hold a `MaxProcessingUnits`.
-        ///
-        /// Note that all the setters affecting `max_limit` are
-        /// mutually exclusive.
-        pub fn set_max_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-            self.max_limit = std::option::Option::Some(
-                crate::model::autoscaling_config::autoscaling_limits::MaxLimit::MaxProcessingUnits(
-                    v.into(),
-                ),
-            );
-            self
         }
     }
 
@@ -4379,18 +4303,6 @@ impl InstancePartition {
         })
     }
 
-    /// Sets the value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
-    /// to hold a `NodeCount`.
-    ///
-    /// Note that all the setters affecting `compute_capacity` are
-    /// mutually exclusive.
-    pub fn set_node_count<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.compute_capacity = std::option::Option::Some(
-            crate::model::instance_partition::ComputeCapacity::NodeCount(v.into()),
-        );
-        self
-    }
-
     /// The value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
     /// if it holds a `ProcessingUnits`, `None` if the field is not set or
     /// holds a different branch.
@@ -4402,18 +4314,6 @@ impl InstancePartition {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [compute_capacity][crate::model::InstancePartition::compute_capacity]
-    /// to hold a `ProcessingUnits`.
-    ///
-    /// Note that all the setters affecting `compute_capacity` are
-    /// mutually exclusive.
-    pub fn set_processing_units<T: std::convert::Into<i32>>(mut self, v: T) -> Self {
-        self.compute_capacity = std::option::Option::Some(
-            crate::model::instance_partition::ComputeCapacity::ProcessingUnits(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/storagetransfer/v1/src/model.rs
+++ b/src/generated/storagetransfer/v1/src/model.rs
@@ -1487,18 +1487,6 @@ impl AwsS3Data {
             _ => std::option::Option::None,
         })
     }
-
-    /// Sets the value of [private_network][crate::model::AwsS3Data::private_network]
-    /// to hold a `ManagedPrivateNetwork`.
-    ///
-    /// Note that all the setters affecting `private_network` are
-    /// mutually exclusive.
-    pub fn set_managed_private_network<T: std::convert::Into<bool>>(mut self, v: T) -> Self {
-        self.private_network = std::option::Option::Some(
-            crate::model::aws_s_3_data::PrivateNetwork::ManagedPrivateNetwork(v.into()),
-        );
-        self
-    }
 }
 
 impl wkt::message::Message for AwsS3Data {
@@ -1877,23 +1865,6 @@ impl AwsS3CompatibleData {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_provider][crate::model::AwsS3CompatibleData::data_provider]
-    /// to hold a `S3Metadata`.
-    ///
-    /// Note that all the setters affecting `data_provider` are
-    /// mutually exclusive.
-    pub fn set_s3_metadata<
-        T: std::convert::Into<std::boxed::Box<crate::model::S3CompatibleMetadata>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_provider = std::option::Option::Some(
-            crate::model::aws_s_3_compatible_data::DataProvider::S3Metadata(v.into()),
-        );
-        self
     }
 }
 
@@ -3190,20 +3161,6 @@ impl TransferSpec {
         })
     }
 
-    /// Sets the value of [data_sink][crate::model::TransferSpec::data_sink]
-    /// to hold a `GcsDataSink`.
-    ///
-    /// Note that all the setters affecting `data_sink` are
-    /// mutually exclusive.
-    pub fn set_gcs_data_sink<T: std::convert::Into<std::boxed::Box<crate::model::GcsData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_sink =
-            std::option::Option::Some(crate::model::transfer_spec::DataSink::GcsDataSink(v.into()));
-        self
-    }
-
     /// The value of [data_sink][crate::model::TransferSpec::data_sink]
     /// if it holds a `PosixDataSink`, `None` if the field is not set or
     /// holds a different branch.
@@ -3215,23 +3172,6 @@ impl TransferSpec {
             crate::model::transfer_spec::DataSink::PosixDataSink(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_sink][crate::model::TransferSpec::data_sink]
-    /// to hold a `PosixDataSink`.
-    ///
-    /// Note that all the setters affecting `data_sink` are
-    /// mutually exclusive.
-    pub fn set_posix_data_sink<
-        T: std::convert::Into<std::boxed::Box<crate::model::PosixFilesystem>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_sink = std::option::Option::Some(
-            crate::model::transfer_spec::DataSink::PosixDataSink(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [data_source][crate::model::TransferSpec::data_source].
@@ -3261,21 +3201,6 @@ impl TransferSpec {
         })
     }
 
-    /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
-    /// to hold a `GcsDataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_gcs_data_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::transfer_spec::DataSource::GcsDataSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_source][crate::model::TransferSpec::data_source]
     /// if it holds a `AwsS3DataSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -3289,23 +3214,6 @@ impl TransferSpec {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
-    /// to hold a `AwsS3DataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_aws_s3_data_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::AwsS3Data>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::transfer_spec::DataSource::AwsS3DataSource(v.into()),
-        );
-        self
     }
 
     /// The value of [data_source][crate::model::TransferSpec::data_source]
@@ -3323,21 +3231,6 @@ impl TransferSpec {
         })
     }
 
-    /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
-    /// to hold a `HttpDataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_http_data_source<T: std::convert::Into<std::boxed::Box<crate::model::HttpData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::transfer_spec::DataSource::HttpDataSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_source][crate::model::TransferSpec::data_source]
     /// if it holds a `PosixDataSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -3351,23 +3244,6 @@ impl TransferSpec {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
-    /// to hold a `PosixDataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_posix_data_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::PosixFilesystem>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::transfer_spec::DataSource::PosixDataSource(v.into()),
-        );
-        self
     }
 
     /// The value of [data_source][crate::model::TransferSpec::data_source]
@@ -3385,23 +3261,6 @@ impl TransferSpec {
         })
     }
 
-    /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
-    /// to hold a `AzureBlobStorageDataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_azure_blob_storage_data_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::AzureBlobStorageData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::transfer_spec::DataSource::AzureBlobStorageDataSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_source][crate::model::TransferSpec::data_source]
     /// if it holds a `AwsS3CompatibleDataSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -3417,23 +3276,6 @@ impl TransferSpec {
         })
     }
 
-    /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
-    /// to hold a `AwsS3CompatibleDataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_aws_s3_compatible_data_source<
-        T: std::convert::Into<std::boxed::Box<crate::model::AwsS3CompatibleData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::transfer_spec::DataSource::AwsS3CompatibleDataSource(v.into()),
-        );
-        self
-    }
-
     /// The value of [data_source][crate::model::TransferSpec::data_source]
     /// if it holds a `HdfsDataSource`, `None` if the field is not set or
     /// holds a different branch.
@@ -3447,21 +3289,6 @@ impl TransferSpec {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_source][crate::model::TransferSpec::data_source]
-    /// to hold a `HdfsDataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_hdfs_data_source<T: std::convert::Into<std::boxed::Box<crate::model::HdfsData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::transfer_spec::DataSource::HdfsDataSource(v.into()),
-        );
-        self
     }
 
     /// Sets the value of [intermediate_data_location][crate::model::TransferSpec::intermediate_data_location].
@@ -3491,25 +3318,6 @@ impl TransferSpec {
             crate::model::transfer_spec::IntermediateDataLocation::GcsIntermediateDataLocation(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [intermediate_data_location][crate::model::TransferSpec::intermediate_data_location]
-    /// to hold a `GcsIntermediateDataLocation`.
-    ///
-    /// Note that all the setters affecting `intermediate_data_location` are
-    /// mutually exclusive.
-    pub fn set_gcs_intermediate_data_location<
-        T: std::convert::Into<std::boxed::Box<crate::model::GcsData>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.intermediate_data_location = std::option::Option::Some(
-            crate::model::transfer_spec::IntermediateDataLocation::GcsIntermediateDataLocation(
-                v.into(),
-            ),
-        );
-        self
     }
 }
 
@@ -3663,21 +3471,6 @@ impl ReplicationSpec {
         })
     }
 
-    /// Sets the value of [data_source][crate::model::ReplicationSpec::data_source]
-    /// to hold a `GcsDataSource`.
-    ///
-    /// Note that all the setters affecting `data_source` are
-    /// mutually exclusive.
-    pub fn set_gcs_data_source<T: std::convert::Into<std::boxed::Box<crate::model::GcsData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_source = std::option::Option::Some(
-            crate::model::replication_spec::DataSource::GcsDataSource(v.into()),
-        );
-        self
-    }
-
     /// Sets the value of [data_sink][crate::model::ReplicationSpec::data_sink].
     ///
     /// Note that all the setters affecting `data_sink` are mutually
@@ -3703,21 +3496,6 @@ impl ReplicationSpec {
             }
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [data_sink][crate::model::ReplicationSpec::data_sink]
-    /// to hold a `GcsDataSink`.
-    ///
-    /// Note that all the setters affecting `data_sink` are
-    /// mutually exclusive.
-    pub fn set_gcs_data_sink<T: std::convert::Into<std::boxed::Box<crate::model::GcsData>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.data_sink = std::option::Option::Some(
-            crate::model::replication_spec::DataSink::GcsDataSink(v.into()),
-        );
-        self
     }
 }
 

--- a/src/generated/type/src/model.rs
+++ b/src/generated/type/src/model.rs
@@ -449,20 +449,6 @@ impl DateTime {
         })
     }
 
-    /// Sets the value of [time_offset][crate::model::DateTime::time_offset]
-    /// to hold a `UtcOffset`.
-    ///
-    /// Note that all the setters affecting `time_offset` are
-    /// mutually exclusive.
-    pub fn set_utc_offset<T: std::convert::Into<std::boxed::Box<wkt::Duration>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time_offset =
-            std::option::Option::Some(crate::model::date_time::TimeOffset::UtcOffset(v.into()));
-        self
-    }
-
     /// The value of [time_offset][crate::model::DateTime::time_offset]
     /// if it holds a `TimeZone`, `None` if the field is not set or
     /// holds a different branch.
@@ -472,20 +458,6 @@ impl DateTime {
             crate::model::date_time::TimeOffset::TimeZone(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [time_offset][crate::model::DateTime::time_offset]
-    /// to hold a `TimeZone`.
-    ///
-    /// Note that all the setters affecting `time_offset` are
-    /// mutually exclusive.
-    pub fn set_time_zone<T: std::convert::Into<std::boxed::Box<crate::model::TimeZone>>>(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.time_offset =
-            std::option::Option::Some(crate::model::date_time::TimeOffset::TimeZone(v.into()));
-        self
     }
 }
 
@@ -1115,17 +1087,6 @@ impl PhoneNumber {
         })
     }
 
-    /// Sets the value of [kind][crate::model::PhoneNumber::kind]
-    /// to hold a `E164Number`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_e164_number<T: std::convert::Into<std::string::String>>(mut self, v: T) -> Self {
-        self.kind =
-            std::option::Option::Some(crate::model::phone_number::Kind::E164Number(v.into()));
-        self
-    }
-
     /// The value of [kind][crate::model::PhoneNumber::kind]
     /// if it holds a `ShortCode`, `None` if the field is not set or
     /// holds a different branch.
@@ -1137,22 +1098,6 @@ impl PhoneNumber {
             crate::model::phone_number::Kind::ShortCode(v) => std::option::Option::Some(v),
             _ => std::option::Option::None,
         })
-    }
-
-    /// Sets the value of [kind][crate::model::PhoneNumber::kind]
-    /// to hold a `ShortCode`.
-    ///
-    /// Note that all the setters affecting `kind` are
-    /// mutually exclusive.
-    pub fn set_short_code<
-        T: std::convert::Into<std::boxed::Box<crate::model::phone_number::ShortCode>>,
-    >(
-        mut self,
-        v: T,
-    ) -> Self {
-        self.kind =
-            std::option::Option::Some(crate::model::phone_number::Kind::ShortCode(v.into()));
-        self
     }
 }
 

--- a/src/integration-tests/src/firestore.rs
+++ b/src/integration-tests/src/firestore.rs
@@ -51,24 +51,27 @@ pub async fn basic(builder: firestore::builder::firestore::ClientBuilder) -> Res
     let project_id = crate::project_id()?;
     let client = builder.build().await?;
     let collection_id = new_collection_id();
-    let response = client
-        .create_document()
-        .set_parent(format!(
-            "projects/{project_id}/databases/(default)/documents"
-        ))
-        .set_collection_id(&collection_id)
-        .set_document(model::Document::new().set_fields([
-            (
-                "greeting",
-                model::Value::new().set_string_value("Hello World!"),
-            ),
-            (
-                "integration-test",
-                model::Value::new().set_boolean_value(true),
-            ),
-        ]))
-        .send()
-        .await?;
+    let response =
+        client
+            .create_document()
+            .set_parent(format!(
+                "projects/{project_id}/databases/(default)/documents"
+            ))
+            .set_collection_id(&collection_id)
+            .set_document(model::Document::new().set_fields([
+                (
+                    "greeting",
+                    model::Value::new().set_value_type(model::value::ValueType::StringValue(
+                        "Hello World!".into(),
+                    )),
+                ),
+                (
+                    "integration-test",
+                    model::Value::new().set_value_type(model::value::ValueType::BooleanValue(true)),
+                ),
+            ]))
+            .send()
+            .await?;
     println!("SUCCESS on create_document: {response:?}");
 
     let document_name = response.name;
@@ -97,7 +100,11 @@ pub async fn basic(builder: firestore::builder::firestore::ClientBuilder) -> Res
         .set_document(
             model::Document::new()
                 .set_name(&document_name)
-                .set_fields([("greeting", model::Value::new().set_string_value("Goodbye."))]),
+                .set_fields([(
+                    "greeting",
+                    model::Value::new()
+                        .set_value_type(model::value::ValueType::StringValue("Goodbye.".into())),
+                )]),
         )
         .set_update_mask(model::DocumentMask::new().set_field_paths(["greeting"]))
         .send()

--- a/src/integration-tests/src/secret_manager/protobuf.rs
+++ b/src/integration-tests/src/secret_manager/protobuf.rs
@@ -51,10 +51,11 @@ pub async fn run(builder: sm::builder::secret_manager_service::ClientBuilder) ->
         .set_secret_id(&secret_id)
         .set_secret(
             sm::model::Secret::new()
-                .set_replication(
-                    sm::model::Replication::new()
-                        .set_automatic(sm::model::replication::Automatic::new()),
-                )
+                .set_replication(sm::model::Replication::new().set_replication(
+                    sm::model::replication::Replication::Automatic(
+                        sm::model::replication::Automatic::new().into(),
+                    ),
+                ))
                 .set_labels([("integration-test", "true")]),
         )
         .send()

--- a/src/integration-tests/tests/serialization.rs
+++ b/src/integration-tests/tests/serialization.rs
@@ -102,16 +102,19 @@ mod serialization {
     #[test]
     fn serde_with_oneof() -> Result<()> {
         // Integer Value
-        let value = aiplatform::model::FeatureValue::default().set_int64_value(0);
+        let value = aiplatform::model::FeatureValue::default()
+            .set_value(aiplatform::model::feature_value::Value::Int64Value(42));
         let got = serde_json::to_value(&value)?;
         let want = serde_json::json!({
-            "int64Value": "0"
+            "int64Value": "42"
         });
         assert_eq!(got, want);
         let rt = serde_json::from_value(got)?;
         assert_eq!(value, rt);
         // Double Value
-        let value = value.set_double_value(f64::INFINITY);
+        let value = value.set_value(aiplatform::model::feature_value::Value::DoubleValue(
+            f64::INFINITY,
+        ));
         let got = serde_json::to_value(&value)?;
         let want = serde_json::json!({
             "doubleValue": "Infinity"
@@ -120,8 +123,8 @@ mod serialization {
         let rt = serde_json::from_value(got)?;
         assert_eq!(value, rt);
         // Bytes Value
-        let value = value.set_bytes_value(bytes::Bytes::from(
-            "the quick brown fox jumps over the lazy dog",
+        let value = value.set_value(aiplatform::model::feature_value::Value::BytesValue(
+            bytes::Bytes::from("the quick brown fox jumps over the lazy dog"),
         ));
         let got = serde_json::to_value(&value)?;
         let want = serde_json::json!({


### PR DESCRIPTION
Setters for `oneof` are error-prone: they give the impression that the
message may contain more than one of these values at a time. Providing
just `set_{oneof_name}()` is less error prone: it consumes a Rust `enum`
and the behavior of those is well understood.

Admittedly the types are harder to use, and some services have a lot of
complex, deeply nested `oneof` fields.

Fixes #2150
