### PR TITLE
cleanup(deps)!: disable default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,6 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -163,7 +162,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -5234,7 +5232,6 @@ dependencies = [
  "num-iter",
  "num-traits",
  "rand 0.8.5",
- "serde",
  "smallvec",
  "zeroize",
 ]
@@ -5564,7 +5561,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
@@ -5604,9 +5600,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
-]
 
 [[package]]
 name = "rand_core"
@@ -6008,8 +6001,6 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
 dependencies = [
- "futures",
- "log",
  "once_cell",
  "parking_lot",
  "scc",
@@ -6158,7 +6149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -6445,7 +6435,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -279,7 +279,7 @@ incremental = false
 
 [workspace.dependencies]
 async-trait        = { default-features = false, version = "0.1" }
-base64             = { default-features = false, version = "0.22" }
+base64             = { default-features = false, version = "0.22", features = ["std"] }
 bon                = { default-features = false, version = "3" }
 bytes              = { default-features = false, version = "1", features = ["serde"] }
 chrono             = { default-features = false, version = "0.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -305,7 +305,7 @@ time               = { default-features = false, version = "0.3" }
 tokio              = { default-features = false, version = "1" }
 tonic              = { default-features = false, version = "0.13", features = ["prost", "tls-native-roots", "tls-ring"] }
 tonic-build        = { default-features = false, version = "0.13" }
-tracing            = { default-features = false, version = "0.1" }
+tracing            = { default-features = false, version = "0.1", features = ["attributes"] }
 tracing-subscriber = { default-features = false, version = "0.3" }
 # Test packags
 anyhow         = { default-features = false, version = "1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -278,52 +278,52 @@ inherits    = "dev"
 incremental = false
 
 [workspace.dependencies]
-async-trait        = { version = "0.1" }
-base64             = { version = "0.22" }
-bon                = { version = "3", default-features = false }
-bytes              = { version = "1", default-features = false, features = ["serde"] }
-chrono             = { version = "0.4", default-features = false }
-crc32c             = { version = "0.6", default-features = false }
-futures            = { version = "0.3" }
-http               = { version = "1", default-features = false, features = ["std"] }
-http-body-util     = { version = "0.1" }
-lazy_static        = { version = "1", default-features = false }
-percent-encoding   = { version = "2", default-features = false }
-pin-project        = { version = "1" }
-prost              = { version = "0.13", default-features = false }
-prost-build        = { version = "0.13", default-features = false }
-prost-types        = { version = "0.13", default-features = false }
-rand               = { version = "0.9" }
-reqwest            = { version = "0.12", default-features = false, features = ["json"] }
-rustls             = { version = "0.23", default-features = false }
-rustls-pemfile     = { version = "2", default-features = false }
-serde              = { version = "1", default-features = false, features = ["serde_derive"] }
-serde_json         = { version = "1", default-features = false, features = ["std"] }
-serde_with         = { version = "3", default-features = false, features = ["base64", "macros", "std"] }
-thiserror          = { version = "2" }
-time               = { version = "0.3", default-features = false }
-tokio              = { version = "1", default-features = false }
-tonic              = { version = "0.13", default-features = false, features = ["prost", "tls-native-roots", "tls-ring"] }
-tonic-build        = { version = "0.13", default-features = false }
-tracing            = { version = "0.1" }
-tracing-subscriber = { version = "0.3", default-features = false }
+async-trait        = { default-features = false, version = "0.1" }
+base64             = { default-features = false, version = "0.22" }
+bon                = { default-features = false, version = "3" }
+bytes              = { default-features = false, version = "1", features = ["serde"] }
+chrono             = { default-features = false, version = "0.4" }
+crc32c             = { default-features = false, version = "0.6" }
+futures            = { default-features = false, version = "0.3" }
+http               = { default-features = false, version = "1", features = ["std"] }
+http-body-util     = { default-features = false, version = "0.1" }
+lazy_static        = { default-features = false, version = "1" }
+percent-encoding   = { default-features = false, version = "2" }
+pin-project        = { default-features = false, version = "1" }
+prost              = { default-features = false, version = "0.13" }
+prost-build        = { default-features = false, version = "0.13" }
+prost-types        = { default-features = false, version = "0.13" }
+rand               = { default-features = false, version = "0.9" }
+reqwest            = { default-features = false, version = "0.12", features = ["json"] }
+rustls             = { default-features = false, version = "0.23" }
+rustls-pemfile     = { default-features = false, version = "2" }
+serde              = { default-features = false, version = "1", features = ["serde_derive"] }
+serde_json         = { default-features = false, version = "1", features = ["std"] }
+serde_with         = { default-features = false, version = "3", features = ["base64", "macros", "std"] }
+thiserror          = { default-features = false, version = "2" }
+time               = { default-features = false, version = "0.3" }
+tokio              = { default-features = false, version = "1" }
+tonic              = { default-features = false, version = "0.13", features = ["prost", "tls-native-roots", "tls-ring"] }
+tonic-build        = { default-features = false, version = "0.13" }
+tracing            = { default-features = false, version = "0.1" }
+tracing-subscriber = { default-features = false, version = "0.3" }
 # Test packags
-anyhow         = "1"
-axum           = { version = "0.8" }
-httptest       = { version = "0.16.3" }
-mockall        = { version = "0.13" }
-mutants        = { version = "0.0.3" }
-regex          = { version = "1", default-features = false }
-rsa            = { version = "0.9", default-features = false }
-rustc_version  = { version = "0.4" }
-scoped-env     = { version = "2" }
-serial_test    = { version = "3" }
-tempfile       = { version = "3" }
-test-case      = { version = "3" }
-tokio-stream   = { version = "0.1", default-features = false }
-tokio-test     = { version = "0.4", default-features = false }
-url            = { version = "2" }
-num-bigint-dig = { version = "0.8" }
+anyhow         = { default-features = false, version = "1" }
+axum           = { default-features = false, version = "0.8" }
+httptest       = { default-features = false, version = "0.16.3" }
+mockall        = { default-features = false, version = "0.13" }
+mutants        = { default-features = false, version = "0.0.3" }
+regex          = { default-features = false, version = "1" }
+rsa            = { default-features = false, version = "0.9" }
+rustc_version  = { default-features = false, version = "0.4" }
+scoped-env     = { default-features = false, version = "2" }
+serial_test    = { default-features = false, version = "3" }
+tempfile       = { default-features = false, version = "3" }
+test-case      = { default-features = false, version = "3" }
+tokio-stream   = { default-features = false, version = "0.1" }
+tokio-test     = { default-features = false, version = "0.4" }
+url            = { default-features = false, version = "2" }
+num-bigint-dig = { default-features = false, version = "0.8" }
 
 # Local packages used as dependencies
 auth                          = { version = "0.20.1", path = "src/auth", package = "google-cloud-auth" }

--- a/src/auth/Cargo.toml
+++ b/src/auth/Cargo.toml
@@ -42,7 +42,7 @@ bon.workspace         = true
 gax.workspace = true
 
 [dev-dependencies]
-axum.workspace           = true
+axum                     = { workspace = true, features = ["http2", "json", "query", "tokio"] }
 httptest.workspace       = true
 mockall.workspace        = true
 regex.workspace          = true

--- a/src/gax-internal/Cargo.toml
+++ b/src/gax-internal/Cargo.toml
@@ -82,7 +82,7 @@ wkt  = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow.workspace      = true
-axum.workspace        = true
+axum                  = { workspace = true, features = ["http2", "json", "query", "tokio"] }
 bytes.workspace       = true
 mockall.workspace     = true
 scoped-env.workspace  = true

--- a/src/gax-internal/echo-server/Cargo.toml
+++ b/src/gax-internal/echo-server/Cargo.toml
@@ -20,7 +20,7 @@ edition.workspace = true
 publish           = false
 
 [dependencies]
-axum.workspace       = true
+axum                 = { workspace = true, features = ["http2", "json", "query", "tokio"] }
 bytes.workspace      = true
 serde_json.workspace = true
 tokio                = { workspace = true, features = ["macros"] }

--- a/src/gax-internal/grpc-server/Cargo.toml
+++ b/src/gax-internal/grpc-server/Cargo.toml
@@ -25,7 +25,7 @@ _generate-protos = ["dep:tonic-build"]
 
 [dependencies]
 anyhow.workspace     = true
-axum.workspace       = true
+axum                 = { workspace = true, features = ["http2", "json", "query", "tokio"] }
 http.workspace       = true
 prost                = { workspace = true, default-features = true }
 serde_json.workspace = true

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -35,7 +35,7 @@ bytes.workspace       = true
 futures.workspace     = true
 http.workspace        = true
 pin-project.workspace = true
-rand.workspace        = true
+rand                  = { workspace = true, features = ["thread_rng"] }
 serde.workspace       = true
 serde_json.workspace  = true
 tokio                 = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/src/integration-tests/Cargo.toml
+++ b/src/integration-tests/Cargo.toml
@@ -36,7 +36,7 @@ gax                   = { workspace = true, features = ["unstable-stream"] }
 iam_v1.workspace      = true
 longrunning.workspace = true
 lro.workspace         = true
-rand.workspace        = true
+rand                  = { workspace = true, features = ["thread_rng"] }
 serde_json.workspace  = true
 tokio                 = { workspace = true, features = ["process"] }
 tracing.workspace     = true
@@ -95,7 +95,7 @@ path    = "../../src/generated/cloud/workflows/executions/v1"
 
 [dev-dependencies]
 anyhow.workspace     = true
-axum.workspace       = true
+axum                 = { workspace = true, features = ["http2", "json", "query", "tokio"] }
 mockall.workspace    = true
 reqwest.workspace    = true
 serde.workspace      = true

--- a/src/lro/Cargo.toml
+++ b/src/lro/Cargo.toml
@@ -52,7 +52,7 @@ unstable-stream = ["dep:futures", "dep:pin-project"]
 _internal-semver = []
 
 [dev-dependencies]
-axum.workspace       = true
+axum                 = { workspace = true, features = ["http2", "json", "query", "tokio"] }
 reqwest.workspace    = true
 serde_json.workspace = true
 tokio                = { workspace = true, features = ["test-util"] }


### PR DESCRIPTION
Disabling the default defaures prevents (some) breaking changes
introduced as we stop using features of our dependencies.

I think making this change for both regular and `dev-` dependencies is
easier to maintain in the future. The less we need to think about these
things, the better.

Fixes #2219
