### PR TITLE
feat!: make errors `#[non_exhaustive]`

### DIFF
--- a/src/gax-internal/src/path_parameter.rs
+++ b/src/gax-internal/src/path_parameter.rs
@@ -20,6 +20,7 @@
 //! a small helper function makes the generated code easier to read.
 
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum Error {
     #[error("missing required parameter {0}")]
     MissingRequiredParameter(String),

--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -93,6 +93,7 @@ pub struct Any(serde_json::Map<String, serde_json::Value>);
 /// # Ok::<(), AnyError>(())
 /// ```
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum AnyError {
     /// Problem serializing an object into an [Any].
     #[error("cannot serialize object into an Any, source={0}")]

--- a/src/wkt/src/duration.rs
+++ b/src/wkt/src/duration.rs
@@ -81,6 +81,7 @@ pub struct Duration {
 /// assert!(matches!(ts, Err(DurationError::Deserialize(_))));
 /// ```
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum DurationError {
     /// One of the components (seconds and/or nanoseconds) was out of range.
     #[error("seconds and/or nanoseconds out of range")]

--- a/src/wkt/src/timestamp.rs
+++ b/src/wkt/src/timestamp.rs
@@ -84,6 +84,7 @@ pub struct Timestamp {
 /// assert!(matches!(ts, Err(TimestampError::Deserialize(_))));
 /// ```
 #[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
 pub enum TimestampError {
     /// One of the components (seconds and/or nanoseconds) was out of range.
     #[error("seconds and/or nanoseconds out of range")]


### PR DESCRIPTION
We do not know if these errors will need to expand, they might. Making
them `#[non_exhaustive]` prevents future breaking changes. We do not
expect the downsides to be too bad, as most applications would not be
matching on these errors.

Fixes #2180
