### PR TITLE
fix(auth): allow token exchange without auth info

### DIFF
--- a/src/auth/src/credentials/internal/sts_exchange.rs
+++ b/src/auth/src/credentials/internal/sts_exchange.rs
@@ -138,12 +138,8 @@ impl ClientAuthentication {
             if let Ok(value) = header {
                 headers.insert("Authorization", value);
             }
-            return Ok(());
         }
-        Err(crate::errors::CredentialsError::from_str(
-            false,
-            "missing client_id and/or client_secret",
-        ))
+        Ok(())
     }
 }
 
@@ -326,34 +322,6 @@ mod test {
         let expected_err = crate::errors::CredentialsError::from_str(
             false,
             "error exchanging token, failed with status 400 Bad Request",
-        );
-        assert_eq!(err.to_string(), expected_err.to_string());
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn exchange_token_missing_auth_err() -> TestResult {
-        let authentication = ClientAuthentication {
-            client_id: None,
-            client_secret: None,
-        };
-
-        let url = "/not-reached".to_string();
-        let headers = http::HeaderMap::new();
-        let token_req = ExchangeTokenRequest {
-            url,
-            headers,
-            authentication,
-            subject_token: "an_example_token".to_string(),
-            subject_token_type: JWT_TOKEN_TYPE.to_string(),
-            ..ExchangeTokenRequest::default()
-        };
-        let err = assert_err!(STSHandler::exchange_token(token_req).await);
-
-        let expected_err = crate::errors::CredentialsError::from_str(
-            false,
-            "missing client_id and/or client_secret",
         );
         assert_eq!(err.to_string(), expected_err.to_string());
 


### PR DESCRIPTION
Token exchange calls doesn't require authentication. From [RFC8693 Request section](https://datatracker.ietf.org/doc/html/rfc8693#Request):

```
The supported methods of client authentication and whether or not to allow unauthenticated or unidentified clients are deployment decisions that are at the discretion of the authorization server. [...] Thus, client authentication allows for additional authorization checks by the STS as to which entities are permitted to impersonate or receive delegations from other entities.
```

-  Example on GCP auth documentation page shows example without any auth header: https://cloud.google.com/iam/docs/workforce-obtaining-short-lived-credentials#use_the_rest_api