### PR TITLE
cleanup(gax)!: use `HeaderMap` for headers

### DIFF
--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -209,21 +209,24 @@ impl ReqwestClient {
 #[derive(serde::Serialize)]
 pub struct NoBody;
 
-const SENSITIVE_HEADER: &str = "[sensitive]";
-
 pub async fn to_http_error<O>(response: reqwest::Response) -> Result<O> {
     let status_code = response.status().as_u16();
-    let headers = self::convert_headers(response.headers());
-    let body = response.bytes().await.map_err(Error::io)?;
-    let error = if let Ok(status) = gax::error::rpc::Status::try_from(&body) {
-        Error::rpc(
+    let response = http::Response::from(response);
+    let (parts, body) = response.into_parts();
+
+    let body = http_body_util::BodyExt::collect(body)
+        .await
+        .map_err(Error::io)?
+        .to_bytes();
+
+    let error = match gax::error::rpc::Status::try_from(&body) {
+        Ok(status) => Error::rpc(
             ServiceErrorBuilder::new(status)
-                .with_headers(headers)
+                .with_headers(parts.headers)
                 .with_http_status_code(status_code)
                 .build(),
-        )
-    } else {
-        Error::rpc(HttpError::new(status_code, headers, Some(body)))
+        ),
+        Err(_) => Error::rpc(HttpError::new(status_code, parts.headers, Some(body))),
     };
     Err(error)
 }
@@ -251,81 +254,12 @@ async fn to_http_response<O: serde::de::DeserializeOwned + Default>(
     ))
 }
 
-fn convert_headers(
-    header_map: &reqwest::header::HeaderMap,
-) -> std::collections::HashMap<String, String> {
-    let mut headers = std::collections::HashMap::new();
-    for (key, value) in header_map {
-        if value.is_sensitive() {
-            headers.insert(key.to_string(), SENSITIVE_HEADER.to_string());
-        } else if let Ok(value) = value.to_str() {
-            headers.insert(key.to_string(), value.to_string());
-        }
-    }
-    headers
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
+    use http::{HeaderMap, HeaderValue};
     use test_case::test_case;
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
-
-    #[test]
-    fn headers_empty() -> TestResult {
-        let http_resp = http::Response::builder()
-            .status(reqwest::StatusCode::OK)
-            .body("")?;
-        let response: reqwest::Response = http_resp.into();
-        let got = super::convert_headers(response.headers());
-        assert!(got.is_empty(), "{got:?}");
-        Ok(())
-    }
-
-    #[test]
-    fn headers_basic() -> TestResult {
-        let http_resp = http::Response::builder()
-            .header("content-type", "application/json")
-            .header("x-test-k1", "v1")
-            .status(reqwest::StatusCode::OK)
-            .body("")?;
-        let response: reqwest::Response = http_resp.into();
-        let got = super::convert_headers(response.headers());
-        let want = HashMap::from(
-            [("content-type", "application/json"), ("x-test-k1", "v1")]
-                .map(|(k, v)| (k.to_string(), v.to_string())),
-        );
-        assert_eq!(got, want);
-        Ok(())
-    }
-
-    #[test]
-    fn headers_sensitive() -> TestResult {
-        let sensitive = {
-            let mut h = reqwest::header::HeaderValue::from_static("abc123");
-            h.set_sensitive(true);
-            h
-        };
-        let http_resp = http::Response::builder()
-            .header("content-type", "application/json")
-            .header("x-test-k1", "v1")
-            .header("x-sensitive", sensitive)
-            .status(reqwest::StatusCode::OK)
-            .body("")?;
-        let response: reqwest::Response = http_resp.into();
-        let got = super::convert_headers(response.headers());
-        let want = HashMap::from(
-            [
-                ("content-type", "application/json"),
-                ("x-test-k1", "v1"),
-                ("x-sensitive", SENSITIVE_HEADER),
-            ]
-            .map(|(k, v)| (k.to_string(), v.to_string())),
-        );
-        assert_eq!(got, want);
-        Ok(())
-    }
 
     #[tokio::test]
     async fn client_http_error_bytes() -> TestResult {
@@ -340,9 +274,8 @@ mod test {
         let err = response.err().unwrap();
         let err = err.as_inner::<HttpError>().unwrap();
         assert_eq!(err.status_code(), 400);
-        let want = HashMap::from(
-            [("content-type", "application/json")].map(|(k, v)| (k.to_string(), v.to_string())),
-        );
+        let mut want = HeaderMap::new();
+        want.insert("content-type", HeaderValue::from_static("application/json"));
         assert_eq!(err.headers(), &want);
         assert_eq!(
             err.payload(),
@@ -385,9 +318,8 @@ mod test {
             )]);
         assert_eq!(err.status(), &want_status);
         assert_eq!(err.http_status_code(), &Some(404_u16));
-        let want = HashMap::from(
-            [("content-type", "application/json")].map(|(k, v)| (k.to_string(), v.to_string())),
-        );
+        let mut want = HeaderMap::new();
+        want.insert("content-type", HeaderValue::from_static("application/json"));
         assert_eq!(err.headers(), &Some(want));
         Ok(())
     }

--- a/src/gax/src/error/core_error.rs
+++ b/src/gax/src/error/core_error.rs
@@ -69,8 +69,8 @@ impl Error {
     /// ```
     /// # use google_cloud_gax::error::Error;
     /// # use google_cloud_gax::error::HttpError;
-    /// # use std::collections::HashMap;
-    /// let error = Error::rpc(HttpError::new(404, HashMap::new(), None));
+    /// use http::HeaderMap;
+    /// let error = Error::rpc(HttpError::new(404, HeaderMap::new(), None));
     /// if let Some(e) = error.as_inner::<HttpError>() {
     ///     assert_eq!(e.status_code(), 404);
     /// }

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -166,7 +166,7 @@ impl Display for CredentialsError {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::collections::HashMap;
+    use http::HeaderMap;
     use test_case::test_case;
 
     #[test_case(true)]
@@ -174,7 +174,7 @@ mod test {
     fn new(retryable: bool) {
         let source = crate::error::HttpError::new(
             404,
-            HashMap::new(),
+            HeaderMap::new(),
             Some(bytes::Bytes::from_static("test-only".as_bytes())),
         );
         let got = CredentialsError::new(retryable, source);

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -524,6 +524,7 @@ impl std::error::Error for Exhausted {}
 mod tests {
     use super::*;
     use crate::error::{Error, ServiceError};
+    use http::HeaderMap;
     use std::time::{Duration, Instant};
 
     mockall::mock! {
@@ -639,14 +640,13 @@ mod tests {
     }
 
     fn http_error(code: u16, message: &str) -> Error {
-        use std::collections::HashMap;
         let error = serde_json::json!({"error": {
             "code": code,
             "message": message,
         }});
         let payload = serde_json::to_string(&error).ok();
         let payload = payload.map(bytes::Bytes::from_owner);
-        let http = crate::error::HttpError::new(code, HashMap::new(), payload);
+        let http = crate::error::HttpError::new(code, HeaderMap::new(), payload);
         Error::rpc(http)
     }
 

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -580,6 +580,7 @@ where
 mod tests {
     use super::*;
     use crate::error::ServiceError;
+    use http::HeaderMap;
 
     // Verify `RetryPolicyArg` can be converted from the desired types.
     #[test]
@@ -723,19 +724,17 @@ mod tests {
     }
 
     fn http_unavailable() -> Error {
-        use std::collections::HashMap;
         Error::rpc(crate::error::HttpError::new(
             503_u16,
-            HashMap::new(),
+            HeaderMap::new(),
             bytes::Bytes::from_owner("SERVICE UNAVAILABLE".to_string()).into(),
         ))
     }
 
     fn http_permission_denied() -> Error {
-        use std::collections::HashMap;
         Error::rpc(crate::error::HttpError::new(
             403_u16,
-            HashMap::new(),
+            HeaderMap::new(),
             bytes::Bytes::from_owner("PERMISSION DENIED".to_string()).into(),
         ))
     }


### PR DESCRIPTION
Fixes #2223
