### PR TITLE
fix(wkt)!: preserve sources of errors

### DIFF
--- a/src/gax-internal/src/prost.rs
+++ b/src/gax-internal/src/prost.rs
@@ -255,13 +255,15 @@ mod test {
             "{fmt}"
         );
 
-        let source = wkt::AnyError::TypeMismatch("blah blah blah".to_string());
+        let source = wkt::AnyError::TypeMismatch {
+            has: "has.type".into(),
+            want: "want.type".into(),
+        };
         let e = ConvertError::other(source);
         let fmt = format!("{e}");
-        assert!(
-            fmt.contains("gax/prost conversion error") && fmt.contains("blah blah blah"),
-            "{fmt}"
-        );
+        ["gax/prost conversion error", "has.type", "want.type"]
+            .into_iter()
+            .for_each(|want| assert!(fmt.contains(want), "missing {want} in {fmt}"));
     }
 
     fn err() -> ConvertError {

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -53,19 +53,19 @@ pub struct Duration {
 }
 
 /// Represent failures in converting or creating [Duration] instances.
-/// 
+///
 /// # Examples
 /// ```
 /// # use google_cloud_wkt::{Duration, DurationError};
 /// let duration = Duration::new(Duration::MAX_SECONDS + 2, 0);
 /// assert!(matches!(duration, Err(DurationError::OutOfRange)));
-/// 
+///
 /// let duration = Duration::new(0, 1_500_000_000);
 /// assert!(matches!(duration, Err(DurationError::OutOfRange)));
-/// 
+///
 /// let duration = Duration::new(120, -500_000_000);
 /// assert!(matches!(duration, Err(DurationError::MismatchedSigns)));
-/// 
+///
 /// let ts = Duration::try_from("invalid");
 /// assert!(matches!(ts, Err(DurationError::Deserialize(_))));
 /// ```

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -58,16 +58,16 @@ pub struct Timestamp {
 }
 
 /// Represent failures in converting or creating [Timestamp] instances.
-/// 
+///
 /// Examples
 /// ```
 /// # use google_cloud_wkt::{Timestamp, TimestampError};
 /// let ts = Timestamp::new(Timestamp::MAX_SECONDS + 2, 0);
 /// assert!(matches!(ts, Err(TimestampError::OutOfRange)));
-/// 
+///
 /// let ts = Timestamp::new(0, 1_500_000_000);
 /// assert!(matches!(ts, Err(TimestampError::OutOfRange)));
-/// 
+///
 /// let ts = Timestamp::try_from("invalid");
 /// assert!(matches!(ts, Err(TimestampError::Deserialize(_))));
 /// ```

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -58,19 +58,35 @@ pub struct Timestamp {
 }
 
 /// Represent failures in converting or creating [Timestamp] instances.
+/// 
+/// Examples
+/// ```
+/// # use google_cloud_wkt::{Timestamp, TimestampError};
+/// let ts = Timestamp::new(Timestamp::MAX_SECONDS + 2, 0);
+/// assert!(matches!(ts, Err(TimestampError::OutOfRange)));
+/// 
+/// let ts = Timestamp::new(0, 1_500_000_000);
+/// assert!(matches!(ts, Err(TimestampError::OutOfRange)));
+/// 
+/// let ts = Timestamp::try_from("invalid");
+/// assert!(matches!(ts, Err(TimestampError::Deserialize(_))));
+/// ```
 #[derive(thiserror::Error, Debug)]
 pub enum TimestampError {
     /// One of the components (seconds and/or nanoseconds) was out of range.
     #[error("seconds and/or nanoseconds out of range")]
-    OutOfRange(),
+    OutOfRange,
 
-    #[error("cannot serialize timestamp: {0}")]
-    Serialize(String),
+    /// There was a problem serializing a timestamp.
+    #[error("cannot serialize timestamp, source={0}")]
+    Serialize(#[source] BoxedError),
 
-    #[error("cannot deserialize timestamp: {0}")]
-    Deserialize(String),
+    /// There was a problem deserializing a timestamp.
+    #[error("cannot deserialize timestamp, source={0}")]
+    Deserialize(#[source] BoxedError),
 }
 
+type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 type Error = TimestampError;
 
 impl Timestamp {
@@ -100,10 +116,10 @@ impl Timestamp {
     /// * `nanos` - the nanoseconds on the timestamp.
     pub fn new(seconds: i64, nanos: i32) -> Result<Self, Error> {
         if !(Self::MIN_SECONDS..=Self::MAX_SECONDS).contains(&seconds) {
-            return Err(Error::OutOfRange());
+            return Err(Error::OutOfRange);
         }
         if !(Self::MIN_NANOS..=Self::MAX_NANOS).contains(&nanos) {
-            return Err(Error::OutOfRange());
+            return Err(Error::OutOfRange);
         }
         Ok(Self { seconds, nanos })
     }
@@ -255,9 +271,9 @@ impl TryFrom<&Timestamp> for String {
         let ts = time::OffsetDateTime::from_unix_timestamp_nanos(
             timestamp.seconds as i128 * NS + timestamp.nanos as i128,
         )
-        .map_err(|e| TimestampError::Serialize(format!("{e}")))?;
+        .map_err(|e| TimestampError::Serialize(e.into()))?;
         ts.format(&Rfc3339)
-            .map_err(|e| TimestampError::Serialize(format!("{e}")))
+            .map_err(|e| TimestampError::Serialize(e.into()))
     }
 }
 
@@ -266,7 +282,7 @@ impl TryFrom<&str> for Timestamp {
     type Error = TimestampError;
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         let odt = time::OffsetDateTime::parse(value, &Rfc3339)
-            .map_err(|e| TimestampError::Deserialize(format!("{e}")))?;
+            .map_err(|e| TimestampError::Deserialize(e.into()))?;
         let nanos_since_epoch = odt.unix_timestamp_nanos();
         let seconds = (nanos_since_epoch / NS) as i64;
         let nanos = (nanos_since_epoch % NS) as i32;
@@ -339,7 +355,7 @@ mod test {
     #[test_case(0, 1_000_000_000; "nanos above range")]
     fn new_out_of_range(seconds: i64, nanos: i32) -> Result {
         let t = Timestamp::new(seconds, nanos);
-        assert!(matches!(t, Err(Error::OutOfRange())), "{t:?}");
+        assert!(matches!(t, Err(Error::OutOfRange)), "{t:?}");
         Ok(())
     }
 

--- a/src/wkt/tests/duration.rs
+++ b/src/wkt/tests/duration.rs
@@ -81,7 +81,7 @@ fn from_std_time_duration() -> Result {
 
     let std_d = std::time::Duration::new(i64::MAX as u64 + 2, 0);
     let got = Duration::try_from(std_d);
-    assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
+    assert!(matches!(got, Err(DurationError::OutOfRange)), "{got:?}");
 
     Ok(())
 }
@@ -95,11 +95,11 @@ fn std_from_duration() -> Result {
 
     let dur = Duration::new(-10, 0)?;
     let got = std::time::Duration::try_from(dur);
-    assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
+    assert!(matches!(got, Err(DurationError::OutOfRange)), "{got:?}");
 
     let dur = Duration::new(0, -10)?;
     let got = std::time::Duration::try_from(dur);
-    assert!(matches!(got, Err(DurationError::OutOfRange())), "{got:?}");
+    assert!(matches!(got, Err(DurationError::OutOfRange)), "{got:?}");
 
     Ok(())
 }


### PR DESCRIPTION
Prefer saving the source of the error instead of the error formatted as
a string.

Add some examples to illustrate how some of these errors work.