### PR TITLE
fix(auth): generate private key for test from primes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "httptest",
  "mockall",
  "mutants",
+ "num-bigint-dig",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -5196,6 +5197,7 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.5",
+ "serde",
  "smallvec",
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -320,6 +320,7 @@ test-case     = { version = "3" }
 tokio-stream  = { version = "0.1", default-features = false }
 tokio-test    = { version = "0.4", default-features = false }
 url           = { version = "2" }
+num-bigint-dig= { version = "0.8" }
 
 # Local packages used as dependencies
 auth                          = { version = "0.20", path = "src/auth", package = "google-cloud-auth" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,22 +305,22 @@ tonic-build        = { version = "0.13", default-features = false }
 tracing            = { version = "0.1" }
 tracing-subscriber = { version = "0.3", default-features = false }
 # Test packags
-anyhow        = "1"
-axum          = { version = "0.8" }
-httptest      = { version = "0.16.3" }
-mockall       = { version = "0.13" }
-mutants       = { version = "0.0.3" }
-regex         = { version = "1", default-features = false }
-rsa           = { version = "0.9", default-features = false }
-rustc_version = { version = "0.4" }
-scoped-env    = { version = "2" }
-serial_test   = { version = "3" }
-tempfile      = { version = "3" }
-test-case     = { version = "3" }
-tokio-stream  = { version = "0.1", default-features = false }
-tokio-test    = { version = "0.4", default-features = false }
-url           = { version = "2" }
-num-bigint-dig= { version = "0.8" }
+anyhow         = "1"
+axum           = { version = "0.8" }
+httptest       = { version = "0.16.3" }
+mockall        = { version = "0.13" }
+mutants        = { version = "0.0.3" }
+regex          = { version = "1", default-features = false }
+rsa            = { version = "0.9", default-features = false }
+rustc_version  = { version = "0.4" }
+scoped-env     = { version = "2" }
+serial_test    = { version = "3" }
+tempfile       = { version = "3" }
+test-case      = { version = "3" }
+tokio-stream   = { version = "0.1", default-features = false }
+tokio-test     = { version = "0.4", default-features = false }
+url            = { version = "2" }
+num-bigint-dig = { version = "0.8" }
 
 # Local packages used as dependencies
 auth                          = { version = "0.20", path = "src/auth", package = "google-cloud-auth" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -42,20 +42,8 @@ bon.workspace         = true
 gax.workspace = true
 
 [dev-dependencies]
-axum.workspace        = true
-httptest.workspace    = true
-mockall.workspace     = true
-regex.workspace       = true
-rsa                   = { workspace = true, features = ["pem"] }
-scoped-env.workspace  = true
-serial_test.workspace = true
-tempfile.workspace    = true
-test-case.workspace   = true
-tokio                 = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
-tokio-test.workspace  = true
-url.workspace         = true
-mutants.workspace     = true
 axum.workspace           = true
+httptest.workspace       = true
 mockall.workspace        = true
 regex.workspace          = true
 rsa                      = { workspace = true, features = ["pem"] }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -55,5 +55,18 @@ tokio                 = { workspace = true, features = ["macros", "rt-multi-thre
 tokio-test.workspace  = true
 url.workspace         = true
 mutants.workspace     = true
+axum.workspace           = true
+mockall.workspace        = true
+regex.workspace          = true
+rsa                      = { workspace = true, features = ["pem"] }
+scoped-env.workspace     = true
+serial_test.workspace    = true
+tempfile.workspace       = true
+test-case.workspace      = true
+tokio                    = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
+tokio-test.workspace     = true
+url.workspace            = true
+mutants.workspace        = true
+num-bigint-dig.workspace = true
 # Blocked by https://github.com/RustCrypto/RSA/issues/466
 rand = "0.8"

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -635,7 +635,7 @@ mod test {
             .map(|s| s.to_string())
     }
 
-    pub static PKCS8_PK: LazyLock<String> = LazyLock::new(|| {
+    pub static RSA_PRIVATE_KEY: LazyLock<RsaPrivateKey> = LazyLock::new(|| {
         let p_str: &str = "141367881524527794394893355677826002829869068195396267579403819572502936761383874443619453704612633353803671595972343528718438130450055151198231345212263093247511629886734453413988207866331439612464122904648042654465604881130663408340669956544709445155137282157402427763452856646879397237752891502149781819597";
         let q_str: &str = "179395413952110013801471600075409598322058038890563483332288896635704255883613060744402506322679437982046475766067250097809676406576067239936945362857700460740092421061356861438909617220234758121022105150630083703531219941303688818533566528599328339894969707615478438750812672509434761181735933851075292740309";
         let e_str: &str = "65537";
@@ -645,11 +645,12 @@ mod test {
         let public_exponent =
             BigUint::parse_bytes(e_str.as_bytes(), 10).expect("Failed to parse public exponent");
 
-        // Create the RsaPrivateKey from pre-defined primes
-        let priv_key = RsaPrivateKey::from_primes(vec![p, q], public_exponent)
-            .expect("Failed to create RsaPrivateKey from primes");
+        RsaPrivateKey::from_primes(vec![p, q], public_exponent)
+            .expect("Failed to create RsaPrivateKey from primes")
+    });
 
-        priv_key
+    pub static PKCS8_PK: LazyLock<String> = LazyLock::new(|| {
+        RSA_PRIVATE_KEY
             .to_pkcs8_pem(LineEnding::LF)
             .expect("Failed to encode key to PKCS#8 PEM")
             .to_string()

--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -608,6 +608,7 @@ pub mod testing {
 mod test {
     use super::*;
     use base64::Engine;
+    use num_bigint_dig::BigUint;
     use reqwest::header::AUTHORIZATION;
     use rsa::RsaPrivateKey;
     use rsa::pkcs8::{EncodePrivateKey, LineEnding};
@@ -635,9 +636,19 @@ mod test {
     }
 
     pub static PKCS8_PK: LazyLock<String> = LazyLock::new(|| {
-        let mut rng = rand::thread_rng();
-        let bits = 2048;
-        let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
+        let p_str: &str = "141367881524527794394893355677826002829869068195396267579403819572502936761383874443619453704612633353803671595972343528718438130450055151198231345212263093247511629886734453413988207866331439612464122904648042654465604881130663408340669956544709445155137282157402427763452856646879397237752891502149781819597";
+        let q_str: &str = "179395413952110013801471600075409598322058038890563483332288896635704255883613060744402506322679437982046475766067250097809676406576067239936945362857700460740092421061356861438909617220234758121022105150630083703531219941303688818533566528599328339894969707615478438750812672509434761181735933851075292740309";
+        let e_str: &str = "65537";
+
+        let p = BigUint::parse_bytes(p_str.as_bytes(), 10).expect("Failed to parse prime P");
+        let q = BigUint::parse_bytes(q_str.as_bytes(), 10).expect("Failed to parse prime Q");
+        let public_exponent =
+            BigUint::parse_bytes(e_str.as_bytes(), 10).expect("Failed to parse public exponent");
+
+        // Create the RsaPrivateKey from pre-defined primes
+        let priv_key = RsaPrivateKey::from_primes(vec![p, q], public_exponent)
+            .expect("Failed to create RsaPrivateKey from primes");
+
         priv_key
             .to_pkcs8_pem(LineEnding::LF)
             .expect("Failed to encode key to PKCS#8 PEM")

--- a/src/auth/src/credentials/service_account.rs
+++ b/src/auth/src/credentials/service_account.rs
@@ -452,12 +452,10 @@ mod test {
     use crate::token::test::MockTokenProvider;
     use http::HeaderValue;
     use http::header::AUTHORIZATION;
-    use rsa::RsaPrivateKey;
     use rsa::pkcs1::EncodeRsaPrivateKey;
     use rsa::pkcs8::LineEnding;
     use rustls_pemfile::Item;
     use serde_json::json;
-    use std::sync::LazyLock;
     use std::time::Duration;
 
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
@@ -576,20 +574,16 @@ mod test {
         })
     }
 
-    static PKCS1_PK: LazyLock<String> = LazyLock::new(|| {
-        let mut rng = rand::thread_rng();
-        let bits = 2048;
-        let priv_key = RsaPrivateKey::new(&mut rng, bits).expect("failed to generate a key");
-        priv_key
-            .to_pkcs1_pem(LineEnding::LF)
-            .expect("Failed to encode key to PKCS#1 PEM")
-            .to_string()
-    });
-
     #[tokio::test]
     async fn get_service_account_headers_pkcs1_private_key_failure() -> TestResult {
         let mut service_account_key = get_mock_service_key();
-        service_account_key["private_key"] = Value::from(PKCS1_PK.clone());
+
+        let key = crate::credentials::test::RSA_PRIVATE_KEY
+            .to_pkcs1_pem(LineEnding::LF)
+            .expect("Failed to encode key to PKCS#1 PEM")
+            .to_string();
+
+        service_account_key["private_key"] = Value::from(key);
         let cred = Builder::new(service_account_key).build()?;
         let expected_error_message = "expected key to be in form of PKCS8, found Pkcs1Key";
         assert!(


### PR DESCRIPTION
Attempting to fix #2121 by using pre-generated primes to speed up key generation.