### PR TITLE
impl(generator/rust): capture LRO types for a service

### DIFF
--- a/generator/internal/rust/annotate.go
+++ b/generator/internal/rust/annotate.go
@@ -78,13 +78,19 @@ type serviceAnnotations struct {
 	// Only a subset of the methods is generated.
 	Methods     []*api.Method
 	DefaultHost string
-	// If true, this service includes methods that return long-running operations.
-	HasLROs  bool
+	// A set of all types involved in an LRO, whether used as metadata or
+	// response.
+	LROTypes []*api.Message
 	APITitle string
 	// If set, gate this service under a feature named `ModuleName`.
 	PerServiceFeatures bool
 	// If true, there is a handwritten client surface.
 	HasVeneer bool
+}
+
+// If true, this service includes methods that return long-running operations.
+func (s *serviceAnnotations) HasLROs() bool {
+	return len(s.LROTypes) > 0
 }
 
 func (a *serviceAnnotations) FeatureName() string {
@@ -457,11 +463,18 @@ func (c *codec) annotateService(s *api.Service, model *api.API) {
 	methods := language.FilterSlice(s.Methods, func(m *api.Method) bool {
 		return c.generateMethod(m)
 	})
-	hasLROs := false
+	seenLROTypes := make(map[string]bool)
+	var lroTypes []*api.Message
 	for _, m := range methods {
 		if m.OperationInfo != nil {
-			hasLROs = true
-			break
+			if _, ok := seenLROTypes[m.OperationInfo.MetadataTypeID]; !ok {
+				seenLROTypes[m.OperationInfo.MetadataTypeID] = true
+				lroTypes = append(lroTypes, model.State.MessageByID[m.OperationInfo.MetadataTypeID])
+			}
+			if _, ok := seenLROTypes[m.OperationInfo.ResponseTypeID]; !ok {
+				seenLROTypes[m.OperationInfo.ResponseTypeID] = true
+				lroTypes = append(lroTypes, model.State.MessageByID[m.OperationInfo.ResponseTypeID])
+			}
 		}
 	}
 	moduleName := toSnake(s.Name)
@@ -473,7 +486,7 @@ func (c *codec) annotateService(s *api.Service, model *api.API) {
 			s.Documentation, s.ID, model.State, []string{s.ID, s.Package}),
 		Methods:            methods,
 		DefaultHost:        s.DefaultHost,
-		HasLROs:            hasLROs,
+		LROTypes:           lroTypes,
 		APITitle:           model.Title,
 		PerServiceFeatures: c.perServiceFeatures,
 		HasVeneer:          c.hasVeneer,


### PR DESCRIPTION
Part of the work for #2037 

Capture the LRO types used by a service. We can include metadata and response types together, as we `match` on the typeid. (It is a lookup either way).

A follow up PR will have the generator own this chunk of code, which is just iterating over the `LROTypes`:

https://github.com/googleapis/google-cloud-rust/blob/ae91098c611434626e9809a1cab470ab81b870a0/src/storage-control/src/convert.rs#L115-L149