### PR TITLE
feat(storage-control): add `RenameFolder` API

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -238,7 +238,8 @@ async fn folders(client: &storage_control::client::Storage, bucket_name: &str) -
     );
 
     println!("\nTesting rename_folder()");
-    let rename = client.rename_folder()
+    let rename = client
+        .rename_folder()
         .set_name(folder_name)
         .set_destination_folder_id("renamed-test-folder/")
         .poller()

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -239,7 +239,7 @@ async fn folders(client: &storage_control::client::Storage, bucket_name: &str) -
 
     println!("\nTesting rename_folder()");
     let rename = client.rename_folder()
-        .set_name(format!("{bucket_name}/folders/test-folder/"))
+        .set_name(folder_name)
         .set_destination_folder_id("renamed-test-folder/")
         .poller()
         .until_done()

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -479,6 +479,7 @@ impl Storage {
     ///         .poller()
     ///         .until_done()
     ///         .await?;
+    ///     println!("folder details={folder:?}");
     ///     Ok(())
     /// }
     /// ```

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -460,6 +460,42 @@ impl Storage {
         self.control.list_folders().set_parent(parent.into())
     }
 
+    /// Renames a source folder to a destination folder.
+    ///
+    /// This operation is only applicable to a hierarchical namespace enabled
+    /// bucket.
+    ///
+    /// During a rename, the source and destination folders are locked until the
+    /// long running operation completes.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_storage_control::client::Storage;
+    /// async fn example(client: &Storage) -> gax::Result<()> {
+    ///     use lro::Poller as _;
+    ///     let folder = client.rename_folder()
+    ///         .set_name("projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/")
+    ///         .set_destination_folder_id("my-folder/my-renamed-subfolder/")
+    ///         .poller()
+    ///         .until_done()
+    ///         .await?;
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// # Long running operations
+    ///
+    /// This method is used to start, and/or poll a [long-running Operation].
+    /// The [Working with long-running operations] chapter in the [user guide]
+    /// covers these operations in detail.
+    ///
+    /// [long-running operation]: https://google.aip.dev/151
+    /// [user guide]: https://googleapis.github.io/google-cloud-rust/
+    /// [working with long-running operations]: https://googleapis.github.io/google-cloud-rust/working_with_long_running_operations.html
+    pub fn rename_folder(&self) -> super::builder::storage::RenameFolder {
+        self.control.rename_folder()
+    }
+
     /// Creates a new client from the provided stub.
     ///
     /// The most common case for calling this function is in tests mocking the


### PR DESCRIPTION
Part of the work for #2037 and #944 

Add `RenameFolder` (an LRO) to the client surface, and use it from the integration test.

This is not the greatest integration test of LROs over gRPC, as the initial RPC returns a `done` Operation. It would be nice to exercise the polling loop (i.e. the `GetOperation` calls).

This RPC fails if a quota project is provided, let's see if one is set in our CI. :crossed_fingers: 