### PR TITLE
cleanup!: errors do not need to be `PartialEq`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-gax-internal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4529,7 +4529,7 @@ dependencies = [
 
 [[package]]
 name = "google-cloud-wkt"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -323,12 +323,12 @@ url           = { version = "2" }
 # Local packages used as dependencies
 auth                          = { version = "0.20", path = "src/auth", package = "google-cloud-auth" }
 gax                           = { version = "0.22", path = "src/gax", package = "google-cloud-gax" }
-gaxi                          = { version = "0.2", path = "src/gax-internal", package = "google-cloud-gax-internal" }
+gaxi                          = { version = "0.3", path = "src/gax-internal", package = "google-cloud-gax-internal" }
 iam_v1                        = { version = "0.3", path = "src/generated/iam/v1", package = "google-cloud-iam-v1" }
 location                      = { version = "0.3", path = "src/generated/cloud/location", package = "google-cloud-location" }
 longrunning                   = { version = "0.24", path = "src/generated/longrunning", package = "google-cloud-longrunning" }
 lro                           = { version = "0.2", path = "src/lro", package = "google-cloud-lro" }
-wkt                           = { version = "0.4", path = "src/wkt", package = "google-cloud-wkt" }
+wkt                           = { version = "0.5", path = "src/wkt", package = "google-cloud-wkt" }
 api                           = { version = "0.3", path = "src/generated/api/types", package = "google-cloud-api" }
 cloud_common                  = { version = "0.3", path = "src/generated/cloud/common", package = "google-cloud-common" }
 gtype                         = { version = "0.3", path = "src/generated/type", package = "google-cloud-type" }

--- a/guide/samples/Cargo.toml
+++ b/guide/samples/Cargo.toml
@@ -38,7 +38,7 @@ google-cloud-speech-v2 = { version = "0.3", path = "../../src/generated/cloud/sp
 google-cloud-language-v2 = { version = "0.3", path = "../../src/generated/cloud/language/v2" }
 # ANCHOR_END: language
 google-cloud-rpc = { version = "0.3", path = "../../src/generated/rpc/types" }
-google-cloud-wkt = { version = "0.4", path = "../../src/wkt" }
+google-cloud-wkt = { version = "0.5", path = "../../src/wkt" }
 
 # ANCHOR: serde_json
 [dependencies.serde_json]

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -14,7 +14,7 @@
 
 [package]
 name        = "google-cloud-gax-internal"
-version     = "0.2.0"
+version     = "0.3.0"
 description = "Google Cloud Client Libraries for Rust - Implementation Details"
 build       = "build.rs"
 # Inherit other attributes from the workspace.

--- a/src/gax-internal/src/prost.rs
+++ b/src/gax-internal/src/prost.rs
@@ -19,7 +19,7 @@ use std::collections::BTreeMap;
 
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
-#[derive(Debug, thiserror::Error)]
+#[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum ConvertError {
     #[error("enum {0} does not contain an integer value")]

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -15,7 +15,7 @@
 [package]
 description = "Google Cloud Client Libraries for Rust - Well Known Types"
 name        = "google-cloud-wkt"
-version     = "0.4.0"
+version     = "0.5.0"
 # Inherit other attributes from the workspace.
 authors.workspace      = true
 categories.workspace   = true

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -53,7 +53,7 @@ pub struct Duration {
 }
 
 /// Represent failures in converting or creating [Duration] instances.
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug)]
 pub enum DurationError {
     /// One of the components (seconds and/or nanoseconds) was out of range.
     #[error("seconds and/or nanoseconds out of range")]
@@ -384,7 +384,7 @@ mod test {
     #[test_case(0, -1_000_000_000 ; "too many negative nanoseconds")]
     fn out_of_range(seconds: i64, nanos: i32) -> Result {
         let d = Duration::new(seconds, nanos);
-        assert_eq!(d, Err(Error::OutOfRange()));
+        assert!(matches!(d, Err(Error::OutOfRange())), "{d:?}");
         Ok(())
     }
 
@@ -392,7 +392,7 @@ mod test {
     #[test_case(-1 , 1 ; "mismatched sign case 2")]
     fn mismatched_sign(seconds: i64, nanos: i32) -> Result {
         let d = Duration::new(seconds, nanos);
-        assert_eq!(d, Err(Error::MismatchedSigns()));
+        assert!(matches!(d, Err(Error::MismatchedSigns())), "{d:?}");
         Ok(())
     }
 
@@ -480,7 +480,7 @@ mod test {
     #[test_case(time::Duration::new(-10_001 * SECONDS_IN_YEAR, 0) ; "below the range")]
     fn from_time_out_of_range(value: time::Duration) {
         let got = Duration::try_from(value);
-        assert_eq!(got, Err(DurationError::OutOfRange()));
+        assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
     }
 
     #[test_case(Duration::default(), time::Duration::default() ; "default")]
@@ -577,6 +577,6 @@ mod test {
     #[test_case(chrono::Duration::new(-10_001 * SECONDS_IN_YEAR, 0).unwrap() ; "below the range")]
     fn from_chrono_time_out_of_range(value: chrono::Duration) {
         let got = Duration::try_from(value);
-        assert_eq!(got, Err(DurationError::OutOfRange()));
+        assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
     }
 }

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -58,7 +58,7 @@ pub struct Timestamp {
 }
 
 /// Represent failures in converting or creating [Timestamp] instances.
-#[derive(thiserror::Error, Debug, PartialEq)]
+#[derive(thiserror::Error, Debug)]
 pub enum TimestampError {
     /// One of the components (seconds and/or nanoseconds) was out of range.
     #[error("seconds and/or nanoseconds out of range")]
@@ -339,7 +339,7 @@ mod test {
     #[test_case(0, 1_000_000_000; "nanos above range")]
     fn new_out_of_range(seconds: i64, nanos: i32) -> Result {
         let t = Timestamp::new(seconds, nanos);
-        assert_eq!(t, Err(Error::OutOfRange()));
+        assert!(matches!(t, Err(Error::OutOfRange())), "{t:?}");
         Ok(())
     }
 

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -81,7 +81,7 @@ fn from_std_time_duration() -> Result {
 
     let std_d = std::time::Duration::new(i64::MAX as u64 + 2, 0);
     let got = Duration::try_from(std_d);
-    assert_eq!(got, Err(DurationError::OutOfRange()));
+    assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
 
     Ok(())
 }
@@ -95,11 +95,11 @@ fn std_from_duration() -> Result {
 
     let dur = Duration::new(-10, 0)?;
     let got = std::time::Duration::try_from(dur);
-    assert_eq!(got, Err(DurationError::OutOfRange()));
+    assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
 
     let dur = Duration::new(0, -10)?;
     let got = std::time::Duration::try_from(dur);
-    assert_eq!(got, Err(DurationError::OutOfRange()));
+    assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
 
     Ok(())
 }


### PR DESCRIPTION
We would like to prevent breaking changes if these errors ever gain
variants that are not comparable.

Fixes #2151
