### PR TITLE
impl(generator/rust): support for LRO over gRPC

### DIFF
--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -154,3 +154,51 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
 }
 
 {{/Codec.Services}}
+{{#Codec.HasLROs}}
+use gaxi::prost::{ConvertError, FromProto, ToProto};
+/// Convert from our `wkt::Any` to a `prost_types::Any`
+///
+/// The encoded types considered for conversion are either metadata or result
+/// types for LROs in this service.
+pub(crate) fn lro_any_to_prost(
+    value: wkt::Any,
+) -> std::result::Result<prost_types::Any, ConvertError> {
+    match value.type_url().unwrap_or_default() {
+        "" => Ok(prost_types::Any::default()),
+{{#Codec.Services}}
+{{#Codec.LROTypes}}
+        "type.googleapis.com/{{Codec.SourceFQN}}" => value
+            .to_msg::<{{Codec.QualifiedName}}>()
+            .map_err(ConvertError::other)?
+            .to_proto()
+            .and_then(|prost_msg| {
+                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
+            }),
+{{/Codec.LROTypes}}
+{{/Codec.Services}}
+        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
+    }
+}
+
+/// Convert from a `prost_types::Any` to our `wkt::Any`
+///
+/// The encoded types considered for conversion are either metadata or result
+/// types for LROs in this service.
+pub(crate) fn lro_any_from_prost(
+    value: prost_types::Any,
+) -> std::result::Result<wkt::Any, ConvertError> {
+    match value.type_url.as_str() {
+        "" => Ok(wkt::Any::default()),
+{{#Codec.Services}}
+{{#Codec.LROTypes}}
+        "type.googleapis.com/{{Codec.SourceFQN}}" => value
+            .to_msg::<crate::{{Codec.PackageModuleName}}::{{Codec.Name}}>()
+            .map_err(ConvertError::other)?
+            .cnv()
+            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
+{{/Codec.LROTypes}}
+{{/Codec.Services}}
+        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
+    }
+}
+{{/Codec.HasLROs}}

--- a/src/storage-control/src/convert.rs
+++ b/src/storage-control/src/convert.rs
@@ -27,8 +27,10 @@
 
 use crate::google;
 use gaxi::prost::{ConvertError, FromProto, ToProto};
-// This would fail if storage admin introduces LROs. We are ok with it, because
-// we know the service will not grow.
+// This would fail if storage admin introduces LROs. This is unlikely as 
+// one of the motivations for `StorageControl` was to separate the LROs.
+// Worst case, we can skip the offending functions until we have fixed
+// this code to support them.
 use crate::generated::gapic_control::transport::{lro_any_from_prost, lro_any_to_prost};
 
 impl ToProto<google::rpc::Status> for rpc::model::Status {

--- a/src/storage-control/src/convert.rs
+++ b/src/storage-control/src/convert.rs
@@ -27,7 +27,7 @@
 
 use crate::google;
 use gaxi::prost::{ConvertError, FromProto, ToProto};
-// This would fail if storage admin introduces LROs. This is unlikely as 
+// This would fail if storage admin introduces LROs. This is unlikely as
 // one of the motivations for `StorageControl` was to separate the LROs.
 // Worst case, we can skip the offending functions until we have fixed
 // this code to support them.

--- a/src/storage-control/src/convert.rs
+++ b/src/storage-control/src/convert.rs
@@ -27,6 +27,9 @@
 
 use crate::google;
 use gaxi::prost::{ConvertError, FromProto, ToProto};
+// This would fail if storage admin introduces LROs. We are ok with it, because
+// we know the service will not grow.
+use crate::generated::gapic_control::transport::{lro_any_from_prost, lro_any_to_prost};
 
 impl ToProto<google::rpc::Status> for rpc::model::Status {
     type Output = google::rpc::Status;
@@ -99,94 +102,6 @@ impl FromProto<longrunning::model::Operation> for google::longrunning::Operation
             .set_or_clear_metadata(metadata)
             .set_done(self.done)
             .set_result(result))
-    }
-}
-
-// TODO(#2037) - The generator should control this code.
-/// Convert from our `wkt::Any` to a `prost_types::Any`
-///
-/// The encoded types considered for conversion are either metadata or result
-/// types for LROs in this service.
-fn lro_any_to_prost(
-    value: wkt::Any,
-) -> std::result::Result<prost_types::Any, gaxi::prost::ConvertError> {
-    match value.type_url().unwrap_or_default() {
-        "" => Ok(prost_types::Any::default()),
-        "type.googleapis.com/google.storage.control.v2.RenameFolderMetadata" => value
-            .to_msg::<crate::model::RenameFolderMetadata>()
-            .map_err(ConvertError::other)?
-            .to_proto()
-            .and_then(|prost_msg| {
-                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
-            }),
-        "type.googleapis.com/google.storage.control.v2.CreateAnywhereCacheMetadata" => value
-            .to_msg::<crate::model::CreateAnywhereCacheMetadata>()
-            .map_err(ConvertError::other)?
-            .to_proto()
-            .and_then(|prost_msg| {
-                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
-            }),
-        "type.googleapis.com/google.storage.control.v2.UpdateAnywhereCacheMetadata" => value
-            .to_msg::<crate::model::UpdateAnywhereCacheMetadata>()
-            .map_err(ConvertError::other)?
-            .to_proto()
-            .and_then(|prost_msg| {
-                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
-            }),
-        "type.googleapis.com/google.storage.control.v2.Folder" => value
-            .to_msg::<crate::model::Folder>()
-            .map_err(ConvertError::other)?
-            .to_proto()
-            .and_then(|prost_msg| {
-                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
-            }),
-        "type.googleapis.com/google.storage.control.v2.AnywhereCache" => value
-            .to_msg::<crate::model::AnywhereCache>()
-            .map_err(ConvertError::other)?
-            .to_proto()
-            .and_then(|prost_msg| {
-                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
-            }),
-        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
-    }
-}
-
-// TODO(#2037) - The generator should control this code.
-/// Convert from a `prost_types::Any` to our `wkt::Any`
-///
-/// The encoded types considered for conversion are either metadata or result
-/// types for LROs in this service.
-pub(crate) fn lro_any_from_prost(
-    value: prost_types::Any,
-) -> std::result::Result<wkt::Any, gaxi::prost::ConvertError> {
-    match value.type_url.as_str() {
-        "" => Ok(wkt::Any::default()),
-        "type.googleapis.com/google.storage.control.v2.RenameFolderMetadata" => value
-            .to_msg::<google::storage::control::v2::RenameFolderMetadata>()
-            .map_err(ConvertError::other)?
-            .cnv()
-            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
-        "type.googleapis.com/google.storage.control.v2.CreateAnywhereCacheMetadata" => value
-            .to_msg::<google::storage::control::v2::CreateAnywhereCacheMetadata>()
-            .map_err(ConvertError::other)?
-            .cnv()
-            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
-        "type.googleapis.com/google.storage.control.v2.UpdateAnywhereCacheMetadata" => value
-            .to_msg::<google::storage::control::v2::UpdateAnywhereCacheMetadata>()
-            .map_err(ConvertError::other)?
-            .cnv()
-            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
-        "type.googleapis.com/google.storage.control.v2.Folder" => value
-            .to_msg::<google::storage::control::v2::Folder>()
-            .map_err(ConvertError::other)?
-            .cnv()
-            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
-        "type.googleapis.com/google.storage.control.v2.AnywhereCache" => value
-            .to_msg::<google::storage::control::v2::AnywhereCache>()
-            .map_err(ConvertError::other)?
-            .cnv()
-            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
-        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
     }
 }
 

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -914,3 +914,90 @@ impl super::stub::StorageControl for StorageControl {
             .and_then(gaxi::grpc::to_gax_response::<TR, longrunning::model::Operation>)
     }
 }
+
+use gaxi::prost::{ConvertError, FromProto, ToProto};
+/// Convert from our `wkt::Any` to a `prost_types::Any`
+///
+/// The encoded types considered for conversion are either metadata or result
+/// types for LROs in this service.
+pub(crate) fn lro_any_to_prost(
+    value: wkt::Any,
+) -> std::result::Result<prost_types::Any, ConvertError> {
+    match value.type_url().unwrap_or_default() {
+        "" => Ok(prost_types::Any::default()),
+        "type.googleapis.com/google.storage.control.v2.RenameFolderMetadata" => value
+            .to_msg::<crate::model::RenameFolderMetadata>()
+            .map_err(ConvertError::other)?
+            .to_proto()
+            .and_then(|prost_msg| {
+                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
+            }),
+        "type.googleapis.com/google.storage.control.v2.Folder" => value
+            .to_msg::<crate::model::Folder>()
+            .map_err(ConvertError::other)?
+            .to_proto()
+            .and_then(|prost_msg| {
+                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
+            }),
+        "type.googleapis.com/google.storage.control.v2.CreateAnywhereCacheMetadata" => value
+            .to_msg::<crate::model::CreateAnywhereCacheMetadata>()
+            .map_err(ConvertError::other)?
+            .to_proto()
+            .and_then(|prost_msg| {
+                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
+            }),
+        "type.googleapis.com/google.storage.control.v2.AnywhereCache" => value
+            .to_msg::<crate::model::AnywhereCache>()
+            .map_err(ConvertError::other)?
+            .to_proto()
+            .and_then(|prost_msg| {
+                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
+            }),
+        "type.googleapis.com/google.storage.control.v2.UpdateAnywhereCacheMetadata" => value
+            .to_msg::<crate::model::UpdateAnywhereCacheMetadata>()
+            .map_err(ConvertError::other)?
+            .to_proto()
+            .and_then(|prost_msg| {
+                prost_types::Any::from_msg(&prost_msg).map_err(ConvertError::other)
+            }),
+        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
+    }
+}
+
+/// Convert from a `prost_types::Any` to our `wkt::Any`
+///
+/// The encoded types considered for conversion are either metadata or result
+/// types for LROs in this service.
+pub(crate) fn lro_any_from_prost(
+    value: prost_types::Any,
+) -> std::result::Result<wkt::Any, ConvertError> {
+    match value.type_url.as_str() {
+        "" => Ok(wkt::Any::default()),
+        "type.googleapis.com/google.storage.control.v2.RenameFolderMetadata" => value
+            .to_msg::<crate::google::storage::control::v2::RenameFolderMetadata>()
+            .map_err(ConvertError::other)?
+            .cnv()
+            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
+        "type.googleapis.com/google.storage.control.v2.Folder" => value
+            .to_msg::<crate::google::storage::control::v2::Folder>()
+            .map_err(ConvertError::other)?
+            .cnv()
+            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
+        "type.googleapis.com/google.storage.control.v2.CreateAnywhereCacheMetadata" => value
+            .to_msg::<crate::google::storage::control::v2::CreateAnywhereCacheMetadata>()
+            .map_err(ConvertError::other)?
+            .cnv()
+            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
+        "type.googleapis.com/google.storage.control.v2.AnywhereCache" => value
+            .to_msg::<crate::google::storage::control::v2::AnywhereCache>()
+            .map_err(ConvertError::other)?
+            .cnv()
+            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
+        "type.googleapis.com/google.storage.control.v2.UpdateAnywhereCacheMetadata" => value
+            .to_msg::<crate::google::storage::control::v2::UpdateAnywhereCacheMetadata>()
+            .map_err(ConvertError::other)?
+            .cnv()
+            .and_then(|our_msg| wkt::Any::from_msg(&our_msg).map_err(ConvertError::other)),
+        type_url => Err(ConvertError::UnexpectedTypeUrl(type_url.to_string())),
+    }
+}


### PR DESCRIPTION
Most of the remaining work for #2037.

Support LRO conversion in the generator. This will stay up to date if new LROs are added to the storage control service.

Reminder that we have unit tests in `convert.rs` and an integration test for the rename folder LRO.

I haven't decided if I want to move the `ToProto` / `FromProto` impls into transport. We definitely could.

Note that the mustache template for each `LROType` could be used for each `ErrorInfo` in a `rpc::Status`.