### PR TITLE
cleanup(generator): one less step to generate library

### DIFF
--- a/generator/internal/sidekick/rust_generate.go
+++ b/generator/internal/sidekick/rust_generate.go
@@ -107,6 +107,9 @@ func rust_generate(rootConfig *config.Config, cmdLine *CommandLine) error {
 		slog.Info("please manually add the typos to `.typos.toml` and fix the problem upstream")
 		return err
 	}
+	if err := runExternalCommand("git", "add", "Cargo.lock", "Cargo.toml"); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
`rust-generate` leaves `Cargo.lock` and `Cargo.toml` unstaged. So add them to remove a (small) manual step in library generation.

(I think it makes more sense to run this command in sidekick, vs. in the instructions).