### PR TITLE
refactor: absolute builder links

### DIFF
--- a/generator/internal/rust/templates/crate/src/builder.rs.mustache
+++ b/generator/internal/rust/templates/crate/src/builder.rs.mustache
@@ -27,7 +27,7 @@ pub mod {{Codec.ModuleName}} {
     use crate::Result;
     {{^Codec.HasVeneer}}
 
-    /// A builder for [{{Codec.Name}}][super::super::client::{{Codec.Name}}].
+    /// A builder for [{{Codec.Name}}][crate::client::{{Codec.Name}}].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -56,7 +56,7 @@ pub mod {{Codec.ModuleName}} {
     }
     {{/Codec.HasVeneer}}
 
-    /// Common implementation for [super::super::client::{{Codec.Name}}] request builders.
+    /// Common implementation for [crate::client::{{Codec.Name}}] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::{{Codec.Name}}>,
@@ -78,7 +78,7 @@ pub mod {{Codec.ModuleName}} {
     {{#Codec.Methods}}
     {{! TODO(#1813) - fix and generate builder docs for veneers }}
     {{^Codec.HasVeneer}}
-    /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.Name}}][super::super::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}] calls.
+    /// The request builder for [{{Codec.ServiceNameToPascal}}::{{Codec.Name}}][crate::client::{{Codec.ServiceNameToPascal}}::{{Codec.Name}}] calls.
     ///
     /// # Example
     /// ```no_run
@@ -145,7 +145,7 @@ pub mod {{Codec.ModuleName}} {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [{{Method.Codec.Name}}][super::super::client::{{Method.Codec.ServiceNameToPascal}}::{{Method.Codec.Name}}].
+        /// on [{{Method.Codec.Name}}][crate::client::{{Method.Codec.ServiceNameToPascal}}::{{Method.Codec.Name}}].
         {{/OperationInfo}}
         {{/Codec.HasVeneer}}
         pub async fn send(self) -> Result<{{Codec.ReturnType}}> {

--- a/src/firestore/src/generated/gapic/builder.rs
+++ b/src/firestore/src/generated/gapic/builder.rs
@@ -17,7 +17,7 @@
 pub mod firestore {
     use crate::Result;
 
-    /// A builder for [Firestore][super::super::client::Firestore].
+    /// A builder for [Firestore][crate::client::Firestore].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod firestore {
         }
     }
 
-    /// Common implementation for [super::super::client::Firestore] request builders.
+    /// Common implementation for [crate::client::Firestore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Firestore>,
@@ -68,7 +68,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::get_document][super::super::client::Firestore::get_document] calls.
+    /// The request builder for [Firestore::get_document][crate::client::Firestore::get_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::list_documents][super::super::client::Firestore::list_documents] calls.
+    /// The request builder for [Firestore::list_documents][crate::client::Firestore::list_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -362,7 +362,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::update_document][super::super::client::Firestore::update_document] calls.
+    /// The request builder for [Firestore::update_document][crate::client::Firestore::update_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -493,7 +493,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::delete_document][super::super::client::Firestore::delete_document] calls.
+    /// The request builder for [Firestore::delete_document][crate::client::Firestore::delete_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -574,7 +574,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::begin_transaction][super::super::client::Firestore::begin_transaction] calls.
+    /// The request builder for [Firestore::begin_transaction][crate::client::Firestore::begin_transaction] calls.
     ///
     /// # Example
     /// ```no_run
@@ -658,7 +658,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::commit][super::super::client::Firestore::commit] calls.
+    /// The request builder for [Firestore::commit][crate::client::Firestore::commit] calls.
     ///
     /// # Example
     /// ```no_run
@@ -738,7 +738,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::rollback][super::super::client::Firestore::rollback] calls.
+    /// The request builder for [Firestore::rollback][crate::client::Firestore::rollback] calls.
     ///
     /// # Example
     /// ```no_run
@@ -809,7 +809,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::partition_query][super::super::client::Firestore::partition_query] calls.
+    /// The request builder for [Firestore::partition_query][crate::client::Firestore::partition_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -972,7 +972,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::list_collection_ids][super::super::client::Firestore::list_collection_ids] calls.
+    /// The request builder for [Firestore::list_collection_ids][crate::client::Firestore::list_collection_ids] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1077,7 +1077,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::batch_write][super::super::client::Firestore::batch_write] calls.
+    /// The request builder for [Firestore::batch_write][crate::client::Firestore::batch_write] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1162,7 +1162,7 @@ pub mod firestore {
         }
     }
 
-    /// The request builder for [Firestore::create_document][super::super::client::Firestore::create_document] calls.
+    /// The request builder for [Firestore::create_document][crate::client::Firestore::create_document] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/api/apikeys/v2/src/builder.rs
+++ b/src/generated/api/apikeys/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod api_keys {
     use crate::Result;
 
-    /// A builder for [ApiKeys][super::super::client::ApiKeys].
+    /// A builder for [ApiKeys][crate::client::ApiKeys].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod api_keys {
         }
     }
 
-    /// Common implementation for [super::super::client::ApiKeys] request builders.
+    /// Common implementation for [crate::client::ApiKeys] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ApiKeys>,
@@ -66,7 +66,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::create_key][super::super::client::ApiKeys::create_key] calls.
+    /// The request builder for [ApiKeys::create_key][crate::client::ApiKeys::create_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -109,7 +109,7 @@ pub mod api_keys {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_key][super::super::client::ApiKeys::create_key].
+        /// on [create_key][crate::client::ApiKeys::create_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_key(self.0.request, self.0.options)
@@ -196,7 +196,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::list_keys][super::super::client::ApiKeys::list_keys] calls.
+    /// The request builder for [ApiKeys::list_keys][crate::client::ApiKeys::list_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -303,7 +303,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::get_key][super::super::client::ApiKeys::get_key] calls.
+    /// The request builder for [ApiKeys::get_key][crate::client::ApiKeys::get_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -364,7 +364,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::get_key_string][super::super::client::ApiKeys::get_key_string] calls.
+    /// The request builder for [ApiKeys::get_key_string][crate::client::ApiKeys::get_key_string] calls.
     ///
     /// # Example
     /// ```no_run
@@ -425,7 +425,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::update_key][super::super::client::ApiKeys::update_key] calls.
+    /// The request builder for [ApiKeys::update_key][crate::client::ApiKeys::update_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -468,7 +468,7 @@ pub mod api_keys {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_key][super::super::client::ApiKeys::update_key].
+        /// on [update_key][crate::client::ApiKeys::update_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_key(self.0.request, self.0.options)
@@ -559,7 +559,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::delete_key][super::super::client::ApiKeys::delete_key] calls.
+    /// The request builder for [ApiKeys::delete_key][crate::client::ApiKeys::delete_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -602,7 +602,7 @@ pub mod api_keys {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_key][super::super::client::ApiKeys::delete_key].
+        /// on [delete_key][crate::client::ApiKeys::delete_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_key(self.0.request, self.0.options)
@@ -667,7 +667,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::undelete_key][super::super::client::ApiKeys::undelete_key] calls.
+    /// The request builder for [ApiKeys::undelete_key][crate::client::ApiKeys::undelete_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -710,7 +710,7 @@ pub mod api_keys {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_key][super::super::client::ApiKeys::undelete_key].
+        /// on [undelete_key][crate::client::ApiKeys::undelete_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_key(self.0.request, self.0.options)
@@ -769,7 +769,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::lookup_key][super::super::client::ApiKeys::lookup_key] calls.
+    /// The request builder for [ApiKeys::lookup_key][crate::client::ApiKeys::lookup_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -830,7 +830,7 @@ pub mod api_keys {
         }
     }
 
-    /// The request builder for [ApiKeys::get_operation][super::super::client::ApiKeys::get_operation] calls.
+    /// The request builder for [ApiKeys::get_operation][crate::client::ApiKeys::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/api/servicecontrol/v1/src/builder.rs
+++ b/src/generated/api/servicecontrol/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod quota_controller {
     use crate::Result;
 
-    /// A builder for [QuotaController][super::super::client::QuotaController].
+    /// A builder for [QuotaController][crate::client::QuotaController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod quota_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::QuotaController] request builders.
+    /// Common implementation for [crate::client::QuotaController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::QuotaController>,
@@ -68,7 +68,7 @@ pub mod quota_controller {
         }
     }
 
-    /// The request builder for [QuotaController::allocate_quota][super::super::client::QuotaController::allocate_quota] calls.
+    /// The request builder for [QuotaController::allocate_quota][crate::client::QuotaController::allocate_quota] calls.
     ///
     /// # Example
     /// ```no_run
@@ -157,7 +157,7 @@ pub mod quota_controller {
 pub mod service_controller {
     use crate::Result;
 
-    /// A builder for [ServiceController][super::super::client::ServiceController].
+    /// A builder for [ServiceController][crate::client::ServiceController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -185,7 +185,7 @@ pub mod service_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::ServiceController] request builders.
+    /// Common implementation for [crate::client::ServiceController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServiceController>,
@@ -208,7 +208,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for [ServiceController::check][super::super::client::ServiceController::check] calls.
+    /// The request builder for [ServiceController::check][crate::client::ServiceController::check] calls.
     ///
     /// # Example
     /// ```no_run
@@ -293,7 +293,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for [ServiceController::report][super::super::client::ServiceController::report] calls.
+    /// The request builder for [ServiceController::report][crate::client::ServiceController::report] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/api/servicecontrol/v2/src/builder.rs
+++ b/src/generated/api/servicecontrol/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod service_controller {
     use crate::Result;
 
-    /// A builder for [ServiceController][super::super::client::ServiceController].
+    /// A builder for [ServiceController][crate::client::ServiceController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod service_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::ServiceController] request builders.
+    /// Common implementation for [crate::client::ServiceController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServiceController>,
@@ -68,7 +68,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for [ServiceController::check][super::super::client::ServiceController::check] calls.
+    /// The request builder for [ServiceController::check][crate::client::ServiceController::check] calls.
     ///
     /// # Example
     /// ```no_run
@@ -170,7 +170,7 @@ pub mod service_controller {
         }
     }
 
-    /// The request builder for [ServiceController::report][super::super::client::ServiceController::report] calls.
+    /// The request builder for [ServiceController::report][crate::client::ServiceController::report] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/api/servicemanagement/v1/src/builder.rs
+++ b/src/generated/api/servicemanagement/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod service_manager {
     use crate::Result;
 
-    /// A builder for [ServiceManager][super::super::client::ServiceManager].
+    /// A builder for [ServiceManager][crate::client::ServiceManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod service_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::ServiceManager] request builders.
+    /// Common implementation for [crate::client::ServiceManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServiceManager>,
@@ -68,7 +68,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::list_services][super::super::client::ServiceManager::list_services] calls.
+    /// The request builder for [ServiceManager::list_services][crate::client::ServiceManager::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -176,7 +176,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::get_service][super::super::client::ServiceManager::get_service] calls.
+    /// The request builder for [ServiceManager::get_service][crate::client::ServiceManager::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -239,7 +239,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::create_service][super::super::client::ServiceManager::create_service] calls.
+    /// The request builder for [ServiceManager::create_service][crate::client::ServiceManager::create_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -284,7 +284,7 @@ pub mod service_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service][super::super::client::ServiceManager::create_service].
+        /// on [create_service][crate::client::ServiceManager::create_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service(self.0.request, self.0.options)
@@ -358,7 +358,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::delete_service][super::super::client::ServiceManager::delete_service] calls.
+    /// The request builder for [ServiceManager::delete_service][crate::client::ServiceManager::delete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -403,7 +403,7 @@ pub mod service_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service][super::super::client::ServiceManager::delete_service].
+        /// on [delete_service][crate::client::ServiceManager::delete_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service(self.0.request, self.0.options)
@@ -462,7 +462,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::undelete_service][super::super::client::ServiceManager::undelete_service] calls.
+    /// The request builder for [ServiceManager::undelete_service][crate::client::ServiceManager::undelete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -507,7 +507,7 @@ pub mod service_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_service][super::super::client::ServiceManager::undelete_service].
+        /// on [undelete_service][crate::client::ServiceManager::undelete_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_service(self.0.request, self.0.options)
@@ -567,7 +567,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::list_service_configs][super::super::client::ServiceManager::list_service_configs] calls.
+    /// The request builder for [ServiceManager::list_service_configs][crate::client::ServiceManager::list_service_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -675,7 +675,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::get_service_config][super::super::client::ServiceManager::get_service_config] calls.
+    /// The request builder for [ServiceManager::get_service_config][crate::client::ServiceManager::get_service_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -758,7 +758,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::create_service_config][super::super::client::ServiceManager::create_service_config] calls.
+    /// The request builder for [ServiceManager::create_service_config][crate::client::ServiceManager::create_service_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -846,7 +846,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::submit_config_source][super::super::client::ServiceManager::submit_config_source] calls.
+    /// The request builder for [ServiceManager::submit_config_source][crate::client::ServiceManager::submit_config_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -894,7 +894,7 @@ pub mod service_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [submit_config_source][super::super::client::ServiceManager::submit_config_source].
+        /// on [submit_config_source][crate::client::ServiceManager::submit_config_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .submit_config_source(self.0.request, self.0.options)
@@ -982,7 +982,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::list_service_rollouts][super::super::client::ServiceManager::list_service_rollouts] calls.
+    /// The request builder for [ServiceManager::list_service_rollouts][crate::client::ServiceManager::list_service_rollouts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1098,7 +1098,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::get_service_rollout][super::super::client::ServiceManager::get_service_rollout] calls.
+    /// The request builder for [ServiceManager::get_service_rollout][crate::client::ServiceManager::get_service_rollout] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1172,7 +1172,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::create_service_rollout][super::super::client::ServiceManager::create_service_rollout] calls.
+    /// The request builder for [ServiceManager::create_service_rollout][crate::client::ServiceManager::create_service_rollout] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1220,7 +1220,7 @@ pub mod service_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service_rollout][super::super::client::ServiceManager::create_service_rollout].
+        /// on [create_service_rollout][crate::client::ServiceManager::create_service_rollout].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service_rollout(self.0.request, self.0.options)
@@ -1299,7 +1299,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::generate_config_report][super::super::client::ServiceManager::generate_config_report] calls.
+    /// The request builder for [ServiceManager::generate_config_report][crate::client::ServiceManager::generate_config_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1397,7 +1397,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::set_iam_policy][super::super::client::ServiceManager::set_iam_policy] calls.
+    /// The request builder for [ServiceManager::set_iam_policy][crate::client::ServiceManager::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1500,7 +1500,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::get_iam_policy][super::super::client::ServiceManager::get_iam_policy] calls.
+    /// The request builder for [ServiceManager::get_iam_policy][crate::client::ServiceManager::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1581,7 +1581,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::test_iam_permissions][super::super::client::ServiceManager::test_iam_permissions] calls.
+    /// The request builder for [ServiceManager::test_iam_permissions][crate::client::ServiceManager::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1660,7 +1660,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::list_operations][super::super::client::ServiceManager::list_operations] calls.
+    /// The request builder for [ServiceManager::list_operations][crate::client::ServiceManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1772,7 +1772,7 @@ pub mod service_manager {
         }
     }
 
-    /// The request builder for [ServiceManager::get_operation][super::super::client::ServiceManager::get_operation] calls.
+    /// The request builder for [ServiceManager::get_operation][crate::client::ServiceManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/api/serviceusage/v1/src/builder.rs
+++ b/src/generated/api/serviceusage/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod service_usage {
     use crate::Result;
 
-    /// A builder for [ServiceUsage][super::super::client::ServiceUsage].
+    /// A builder for [ServiceUsage][crate::client::ServiceUsage].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod service_usage {
         }
     }
 
-    /// Common implementation for [super::super::client::ServiceUsage] request builders.
+    /// Common implementation for [crate::client::ServiceUsage] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServiceUsage>,
@@ -68,7 +68,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::enable_service][super::super::client::ServiceUsage::enable_service] calls.
+    /// The request builder for [ServiceUsage::enable_service][crate::client::ServiceUsage::enable_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod service_usage {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [enable_service][super::super::client::ServiceUsage::enable_service].
+        /// on [enable_service][crate::client::ServiceUsage::enable_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .enable_service(self.0.request, self.0.options)
@@ -171,7 +171,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::disable_service][super::super::client::ServiceUsage::disable_service] calls.
+    /// The request builder for [ServiceUsage::disable_service][crate::client::ServiceUsage::disable_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -216,7 +216,7 @@ pub mod service_usage {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [disable_service][super::super::client::ServiceUsage::disable_service].
+        /// on [disable_service][crate::client::ServiceUsage::disable_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .disable_service(self.0.request, self.0.options)
@@ -291,7 +291,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::get_service][super::super::client::ServiceUsage::get_service] calls.
+    /// The request builder for [ServiceUsage::get_service][crate::client::ServiceUsage::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -352,7 +352,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::list_services][super::super::client::ServiceUsage::list_services] calls.
+    /// The request builder for [ServiceUsage::list_services][crate::client::ServiceUsage::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -459,7 +459,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::batch_enable_services][super::super::client::ServiceUsage::batch_enable_services] calls.
+    /// The request builder for [ServiceUsage::batch_enable_services][crate::client::ServiceUsage::batch_enable_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -507,7 +507,7 @@ pub mod service_usage {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_enable_services][super::super::client::ServiceUsage::batch_enable_services].
+        /// on [batch_enable_services][crate::client::ServiceUsage::batch_enable_services].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_enable_services(self.0.request, self.0.options)
@@ -576,7 +576,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::batch_get_services][super::super::client::ServiceUsage::batch_get_services] calls.
+    /// The request builder for [ServiceUsage::batch_get_services][crate::client::ServiceUsage::batch_get_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -651,7 +651,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::list_operations][super::super::client::ServiceUsage::list_operations] calls.
+    /// The request builder for [ServiceUsage::list_operations][crate::client::ServiceUsage::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -763,7 +763,7 @@ pub mod service_usage {
         }
     }
 
-    /// The request builder for [ServiceUsage::get_operation][super::super::client::ServiceUsage::get_operation] calls.
+    /// The request builder for [ServiceUsage::get_operation][crate::client::ServiceUsage::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/appengine/v1/src/builder.rs
+++ b/src/generated/appengine/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod applications {
     use crate::Result;
 
-    /// A builder for [Applications][super::super::client::Applications].
+    /// A builder for [Applications][crate::client::Applications].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod applications {
         }
     }
 
-    /// Common implementation for [super::super::client::Applications] request builders.
+    /// Common implementation for [crate::client::Applications] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Applications>,
@@ -68,7 +68,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for [Applications::get_application][super::super::client::Applications::get_application] calls.
+    /// The request builder for [Applications::get_application][crate::client::Applications::get_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -129,7 +129,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for [Applications::create_application][super::super::client::Applications::create_application] calls.
+    /// The request builder for [Applications::create_application][crate::client::Applications::create_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -177,7 +177,7 @@ pub mod applications {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_application][super::super::client::Applications::create_application].
+        /// on [create_application][crate::client::Applications::create_application].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_application(self.0.request, self.0.options)
@@ -247,7 +247,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for [Applications::update_application][super::super::client::Applications::update_application] calls.
+    /// The request builder for [Applications::update_application][crate::client::Applications::update_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -295,7 +295,7 @@ pub mod applications {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_application][super::super::client::Applications::update_application].
+        /// on [update_application][crate::client::Applications::update_application].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_application(self.0.request, self.0.options)
@@ -389,7 +389,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for [Applications::repair_application][super::super::client::Applications::repair_application] calls.
+    /// The request builder for [Applications::repair_application][crate::client::Applications::repair_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -437,7 +437,7 @@ pub mod applications {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [repair_application][super::super::client::Applications::repair_application].
+        /// on [repair_application][crate::client::Applications::repair_application].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .repair_application(self.0.request, self.0.options)
@@ -495,7 +495,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for [Applications::list_operations][super::super::client::Applications::list_operations] calls.
+    /// The request builder for [Applications::list_operations][crate::client::Applications::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -607,7 +607,7 @@ pub mod applications {
         }
     }
 
-    /// The request builder for [Applications::get_operation][super::super::client::Applications::get_operation] calls.
+    /// The request builder for [Applications::get_operation][crate::client::Applications::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -675,7 +675,7 @@ pub mod applications {
 pub mod services {
     use crate::Result;
 
-    /// A builder for [Services][super::super::client::Services].
+    /// A builder for [Services][crate::client::Services].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -703,7 +703,7 @@ pub mod services {
         }
     }
 
-    /// Common implementation for [super::super::client::Services] request builders.
+    /// Common implementation for [crate::client::Services] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Services>,
@@ -724,7 +724,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::list_services][super::super::client::Services::list_services] calls.
+    /// The request builder for [Services::list_services][crate::client::Services::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -823,7 +823,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::get_service][super::super::client::Services::get_service] calls.
+    /// The request builder for [Services::get_service][crate::client::Services::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -882,7 +882,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::update_service][super::super::client::Services::update_service] calls.
+    /// The request builder for [Services::update_service][crate::client::Services::update_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -925,7 +925,7 @@ pub mod services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service][super::super::client::Services::update_service].
+        /// on [update_service][crate::client::Services::update_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service(self.0.request, self.0.options)
@@ -1022,7 +1022,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::delete_service][super::super::client::Services::delete_service] calls.
+    /// The request builder for [Services::delete_service][crate::client::Services::delete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1065,7 +1065,7 @@ pub mod services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service][super::super::client::Services::delete_service].
+        /// on [delete_service][crate::client::Services::delete_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service(self.0.request, self.0.options)
@@ -1123,7 +1123,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::list_operations][super::super::client::Services::list_operations] calls.
+    /// The request builder for [Services::list_operations][crate::client::Services::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1233,7 +1233,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::get_operation][super::super::client::Services::get_operation] calls.
+    /// The request builder for [Services::get_operation][crate::client::Services::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1299,7 +1299,7 @@ pub mod services {
 pub mod versions {
     use crate::Result;
 
-    /// A builder for [Versions][super::super::client::Versions].
+    /// A builder for [Versions][crate::client::Versions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1327,7 +1327,7 @@ pub mod versions {
         }
     }
 
-    /// Common implementation for [super::super::client::Versions] request builders.
+    /// Common implementation for [crate::client::Versions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Versions>,
@@ -1348,7 +1348,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
+    /// The request builder for [Versions::list_versions][crate::client::Versions::list_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1453,7 +1453,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
+    /// The request builder for [Versions::get_version][crate::client::Versions::get_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1518,7 +1518,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
+    /// The request builder for [Versions::create_version][crate::client::Versions::create_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1561,7 +1561,7 @@ pub mod versions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_version][super::super::client::Versions::create_version].
+        /// on [create_version][crate::client::Versions::create_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_version(self.0.request, self.0.options)
@@ -1637,7 +1637,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
+    /// The request builder for [Versions::update_version][crate::client::Versions::update_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1680,7 +1680,7 @@ pub mod versions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_version][super::super::client::Versions::update_version].
+        /// on [update_version][crate::client::Versions::update_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_version(self.0.request, self.0.options)
@@ -1771,7 +1771,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
+    /// The request builder for [Versions::delete_version][crate::client::Versions::delete_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1814,7 +1814,7 @@ pub mod versions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_version][super::super::client::Versions::delete_version].
+        /// on [delete_version][crate::client::Versions::delete_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_version(self.0.request, self.0.options)
@@ -1872,7 +1872,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
+    /// The request builder for [Versions::list_operations][crate::client::Versions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1982,7 +1982,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
+    /// The request builder for [Versions::get_operation][crate::client::Versions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2048,7 +2048,7 @@ pub mod versions {
 pub mod instances {
     use crate::Result;
 
-    /// A builder for [Instances][super::super::client::Instances].
+    /// A builder for [Instances][crate::client::Instances].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2076,7 +2076,7 @@ pub mod instances {
         }
     }
 
-    /// Common implementation for [super::super::client::Instances] request builders.
+    /// Common implementation for [crate::client::Instances] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Instances>,
@@ -2099,7 +2099,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for [Instances::list_instances][super::super::client::Instances::list_instances] calls.
+    /// The request builder for [Instances::list_instances][crate::client::Instances::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2200,7 +2200,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for [Instances::get_instance][super::super::client::Instances::get_instance] calls.
+    /// The request builder for [Instances::get_instance][crate::client::Instances::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2261,7 +2261,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for [Instances::delete_instance][super::super::client::Instances::delete_instance] calls.
+    /// The request builder for [Instances::delete_instance][crate::client::Instances::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2306,7 +2306,7 @@ pub mod instances {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::Instances::delete_instance].
+        /// on [delete_instance][crate::client::Instances::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -2364,7 +2364,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for [Instances::debug_instance][super::super::client::Instances::debug_instance] calls.
+    /// The request builder for [Instances::debug_instance][crate::client::Instances::debug_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2409,7 +2409,7 @@ pub mod instances {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [debug_instance][super::super::client::Instances::debug_instance].
+        /// on [debug_instance][crate::client::Instances::debug_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .debug_instance(self.0.request, self.0.options)
@@ -2470,7 +2470,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for [Instances::list_operations][super::super::client::Instances::list_operations] calls.
+    /// The request builder for [Instances::list_operations][crate::client::Instances::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2582,7 +2582,7 @@ pub mod instances {
         }
     }
 
-    /// The request builder for [Instances::get_operation][super::super::client::Instances::get_operation] calls.
+    /// The request builder for [Instances::get_operation][crate::client::Instances::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2650,7 +2650,7 @@ pub mod instances {
 pub mod firewall {
     use crate::Result;
 
-    /// A builder for [Firewall][super::super::client::Firewall].
+    /// A builder for [Firewall][crate::client::Firewall].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2678,7 +2678,7 @@ pub mod firewall {
         }
     }
 
-    /// Common implementation for [super::super::client::Firewall] request builders.
+    /// Common implementation for [crate::client::Firewall] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Firewall>,
@@ -2699,7 +2699,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::list_ingress_rules][super::super::client::Firewall::list_ingress_rules] calls.
+    /// The request builder for [Firewall::list_ingress_rules][crate::client::Firewall::list_ingress_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2807,7 +2807,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::batch_update_ingress_rules][super::super::client::Firewall::batch_update_ingress_rules] calls.
+    /// The request builder for [Firewall::batch_update_ingress_rules][crate::client::Firewall::batch_update_ingress_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2882,7 +2882,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::create_ingress_rule][super::super::client::Firewall::create_ingress_rule] calls.
+    /// The request builder for [Firewall::create_ingress_rule][crate::client::Firewall::create_ingress_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2962,7 +2962,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::get_ingress_rule][super::super::client::Firewall::get_ingress_rule] calls.
+    /// The request builder for [Firewall::get_ingress_rule][crate::client::Firewall::get_ingress_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3021,7 +3021,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::update_ingress_rule][super::super::client::Firewall::update_ingress_rule] calls.
+    /// The request builder for [Firewall::update_ingress_rule][crate::client::Firewall::update_ingress_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3119,7 +3119,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::delete_ingress_rule][super::super::client::Firewall::delete_ingress_rule] calls.
+    /// The request builder for [Firewall::delete_ingress_rule][crate::client::Firewall::delete_ingress_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3181,7 +3181,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::list_operations][super::super::client::Firewall::list_operations] calls.
+    /// The request builder for [Firewall::list_operations][crate::client::Firewall::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3291,7 +3291,7 @@ pub mod firewall {
         }
     }
 
-    /// The request builder for [Firewall::get_operation][super::super::client::Firewall::get_operation] calls.
+    /// The request builder for [Firewall::get_operation][crate::client::Firewall::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3357,7 +3357,7 @@ pub mod firewall {
 pub mod authorized_domains {
     use crate::Result;
 
-    /// A builder for [AuthorizedDomains][super::super::client::AuthorizedDomains].
+    /// A builder for [AuthorizedDomains][crate::client::AuthorizedDomains].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3385,7 +3385,7 @@ pub mod authorized_domains {
         }
     }
 
-    /// Common implementation for [super::super::client::AuthorizedDomains] request builders.
+    /// Common implementation for [crate::client::AuthorizedDomains] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AuthorizedDomains>,
@@ -3408,7 +3408,7 @@ pub mod authorized_domains {
         }
     }
 
-    /// The request builder for [AuthorizedDomains::list_authorized_domains][super::super::client::AuthorizedDomains::list_authorized_domains] calls.
+    /// The request builder for [AuthorizedDomains::list_authorized_domains][crate::client::AuthorizedDomains::list_authorized_domains] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3514,7 +3514,7 @@ pub mod authorized_domains {
         }
     }
 
-    /// The request builder for [AuthorizedDomains::list_operations][super::super::client::AuthorizedDomains::list_operations] calls.
+    /// The request builder for [AuthorizedDomains::list_operations][crate::client::AuthorizedDomains::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3626,7 +3626,7 @@ pub mod authorized_domains {
         }
     }
 
-    /// The request builder for [AuthorizedDomains::get_operation][super::super::client::AuthorizedDomains::get_operation] calls.
+    /// The request builder for [AuthorizedDomains::get_operation][crate::client::AuthorizedDomains::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3694,7 +3694,7 @@ pub mod authorized_domains {
 pub mod authorized_certificates {
     use crate::Result;
 
-    /// A builder for [AuthorizedCertificates][super::super::client::AuthorizedCertificates].
+    /// A builder for [AuthorizedCertificates][crate::client::AuthorizedCertificates].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3722,7 +3722,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// Common implementation for [super::super::client::AuthorizedCertificates] request builders.
+    /// Common implementation for [crate::client::AuthorizedCertificates] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AuthorizedCertificates>,
@@ -3745,7 +3745,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for [AuthorizedCertificates::list_authorized_certificates][super::super::client::AuthorizedCertificates::list_authorized_certificates] calls.
+    /// The request builder for [AuthorizedCertificates::list_authorized_certificates][crate::client::AuthorizedCertificates::list_authorized_certificates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3861,7 +3861,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for [AuthorizedCertificates::get_authorized_certificate][super::super::client::AuthorizedCertificates::get_authorized_certificate] calls.
+    /// The request builder for [AuthorizedCertificates::get_authorized_certificate][crate::client::AuthorizedCertificates::get_authorized_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3933,7 +3933,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for [AuthorizedCertificates::create_authorized_certificate][super::super::client::AuthorizedCertificates::create_authorized_certificate] calls.
+    /// The request builder for [AuthorizedCertificates::create_authorized_certificate][crate::client::AuthorizedCertificates::create_authorized_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4017,7 +4017,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for [AuthorizedCertificates::update_authorized_certificate][super::super::client::AuthorizedCertificates::update_authorized_certificate] calls.
+    /// The request builder for [AuthorizedCertificates::update_authorized_certificate][crate::client::AuthorizedCertificates::update_authorized_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4119,7 +4119,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for [AuthorizedCertificates::delete_authorized_certificate][super::super::client::AuthorizedCertificates::delete_authorized_certificate] calls.
+    /// The request builder for [AuthorizedCertificates::delete_authorized_certificate][crate::client::AuthorizedCertificates::delete_authorized_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4185,7 +4185,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for [AuthorizedCertificates::list_operations][super::super::client::AuthorizedCertificates::list_operations] calls.
+    /// The request builder for [AuthorizedCertificates::list_operations][crate::client::AuthorizedCertificates::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4297,7 +4297,7 @@ pub mod authorized_certificates {
         }
     }
 
-    /// The request builder for [AuthorizedCertificates::get_operation][super::super::client::AuthorizedCertificates::get_operation] calls.
+    /// The request builder for [AuthorizedCertificates::get_operation][crate::client::AuthorizedCertificates::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4365,7 +4365,7 @@ pub mod authorized_certificates {
 pub mod domain_mappings {
     use crate::Result;
 
-    /// A builder for [DomainMappings][super::super::client::DomainMappings].
+    /// A builder for [DomainMappings][crate::client::DomainMappings].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4393,7 +4393,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// Common implementation for [super::super::client::DomainMappings] request builders.
+    /// Common implementation for [crate::client::DomainMappings] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DomainMappings>,
@@ -4416,7 +4416,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for [DomainMappings::list_domain_mappings][super::super::client::DomainMappings::list_domain_mappings] calls.
+    /// The request builder for [DomainMappings::list_domain_mappings][crate::client::DomainMappings::list_domain_mappings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4522,7 +4522,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for [DomainMappings::get_domain_mapping][super::super::client::DomainMappings::get_domain_mapping] calls.
+    /// The request builder for [DomainMappings::get_domain_mapping][crate::client::DomainMappings::get_domain_mapping] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4586,7 +4586,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for [DomainMappings::create_domain_mapping][super::super::client::DomainMappings::create_domain_mapping] calls.
+    /// The request builder for [DomainMappings::create_domain_mapping][crate::client::DomainMappings::create_domain_mapping] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4634,7 +4634,7 @@ pub mod domain_mappings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_domain_mapping][super::super::client::DomainMappings::create_domain_mapping].
+        /// on [create_domain_mapping][crate::client::DomainMappings::create_domain_mapping].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_domain_mapping(self.0.request, self.0.options)
@@ -4719,7 +4719,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for [DomainMappings::update_domain_mapping][super::super::client::DomainMappings::update_domain_mapping] calls.
+    /// The request builder for [DomainMappings::update_domain_mapping][crate::client::DomainMappings::update_domain_mapping] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4767,7 +4767,7 @@ pub mod domain_mappings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_domain_mapping][super::super::client::DomainMappings::update_domain_mapping].
+        /// on [update_domain_mapping][crate::client::DomainMappings::update_domain_mapping].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_domain_mapping(self.0.request, self.0.options)
@@ -4861,7 +4861,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for [DomainMappings::delete_domain_mapping][super::super::client::DomainMappings::delete_domain_mapping] calls.
+    /// The request builder for [DomainMappings::delete_domain_mapping][crate::client::DomainMappings::delete_domain_mapping] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4909,7 +4909,7 @@ pub mod domain_mappings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_domain_mapping][super::super::client::DomainMappings::delete_domain_mapping].
+        /// on [delete_domain_mapping][crate::client::DomainMappings::delete_domain_mapping].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_domain_mapping(self.0.request, self.0.options)
@@ -4967,7 +4967,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for [DomainMappings::list_operations][super::super::client::DomainMappings::list_operations] calls.
+    /// The request builder for [DomainMappings::list_operations][crate::client::DomainMappings::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5079,7 +5079,7 @@ pub mod domain_mappings {
         }
     }
 
-    /// The request builder for [DomainMappings::get_operation][super::super::client::DomainMappings::get_operation] calls.
+    /// The request builder for [DomainMappings::get_operation][crate::client::DomainMappings::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/bigtable/admin/v2/src/builder.rs
+++ b/src/generated/bigtable/admin/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod bigtable_instance_admin {
     use crate::Result;
 
-    /// A builder for [BigtableInstanceAdmin][super::super::client::BigtableInstanceAdmin].
+    /// A builder for [BigtableInstanceAdmin][crate::client::BigtableInstanceAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::BigtableInstanceAdmin] request builders.
+    /// Common implementation for [crate::client::BigtableInstanceAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::BigtableInstanceAdmin>,
@@ -68,7 +68,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::create_instance][super::super::client::BigtableInstanceAdmin::create_instance] calls.
+    /// The request builder for [BigtableInstanceAdmin::create_instance][crate::client::BigtableInstanceAdmin::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::BigtableInstanceAdmin::create_instance].
+        /// on [create_instance][crate::client::BigtableInstanceAdmin::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -216,7 +216,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::get_instance][super::super::client::BigtableInstanceAdmin::get_instance] calls.
+    /// The request builder for [BigtableInstanceAdmin::get_instance][crate::client::BigtableInstanceAdmin::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -279,7 +279,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::list_instances][super::super::client::BigtableInstanceAdmin::list_instances] calls.
+    /// The request builder for [BigtableInstanceAdmin::list_instances][crate::client::BigtableInstanceAdmin::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -348,7 +348,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::update_instance][super::super::client::BigtableInstanceAdmin::update_instance] calls.
+    /// The request builder for [BigtableInstanceAdmin::update_instance][crate::client::BigtableInstanceAdmin::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -494,7 +494,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::partial_update_instance][super::super::client::BigtableInstanceAdmin::partial_update_instance] calls.
+    /// The request builder for [BigtableInstanceAdmin::partial_update_instance][crate::client::BigtableInstanceAdmin::partial_update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -542,7 +542,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [partial_update_instance][super::super::client::BigtableInstanceAdmin::partial_update_instance].
+        /// on [partial_update_instance][crate::client::BigtableInstanceAdmin::partial_update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .partial_update_instance(self.0.request, self.0.options)
@@ -638,7 +638,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::delete_instance][super::super::client::BigtableInstanceAdmin::delete_instance] calls.
+    /// The request builder for [BigtableInstanceAdmin::delete_instance][crate::client::BigtableInstanceAdmin::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -701,7 +701,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::create_cluster][super::super::client::BigtableInstanceAdmin::create_cluster] calls.
+    /// The request builder for [BigtableInstanceAdmin::create_cluster][crate::client::BigtableInstanceAdmin::create_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -746,7 +746,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cluster][super::super::client::BigtableInstanceAdmin::create_cluster].
+        /// on [create_cluster][crate::client::BigtableInstanceAdmin::create_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cluster(self.0.request, self.0.options)
@@ -835,7 +835,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::get_cluster][super::super::client::BigtableInstanceAdmin::get_cluster] calls.
+    /// The request builder for [BigtableInstanceAdmin::get_cluster][crate::client::BigtableInstanceAdmin::get_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -898,7 +898,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::list_clusters][super::super::client::BigtableInstanceAdmin::list_clusters] calls.
+    /// The request builder for [BigtableInstanceAdmin::list_clusters][crate::client::BigtableInstanceAdmin::list_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -967,7 +967,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::update_cluster][super::super::client::BigtableInstanceAdmin::update_cluster] calls.
+    /// The request builder for [BigtableInstanceAdmin::update_cluster][crate::client::BigtableInstanceAdmin::update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1012,7 +1012,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_cluster][super::super::client::BigtableInstanceAdmin::update_cluster].
+        /// on [update_cluster][crate::client::BigtableInstanceAdmin::update_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_cluster(self.0.request, self.0.options)
@@ -1147,7 +1147,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::partial_update_cluster][super::super::client::BigtableInstanceAdmin::partial_update_cluster] calls.
+    /// The request builder for [BigtableInstanceAdmin::partial_update_cluster][crate::client::BigtableInstanceAdmin::partial_update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1195,7 +1195,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [partial_update_cluster][super::super::client::BigtableInstanceAdmin::partial_update_cluster].
+        /// on [partial_update_cluster][crate::client::BigtableInstanceAdmin::partial_update_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .partial_update_cluster(self.0.request, self.0.options)
@@ -1291,7 +1291,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::delete_cluster][super::super::client::BigtableInstanceAdmin::delete_cluster] calls.
+    /// The request builder for [BigtableInstanceAdmin::delete_cluster][crate::client::BigtableInstanceAdmin::delete_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1354,7 +1354,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::create_app_profile][super::super::client::BigtableInstanceAdmin::create_app_profile] calls.
+    /// The request builder for [BigtableInstanceAdmin::create_app_profile][crate::client::BigtableInstanceAdmin::create_app_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1456,7 +1456,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::get_app_profile][super::super::client::BigtableInstanceAdmin::get_app_profile] calls.
+    /// The request builder for [BigtableInstanceAdmin::get_app_profile][crate::client::BigtableInstanceAdmin::get_app_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1519,7 +1519,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::list_app_profiles][super::super::client::BigtableInstanceAdmin::list_app_profiles] calls.
+    /// The request builder for [BigtableInstanceAdmin::list_app_profiles][crate::client::BigtableInstanceAdmin::list_app_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1622,7 +1622,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::update_app_profile][super::super::client::BigtableInstanceAdmin::update_app_profile] calls.
+    /// The request builder for [BigtableInstanceAdmin::update_app_profile][crate::client::BigtableInstanceAdmin::update_app_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1670,7 +1670,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_app_profile][super::super::client::BigtableInstanceAdmin::update_app_profile].
+        /// on [update_app_profile][crate::client::BigtableInstanceAdmin::update_app_profile].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_app_profile(self.0.request, self.0.options)
@@ -1772,7 +1772,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::delete_app_profile][super::super::client::BigtableInstanceAdmin::delete_app_profile] calls.
+    /// The request builder for [BigtableInstanceAdmin::delete_app_profile][crate::client::BigtableInstanceAdmin::delete_app_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1846,7 +1846,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::get_iam_policy][super::super::client::BigtableInstanceAdmin::get_iam_policy] calls.
+    /// The request builder for [BigtableInstanceAdmin::get_iam_policy][crate::client::BigtableInstanceAdmin::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1927,7 +1927,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::set_iam_policy][super::super::client::BigtableInstanceAdmin::set_iam_policy] calls.
+    /// The request builder for [BigtableInstanceAdmin::set_iam_policy][crate::client::BigtableInstanceAdmin::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2030,7 +2030,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::test_iam_permissions][super::super::client::BigtableInstanceAdmin::test_iam_permissions] calls.
+    /// The request builder for [BigtableInstanceAdmin::test_iam_permissions][crate::client::BigtableInstanceAdmin::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2109,7 +2109,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::list_hot_tablets][super::super::client::BigtableInstanceAdmin::list_hot_tablets] calls.
+    /// The request builder for [BigtableInstanceAdmin::list_hot_tablets][crate::client::BigtableInstanceAdmin::list_hot_tablets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2248,7 +2248,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::create_logical_view][super::super::client::BigtableInstanceAdmin::create_logical_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::create_logical_view][crate::client::BigtableInstanceAdmin::create_logical_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2296,7 +2296,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_logical_view][super::super::client::BigtableInstanceAdmin::create_logical_view].
+        /// on [create_logical_view][crate::client::BigtableInstanceAdmin::create_logical_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_logical_view(self.0.request, self.0.options)
@@ -2386,7 +2386,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::get_logical_view][super::super::client::BigtableInstanceAdmin::get_logical_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::get_logical_view][crate::client::BigtableInstanceAdmin::get_logical_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2449,7 +2449,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::list_logical_views][super::super::client::BigtableInstanceAdmin::list_logical_views] calls.
+    /// The request builder for [BigtableInstanceAdmin::list_logical_views][crate::client::BigtableInstanceAdmin::list_logical_views] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2555,7 +2555,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::update_logical_view][super::super::client::BigtableInstanceAdmin::update_logical_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::update_logical_view][crate::client::BigtableInstanceAdmin::update_logical_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2603,7 +2603,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_logical_view][super::super::client::BigtableInstanceAdmin::update_logical_view].
+        /// on [update_logical_view][crate::client::BigtableInstanceAdmin::update_logical_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_logical_view(self.0.request, self.0.options)
@@ -2695,7 +2695,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::delete_logical_view][super::super::client::BigtableInstanceAdmin::delete_logical_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::delete_logical_view][crate::client::BigtableInstanceAdmin::delete_logical_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2767,7 +2767,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::create_materialized_view][super::super::client::BigtableInstanceAdmin::create_materialized_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::create_materialized_view][crate::client::BigtableInstanceAdmin::create_materialized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2815,7 +2815,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_materialized_view][super::super::client::BigtableInstanceAdmin::create_materialized_view].
+        /// on [create_materialized_view][crate::client::BigtableInstanceAdmin::create_materialized_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_materialized_view(self.0.request, self.0.options)
@@ -2905,7 +2905,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::get_materialized_view][super::super::client::BigtableInstanceAdmin::get_materialized_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::get_materialized_view][crate::client::BigtableInstanceAdmin::get_materialized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2971,7 +2971,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::list_materialized_views][super::super::client::BigtableInstanceAdmin::list_materialized_views] calls.
+    /// The request builder for [BigtableInstanceAdmin::list_materialized_views][crate::client::BigtableInstanceAdmin::list_materialized_views] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3079,7 +3079,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::update_materialized_view][super::super::client::BigtableInstanceAdmin::update_materialized_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::update_materialized_view][crate::client::BigtableInstanceAdmin::update_materialized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3127,7 +3127,7 @@ pub mod bigtable_instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_materialized_view][super::super::client::BigtableInstanceAdmin::update_materialized_view].
+        /// on [update_materialized_view][crate::client::BigtableInstanceAdmin::update_materialized_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_materialized_view(self.0.request, self.0.options)
@@ -3219,7 +3219,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::delete_materialized_view][super::super::client::BigtableInstanceAdmin::delete_materialized_view] calls.
+    /// The request builder for [BigtableInstanceAdmin::delete_materialized_view][crate::client::BigtableInstanceAdmin::delete_materialized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3291,7 +3291,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::list_operations][super::super::client::BigtableInstanceAdmin::list_operations] calls.
+    /// The request builder for [BigtableInstanceAdmin::list_operations][crate::client::BigtableInstanceAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3403,7 +3403,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::get_operation][super::super::client::BigtableInstanceAdmin::get_operation] calls.
+    /// The request builder for [BigtableInstanceAdmin::get_operation][crate::client::BigtableInstanceAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3467,7 +3467,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::delete_operation][super::super::client::BigtableInstanceAdmin::delete_operation] calls.
+    /// The request builder for [BigtableInstanceAdmin::delete_operation][crate::client::BigtableInstanceAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3531,7 +3531,7 @@ pub mod bigtable_instance_admin {
         }
     }
 
-    /// The request builder for [BigtableInstanceAdmin::cancel_operation][super::super::client::BigtableInstanceAdmin::cancel_operation] calls.
+    /// The request builder for [BigtableInstanceAdmin::cancel_operation][crate::client::BigtableInstanceAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3599,7 +3599,7 @@ pub mod bigtable_instance_admin {
 pub mod bigtable_table_admin {
     use crate::Result;
 
-    /// A builder for [BigtableTableAdmin][super::super::client::BigtableTableAdmin].
+    /// A builder for [BigtableTableAdmin][crate::client::BigtableTableAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3627,7 +3627,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::BigtableTableAdmin] request builders.
+    /// Common implementation for [crate::client::BigtableTableAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::BigtableTableAdmin>,
@@ -3650,7 +3650,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::create_table][super::super::client::BigtableTableAdmin::create_table] calls.
+    /// The request builder for [BigtableTableAdmin::create_table][crate::client::BigtableTableAdmin::create_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3754,7 +3754,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::create_table_from_snapshot][super::super::client::BigtableTableAdmin::create_table_from_snapshot] calls.
+    /// The request builder for [BigtableTableAdmin::create_table_from_snapshot][crate::client::BigtableTableAdmin::create_table_from_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3804,7 +3804,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_table_from_snapshot][super::super::client::BigtableTableAdmin::create_table_from_snapshot].
+        /// on [create_table_from_snapshot][crate::client::BigtableTableAdmin::create_table_from_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_table_from_snapshot(self.0.request, self.0.options)
@@ -3880,7 +3880,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::list_tables][super::super::client::BigtableTableAdmin::list_tables] calls.
+    /// The request builder for [BigtableTableAdmin::list_tables][crate::client::BigtableTableAdmin::list_tables] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3989,7 +3989,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::get_table][super::super::client::BigtableTableAdmin::get_table] calls.
+    /// The request builder for [BigtableTableAdmin::get_table][crate::client::BigtableTableAdmin::get_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4058,7 +4058,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::update_table][super::super::client::BigtableTableAdmin::update_table] calls.
+    /// The request builder for [BigtableTableAdmin::update_table][crate::client::BigtableTableAdmin::update_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4103,7 +4103,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_table][super::super::client::BigtableTableAdmin::update_table].
+        /// on [update_table][crate::client::BigtableTableAdmin::update_table].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_table(self.0.request, self.0.options)
@@ -4202,7 +4202,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::delete_table][super::super::client::BigtableTableAdmin::delete_table] calls.
+    /// The request builder for [BigtableTableAdmin::delete_table][crate::client::BigtableTableAdmin::delete_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4265,7 +4265,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::undelete_table][super::super::client::BigtableTableAdmin::undelete_table] calls.
+    /// The request builder for [BigtableTableAdmin::undelete_table][crate::client::BigtableTableAdmin::undelete_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4310,7 +4310,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_table][super::super::client::BigtableTableAdmin::undelete_table].
+        /// on [undelete_table][crate::client::BigtableTableAdmin::undelete_table].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_table(self.0.request, self.0.options)
@@ -4367,7 +4367,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::create_authorized_view][super::super::client::BigtableTableAdmin::create_authorized_view] calls.
+    /// The request builder for [BigtableTableAdmin::create_authorized_view][crate::client::BigtableTableAdmin::create_authorized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4415,7 +4415,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_authorized_view][super::super::client::BigtableTableAdmin::create_authorized_view].
+        /// on [create_authorized_view][crate::client::BigtableTableAdmin::create_authorized_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_authorized_view(self.0.request, self.0.options)
@@ -4505,7 +4505,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::list_authorized_views][super::super::client::BigtableTableAdmin::list_authorized_views] calls.
+    /// The request builder for [BigtableTableAdmin::list_authorized_views][crate::client::BigtableTableAdmin::list_authorized_views] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4622,7 +4622,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::get_authorized_view][super::super::client::BigtableTableAdmin::get_authorized_view] calls.
+    /// The request builder for [BigtableTableAdmin::get_authorized_view][crate::client::BigtableTableAdmin::get_authorized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4697,7 +4697,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::update_authorized_view][super::super::client::BigtableTableAdmin::update_authorized_view] calls.
+    /// The request builder for [BigtableTableAdmin::update_authorized_view][crate::client::BigtableTableAdmin::update_authorized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4745,7 +4745,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_authorized_view][super::super::client::BigtableTableAdmin::update_authorized_view].
+        /// on [update_authorized_view][crate::client::BigtableTableAdmin::update_authorized_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_authorized_view(self.0.request, self.0.options)
@@ -4843,7 +4843,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::delete_authorized_view][super::super::client::BigtableTableAdmin::delete_authorized_view] calls.
+    /// The request builder for [BigtableTableAdmin::delete_authorized_view][crate::client::BigtableTableAdmin::delete_authorized_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4915,7 +4915,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::modify_column_families][super::super::client::BigtableTableAdmin::modify_column_families] calls.
+    /// The request builder for [BigtableTableAdmin::modify_column_families][crate::client::BigtableTableAdmin::modify_column_families] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5000,7 +5000,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::drop_row_range][super::super::client::BigtableTableAdmin::drop_row_range] calls.
+    /// The request builder for [BigtableTableAdmin::drop_row_range][crate::client::BigtableTableAdmin::drop_row_range] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5095,7 +5095,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::generate_consistency_token][super::super::client::BigtableTableAdmin::generate_consistency_token] calls.
+    /// The request builder for [BigtableTableAdmin::generate_consistency_token][crate::client::BigtableTableAdmin::generate_consistency_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5163,7 +5163,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::check_consistency][super::super::client::BigtableTableAdmin::check_consistency] calls.
+    /// The request builder for [BigtableTableAdmin::check_consistency][crate::client::BigtableTableAdmin::check_consistency] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5279,7 +5279,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::snapshot_table][super::super::client::BigtableTableAdmin::snapshot_table] calls.
+    /// The request builder for [BigtableTableAdmin::snapshot_table][crate::client::BigtableTableAdmin::snapshot_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5324,7 +5324,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [snapshot_table][super::super::client::BigtableTableAdmin::snapshot_table].
+        /// on [snapshot_table][crate::client::BigtableTableAdmin::snapshot_table].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .snapshot_table(self.0.request, self.0.options)
@@ -5423,7 +5423,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::get_snapshot][super::super::client::BigtableTableAdmin::get_snapshot] calls.
+    /// The request builder for [BigtableTableAdmin::get_snapshot][crate::client::BigtableTableAdmin::get_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5486,7 +5486,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::list_snapshots][super::super::client::BigtableTableAdmin::list_snapshots] calls.
+    /// The request builder for [BigtableTableAdmin::list_snapshots][crate::client::BigtableTableAdmin::list_snapshots] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5589,7 +5589,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::delete_snapshot][super::super::client::BigtableTableAdmin::delete_snapshot] calls.
+    /// The request builder for [BigtableTableAdmin::delete_snapshot][crate::client::BigtableTableAdmin::delete_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5652,7 +5652,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::create_backup][super::super::client::BigtableTableAdmin::create_backup] calls.
+    /// The request builder for [BigtableTableAdmin::create_backup][crate::client::BigtableTableAdmin::create_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5697,7 +5697,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup][super::super::client::BigtableTableAdmin::create_backup].
+        /// on [create_backup][crate::client::BigtableTableAdmin::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
@@ -5784,7 +5784,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::get_backup][super::super::client::BigtableTableAdmin::get_backup] calls.
+    /// The request builder for [BigtableTableAdmin::get_backup][crate::client::BigtableTableAdmin::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5847,7 +5847,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::update_backup][super::super::client::BigtableTableAdmin::update_backup] calls.
+    /// The request builder for [BigtableTableAdmin::update_backup][crate::client::BigtableTableAdmin::update_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5946,7 +5946,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::delete_backup][super::super::client::BigtableTableAdmin::delete_backup] calls.
+    /// The request builder for [BigtableTableAdmin::delete_backup][crate::client::BigtableTableAdmin::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6009,7 +6009,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::list_backups][super::super::client::BigtableTableAdmin::list_backups] calls.
+    /// The request builder for [BigtableTableAdmin::list_backups][crate::client::BigtableTableAdmin::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6124,7 +6124,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::restore_table][super::super::client::BigtableTableAdmin::restore_table] calls.
+    /// The request builder for [BigtableTableAdmin::restore_table][crate::client::BigtableTableAdmin::restore_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6169,7 +6169,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_table][super::super::client::BigtableTableAdmin::restore_table].
+        /// on [restore_table][crate::client::BigtableTableAdmin::restore_table].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_table(self.0.request, self.0.options)
@@ -6256,7 +6256,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::copy_backup][super::super::client::BigtableTableAdmin::copy_backup] calls.
+    /// The request builder for [BigtableTableAdmin::copy_backup][crate::client::BigtableTableAdmin::copy_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6301,7 +6301,7 @@ pub mod bigtable_table_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [copy_backup][super::super::client::BigtableTableAdmin::copy_backup].
+        /// on [copy_backup][crate::client::BigtableTableAdmin::copy_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .copy_backup(self.0.request, self.0.options)
@@ -6396,7 +6396,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::get_iam_policy][super::super::client::BigtableTableAdmin::get_iam_policy] calls.
+    /// The request builder for [BigtableTableAdmin::get_iam_policy][crate::client::BigtableTableAdmin::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6477,7 +6477,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::set_iam_policy][super::super::client::BigtableTableAdmin::set_iam_policy] calls.
+    /// The request builder for [BigtableTableAdmin::set_iam_policy][crate::client::BigtableTableAdmin::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6580,7 +6580,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::test_iam_permissions][super::super::client::BigtableTableAdmin::test_iam_permissions] calls.
+    /// The request builder for [BigtableTableAdmin::test_iam_permissions][crate::client::BigtableTableAdmin::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6659,7 +6659,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::list_operations][super::super::client::BigtableTableAdmin::list_operations] calls.
+    /// The request builder for [BigtableTableAdmin::list_operations][crate::client::BigtableTableAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6771,7 +6771,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::get_operation][super::super::client::BigtableTableAdmin::get_operation] calls.
+    /// The request builder for [BigtableTableAdmin::get_operation][crate::client::BigtableTableAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6835,7 +6835,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::delete_operation][super::super::client::BigtableTableAdmin::delete_operation] calls.
+    /// The request builder for [BigtableTableAdmin::delete_operation][crate::client::BigtableTableAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6899,7 +6899,7 @@ pub mod bigtable_table_admin {
         }
     }
 
-    /// The request builder for [BigtableTableAdmin::cancel_operation][super::super::client::BigtableTableAdmin::cancel_operation] calls.
+    /// The request builder for [BigtableTableAdmin::cancel_operation][crate::client::BigtableTableAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/accessapproval/v1/src/builder.rs
+++ b/src/generated/cloud/accessapproval/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod access_approval {
     use crate::Result;
 
-    /// A builder for [AccessApproval][super::super::client::AccessApproval].
+    /// A builder for [AccessApproval][crate::client::AccessApproval].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod access_approval {
         }
     }
 
-    /// Common implementation for [super::super::client::AccessApproval] request builders.
+    /// Common implementation for [crate::client::AccessApproval] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AccessApproval>,
@@ -68,7 +68,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::list_approval_requests][super::super::client::AccessApproval::list_approval_requests] calls.
+    /// The request builder for [AccessApproval::list_approval_requests][crate::client::AccessApproval::list_approval_requests] calls.
     ///
     /// # Example
     /// ```no_run
@@ -180,7 +180,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::get_approval_request][super::super::client::AccessApproval::get_approval_request] calls.
+    /// The request builder for [AccessApproval::get_approval_request][crate::client::AccessApproval::get_approval_request] calls.
     ///
     /// # Example
     /// ```no_run
@@ -244,7 +244,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::approve_approval_request][super::super::client::AccessApproval::approve_approval_request] calls.
+    /// The request builder for [AccessApproval::approve_approval_request][crate::client::AccessApproval::approve_approval_request] calls.
     ///
     /// # Example
     /// ```no_run
@@ -326,7 +326,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::dismiss_approval_request][super::super::client::AccessApproval::dismiss_approval_request] calls.
+    /// The request builder for [AccessApproval::dismiss_approval_request][crate::client::AccessApproval::dismiss_approval_request] calls.
     ///
     /// # Example
     /// ```no_run
@@ -390,7 +390,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::invalidate_approval_request][super::super::client::AccessApproval::invalidate_approval_request] calls.
+    /// The request builder for [AccessApproval::invalidate_approval_request][crate::client::AccessApproval::invalidate_approval_request] calls.
     ///
     /// # Example
     /// ```no_run
@@ -456,7 +456,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::get_access_approval_settings][super::super::client::AccessApproval::get_access_approval_settings] calls.
+    /// The request builder for [AccessApproval::get_access_approval_settings][crate::client::AccessApproval::get_access_approval_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -522,7 +522,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::update_access_approval_settings][super::super::client::AccessApproval::update_access_approval_settings] calls.
+    /// The request builder for [AccessApproval::update_access_approval_settings][crate::client::AccessApproval::update_access_approval_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -618,7 +618,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::delete_access_approval_settings][super::super::client::AccessApproval::delete_access_approval_settings] calls.
+    /// The request builder for [AccessApproval::delete_access_approval_settings][crate::client::AccessApproval::delete_access_approval_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -684,7 +684,7 @@ pub mod access_approval {
         }
     }
 
-    /// The request builder for [AccessApproval::get_access_approval_service_account][super::super::client::AccessApproval::get_access_approval_service_account] calls.
+    /// The request builder for [AccessApproval::get_access_approval_service_account][crate::client::AccessApproval::get_access_approval_service_account] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/advisorynotifications/v1/src/builder.rs
+++ b/src/generated/cloud/advisorynotifications/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod advisory_notifications_service {
     use crate::Result;
 
-    /// A builder for [AdvisoryNotificationsService][super::super::client::AdvisoryNotificationsService].
+    /// A builder for [AdvisoryNotificationsService][crate::client::AdvisoryNotificationsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AdvisoryNotificationsService] request builders.
+    /// Common implementation for [crate::client::AdvisoryNotificationsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AdvisoryNotificationsService>,
@@ -68,7 +68,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for [AdvisoryNotificationsService::list_notifications][super::super::client::AdvisoryNotificationsService::list_notifications] calls.
+    /// The request builder for [AdvisoryNotificationsService::list_notifications][crate::client::AdvisoryNotificationsService::list_notifications] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for [AdvisoryNotificationsService::get_notification][super::super::client::AdvisoryNotificationsService::get_notification] calls.
+    /// The request builder for [AdvisoryNotificationsService::get_notification][crate::client::AdvisoryNotificationsService::get_notification] calls.
     ///
     /// # Example
     /// ```no_run
@@ -255,7 +255,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for [AdvisoryNotificationsService::get_settings][super::super::client::AdvisoryNotificationsService::get_settings] calls.
+    /// The request builder for [AdvisoryNotificationsService::get_settings][crate::client::AdvisoryNotificationsService::get_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -318,7 +318,7 @@ pub mod advisory_notifications_service {
         }
     }
 
-    /// The request builder for [AdvisoryNotificationsService::update_settings][super::super::client::AdvisoryNotificationsService::update_settings] calls.
+    /// The request builder for [AdvisoryNotificationsService::update_settings][crate::client::AdvisoryNotificationsService::update_settings] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/aiplatform/v1/src/builder.rs
+++ b/src/generated/cloud/aiplatform/v1/src/builder.rs
@@ -19,7 +19,7 @@
 pub mod dataset_service {
     use crate::Result;
 
-    /// A builder for [DatasetService][super::super::client::DatasetService].
+    /// A builder for [DatasetService][crate::client::DatasetService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -47,7 +47,7 @@ pub mod dataset_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DatasetService] request builders.
+    /// Common implementation for [crate::client::DatasetService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DatasetService>,
@@ -70,7 +70,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::create_dataset][super::super::client::DatasetService::create_dataset] calls.
+    /// The request builder for [DatasetService::create_dataset][crate::client::DatasetService::create_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -115,7 +115,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_dataset][super::super::client::DatasetService::create_dataset].
+        /// on [create_dataset][crate::client::DatasetService::create_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_dataset(self.0.request, self.0.options)
@@ -197,7 +197,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::get_dataset][super::super::client::DatasetService::get_dataset] calls.
+    /// The request builder for [DatasetService::get_dataset][crate::client::DatasetService::get_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -278,7 +278,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::update_dataset][super::super::client::DatasetService::update_dataset] calls.
+    /// The request builder for [DatasetService::update_dataset][crate::client::DatasetService::update_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -377,7 +377,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_datasets][super::super::client::DatasetService::list_datasets] calls.
+    /// The request builder for [DatasetService::list_datasets][crate::client::DatasetService::list_datasets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -510,7 +510,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::delete_dataset][super::super::client::DatasetService::delete_dataset] calls.
+    /// The request builder for [DatasetService::delete_dataset][crate::client::DatasetService::delete_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -555,7 +555,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_dataset][super::super::client::DatasetService::delete_dataset].
+        /// on [delete_dataset][crate::client::DatasetService::delete_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_dataset(self.0.request, self.0.options)
@@ -615,7 +615,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::import_data][super::super::client::DatasetService::import_data] calls.
+    /// The request builder for [DatasetService::import_data][crate::client::DatasetService::import_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -660,7 +660,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_data][super::super::client::DatasetService::import_data].
+        /// on [import_data][crate::client::DatasetService::import_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_data(self.0.request, self.0.options)
@@ -733,7 +733,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::export_data][super::super::client::DatasetService::export_data] calls.
+    /// The request builder for [DatasetService::export_data][crate::client::DatasetService::export_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -778,7 +778,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_data][super::super::client::DatasetService::export_data].
+        /// on [export_data][crate::client::DatasetService::export_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_data(self.0.request, self.0.options)
@@ -860,7 +860,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::create_dataset_version][super::super::client::DatasetService::create_dataset_version] calls.
+    /// The request builder for [DatasetService::create_dataset_version][crate::client::DatasetService::create_dataset_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -908,7 +908,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_dataset_version][super::super::client::DatasetService::create_dataset_version].
+        /// on [create_dataset_version][crate::client::DatasetService::create_dataset_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_dataset_version(self.0.request, self.0.options)
@@ -992,7 +992,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::update_dataset_version][super::super::client::DatasetService::update_dataset_version] calls.
+    /// The request builder for [DatasetService::update_dataset_version][crate::client::DatasetService::update_dataset_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1094,7 +1094,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::delete_dataset_version][super::super::client::DatasetService::delete_dataset_version] calls.
+    /// The request builder for [DatasetService::delete_dataset_version][crate::client::DatasetService::delete_dataset_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1142,7 +1142,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_dataset_version][super::super::client::DatasetService::delete_dataset_version].
+        /// on [delete_dataset_version][crate::client::DatasetService::delete_dataset_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_dataset_version(self.0.request, self.0.options)
@@ -1202,7 +1202,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::get_dataset_version][super::super::client::DatasetService::get_dataset_version] calls.
+    /// The request builder for [DatasetService::get_dataset_version][crate::client::DatasetService::get_dataset_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1286,7 +1286,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_dataset_versions][super::super::client::DatasetService::list_dataset_versions] calls.
+    /// The request builder for [DatasetService::list_dataset_versions][crate::client::DatasetService::list_dataset_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1424,7 +1424,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::restore_dataset_version][super::super::client::DatasetService::restore_dataset_version] calls.
+    /// The request builder for [DatasetService::restore_dataset_version][crate::client::DatasetService::restore_dataset_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1472,7 +1472,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_dataset_version][super::super::client::DatasetService::restore_dataset_version].
+        /// on [restore_dataset_version][crate::client::DatasetService::restore_dataset_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_dataset_version(self.0.request, self.0.options)
@@ -1534,7 +1534,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_data_items][super::super::client::DatasetService::list_data_items] calls.
+    /// The request builder for [DatasetService::list_data_items][crate::client::DatasetService::list_data_items] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1667,7 +1667,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::search_data_items][super::super::client::DatasetService::search_data_items] calls.
+    /// The request builder for [DatasetService::search_data_items][crate::client::DatasetService::search_data_items] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1880,7 +1880,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_saved_queries][super::super::client::DatasetService::list_saved_queries] calls.
+    /// The request builder for [DatasetService::list_saved_queries][crate::client::DatasetService::list_saved_queries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2016,7 +2016,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::delete_saved_query][super::super::client::DatasetService::delete_saved_query] calls.
+    /// The request builder for [DatasetService::delete_saved_query][crate::client::DatasetService::delete_saved_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2064,7 +2064,7 @@ pub mod dataset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_saved_query][super::super::client::DatasetService::delete_saved_query].
+        /// on [delete_saved_query][crate::client::DatasetService::delete_saved_query].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_saved_query(self.0.request, self.0.options)
@@ -2124,7 +2124,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::get_annotation_spec][super::super::client::DatasetService::get_annotation_spec] calls.
+    /// The request builder for [DatasetService::get_annotation_spec][crate::client::DatasetService::get_annotation_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2208,7 +2208,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_annotations][super::super::client::DatasetService::list_annotations] calls.
+    /// The request builder for [DatasetService::list_annotations][crate::client::DatasetService::list_annotations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2341,7 +2341,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_locations][super::super::client::DatasetService::list_locations] calls.
+    /// The request builder for [DatasetService::list_locations][crate::client::DatasetService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2451,7 +2451,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::get_location][super::super::client::DatasetService::get_location] calls.
+    /// The request builder for [DatasetService::get_location][crate::client::DatasetService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2512,7 +2512,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::set_iam_policy][super::super::client::DatasetService::set_iam_policy] calls.
+    /// The request builder for [DatasetService::set_iam_policy][crate::client::DatasetService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2615,7 +2615,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::get_iam_policy][super::super::client::DatasetService::get_iam_policy] calls.
+    /// The request builder for [DatasetService::get_iam_policy][crate::client::DatasetService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2696,7 +2696,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::test_iam_permissions][super::super::client::DatasetService::test_iam_permissions] calls.
+    /// The request builder for [DatasetService::test_iam_permissions][crate::client::DatasetService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2775,7 +2775,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_operations][super::super::client::DatasetService::list_operations] calls.
+    /// The request builder for [DatasetService::list_operations][crate::client::DatasetService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2887,7 +2887,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::get_operation][super::super::client::DatasetService::get_operation] calls.
+    /// The request builder for [DatasetService::get_operation][crate::client::DatasetService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2951,7 +2951,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::delete_operation][super::super::client::DatasetService::delete_operation] calls.
+    /// The request builder for [DatasetService::delete_operation][crate::client::DatasetService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3015,7 +3015,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::cancel_operation][super::super::client::DatasetService::cancel_operation] calls.
+    /// The request builder for [DatasetService::cancel_operation][crate::client::DatasetService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3079,7 +3079,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::wait_operation][super::super::client::DatasetService::wait_operation] calls.
+    /// The request builder for [DatasetService::wait_operation][crate::client::DatasetService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3167,7 +3167,7 @@ pub mod dataset_service {
 pub mod deployment_resource_pool_service {
     use crate::Result;
 
-    /// A builder for [DeploymentResourcePoolService][super::super::client::DeploymentResourcePoolService].
+    /// A builder for [DeploymentResourcePoolService][crate::client::DeploymentResourcePoolService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3195,7 +3195,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DeploymentResourcePoolService] request builders.
+    /// Common implementation for [crate::client::DeploymentResourcePoolService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DeploymentResourcePoolService>,
@@ -3218,7 +3218,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::create_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::create_deployment_resource_pool] calls.
+    /// The request builder for [DeploymentResourcePoolService::create_deployment_resource_pool][crate::client::DeploymentResourcePoolService::create_deployment_resource_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3268,7 +3268,7 @@ pub mod deployment_resource_pool_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::create_deployment_resource_pool].
+        /// on [create_deployment_resource_pool][crate::client::DeploymentResourcePoolService::create_deployment_resource_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_deployment_resource_pool(self.0.request, self.0.options)
@@ -3363,7 +3363,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::get_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::get_deployment_resource_pool] calls.
+    /// The request builder for [DeploymentResourcePoolService::get_deployment_resource_pool][crate::client::DeploymentResourcePoolService::get_deployment_resource_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3431,7 +3431,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::list_deployment_resource_pools][super::super::client::DeploymentResourcePoolService::list_deployment_resource_pools] calls.
+    /// The request builder for [DeploymentResourcePoolService::list_deployment_resource_pools][crate::client::DeploymentResourcePoolService::list_deployment_resource_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3543,7 +3543,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::update_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::update_deployment_resource_pool] calls.
+    /// The request builder for [DeploymentResourcePoolService::update_deployment_resource_pool][crate::client::DeploymentResourcePoolService::update_deployment_resource_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3593,7 +3593,7 @@ pub mod deployment_resource_pool_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::update_deployment_resource_pool].
+        /// on [update_deployment_resource_pool][crate::client::DeploymentResourcePoolService::update_deployment_resource_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_deployment_resource_pool(self.0.request, self.0.options)
@@ -3691,7 +3691,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::delete_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::delete_deployment_resource_pool] calls.
+    /// The request builder for [DeploymentResourcePoolService::delete_deployment_resource_pool][crate::client::DeploymentResourcePoolService::delete_deployment_resource_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3741,7 +3741,7 @@ pub mod deployment_resource_pool_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_deployment_resource_pool][super::super::client::DeploymentResourcePoolService::delete_deployment_resource_pool].
+        /// on [delete_deployment_resource_pool][crate::client::DeploymentResourcePoolService::delete_deployment_resource_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_deployment_resource_pool(self.0.request, self.0.options)
@@ -3801,7 +3801,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::query_deployed_models][super::super::client::DeploymentResourcePoolService::query_deployed_models] calls.
+    /// The request builder for [DeploymentResourcePoolService::query_deployed_models][crate::client::DeploymentResourcePoolService::query_deployed_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3909,7 +3909,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::list_locations][super::super::client::DeploymentResourcePoolService::list_locations] calls.
+    /// The request builder for [DeploymentResourcePoolService::list_locations][crate::client::DeploymentResourcePoolService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4019,7 +4019,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::get_location][super::super::client::DeploymentResourcePoolService::get_location] calls.
+    /// The request builder for [DeploymentResourcePoolService::get_location][crate::client::DeploymentResourcePoolService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4080,7 +4080,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::set_iam_policy][super::super::client::DeploymentResourcePoolService::set_iam_policy] calls.
+    /// The request builder for [DeploymentResourcePoolService::set_iam_policy][crate::client::DeploymentResourcePoolService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4183,7 +4183,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::get_iam_policy][super::super::client::DeploymentResourcePoolService::get_iam_policy] calls.
+    /// The request builder for [DeploymentResourcePoolService::get_iam_policy][crate::client::DeploymentResourcePoolService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4264,7 +4264,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::test_iam_permissions][super::super::client::DeploymentResourcePoolService::test_iam_permissions] calls.
+    /// The request builder for [DeploymentResourcePoolService::test_iam_permissions][crate::client::DeploymentResourcePoolService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4343,7 +4343,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::list_operations][super::super::client::DeploymentResourcePoolService::list_operations] calls.
+    /// The request builder for [DeploymentResourcePoolService::list_operations][crate::client::DeploymentResourcePoolService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4455,7 +4455,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::get_operation][super::super::client::DeploymentResourcePoolService::get_operation] calls.
+    /// The request builder for [DeploymentResourcePoolService::get_operation][crate::client::DeploymentResourcePoolService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4519,7 +4519,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::delete_operation][super::super::client::DeploymentResourcePoolService::delete_operation] calls.
+    /// The request builder for [DeploymentResourcePoolService::delete_operation][crate::client::DeploymentResourcePoolService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4583,7 +4583,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::cancel_operation][super::super::client::DeploymentResourcePoolService::cancel_operation] calls.
+    /// The request builder for [DeploymentResourcePoolService::cancel_operation][crate::client::DeploymentResourcePoolService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4647,7 +4647,7 @@ pub mod deployment_resource_pool_service {
         }
     }
 
-    /// The request builder for [DeploymentResourcePoolService::wait_operation][super::super::client::DeploymentResourcePoolService::wait_operation] calls.
+    /// The request builder for [DeploymentResourcePoolService::wait_operation][crate::client::DeploymentResourcePoolService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4735,7 +4735,7 @@ pub mod deployment_resource_pool_service {
 pub mod endpoint_service {
     use crate::Result;
 
-    /// A builder for [EndpointService][super::super::client::EndpointService].
+    /// A builder for [EndpointService][crate::client::EndpointService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4763,7 +4763,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EndpointService] request builders.
+    /// Common implementation for [crate::client::EndpointService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EndpointService>,
@@ -4786,7 +4786,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::create_endpoint][super::super::client::EndpointService::create_endpoint] calls.
+    /// The request builder for [EndpointService::create_endpoint][crate::client::EndpointService::create_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4831,7 +4831,7 @@ pub mod endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_endpoint][super::super::client::EndpointService::create_endpoint].
+        /// on [create_endpoint][crate::client::EndpointService::create_endpoint].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_endpoint(self.0.request, self.0.options)
@@ -4919,7 +4919,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::get_endpoint][super::super::client::EndpointService::get_endpoint] calls.
+    /// The request builder for [EndpointService::get_endpoint][crate::client::EndpointService::get_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4982,7 +4982,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::list_endpoints][super::super::client::EndpointService::list_endpoints] calls.
+    /// The request builder for [EndpointService::list_endpoints][crate::client::EndpointService::list_endpoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5115,7 +5115,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::update_endpoint][super::super::client::EndpointService::update_endpoint] calls.
+    /// The request builder for [EndpointService::update_endpoint][crate::client::EndpointService::update_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5214,7 +5214,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::update_endpoint_long_running][super::super::client::EndpointService::update_endpoint_long_running] calls.
+    /// The request builder for [EndpointService::update_endpoint_long_running][crate::client::EndpointService::update_endpoint_long_running] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5264,7 +5264,7 @@ pub mod endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_endpoint_long_running][super::super::client::EndpointService::update_endpoint_long_running].
+        /// on [update_endpoint_long_running][crate::client::EndpointService::update_endpoint_long_running].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_endpoint_long_running(self.0.request, self.0.options)
@@ -5338,7 +5338,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::delete_endpoint][super::super::client::EndpointService::delete_endpoint] calls.
+    /// The request builder for [EndpointService::delete_endpoint][crate::client::EndpointService::delete_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5383,7 +5383,7 @@ pub mod endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_endpoint][super::super::client::EndpointService::delete_endpoint].
+        /// on [delete_endpoint][crate::client::EndpointService::delete_endpoint].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_endpoint(self.0.request, self.0.options)
@@ -5443,7 +5443,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::deploy_model][super::super::client::EndpointService::deploy_model] calls.
+    /// The request builder for [EndpointService::deploy_model][crate::client::EndpointService::deploy_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5488,7 +5488,7 @@ pub mod endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [deploy_model][super::super::client::EndpointService::deploy_model].
+        /// on [deploy_model][crate::client::EndpointService::deploy_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .deploy_model(self.0.request, self.0.options)
@@ -5584,7 +5584,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::undeploy_model][super::super::client::EndpointService::undeploy_model] calls.
+    /// The request builder for [EndpointService::undeploy_model][crate::client::EndpointService::undeploy_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5629,7 +5629,7 @@ pub mod endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undeploy_model][super::super::client::EndpointService::undeploy_model].
+        /// on [undeploy_model][crate::client::EndpointService::undeploy_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undeploy_model(self.0.request, self.0.options)
@@ -5711,7 +5711,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::mutate_deployed_model][super::super::client::EndpointService::mutate_deployed_model] calls.
+    /// The request builder for [EndpointService::mutate_deployed_model][crate::client::EndpointService::mutate_deployed_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5759,7 +5759,7 @@ pub mod endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [mutate_deployed_model][super::super::client::EndpointService::mutate_deployed_model].
+        /// on [mutate_deployed_model][crate::client::EndpointService::mutate_deployed_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .mutate_deployed_model(self.0.request, self.0.options)
@@ -5865,7 +5865,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::list_locations][super::super::client::EndpointService::list_locations] calls.
+    /// The request builder for [EndpointService::list_locations][crate::client::EndpointService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5975,7 +5975,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::get_location][super::super::client::EndpointService::get_location] calls.
+    /// The request builder for [EndpointService::get_location][crate::client::EndpointService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6036,7 +6036,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::set_iam_policy][super::super::client::EndpointService::set_iam_policy] calls.
+    /// The request builder for [EndpointService::set_iam_policy][crate::client::EndpointService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6139,7 +6139,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::get_iam_policy][super::super::client::EndpointService::get_iam_policy] calls.
+    /// The request builder for [EndpointService::get_iam_policy][crate::client::EndpointService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6220,7 +6220,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::test_iam_permissions][super::super::client::EndpointService::test_iam_permissions] calls.
+    /// The request builder for [EndpointService::test_iam_permissions][crate::client::EndpointService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6299,7 +6299,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::list_operations][super::super::client::EndpointService::list_operations] calls.
+    /// The request builder for [EndpointService::list_operations][crate::client::EndpointService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6411,7 +6411,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::get_operation][super::super::client::EndpointService::get_operation] calls.
+    /// The request builder for [EndpointService::get_operation][crate::client::EndpointService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6475,7 +6475,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::delete_operation][super::super::client::EndpointService::delete_operation] calls.
+    /// The request builder for [EndpointService::delete_operation][crate::client::EndpointService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6539,7 +6539,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::cancel_operation][super::super::client::EndpointService::cancel_operation] calls.
+    /// The request builder for [EndpointService::cancel_operation][crate::client::EndpointService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6603,7 +6603,7 @@ pub mod endpoint_service {
         }
     }
 
-    /// The request builder for [EndpointService::wait_operation][super::super::client::EndpointService::wait_operation] calls.
+    /// The request builder for [EndpointService::wait_operation][crate::client::EndpointService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6691,7 +6691,7 @@ pub mod endpoint_service {
 pub mod evaluation_service {
     use crate::Result;
 
-    /// A builder for [EvaluationService][super::super::client::EvaluationService].
+    /// A builder for [EvaluationService][crate::client::EvaluationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6719,7 +6719,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EvaluationService] request builders.
+    /// Common implementation for [crate::client::EvaluationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EvaluationService>,
@@ -6742,7 +6742,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::evaluate_instances][super::super::client::EvaluationService::evaluate_instances] calls.
+    /// The request builder for [EvaluationService::evaluate_instances][crate::client::EvaluationService::evaluate_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7196,7 +7196,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::list_locations][super::super::client::EvaluationService::list_locations] calls.
+    /// The request builder for [EvaluationService::list_locations][crate::client::EvaluationService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7306,7 +7306,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::get_location][super::super::client::EvaluationService::get_location] calls.
+    /// The request builder for [EvaluationService::get_location][crate::client::EvaluationService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7367,7 +7367,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::set_iam_policy][super::super::client::EvaluationService::set_iam_policy] calls.
+    /// The request builder for [EvaluationService::set_iam_policy][crate::client::EvaluationService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7470,7 +7470,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::get_iam_policy][super::super::client::EvaluationService::get_iam_policy] calls.
+    /// The request builder for [EvaluationService::get_iam_policy][crate::client::EvaluationService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7551,7 +7551,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::test_iam_permissions][super::super::client::EvaluationService::test_iam_permissions] calls.
+    /// The request builder for [EvaluationService::test_iam_permissions][crate::client::EvaluationService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7630,7 +7630,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::list_operations][super::super::client::EvaluationService::list_operations] calls.
+    /// The request builder for [EvaluationService::list_operations][crate::client::EvaluationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7742,7 +7742,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::get_operation][super::super::client::EvaluationService::get_operation] calls.
+    /// The request builder for [EvaluationService::get_operation][crate::client::EvaluationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7806,7 +7806,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::delete_operation][super::super::client::EvaluationService::delete_operation] calls.
+    /// The request builder for [EvaluationService::delete_operation][crate::client::EvaluationService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7870,7 +7870,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::cancel_operation][super::super::client::EvaluationService::cancel_operation] calls.
+    /// The request builder for [EvaluationService::cancel_operation][crate::client::EvaluationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7934,7 +7934,7 @@ pub mod evaluation_service {
         }
     }
 
-    /// The request builder for [EvaluationService::wait_operation][super::super::client::EvaluationService::wait_operation] calls.
+    /// The request builder for [EvaluationService::wait_operation][crate::client::EvaluationService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8022,7 +8022,7 @@ pub mod evaluation_service {
 pub mod feature_online_store_admin_service {
     use crate::Result;
 
-    /// A builder for [FeatureOnlineStoreAdminService][super::super::client::FeatureOnlineStoreAdminService].
+    /// A builder for [FeatureOnlineStoreAdminService][crate::client::FeatureOnlineStoreAdminService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -8050,7 +8050,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// Common implementation for [super::super::client::FeatureOnlineStoreAdminService] request builders.
+    /// Common implementation for [crate::client::FeatureOnlineStoreAdminService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FeatureOnlineStoreAdminService>,
@@ -8073,7 +8073,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::create_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::create_feature_online_store] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::create_feature_online_store][crate::client::FeatureOnlineStoreAdminService::create_feature_online_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8123,7 +8123,7 @@ pub mod feature_online_store_admin_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::create_feature_online_store].
+        /// on [create_feature_online_store][crate::client::FeatureOnlineStoreAdminService::create_feature_online_store].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_feature_online_store(self.0.request, self.0.options)
@@ -8215,7 +8215,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::get_feature_online_store] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_online_store][crate::client::FeatureOnlineStoreAdminService::get_feature_online_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8281,7 +8281,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_online_stores][super::super::client::FeatureOnlineStoreAdminService::list_feature_online_stores] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_online_stores][crate::client::FeatureOnlineStoreAdminService::list_feature_online_stores] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8405,7 +8405,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::update_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::update_feature_online_store] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::update_feature_online_store][crate::client::FeatureOnlineStoreAdminService::update_feature_online_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8455,7 +8455,7 @@ pub mod feature_online_store_admin_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::update_feature_online_store].
+        /// on [update_feature_online_store][crate::client::FeatureOnlineStoreAdminService::update_feature_online_store].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_feature_online_store(self.0.request, self.0.options)
@@ -8549,7 +8549,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::delete_feature_online_store] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_online_store][crate::client::FeatureOnlineStoreAdminService::delete_feature_online_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8599,7 +8599,7 @@ pub mod feature_online_store_admin_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_feature_online_store][super::super::client::FeatureOnlineStoreAdminService::delete_feature_online_store].
+        /// on [delete_feature_online_store][crate::client::FeatureOnlineStoreAdminService::delete_feature_online_store].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_feature_online_store(self.0.request, self.0.options)
@@ -8665,7 +8665,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::create_feature_view][super::super::client::FeatureOnlineStoreAdminService::create_feature_view] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::create_feature_view][crate::client::FeatureOnlineStoreAdminService::create_feature_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8713,7 +8713,7 @@ pub mod feature_online_store_admin_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_feature_view][super::super::client::FeatureOnlineStoreAdminService::create_feature_view].
+        /// on [create_feature_view][crate::client::FeatureOnlineStoreAdminService::create_feature_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_feature_view(self.0.request, self.0.options)
@@ -8809,7 +8809,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view][super::super::client::FeatureOnlineStoreAdminService::get_feature_view] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view][crate::client::FeatureOnlineStoreAdminService::get_feature_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8872,7 +8872,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_views][super::super::client::FeatureOnlineStoreAdminService::list_feature_views] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_views][crate::client::FeatureOnlineStoreAdminService::list_feature_views] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8990,7 +8990,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::update_feature_view][super::super::client::FeatureOnlineStoreAdminService::update_feature_view] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::update_feature_view][crate::client::FeatureOnlineStoreAdminService::update_feature_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9038,7 +9038,7 @@ pub mod feature_online_store_admin_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_feature_view][super::super::client::FeatureOnlineStoreAdminService::update_feature_view].
+        /// on [update_feature_view][crate::client::FeatureOnlineStoreAdminService::update_feature_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_feature_view(self.0.request, self.0.options)
@@ -9130,7 +9130,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_view][super::super::client::FeatureOnlineStoreAdminService::delete_feature_view] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::delete_feature_view][crate::client::FeatureOnlineStoreAdminService::delete_feature_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9178,7 +9178,7 @@ pub mod feature_online_store_admin_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_feature_view][super::super::client::FeatureOnlineStoreAdminService::delete_feature_view].
+        /// on [delete_feature_view][crate::client::FeatureOnlineStoreAdminService::delete_feature_view].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_feature_view(self.0.request, self.0.options)
@@ -9238,7 +9238,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::sync_feature_view][super::super::client::FeatureOnlineStoreAdminService::sync_feature_view] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::sync_feature_view][crate::client::FeatureOnlineStoreAdminService::sync_feature_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9301,7 +9301,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view_sync][super::super::client::FeatureOnlineStoreAdminService::get_feature_view_sync] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_feature_view_sync][crate::client::FeatureOnlineStoreAdminService::get_feature_view_sync] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9367,7 +9367,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_view_syncs][super::super::client::FeatureOnlineStoreAdminService::list_feature_view_syncs] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_feature_view_syncs][crate::client::FeatureOnlineStoreAdminService::list_feature_view_syncs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9487,7 +9487,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::list_locations][super::super::client::FeatureOnlineStoreAdminService::list_locations] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_locations][crate::client::FeatureOnlineStoreAdminService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9597,7 +9597,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::get_location][super::super::client::FeatureOnlineStoreAdminService::get_location] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_location][crate::client::FeatureOnlineStoreAdminService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9658,7 +9658,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::set_iam_policy][super::super::client::FeatureOnlineStoreAdminService::set_iam_policy] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::set_iam_policy][crate::client::FeatureOnlineStoreAdminService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9761,7 +9761,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::get_iam_policy][super::super::client::FeatureOnlineStoreAdminService::get_iam_policy] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_iam_policy][crate::client::FeatureOnlineStoreAdminService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9842,7 +9842,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::test_iam_permissions][super::super::client::FeatureOnlineStoreAdminService::test_iam_permissions] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::test_iam_permissions][crate::client::FeatureOnlineStoreAdminService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9921,7 +9921,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::list_operations][super::super::client::FeatureOnlineStoreAdminService::list_operations] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::list_operations][crate::client::FeatureOnlineStoreAdminService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10033,7 +10033,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::get_operation][super::super::client::FeatureOnlineStoreAdminService::get_operation] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::get_operation][crate::client::FeatureOnlineStoreAdminService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10097,7 +10097,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::delete_operation][super::super::client::FeatureOnlineStoreAdminService::delete_operation] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::delete_operation][crate::client::FeatureOnlineStoreAdminService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10161,7 +10161,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::cancel_operation][super::super::client::FeatureOnlineStoreAdminService::cancel_operation] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::cancel_operation][crate::client::FeatureOnlineStoreAdminService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10225,7 +10225,7 @@ pub mod feature_online_store_admin_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreAdminService::wait_operation][super::super::client::FeatureOnlineStoreAdminService::wait_operation] calls.
+    /// The request builder for [FeatureOnlineStoreAdminService::wait_operation][crate::client::FeatureOnlineStoreAdminService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10313,7 +10313,7 @@ pub mod feature_online_store_admin_service {
 pub mod feature_online_store_service {
     use crate::Result;
 
-    /// A builder for [FeatureOnlineStoreService][super::super::client::FeatureOnlineStoreService].
+    /// A builder for [FeatureOnlineStoreService][crate::client::FeatureOnlineStoreService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -10341,7 +10341,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// Common implementation for [super::super::client::FeatureOnlineStoreService] request builders.
+    /// Common implementation for [crate::client::FeatureOnlineStoreService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FeatureOnlineStoreService>,
@@ -10364,7 +10364,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::fetch_feature_values][super::super::client::FeatureOnlineStoreService::fetch_feature_values] calls.
+    /// The request builder for [FeatureOnlineStoreService::fetch_feature_values][crate::client::FeatureOnlineStoreService::fetch_feature_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10457,7 +10457,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::search_nearest_entities][super::super::client::FeatureOnlineStoreService::search_nearest_entities] calls.
+    /// The request builder for [FeatureOnlineStoreService::search_nearest_entities][crate::client::FeatureOnlineStoreService::search_nearest_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10551,7 +10551,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::list_locations][super::super::client::FeatureOnlineStoreService::list_locations] calls.
+    /// The request builder for [FeatureOnlineStoreService::list_locations][crate::client::FeatureOnlineStoreService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10661,7 +10661,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::get_location][super::super::client::FeatureOnlineStoreService::get_location] calls.
+    /// The request builder for [FeatureOnlineStoreService::get_location][crate::client::FeatureOnlineStoreService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10722,7 +10722,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::set_iam_policy][super::super::client::FeatureOnlineStoreService::set_iam_policy] calls.
+    /// The request builder for [FeatureOnlineStoreService::set_iam_policy][crate::client::FeatureOnlineStoreService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10825,7 +10825,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::get_iam_policy][super::super::client::FeatureOnlineStoreService::get_iam_policy] calls.
+    /// The request builder for [FeatureOnlineStoreService::get_iam_policy][crate::client::FeatureOnlineStoreService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10906,7 +10906,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::test_iam_permissions][super::super::client::FeatureOnlineStoreService::test_iam_permissions] calls.
+    /// The request builder for [FeatureOnlineStoreService::test_iam_permissions][crate::client::FeatureOnlineStoreService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10985,7 +10985,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::list_operations][super::super::client::FeatureOnlineStoreService::list_operations] calls.
+    /// The request builder for [FeatureOnlineStoreService::list_operations][crate::client::FeatureOnlineStoreService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11097,7 +11097,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::get_operation][super::super::client::FeatureOnlineStoreService::get_operation] calls.
+    /// The request builder for [FeatureOnlineStoreService::get_operation][crate::client::FeatureOnlineStoreService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11161,7 +11161,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::delete_operation][super::super::client::FeatureOnlineStoreService::delete_operation] calls.
+    /// The request builder for [FeatureOnlineStoreService::delete_operation][crate::client::FeatureOnlineStoreService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11225,7 +11225,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::cancel_operation][super::super::client::FeatureOnlineStoreService::cancel_operation] calls.
+    /// The request builder for [FeatureOnlineStoreService::cancel_operation][crate::client::FeatureOnlineStoreService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11289,7 +11289,7 @@ pub mod feature_online_store_service {
         }
     }
 
-    /// The request builder for [FeatureOnlineStoreService::wait_operation][super::super::client::FeatureOnlineStoreService::wait_operation] calls.
+    /// The request builder for [FeatureOnlineStoreService::wait_operation][crate::client::FeatureOnlineStoreService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11377,7 +11377,7 @@ pub mod feature_online_store_service {
 pub mod feature_registry_service {
     use crate::Result;
 
-    /// A builder for [FeatureRegistryService][super::super::client::FeatureRegistryService].
+    /// A builder for [FeatureRegistryService][crate::client::FeatureRegistryService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -11405,7 +11405,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// Common implementation for [super::super::client::FeatureRegistryService] request builders.
+    /// Common implementation for [crate::client::FeatureRegistryService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FeatureRegistryService>,
@@ -11428,7 +11428,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::create_feature_group][super::super::client::FeatureRegistryService::create_feature_group] calls.
+    /// The request builder for [FeatureRegistryService::create_feature_group][crate::client::FeatureRegistryService::create_feature_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11476,7 +11476,7 @@ pub mod feature_registry_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_feature_group][super::super::client::FeatureRegistryService::create_feature_group].
+        /// on [create_feature_group][crate::client::FeatureRegistryService::create_feature_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_feature_group(self.0.request, self.0.options)
@@ -11568,7 +11568,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::get_feature_group][super::super::client::FeatureRegistryService::get_feature_group] calls.
+    /// The request builder for [FeatureRegistryService::get_feature_group][crate::client::FeatureRegistryService::get_feature_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11631,7 +11631,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::list_feature_groups][super::super::client::FeatureRegistryService::list_feature_groups] calls.
+    /// The request builder for [FeatureRegistryService::list_feature_groups][crate::client::FeatureRegistryService::list_feature_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11749,7 +11749,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::update_feature_group][super::super::client::FeatureRegistryService::update_feature_group] calls.
+    /// The request builder for [FeatureRegistryService::update_feature_group][crate::client::FeatureRegistryService::update_feature_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11797,7 +11797,7 @@ pub mod feature_registry_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_feature_group][super::super::client::FeatureRegistryService::update_feature_group].
+        /// on [update_feature_group][crate::client::FeatureRegistryService::update_feature_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_feature_group(self.0.request, self.0.options)
@@ -11891,7 +11891,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::delete_feature_group][super::super::client::FeatureRegistryService::delete_feature_group] calls.
+    /// The request builder for [FeatureRegistryService::delete_feature_group][crate::client::FeatureRegistryService::delete_feature_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11939,7 +11939,7 @@ pub mod feature_registry_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_feature_group][super::super::client::FeatureRegistryService::delete_feature_group].
+        /// on [delete_feature_group][crate::client::FeatureRegistryService::delete_feature_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_feature_group(self.0.request, self.0.options)
@@ -12005,7 +12005,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::create_feature][super::super::client::FeatureRegistryService::create_feature] calls.
+    /// The request builder for [FeatureRegistryService::create_feature][crate::client::FeatureRegistryService::create_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12050,7 +12050,7 @@ pub mod feature_registry_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_feature][super::super::client::FeatureRegistryService::create_feature].
+        /// on [create_feature][crate::client::FeatureRegistryService::create_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_feature(self.0.request, self.0.options)
@@ -12140,7 +12140,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::batch_create_features][super::super::client::FeatureRegistryService::batch_create_features] calls.
+    /// The request builder for [FeatureRegistryService::batch_create_features][crate::client::FeatureRegistryService::batch_create_features] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12188,7 +12188,7 @@ pub mod feature_registry_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_create_features][super::super::client::FeatureRegistryService::batch_create_features].
+        /// on [batch_create_features][crate::client::FeatureRegistryService::batch_create_features].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_create_features(self.0.request, self.0.options)
@@ -12263,7 +12263,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::get_feature][super::super::client::FeatureRegistryService::get_feature] calls.
+    /// The request builder for [FeatureRegistryService::get_feature][crate::client::FeatureRegistryService::get_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12326,7 +12326,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::list_features][super::super::client::FeatureRegistryService::list_features] calls.
+    /// The request builder for [FeatureRegistryService::list_features][crate::client::FeatureRegistryService::list_features] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12465,7 +12465,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::update_feature][super::super::client::FeatureRegistryService::update_feature] calls.
+    /// The request builder for [FeatureRegistryService::update_feature][crate::client::FeatureRegistryService::update_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12510,7 +12510,7 @@ pub mod feature_registry_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_feature][super::super::client::FeatureRegistryService::update_feature].
+        /// on [update_feature][crate::client::FeatureRegistryService::update_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_feature(self.0.request, self.0.options)
@@ -12602,7 +12602,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::delete_feature][super::super::client::FeatureRegistryService::delete_feature] calls.
+    /// The request builder for [FeatureRegistryService::delete_feature][crate::client::FeatureRegistryService::delete_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12647,7 +12647,7 @@ pub mod feature_registry_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_feature][super::super::client::FeatureRegistryService::delete_feature].
+        /// on [delete_feature][crate::client::FeatureRegistryService::delete_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_feature(self.0.request, self.0.options)
@@ -12707,7 +12707,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::list_locations][super::super::client::FeatureRegistryService::list_locations] calls.
+    /// The request builder for [FeatureRegistryService::list_locations][crate::client::FeatureRegistryService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12817,7 +12817,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::get_location][super::super::client::FeatureRegistryService::get_location] calls.
+    /// The request builder for [FeatureRegistryService::get_location][crate::client::FeatureRegistryService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12878,7 +12878,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::set_iam_policy][super::super::client::FeatureRegistryService::set_iam_policy] calls.
+    /// The request builder for [FeatureRegistryService::set_iam_policy][crate::client::FeatureRegistryService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12981,7 +12981,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::get_iam_policy][super::super::client::FeatureRegistryService::get_iam_policy] calls.
+    /// The request builder for [FeatureRegistryService::get_iam_policy][crate::client::FeatureRegistryService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13062,7 +13062,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::test_iam_permissions][super::super::client::FeatureRegistryService::test_iam_permissions] calls.
+    /// The request builder for [FeatureRegistryService::test_iam_permissions][crate::client::FeatureRegistryService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13141,7 +13141,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::list_operations][super::super::client::FeatureRegistryService::list_operations] calls.
+    /// The request builder for [FeatureRegistryService::list_operations][crate::client::FeatureRegistryService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13253,7 +13253,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::get_operation][super::super::client::FeatureRegistryService::get_operation] calls.
+    /// The request builder for [FeatureRegistryService::get_operation][crate::client::FeatureRegistryService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13317,7 +13317,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::delete_operation][super::super::client::FeatureRegistryService::delete_operation] calls.
+    /// The request builder for [FeatureRegistryService::delete_operation][crate::client::FeatureRegistryService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13381,7 +13381,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::cancel_operation][super::super::client::FeatureRegistryService::cancel_operation] calls.
+    /// The request builder for [FeatureRegistryService::cancel_operation][crate::client::FeatureRegistryService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13445,7 +13445,7 @@ pub mod feature_registry_service {
         }
     }
 
-    /// The request builder for [FeatureRegistryService::wait_operation][super::super::client::FeatureRegistryService::wait_operation] calls.
+    /// The request builder for [FeatureRegistryService::wait_operation][crate::client::FeatureRegistryService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13533,7 +13533,7 @@ pub mod feature_registry_service {
 pub mod featurestore_online_serving_service {
     use crate::Result;
 
-    /// A builder for [FeaturestoreOnlineServingService][super::super::client::FeaturestoreOnlineServingService].
+    /// A builder for [FeaturestoreOnlineServingService][crate::client::FeaturestoreOnlineServingService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -13561,7 +13561,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// Common implementation for [super::super::client::FeaturestoreOnlineServingService] request builders.
+    /// Common implementation for [crate::client::FeaturestoreOnlineServingService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FeaturestoreOnlineServingService>,
@@ -13584,7 +13584,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::read_feature_values][super::super::client::FeaturestoreOnlineServingService::read_feature_values] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::read_feature_values][crate::client::FeaturestoreOnlineServingService::read_feature_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13680,7 +13680,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::write_feature_values][super::super::client::FeaturestoreOnlineServingService::write_feature_values] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::write_feature_values][crate::client::FeaturestoreOnlineServingService::write_feature_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13759,7 +13759,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::list_locations][super::super::client::FeaturestoreOnlineServingService::list_locations] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::list_locations][crate::client::FeaturestoreOnlineServingService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13869,7 +13869,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::get_location][super::super::client::FeaturestoreOnlineServingService::get_location] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::get_location][crate::client::FeaturestoreOnlineServingService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13930,7 +13930,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::set_iam_policy][super::super::client::FeaturestoreOnlineServingService::set_iam_policy] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::set_iam_policy][crate::client::FeaturestoreOnlineServingService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14033,7 +14033,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::get_iam_policy][super::super::client::FeaturestoreOnlineServingService::get_iam_policy] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::get_iam_policy][crate::client::FeaturestoreOnlineServingService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14114,7 +14114,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::test_iam_permissions][super::super::client::FeaturestoreOnlineServingService::test_iam_permissions] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::test_iam_permissions][crate::client::FeaturestoreOnlineServingService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14193,7 +14193,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::list_operations][super::super::client::FeaturestoreOnlineServingService::list_operations] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::list_operations][crate::client::FeaturestoreOnlineServingService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14305,7 +14305,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::get_operation][super::super::client::FeaturestoreOnlineServingService::get_operation] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::get_operation][crate::client::FeaturestoreOnlineServingService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14369,7 +14369,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::delete_operation][super::super::client::FeaturestoreOnlineServingService::delete_operation] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::delete_operation][crate::client::FeaturestoreOnlineServingService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14433,7 +14433,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::cancel_operation][super::super::client::FeaturestoreOnlineServingService::cancel_operation] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::cancel_operation][crate::client::FeaturestoreOnlineServingService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14497,7 +14497,7 @@ pub mod featurestore_online_serving_service {
         }
     }
 
-    /// The request builder for [FeaturestoreOnlineServingService::wait_operation][super::super::client::FeaturestoreOnlineServingService::wait_operation] calls.
+    /// The request builder for [FeaturestoreOnlineServingService::wait_operation][crate::client::FeaturestoreOnlineServingService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14585,7 +14585,7 @@ pub mod featurestore_online_serving_service {
 pub mod featurestore_service {
     use crate::Result;
 
-    /// A builder for [FeaturestoreService][super::super::client::FeaturestoreService].
+    /// A builder for [FeaturestoreService][crate::client::FeaturestoreService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -14613,7 +14613,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// Common implementation for [super::super::client::FeaturestoreService] request builders.
+    /// Common implementation for [crate::client::FeaturestoreService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FeaturestoreService>,
@@ -14636,7 +14636,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::create_featurestore][super::super::client::FeaturestoreService::create_featurestore] calls.
+    /// The request builder for [FeaturestoreService::create_featurestore][crate::client::FeaturestoreService::create_featurestore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14684,7 +14684,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_featurestore][super::super::client::FeaturestoreService::create_featurestore].
+        /// on [create_featurestore][crate::client::FeaturestoreService::create_featurestore].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_featurestore(self.0.request, self.0.options)
@@ -14776,7 +14776,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::get_featurestore][super::super::client::FeaturestoreService::get_featurestore] calls.
+    /// The request builder for [FeaturestoreService::get_featurestore][crate::client::FeaturestoreService::get_featurestore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14839,7 +14839,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::list_featurestores][super::super::client::FeaturestoreService::list_featurestores] calls.
+    /// The request builder for [FeaturestoreService::list_featurestores][crate::client::FeaturestoreService::list_featurestores] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14975,7 +14975,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::update_featurestore][super::super::client::FeaturestoreService::update_featurestore] calls.
+    /// The request builder for [FeaturestoreService::update_featurestore][crate::client::FeaturestoreService::update_featurestore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15023,7 +15023,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_featurestore][super::super::client::FeaturestoreService::update_featurestore].
+        /// on [update_featurestore][crate::client::FeaturestoreService::update_featurestore].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_featurestore(self.0.request, self.0.options)
@@ -15117,7 +15117,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::delete_featurestore][super::super::client::FeaturestoreService::delete_featurestore] calls.
+    /// The request builder for [FeaturestoreService::delete_featurestore][crate::client::FeaturestoreService::delete_featurestore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15165,7 +15165,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_featurestore][super::super::client::FeaturestoreService::delete_featurestore].
+        /// on [delete_featurestore][crate::client::FeaturestoreService::delete_featurestore].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_featurestore(self.0.request, self.0.options)
@@ -15231,7 +15231,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::create_entity_type][super::super::client::FeaturestoreService::create_entity_type] calls.
+    /// The request builder for [FeaturestoreService::create_entity_type][crate::client::FeaturestoreService::create_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15279,7 +15279,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_entity_type][super::super::client::FeaturestoreService::create_entity_type].
+        /// on [create_entity_type][crate::client::FeaturestoreService::create_entity_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_entity_type(self.0.request, self.0.options)
@@ -15365,7 +15365,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::get_entity_type][super::super::client::FeaturestoreService::get_entity_type] calls.
+    /// The request builder for [FeaturestoreService::get_entity_type][crate::client::FeaturestoreService::get_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15428,7 +15428,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::list_entity_types][super::super::client::FeaturestoreService::list_entity_types] calls.
+    /// The request builder for [FeaturestoreService::list_entity_types][crate::client::FeaturestoreService::list_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15561,7 +15561,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::update_entity_type][super::super::client::FeaturestoreService::update_entity_type] calls.
+    /// The request builder for [FeaturestoreService::update_entity_type][crate::client::FeaturestoreService::update_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15659,7 +15659,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::delete_entity_type][super::super::client::FeaturestoreService::delete_entity_type] calls.
+    /// The request builder for [FeaturestoreService::delete_entity_type][crate::client::FeaturestoreService::delete_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15707,7 +15707,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_entity_type][super::super::client::FeaturestoreService::delete_entity_type].
+        /// on [delete_entity_type][crate::client::FeaturestoreService::delete_entity_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_entity_type(self.0.request, self.0.options)
@@ -15773,7 +15773,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::create_feature][super::super::client::FeaturestoreService::create_feature] calls.
+    /// The request builder for [FeaturestoreService::create_feature][crate::client::FeaturestoreService::create_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15818,7 +15818,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_feature][super::super::client::FeaturestoreService::create_feature].
+        /// on [create_feature][crate::client::FeaturestoreService::create_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_feature(self.0.request, self.0.options)
@@ -15908,7 +15908,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::batch_create_features][super::super::client::FeaturestoreService::batch_create_features] calls.
+    /// The request builder for [FeaturestoreService::batch_create_features][crate::client::FeaturestoreService::batch_create_features] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15956,7 +15956,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_create_features][super::super::client::FeaturestoreService::batch_create_features].
+        /// on [batch_create_features][crate::client::FeaturestoreService::batch_create_features].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_create_features(self.0.request, self.0.options)
@@ -16031,7 +16031,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::get_feature][super::super::client::FeaturestoreService::get_feature] calls.
+    /// The request builder for [FeaturestoreService::get_feature][crate::client::FeaturestoreService::get_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16094,7 +16094,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::list_features][super::super::client::FeaturestoreService::list_features] calls.
+    /// The request builder for [FeaturestoreService::list_features][crate::client::FeaturestoreService::list_features] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16233,7 +16233,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::update_feature][super::super::client::FeaturestoreService::update_feature] calls.
+    /// The request builder for [FeaturestoreService::update_feature][crate::client::FeaturestoreService::update_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16328,7 +16328,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::delete_feature][super::super::client::FeaturestoreService::delete_feature] calls.
+    /// The request builder for [FeaturestoreService::delete_feature][crate::client::FeaturestoreService::delete_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16373,7 +16373,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_feature][super::super::client::FeaturestoreService::delete_feature].
+        /// on [delete_feature][crate::client::FeaturestoreService::delete_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_feature(self.0.request, self.0.options)
@@ -16433,7 +16433,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::import_feature_values][super::super::client::FeaturestoreService::import_feature_values] calls.
+    /// The request builder for [FeaturestoreService::import_feature_values][crate::client::FeaturestoreService::import_feature_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16481,7 +16481,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_feature_values][super::super::client::FeaturestoreService::import_feature_values].
+        /// on [import_feature_values][crate::client::FeaturestoreService::import_feature_values].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_feature_values(self.0.request, self.0.options)
@@ -16673,7 +16673,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::batch_read_feature_values][super::super::client::FeaturestoreService::batch_read_feature_values] calls.
+    /// The request builder for [FeaturestoreService::batch_read_feature_values][crate::client::FeaturestoreService::batch_read_feature_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16721,7 +16721,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_read_feature_values][super::super::client::FeaturestoreService::batch_read_feature_values].
+        /// on [batch_read_feature_values][crate::client::FeaturestoreService::batch_read_feature_values].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_read_feature_values(self.0.request, self.0.options)
@@ -16893,7 +16893,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::export_feature_values][super::super::client::FeaturestoreService::export_feature_values] calls.
+    /// The request builder for [FeaturestoreService::export_feature_values][crate::client::FeaturestoreService::export_feature_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16941,7 +16941,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_feature_values][super::super::client::FeaturestoreService::export_feature_values].
+        /// on [export_feature_values][crate::client::FeaturestoreService::export_feature_values].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_feature_values(self.0.request, self.0.options)
@@ -17104,7 +17104,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::delete_feature_values][super::super::client::FeaturestoreService::delete_feature_values] calls.
+    /// The request builder for [FeaturestoreService::delete_feature_values][crate::client::FeaturestoreService::delete_feature_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17152,7 +17152,7 @@ pub mod featurestore_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_feature_values][super::super::client::FeaturestoreService::delete_feature_values].
+        /// on [delete_feature_values][crate::client::FeaturestoreService::delete_feature_values].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_feature_values(self.0.request, self.0.options)
@@ -17264,7 +17264,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::search_features][super::super::client::FeaturestoreService::search_features] calls.
+    /// The request builder for [FeaturestoreService::search_features][crate::client::FeaturestoreService::search_features] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17373,7 +17373,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::list_locations][super::super::client::FeaturestoreService::list_locations] calls.
+    /// The request builder for [FeaturestoreService::list_locations][crate::client::FeaturestoreService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17483,7 +17483,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::get_location][super::super::client::FeaturestoreService::get_location] calls.
+    /// The request builder for [FeaturestoreService::get_location][crate::client::FeaturestoreService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17544,7 +17544,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::set_iam_policy][super::super::client::FeaturestoreService::set_iam_policy] calls.
+    /// The request builder for [FeaturestoreService::set_iam_policy][crate::client::FeaturestoreService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17647,7 +17647,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::get_iam_policy][super::super::client::FeaturestoreService::get_iam_policy] calls.
+    /// The request builder for [FeaturestoreService::get_iam_policy][crate::client::FeaturestoreService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17728,7 +17728,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::test_iam_permissions][super::super::client::FeaturestoreService::test_iam_permissions] calls.
+    /// The request builder for [FeaturestoreService::test_iam_permissions][crate::client::FeaturestoreService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17807,7 +17807,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::list_operations][super::super::client::FeaturestoreService::list_operations] calls.
+    /// The request builder for [FeaturestoreService::list_operations][crate::client::FeaturestoreService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17919,7 +17919,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::get_operation][super::super::client::FeaturestoreService::get_operation] calls.
+    /// The request builder for [FeaturestoreService::get_operation][crate::client::FeaturestoreService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17983,7 +17983,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::delete_operation][super::super::client::FeaturestoreService::delete_operation] calls.
+    /// The request builder for [FeaturestoreService::delete_operation][crate::client::FeaturestoreService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18047,7 +18047,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::cancel_operation][super::super::client::FeaturestoreService::cancel_operation] calls.
+    /// The request builder for [FeaturestoreService::cancel_operation][crate::client::FeaturestoreService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18111,7 +18111,7 @@ pub mod featurestore_service {
         }
     }
 
-    /// The request builder for [FeaturestoreService::wait_operation][super::super::client::FeaturestoreService::wait_operation] calls.
+    /// The request builder for [FeaturestoreService::wait_operation][crate::client::FeaturestoreService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18199,7 +18199,7 @@ pub mod featurestore_service {
 pub mod gen_ai_cache_service {
     use crate::Result;
 
-    /// A builder for [GenAiCacheService][super::super::client::GenAiCacheService].
+    /// A builder for [GenAiCacheService][crate::client::GenAiCacheService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -18227,7 +18227,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// Common implementation for [super::super::client::GenAiCacheService] request builders.
+    /// Common implementation for [crate::client::GenAiCacheService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GenAiCacheService>,
@@ -18250,7 +18250,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::create_cached_content][super::super::client::GenAiCacheService::create_cached_content] calls.
+    /// The request builder for [GenAiCacheService::create_cached_content][crate::client::GenAiCacheService::create_cached_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18338,7 +18338,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::get_cached_content][super::super::client::GenAiCacheService::get_cached_content] calls.
+    /// The request builder for [GenAiCacheService::get_cached_content][crate::client::GenAiCacheService::get_cached_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18404,7 +18404,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::update_cached_content][super::super::client::GenAiCacheService::update_cached_content] calls.
+    /// The request builder for [GenAiCacheService::update_cached_content][crate::client::GenAiCacheService::update_cached_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18506,7 +18506,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::delete_cached_content][super::super::client::GenAiCacheService::delete_cached_content] calls.
+    /// The request builder for [GenAiCacheService::delete_cached_content][crate::client::GenAiCacheService::delete_cached_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18572,7 +18572,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::list_cached_contents][super::super::client::GenAiCacheService::list_cached_contents] calls.
+    /// The request builder for [GenAiCacheService::list_cached_contents][crate::client::GenAiCacheService::list_cached_contents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18680,7 +18680,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::list_locations][super::super::client::GenAiCacheService::list_locations] calls.
+    /// The request builder for [GenAiCacheService::list_locations][crate::client::GenAiCacheService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18790,7 +18790,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::get_location][super::super::client::GenAiCacheService::get_location] calls.
+    /// The request builder for [GenAiCacheService::get_location][crate::client::GenAiCacheService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18851,7 +18851,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::set_iam_policy][super::super::client::GenAiCacheService::set_iam_policy] calls.
+    /// The request builder for [GenAiCacheService::set_iam_policy][crate::client::GenAiCacheService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18954,7 +18954,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::get_iam_policy][super::super::client::GenAiCacheService::get_iam_policy] calls.
+    /// The request builder for [GenAiCacheService::get_iam_policy][crate::client::GenAiCacheService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19035,7 +19035,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::test_iam_permissions][super::super::client::GenAiCacheService::test_iam_permissions] calls.
+    /// The request builder for [GenAiCacheService::test_iam_permissions][crate::client::GenAiCacheService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19114,7 +19114,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::list_operations][super::super::client::GenAiCacheService::list_operations] calls.
+    /// The request builder for [GenAiCacheService::list_operations][crate::client::GenAiCacheService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19226,7 +19226,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::get_operation][super::super::client::GenAiCacheService::get_operation] calls.
+    /// The request builder for [GenAiCacheService::get_operation][crate::client::GenAiCacheService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19290,7 +19290,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::delete_operation][super::super::client::GenAiCacheService::delete_operation] calls.
+    /// The request builder for [GenAiCacheService::delete_operation][crate::client::GenAiCacheService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19354,7 +19354,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::cancel_operation][super::super::client::GenAiCacheService::cancel_operation] calls.
+    /// The request builder for [GenAiCacheService::cancel_operation][crate::client::GenAiCacheService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19418,7 +19418,7 @@ pub mod gen_ai_cache_service {
         }
     }
 
-    /// The request builder for [GenAiCacheService::wait_operation][super::super::client::GenAiCacheService::wait_operation] calls.
+    /// The request builder for [GenAiCacheService::wait_operation][crate::client::GenAiCacheService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19506,7 +19506,7 @@ pub mod gen_ai_cache_service {
 pub mod gen_ai_tuning_service {
     use crate::Result;
 
-    /// A builder for [GenAiTuningService][super::super::client::GenAiTuningService].
+    /// A builder for [GenAiTuningService][crate::client::GenAiTuningService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -19534,7 +19534,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// Common implementation for [super::super::client::GenAiTuningService] request builders.
+    /// Common implementation for [crate::client::GenAiTuningService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GenAiTuningService>,
@@ -19557,7 +19557,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::create_tuning_job][super::super::client::GenAiTuningService::create_tuning_job] calls.
+    /// The request builder for [GenAiTuningService::create_tuning_job][crate::client::GenAiTuningService::create_tuning_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19642,7 +19642,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::get_tuning_job][super::super::client::GenAiTuningService::get_tuning_job] calls.
+    /// The request builder for [GenAiTuningService::get_tuning_job][crate::client::GenAiTuningService::get_tuning_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19705,7 +19705,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::list_tuning_jobs][super::super::client::GenAiTuningService::list_tuning_jobs] calls.
+    /// The request builder for [GenAiTuningService::list_tuning_jobs][crate::client::GenAiTuningService::list_tuning_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19814,7 +19814,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::cancel_tuning_job][super::super::client::GenAiTuningService::cancel_tuning_job] calls.
+    /// The request builder for [GenAiTuningService::cancel_tuning_job][crate::client::GenAiTuningService::cancel_tuning_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19877,7 +19877,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::rebase_tuned_model][super::super::client::GenAiTuningService::rebase_tuned_model] calls.
+    /// The request builder for [GenAiTuningService::rebase_tuned_model][crate::client::GenAiTuningService::rebase_tuned_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19925,7 +19925,7 @@ pub mod gen_ai_tuning_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [rebase_tuned_model][super::super::client::GenAiTuningService::rebase_tuned_model].
+        /// on [rebase_tuned_model][crate::client::GenAiTuningService::rebase_tuned_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .rebase_tuned_model(self.0.request, self.0.options)
@@ -20049,7 +20049,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::list_locations][super::super::client::GenAiTuningService::list_locations] calls.
+    /// The request builder for [GenAiTuningService::list_locations][crate::client::GenAiTuningService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20159,7 +20159,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::get_location][super::super::client::GenAiTuningService::get_location] calls.
+    /// The request builder for [GenAiTuningService::get_location][crate::client::GenAiTuningService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20220,7 +20220,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::set_iam_policy][super::super::client::GenAiTuningService::set_iam_policy] calls.
+    /// The request builder for [GenAiTuningService::set_iam_policy][crate::client::GenAiTuningService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20323,7 +20323,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::get_iam_policy][super::super::client::GenAiTuningService::get_iam_policy] calls.
+    /// The request builder for [GenAiTuningService::get_iam_policy][crate::client::GenAiTuningService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20404,7 +20404,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::test_iam_permissions][super::super::client::GenAiTuningService::test_iam_permissions] calls.
+    /// The request builder for [GenAiTuningService::test_iam_permissions][crate::client::GenAiTuningService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20483,7 +20483,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::list_operations][super::super::client::GenAiTuningService::list_operations] calls.
+    /// The request builder for [GenAiTuningService::list_operations][crate::client::GenAiTuningService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20595,7 +20595,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::get_operation][super::super::client::GenAiTuningService::get_operation] calls.
+    /// The request builder for [GenAiTuningService::get_operation][crate::client::GenAiTuningService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20659,7 +20659,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::delete_operation][super::super::client::GenAiTuningService::delete_operation] calls.
+    /// The request builder for [GenAiTuningService::delete_operation][crate::client::GenAiTuningService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20723,7 +20723,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::cancel_operation][super::super::client::GenAiTuningService::cancel_operation] calls.
+    /// The request builder for [GenAiTuningService::cancel_operation][crate::client::GenAiTuningService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20787,7 +20787,7 @@ pub mod gen_ai_tuning_service {
         }
     }
 
-    /// The request builder for [GenAiTuningService::wait_operation][super::super::client::GenAiTuningService::wait_operation] calls.
+    /// The request builder for [GenAiTuningService::wait_operation][crate::client::GenAiTuningService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20875,7 +20875,7 @@ pub mod gen_ai_tuning_service {
 pub mod index_endpoint_service {
     use crate::Result;
 
-    /// A builder for [IndexEndpointService][super::super::client::IndexEndpointService].
+    /// A builder for [IndexEndpointService][crate::client::IndexEndpointService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -20903,7 +20903,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// Common implementation for [super::super::client::IndexEndpointService] request builders.
+    /// Common implementation for [crate::client::IndexEndpointService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::IndexEndpointService>,
@@ -20926,7 +20926,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::create_index_endpoint][super::super::client::IndexEndpointService::create_index_endpoint] calls.
+    /// The request builder for [IndexEndpointService::create_index_endpoint][crate::client::IndexEndpointService::create_index_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20974,7 +20974,7 @@ pub mod index_endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_index_endpoint][super::super::client::IndexEndpointService::create_index_endpoint].
+        /// on [create_index_endpoint][crate::client::IndexEndpointService::create_index_endpoint].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_index_endpoint(self.0.request, self.0.options)
@@ -21058,7 +21058,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::get_index_endpoint][super::super::client::IndexEndpointService::get_index_endpoint] calls.
+    /// The request builder for [IndexEndpointService::get_index_endpoint][crate::client::IndexEndpointService::get_index_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21124,7 +21124,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::list_index_endpoints][super::super::client::IndexEndpointService::list_index_endpoints] calls.
+    /// The request builder for [IndexEndpointService::list_index_endpoints][crate::client::IndexEndpointService::list_index_endpoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21256,7 +21256,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::update_index_endpoint][super::super::client::IndexEndpointService::update_index_endpoint] calls.
+    /// The request builder for [IndexEndpointService::update_index_endpoint][crate::client::IndexEndpointService::update_index_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21358,7 +21358,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::delete_index_endpoint][super::super::client::IndexEndpointService::delete_index_endpoint] calls.
+    /// The request builder for [IndexEndpointService::delete_index_endpoint][crate::client::IndexEndpointService::delete_index_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21406,7 +21406,7 @@ pub mod index_endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_index_endpoint][super::super::client::IndexEndpointService::delete_index_endpoint].
+        /// on [delete_index_endpoint][crate::client::IndexEndpointService::delete_index_endpoint].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_index_endpoint(self.0.request, self.0.options)
@@ -21466,7 +21466,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::deploy_index][super::super::client::IndexEndpointService::deploy_index] calls.
+    /// The request builder for [IndexEndpointService::deploy_index][crate::client::IndexEndpointService::deploy_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21511,7 +21511,7 @@ pub mod index_endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [deploy_index][super::super::client::IndexEndpointService::deploy_index].
+        /// on [deploy_index][crate::client::IndexEndpointService::deploy_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .deploy_index(self.0.request, self.0.options)
@@ -21595,7 +21595,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::undeploy_index][super::super::client::IndexEndpointService::undeploy_index] calls.
+    /// The request builder for [IndexEndpointService::undeploy_index][crate::client::IndexEndpointService::undeploy_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21640,7 +21640,7 @@ pub mod index_endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undeploy_index][super::super::client::IndexEndpointService::undeploy_index].
+        /// on [undeploy_index][crate::client::IndexEndpointService::undeploy_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undeploy_index(self.0.request, self.0.options)
@@ -21710,7 +21710,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::mutate_deployed_index][super::super::client::IndexEndpointService::mutate_deployed_index] calls.
+    /// The request builder for [IndexEndpointService::mutate_deployed_index][crate::client::IndexEndpointService::mutate_deployed_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21758,7 +21758,7 @@ pub mod index_endpoint_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [mutate_deployed_index][super::super::client::IndexEndpointService::mutate_deployed_index].
+        /// on [mutate_deployed_index][crate::client::IndexEndpointService::mutate_deployed_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .mutate_deployed_index(self.0.request, self.0.options)
@@ -21842,7 +21842,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::list_locations][super::super::client::IndexEndpointService::list_locations] calls.
+    /// The request builder for [IndexEndpointService::list_locations][crate::client::IndexEndpointService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -21952,7 +21952,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::get_location][super::super::client::IndexEndpointService::get_location] calls.
+    /// The request builder for [IndexEndpointService::get_location][crate::client::IndexEndpointService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22013,7 +22013,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::set_iam_policy][super::super::client::IndexEndpointService::set_iam_policy] calls.
+    /// The request builder for [IndexEndpointService::set_iam_policy][crate::client::IndexEndpointService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22116,7 +22116,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::get_iam_policy][super::super::client::IndexEndpointService::get_iam_policy] calls.
+    /// The request builder for [IndexEndpointService::get_iam_policy][crate::client::IndexEndpointService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22197,7 +22197,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::test_iam_permissions][super::super::client::IndexEndpointService::test_iam_permissions] calls.
+    /// The request builder for [IndexEndpointService::test_iam_permissions][crate::client::IndexEndpointService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22276,7 +22276,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::list_operations][super::super::client::IndexEndpointService::list_operations] calls.
+    /// The request builder for [IndexEndpointService::list_operations][crate::client::IndexEndpointService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22388,7 +22388,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::get_operation][super::super::client::IndexEndpointService::get_operation] calls.
+    /// The request builder for [IndexEndpointService::get_operation][crate::client::IndexEndpointService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22452,7 +22452,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::delete_operation][super::super::client::IndexEndpointService::delete_operation] calls.
+    /// The request builder for [IndexEndpointService::delete_operation][crate::client::IndexEndpointService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22516,7 +22516,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::cancel_operation][super::super::client::IndexEndpointService::cancel_operation] calls.
+    /// The request builder for [IndexEndpointService::cancel_operation][crate::client::IndexEndpointService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22580,7 +22580,7 @@ pub mod index_endpoint_service {
         }
     }
 
-    /// The request builder for [IndexEndpointService::wait_operation][super::super::client::IndexEndpointService::wait_operation] calls.
+    /// The request builder for [IndexEndpointService::wait_operation][crate::client::IndexEndpointService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22668,7 +22668,7 @@ pub mod index_endpoint_service {
 pub mod index_service {
     use crate::Result;
 
-    /// A builder for [IndexService][super::super::client::IndexService].
+    /// A builder for [IndexService][crate::client::IndexService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -22696,7 +22696,7 @@ pub mod index_service {
         }
     }
 
-    /// Common implementation for [super::super::client::IndexService] request builders.
+    /// Common implementation for [crate::client::IndexService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::IndexService>,
@@ -22719,7 +22719,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::create_index][super::super::client::IndexService::create_index] calls.
+    /// The request builder for [IndexService::create_index][crate::client::IndexService::create_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22764,7 +22764,7 @@ pub mod index_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_index][super::super::client::IndexService::create_index].
+        /// on [create_index][crate::client::IndexService::create_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_index(self.0.request, self.0.options)
@@ -22846,7 +22846,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::get_index][super::super::client::IndexService::get_index] calls.
+    /// The request builder for [IndexService::get_index][crate::client::IndexService::get_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -22909,7 +22909,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::list_indexes][super::super::client::IndexService::list_indexes] calls.
+    /// The request builder for [IndexService::list_indexes][crate::client::IndexService::list_indexes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23036,7 +23036,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::update_index][super::super::client::IndexService::update_index] calls.
+    /// The request builder for [IndexService::update_index][crate::client::IndexService::update_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23081,7 +23081,7 @@ pub mod index_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_index][super::super::client::IndexService::update_index].
+        /// on [update_index][crate::client::IndexService::update_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_index(self.0.request, self.0.options)
@@ -23173,7 +23173,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::delete_index][super::super::client::IndexService::delete_index] calls.
+    /// The request builder for [IndexService::delete_index][crate::client::IndexService::delete_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23218,7 +23218,7 @@ pub mod index_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_index][super::super::client::IndexService::delete_index].
+        /// on [delete_index][crate::client::IndexService::delete_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_index(self.0.request, self.0.options)
@@ -23278,7 +23278,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::upsert_datapoints][super::super::client::IndexService::upsert_datapoints] calls.
+    /// The request builder for [IndexService::upsert_datapoints][crate::client::IndexService::upsert_datapoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23373,7 +23373,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::remove_datapoints][super::super::client::IndexService::remove_datapoints] calls.
+    /// The request builder for [IndexService::remove_datapoints][crate::client::IndexService::remove_datapoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23450,7 +23450,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::list_locations][super::super::client::IndexService::list_locations] calls.
+    /// The request builder for [IndexService::list_locations][crate::client::IndexService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23560,7 +23560,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::get_location][super::super::client::IndexService::get_location] calls.
+    /// The request builder for [IndexService::get_location][crate::client::IndexService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23621,7 +23621,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::set_iam_policy][super::super::client::IndexService::set_iam_policy] calls.
+    /// The request builder for [IndexService::set_iam_policy][crate::client::IndexService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23724,7 +23724,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::get_iam_policy][super::super::client::IndexService::get_iam_policy] calls.
+    /// The request builder for [IndexService::get_iam_policy][crate::client::IndexService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23805,7 +23805,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::test_iam_permissions][super::super::client::IndexService::test_iam_permissions] calls.
+    /// The request builder for [IndexService::test_iam_permissions][crate::client::IndexService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23884,7 +23884,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::list_operations][super::super::client::IndexService::list_operations] calls.
+    /// The request builder for [IndexService::list_operations][crate::client::IndexService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -23996,7 +23996,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::get_operation][super::super::client::IndexService::get_operation] calls.
+    /// The request builder for [IndexService::get_operation][crate::client::IndexService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24060,7 +24060,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::delete_operation][super::super::client::IndexService::delete_operation] calls.
+    /// The request builder for [IndexService::delete_operation][crate::client::IndexService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24124,7 +24124,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::cancel_operation][super::super::client::IndexService::cancel_operation] calls.
+    /// The request builder for [IndexService::cancel_operation][crate::client::IndexService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24188,7 +24188,7 @@ pub mod index_service {
         }
     }
 
-    /// The request builder for [IndexService::wait_operation][super::super::client::IndexService::wait_operation] calls.
+    /// The request builder for [IndexService::wait_operation][crate::client::IndexService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24276,7 +24276,7 @@ pub mod index_service {
 pub mod job_service {
     use crate::Result;
 
-    /// A builder for [JobService][super::super::client::JobService].
+    /// A builder for [JobService][crate::client::JobService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -24304,7 +24304,7 @@ pub mod job_service {
         }
     }
 
-    /// Common implementation for [super::super::client::JobService] request builders.
+    /// Common implementation for [crate::client::JobService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::JobService>,
@@ -24327,7 +24327,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::create_custom_job][super::super::client::JobService::create_custom_job] calls.
+    /// The request builder for [JobService::create_custom_job][crate::client::JobService::create_custom_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24412,7 +24412,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_custom_job][super::super::client::JobService::get_custom_job] calls.
+    /// The request builder for [JobService::get_custom_job][crate::client::JobService::get_custom_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24475,7 +24475,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_custom_jobs][super::super::client::JobService::list_custom_jobs] calls.
+    /// The request builder for [JobService::list_custom_jobs][crate::client::JobService::list_custom_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24602,7 +24602,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_custom_job][super::super::client::JobService::delete_custom_job] calls.
+    /// The request builder for [JobService::delete_custom_job][crate::client::JobService::delete_custom_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24647,7 +24647,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_custom_job][super::super::client::JobService::delete_custom_job].
+        /// on [delete_custom_job][crate::client::JobService::delete_custom_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_custom_job(self.0.request, self.0.options)
@@ -24707,7 +24707,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::cancel_custom_job][super::super::client::JobService::cancel_custom_job] calls.
+    /// The request builder for [JobService::cancel_custom_job][crate::client::JobService::cancel_custom_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24770,7 +24770,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::create_data_labeling_job][super::super::client::JobService::create_data_labeling_job] calls.
+    /// The request builder for [JobService::create_data_labeling_job][crate::client::JobService::create_data_labeling_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24858,7 +24858,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_data_labeling_job][super::super::client::JobService::get_data_labeling_job] calls.
+    /// The request builder for [JobService::get_data_labeling_job][crate::client::JobService::get_data_labeling_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -24924,7 +24924,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_data_labeling_jobs][super::super::client::JobService::list_data_labeling_jobs] calls.
+    /// The request builder for [JobService::list_data_labeling_jobs][crate::client::JobService::list_data_labeling_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25062,7 +25062,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_data_labeling_job][super::super::client::JobService::delete_data_labeling_job] calls.
+    /// The request builder for [JobService::delete_data_labeling_job][crate::client::JobService::delete_data_labeling_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25110,7 +25110,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_data_labeling_job][super::super::client::JobService::delete_data_labeling_job].
+        /// on [delete_data_labeling_job][crate::client::JobService::delete_data_labeling_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_data_labeling_job(self.0.request, self.0.options)
@@ -25170,7 +25170,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::cancel_data_labeling_job][super::super::client::JobService::cancel_data_labeling_job] calls.
+    /// The request builder for [JobService::cancel_data_labeling_job][crate::client::JobService::cancel_data_labeling_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25236,7 +25236,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::create_hyperparameter_tuning_job][super::super::client::JobService::create_hyperparameter_tuning_job] calls.
+    /// The request builder for [JobService::create_hyperparameter_tuning_job][crate::client::JobService::create_hyperparameter_tuning_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25329,7 +25329,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_hyperparameter_tuning_job][super::super::client::JobService::get_hyperparameter_tuning_job] calls.
+    /// The request builder for [JobService::get_hyperparameter_tuning_job][crate::client::JobService::get_hyperparameter_tuning_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25397,7 +25397,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_hyperparameter_tuning_jobs][super::super::client::JobService::list_hyperparameter_tuning_jobs] calls.
+    /// The request builder for [JobService::list_hyperparameter_tuning_jobs][crate::client::JobService::list_hyperparameter_tuning_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25533,7 +25533,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_hyperparameter_tuning_job][super::super::client::JobService::delete_hyperparameter_tuning_job] calls.
+    /// The request builder for [JobService::delete_hyperparameter_tuning_job][crate::client::JobService::delete_hyperparameter_tuning_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25583,7 +25583,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_hyperparameter_tuning_job][super::super::client::JobService::delete_hyperparameter_tuning_job].
+        /// on [delete_hyperparameter_tuning_job][crate::client::JobService::delete_hyperparameter_tuning_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_hyperparameter_tuning_job(self.0.request, self.0.options)
@@ -25643,7 +25643,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::cancel_hyperparameter_tuning_job][super::super::client::JobService::cancel_hyperparameter_tuning_job] calls.
+    /// The request builder for [JobService::cancel_hyperparameter_tuning_job][crate::client::JobService::cancel_hyperparameter_tuning_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25711,7 +25711,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::create_nas_job][super::super::client::JobService::create_nas_job] calls.
+    /// The request builder for [JobService::create_nas_job][crate::client::JobService::create_nas_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25796,7 +25796,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_nas_job][super::super::client::JobService::get_nas_job] calls.
+    /// The request builder for [JobService::get_nas_job][crate::client::JobService::get_nas_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25859,7 +25859,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_nas_jobs][super::super::client::JobService::list_nas_jobs] calls.
+    /// The request builder for [JobService::list_nas_jobs][crate::client::JobService::list_nas_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -25986,7 +25986,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_nas_job][super::super::client::JobService::delete_nas_job] calls.
+    /// The request builder for [JobService::delete_nas_job][crate::client::JobService::delete_nas_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26031,7 +26031,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_nas_job][super::super::client::JobService::delete_nas_job].
+        /// on [delete_nas_job][crate::client::JobService::delete_nas_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_nas_job(self.0.request, self.0.options)
@@ -26091,7 +26091,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::cancel_nas_job][super::super::client::JobService::cancel_nas_job] calls.
+    /// The request builder for [JobService::cancel_nas_job][crate::client::JobService::cancel_nas_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26154,7 +26154,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_nas_trial_detail][super::super::client::JobService::get_nas_trial_detail] calls.
+    /// The request builder for [JobService::get_nas_trial_detail][crate::client::JobService::get_nas_trial_detail] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26220,7 +26220,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_nas_trial_details][super::super::client::JobService::list_nas_trial_details] calls.
+    /// The request builder for [JobService::list_nas_trial_details][crate::client::JobService::list_nas_trial_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26328,7 +26328,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::create_batch_prediction_job][super::super::client::JobService::create_batch_prediction_job] calls.
+    /// The request builder for [JobService::create_batch_prediction_job][crate::client::JobService::create_batch_prediction_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26418,7 +26418,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_batch_prediction_job][super::super::client::JobService::get_batch_prediction_job] calls.
+    /// The request builder for [JobService::get_batch_prediction_job][crate::client::JobService::get_batch_prediction_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26484,7 +26484,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_batch_prediction_jobs][super::super::client::JobService::list_batch_prediction_jobs] calls.
+    /// The request builder for [JobService::list_batch_prediction_jobs][crate::client::JobService::list_batch_prediction_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26620,7 +26620,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_batch_prediction_job][super::super::client::JobService::delete_batch_prediction_job] calls.
+    /// The request builder for [JobService::delete_batch_prediction_job][crate::client::JobService::delete_batch_prediction_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26670,7 +26670,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_batch_prediction_job][super::super::client::JobService::delete_batch_prediction_job].
+        /// on [delete_batch_prediction_job][crate::client::JobService::delete_batch_prediction_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_batch_prediction_job(self.0.request, self.0.options)
@@ -26730,7 +26730,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::cancel_batch_prediction_job][super::super::client::JobService::cancel_batch_prediction_job] calls.
+    /// The request builder for [JobService::cancel_batch_prediction_job][crate::client::JobService::cancel_batch_prediction_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26798,7 +26798,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::create_model_deployment_monitoring_job][super::super::client::JobService::create_model_deployment_monitoring_job] calls.
+    /// The request builder for [JobService::create_model_deployment_monitoring_job][crate::client::JobService::create_model_deployment_monitoring_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -26891,7 +26891,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::search_model_deployment_monitoring_stats_anomalies][super::super::client::JobService::search_model_deployment_monitoring_stats_anomalies] calls.
+    /// The request builder for [JobService::search_model_deployment_monitoring_stats_anomalies][crate::client::JobService::search_model_deployment_monitoring_stats_anomalies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27073,7 +27073,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_model_deployment_monitoring_job][super::super::client::JobService::get_model_deployment_monitoring_job] calls.
+    /// The request builder for [JobService::get_model_deployment_monitoring_job][crate::client::JobService::get_model_deployment_monitoring_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27141,7 +27141,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_model_deployment_monitoring_jobs][super::super::client::JobService::list_model_deployment_monitoring_jobs] calls.
+    /// The request builder for [JobService::list_model_deployment_monitoring_jobs][crate::client::JobService::list_model_deployment_monitoring_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27277,7 +27277,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::update_model_deployment_monitoring_job][super::super::client::JobService::update_model_deployment_monitoring_job] calls.
+    /// The request builder for [JobService::update_model_deployment_monitoring_job][crate::client::JobService::update_model_deployment_monitoring_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27327,7 +27327,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_model_deployment_monitoring_job][super::super::client::JobService::update_model_deployment_monitoring_job].
+        /// on [update_model_deployment_monitoring_job][crate::client::JobService::update_model_deployment_monitoring_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_model_deployment_monitoring_job(self.0.request, self.0.options)
@@ -27428,7 +27428,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_model_deployment_monitoring_job][super::super::client::JobService::delete_model_deployment_monitoring_job] calls.
+    /// The request builder for [JobService::delete_model_deployment_monitoring_job][crate::client::JobService::delete_model_deployment_monitoring_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27478,7 +27478,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_model_deployment_monitoring_job][super::super::client::JobService::delete_model_deployment_monitoring_job].
+        /// on [delete_model_deployment_monitoring_job][crate::client::JobService::delete_model_deployment_monitoring_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_model_deployment_monitoring_job(self.0.request, self.0.options)
@@ -27538,7 +27538,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::pause_model_deployment_monitoring_job][super::super::client::JobService::pause_model_deployment_monitoring_job] calls.
+    /// The request builder for [JobService::pause_model_deployment_monitoring_job][crate::client::JobService::pause_model_deployment_monitoring_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27606,7 +27606,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::resume_model_deployment_monitoring_job][super::super::client::JobService::resume_model_deployment_monitoring_job] calls.
+    /// The request builder for [JobService::resume_model_deployment_monitoring_job][crate::client::JobService::resume_model_deployment_monitoring_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27674,7 +27674,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_locations][super::super::client::JobService::list_locations] calls.
+    /// The request builder for [JobService::list_locations][crate::client::JobService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27784,7 +27784,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_location][super::super::client::JobService::get_location] calls.
+    /// The request builder for [JobService::get_location][crate::client::JobService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27845,7 +27845,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::set_iam_policy][super::super::client::JobService::set_iam_policy] calls.
+    /// The request builder for [JobService::set_iam_policy][crate::client::JobService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -27948,7 +27948,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_iam_policy][super::super::client::JobService::get_iam_policy] calls.
+    /// The request builder for [JobService::get_iam_policy][crate::client::JobService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28029,7 +28029,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::test_iam_permissions][super::super::client::JobService::test_iam_permissions] calls.
+    /// The request builder for [JobService::test_iam_permissions][crate::client::JobService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28108,7 +28108,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_operations][super::super::client::JobService::list_operations] calls.
+    /// The request builder for [JobService::list_operations][crate::client::JobService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28220,7 +28220,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_operation][super::super::client::JobService::get_operation] calls.
+    /// The request builder for [JobService::get_operation][crate::client::JobService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28284,7 +28284,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_operation][super::super::client::JobService::delete_operation] calls.
+    /// The request builder for [JobService::delete_operation][crate::client::JobService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28348,7 +28348,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::cancel_operation][super::super::client::JobService::cancel_operation] calls.
+    /// The request builder for [JobService::cancel_operation][crate::client::JobService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28412,7 +28412,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::wait_operation][super::super::client::JobService::wait_operation] calls.
+    /// The request builder for [JobService::wait_operation][crate::client::JobService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28500,7 +28500,7 @@ pub mod job_service {
 pub mod llm_utility_service {
     use crate::Result;
 
-    /// A builder for [LlmUtilityService][super::super::client::LlmUtilityService].
+    /// A builder for [LlmUtilityService][crate::client::LlmUtilityService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -28528,7 +28528,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// Common implementation for [super::super::client::LlmUtilityService] request builders.
+    /// Common implementation for [crate::client::LlmUtilityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LlmUtilityService>,
@@ -28551,7 +28551,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::count_tokens][super::super::client::LlmUtilityService::count_tokens] calls.
+    /// The request builder for [LlmUtilityService::count_tokens][crate::client::LlmUtilityService::count_tokens] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28689,7 +28689,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::compute_tokens][super::super::client::LlmUtilityService::compute_tokens] calls.
+    /// The request builder for [LlmUtilityService::compute_tokens][crate::client::LlmUtilityService::compute_tokens] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28780,7 +28780,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::list_locations][super::super::client::LlmUtilityService::list_locations] calls.
+    /// The request builder for [LlmUtilityService::list_locations][crate::client::LlmUtilityService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28890,7 +28890,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::get_location][super::super::client::LlmUtilityService::get_location] calls.
+    /// The request builder for [LlmUtilityService::get_location][crate::client::LlmUtilityService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -28951,7 +28951,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::set_iam_policy][super::super::client::LlmUtilityService::set_iam_policy] calls.
+    /// The request builder for [LlmUtilityService::set_iam_policy][crate::client::LlmUtilityService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29054,7 +29054,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::get_iam_policy][super::super::client::LlmUtilityService::get_iam_policy] calls.
+    /// The request builder for [LlmUtilityService::get_iam_policy][crate::client::LlmUtilityService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29135,7 +29135,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::test_iam_permissions][super::super::client::LlmUtilityService::test_iam_permissions] calls.
+    /// The request builder for [LlmUtilityService::test_iam_permissions][crate::client::LlmUtilityService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29214,7 +29214,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::list_operations][super::super::client::LlmUtilityService::list_operations] calls.
+    /// The request builder for [LlmUtilityService::list_operations][crate::client::LlmUtilityService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29326,7 +29326,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::get_operation][super::super::client::LlmUtilityService::get_operation] calls.
+    /// The request builder for [LlmUtilityService::get_operation][crate::client::LlmUtilityService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29390,7 +29390,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::delete_operation][super::super::client::LlmUtilityService::delete_operation] calls.
+    /// The request builder for [LlmUtilityService::delete_operation][crate::client::LlmUtilityService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29454,7 +29454,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::cancel_operation][super::super::client::LlmUtilityService::cancel_operation] calls.
+    /// The request builder for [LlmUtilityService::cancel_operation][crate::client::LlmUtilityService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29518,7 +29518,7 @@ pub mod llm_utility_service {
         }
     }
 
-    /// The request builder for [LlmUtilityService::wait_operation][super::super::client::LlmUtilityService::wait_operation] calls.
+    /// The request builder for [LlmUtilityService::wait_operation][crate::client::LlmUtilityService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29606,7 +29606,7 @@ pub mod llm_utility_service {
 pub mod match_service {
     use crate::Result;
 
-    /// A builder for [MatchService][super::super::client::MatchService].
+    /// A builder for [MatchService][crate::client::MatchService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -29634,7 +29634,7 @@ pub mod match_service {
         }
     }
 
-    /// Common implementation for [super::super::client::MatchService] request builders.
+    /// Common implementation for [crate::client::MatchService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MatchService>,
@@ -29657,7 +29657,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::find_neighbors][super::super::client::MatchService::find_neighbors] calls.
+    /// The request builder for [MatchService::find_neighbors][crate::client::MatchService::find_neighbors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29743,7 +29743,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::read_index_datapoints][super::super::client::MatchService::read_index_datapoints] calls.
+    /// The request builder for [MatchService::read_index_datapoints][crate::client::MatchService::read_index_datapoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29826,7 +29826,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::list_locations][super::super::client::MatchService::list_locations] calls.
+    /// The request builder for [MatchService::list_locations][crate::client::MatchService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29936,7 +29936,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::get_location][super::super::client::MatchService::get_location] calls.
+    /// The request builder for [MatchService::get_location][crate::client::MatchService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -29997,7 +29997,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::set_iam_policy][super::super::client::MatchService::set_iam_policy] calls.
+    /// The request builder for [MatchService::set_iam_policy][crate::client::MatchService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30100,7 +30100,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::get_iam_policy][super::super::client::MatchService::get_iam_policy] calls.
+    /// The request builder for [MatchService::get_iam_policy][crate::client::MatchService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30181,7 +30181,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::test_iam_permissions][super::super::client::MatchService::test_iam_permissions] calls.
+    /// The request builder for [MatchService::test_iam_permissions][crate::client::MatchService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30260,7 +30260,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::list_operations][super::super::client::MatchService::list_operations] calls.
+    /// The request builder for [MatchService::list_operations][crate::client::MatchService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30372,7 +30372,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::get_operation][super::super::client::MatchService::get_operation] calls.
+    /// The request builder for [MatchService::get_operation][crate::client::MatchService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30436,7 +30436,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::delete_operation][super::super::client::MatchService::delete_operation] calls.
+    /// The request builder for [MatchService::delete_operation][crate::client::MatchService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30500,7 +30500,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::cancel_operation][super::super::client::MatchService::cancel_operation] calls.
+    /// The request builder for [MatchService::cancel_operation][crate::client::MatchService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30564,7 +30564,7 @@ pub mod match_service {
         }
     }
 
-    /// The request builder for [MatchService::wait_operation][super::super::client::MatchService::wait_operation] calls.
+    /// The request builder for [MatchService::wait_operation][crate::client::MatchService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30652,7 +30652,7 @@ pub mod match_service {
 pub mod metadata_service {
     use crate::Result;
 
-    /// A builder for [MetadataService][super::super::client::MetadataService].
+    /// A builder for [MetadataService][crate::client::MetadataService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -30680,7 +30680,7 @@ pub mod metadata_service {
         }
     }
 
-    /// Common implementation for [super::super::client::MetadataService] request builders.
+    /// Common implementation for [crate::client::MetadataService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MetadataService>,
@@ -30703,7 +30703,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::create_metadata_store][super::super::client::MetadataService::create_metadata_store] calls.
+    /// The request builder for [MetadataService::create_metadata_store][crate::client::MetadataService::create_metadata_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30751,7 +30751,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_metadata_store][super::super::client::MetadataService::create_metadata_store].
+        /// on [create_metadata_store][crate::client::MetadataService::create_metadata_store].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_metadata_store(self.0.request, self.0.options)
@@ -30841,7 +30841,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_metadata_store][super::super::client::MetadataService::get_metadata_store] calls.
+    /// The request builder for [MetadataService::get_metadata_store][crate::client::MetadataService::get_metadata_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -30907,7 +30907,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_metadata_stores][super::super::client::MetadataService::list_metadata_stores] calls.
+    /// The request builder for [MetadataService::list_metadata_stores][crate::client::MetadataService::list_metadata_stores] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31015,7 +31015,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_metadata_store][super::super::client::MetadataService::delete_metadata_store] calls.
+    /// The request builder for [MetadataService::delete_metadata_store][crate::client::MetadataService::delete_metadata_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31063,7 +31063,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_metadata_store][super::super::client::MetadataService::delete_metadata_store].
+        /// on [delete_metadata_store][crate::client::MetadataService::delete_metadata_store].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_metadata_store(self.0.request, self.0.options)
@@ -31134,7 +31134,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::create_artifact][super::super::client::MetadataService::create_artifact] calls.
+    /// The request builder for [MetadataService::create_artifact][crate::client::MetadataService::create_artifact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31225,7 +31225,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_artifact][super::super::client::MetadataService::get_artifact] calls.
+    /// The request builder for [MetadataService::get_artifact][crate::client::MetadataService::get_artifact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31288,7 +31288,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_artifacts][super::super::client::MetadataService::list_artifacts] calls.
+    /// The request builder for [MetadataService::list_artifacts][crate::client::MetadataService::list_artifacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31403,7 +31403,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::update_artifact][super::super::client::MetadataService::update_artifact] calls.
+    /// The request builder for [MetadataService::update_artifact][crate::client::MetadataService::update_artifact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31504,7 +31504,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_artifact][super::super::client::MetadataService::delete_artifact] calls.
+    /// The request builder for [MetadataService::delete_artifact][crate::client::MetadataService::delete_artifact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31549,7 +31549,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_artifact][super::super::client::MetadataService::delete_artifact].
+        /// on [delete_artifact][crate::client::MetadataService::delete_artifact].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_artifact(self.0.request, self.0.options)
@@ -31615,7 +31615,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::purge_artifacts][super::super::client::MetadataService::purge_artifacts] calls.
+    /// The request builder for [MetadataService::purge_artifacts][crate::client::MetadataService::purge_artifacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31660,7 +31660,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_artifacts][super::super::client::MetadataService::purge_artifacts].
+        /// on [purge_artifacts][crate::client::MetadataService::purge_artifacts].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_artifacts(self.0.request, self.0.options)
@@ -31734,7 +31734,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::create_context][super::super::client::MetadataService::create_context] calls.
+    /// The request builder for [MetadataService::create_context][crate::client::MetadataService::create_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31825,7 +31825,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_context][super::super::client::MetadataService::get_context] calls.
+    /// The request builder for [MetadataService::get_context][crate::client::MetadataService::get_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -31888,7 +31888,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_contexts][super::super::client::MetadataService::list_contexts] calls.
+    /// The request builder for [MetadataService::list_contexts][crate::client::MetadataService::list_contexts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32003,7 +32003,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::update_context][super::super::client::MetadataService::update_context] calls.
+    /// The request builder for [MetadataService::update_context][crate::client::MetadataService::update_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32104,7 +32104,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_context][super::super::client::MetadataService::delete_context] calls.
+    /// The request builder for [MetadataService::delete_context][crate::client::MetadataService::delete_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32149,7 +32149,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_context][super::super::client::MetadataService::delete_context].
+        /// on [delete_context][crate::client::MetadataService::delete_context].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_context(self.0.request, self.0.options)
@@ -32221,7 +32221,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::purge_contexts][super::super::client::MetadataService::purge_contexts] calls.
+    /// The request builder for [MetadataService::purge_contexts][crate::client::MetadataService::purge_contexts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32266,7 +32266,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_contexts][super::super::client::MetadataService::purge_contexts].
+        /// on [purge_contexts][crate::client::MetadataService::purge_contexts].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_contexts(self.0.request, self.0.options)
@@ -32340,7 +32340,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::add_context_artifacts_and_executions][super::super::client::MetadataService::add_context_artifacts_and_executions] calls.
+    /// The request builder for [MetadataService::add_context_artifacts_and_executions][crate::client::MetadataService::add_context_artifacts_and_executions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32430,7 +32430,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::add_context_children][super::super::client::MetadataService::add_context_children] calls.
+    /// The request builder for [MetadataService::add_context_children][crate::client::MetadataService::add_context_children] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32507,7 +32507,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::remove_context_children][super::super::client::MetadataService::remove_context_children] calls.
+    /// The request builder for [MetadataService::remove_context_children][crate::client::MetadataService::remove_context_children] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32584,7 +32584,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::query_context_lineage_subgraph][super::super::client::MetadataService::query_context_lineage_subgraph] calls.
+    /// The request builder for [MetadataService::query_context_lineage_subgraph][crate::client::MetadataService::query_context_lineage_subgraph] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32652,7 +32652,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::create_execution][super::super::client::MetadataService::create_execution] calls.
+    /// The request builder for [MetadataService::create_execution][crate::client::MetadataService::create_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32743,7 +32743,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_execution][super::super::client::MetadataService::get_execution] calls.
+    /// The request builder for [MetadataService::get_execution][crate::client::MetadataService::get_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32806,7 +32806,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_executions][super::super::client::MetadataService::list_executions] calls.
+    /// The request builder for [MetadataService::list_executions][crate::client::MetadataService::list_executions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -32921,7 +32921,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::update_execution][super::super::client::MetadataService::update_execution] calls.
+    /// The request builder for [MetadataService::update_execution][crate::client::MetadataService::update_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33022,7 +33022,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_execution][super::super::client::MetadataService::delete_execution] calls.
+    /// The request builder for [MetadataService::delete_execution][crate::client::MetadataService::delete_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33067,7 +33067,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_execution][super::super::client::MetadataService::delete_execution].
+        /// on [delete_execution][crate::client::MetadataService::delete_execution].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_execution(self.0.request, self.0.options)
@@ -33133,7 +33133,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::purge_executions][super::super::client::MetadataService::purge_executions] calls.
+    /// The request builder for [MetadataService::purge_executions][crate::client::MetadataService::purge_executions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33178,7 +33178,7 @@ pub mod metadata_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_executions][super::super::client::MetadataService::purge_executions].
+        /// on [purge_executions][crate::client::MetadataService::purge_executions].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_executions(self.0.request, self.0.options)
@@ -33252,7 +33252,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::add_execution_events][super::super::client::MetadataService::add_execution_events] calls.
+    /// The request builder for [MetadataService::add_execution_events][crate::client::MetadataService::add_execution_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33329,7 +33329,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::query_execution_inputs_and_outputs][super::super::client::MetadataService::query_execution_inputs_and_outputs] calls.
+    /// The request builder for [MetadataService::query_execution_inputs_and_outputs][crate::client::MetadataService::query_execution_inputs_and_outputs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33397,7 +33397,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::create_metadata_schema][super::super::client::MetadataService::create_metadata_schema] calls.
+    /// The request builder for [MetadataService::create_metadata_schema][crate::client::MetadataService::create_metadata_schema] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33491,7 +33491,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_metadata_schema][super::super::client::MetadataService::get_metadata_schema] calls.
+    /// The request builder for [MetadataService::get_metadata_schema][crate::client::MetadataService::get_metadata_schema] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33557,7 +33557,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_metadata_schemas][super::super::client::MetadataService::list_metadata_schemas] calls.
+    /// The request builder for [MetadataService::list_metadata_schemas][crate::client::MetadataService::list_metadata_schemas] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33671,7 +33671,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::query_artifact_lineage_subgraph][super::super::client::MetadataService::query_artifact_lineage_subgraph] calls.
+    /// The request builder for [MetadataService::query_artifact_lineage_subgraph][crate::client::MetadataService::query_artifact_lineage_subgraph] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33751,7 +33751,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_locations][super::super::client::MetadataService::list_locations] calls.
+    /// The request builder for [MetadataService::list_locations][crate::client::MetadataService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33861,7 +33861,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_location][super::super::client::MetadataService::get_location] calls.
+    /// The request builder for [MetadataService::get_location][crate::client::MetadataService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -33922,7 +33922,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::set_iam_policy][super::super::client::MetadataService::set_iam_policy] calls.
+    /// The request builder for [MetadataService::set_iam_policy][crate::client::MetadataService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34025,7 +34025,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_iam_policy][super::super::client::MetadataService::get_iam_policy] calls.
+    /// The request builder for [MetadataService::get_iam_policy][crate::client::MetadataService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34106,7 +34106,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::test_iam_permissions][super::super::client::MetadataService::test_iam_permissions] calls.
+    /// The request builder for [MetadataService::test_iam_permissions][crate::client::MetadataService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34185,7 +34185,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_operations][super::super::client::MetadataService::list_operations] calls.
+    /// The request builder for [MetadataService::list_operations][crate::client::MetadataService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34297,7 +34297,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_operation][super::super::client::MetadataService::get_operation] calls.
+    /// The request builder for [MetadataService::get_operation][crate::client::MetadataService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34361,7 +34361,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_operation][super::super::client::MetadataService::delete_operation] calls.
+    /// The request builder for [MetadataService::delete_operation][crate::client::MetadataService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34425,7 +34425,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::cancel_operation][super::super::client::MetadataService::cancel_operation] calls.
+    /// The request builder for [MetadataService::cancel_operation][crate::client::MetadataService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34489,7 +34489,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::wait_operation][super::super::client::MetadataService::wait_operation] calls.
+    /// The request builder for [MetadataService::wait_operation][crate::client::MetadataService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34577,7 +34577,7 @@ pub mod metadata_service {
 pub mod migration_service {
     use crate::Result;
 
-    /// A builder for [MigrationService][super::super::client::MigrationService].
+    /// A builder for [MigrationService][crate::client::MigrationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -34605,7 +34605,7 @@ pub mod migration_service {
         }
     }
 
-    /// Common implementation for [super::super::client::MigrationService] request builders.
+    /// Common implementation for [crate::client::MigrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MigrationService>,
@@ -34628,7 +34628,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::search_migratable_resources][super::super::client::MigrationService::search_migratable_resources] calls.
+    /// The request builder for [MigrationService::search_migratable_resources][crate::client::MigrationService::search_migratable_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34746,7 +34746,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::batch_migrate_resources][super::super::client::MigrationService::batch_migrate_resources] calls.
+    /// The request builder for [MigrationService::batch_migrate_resources][crate::client::MigrationService::batch_migrate_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34794,7 +34794,7 @@ pub mod migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_migrate_resources][super::super::client::MigrationService::batch_migrate_resources].
+        /// on [batch_migrate_resources][crate::client::MigrationService::batch_migrate_resources].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_migrate_resources(self.0.request, self.0.options)
@@ -34869,7 +34869,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::list_locations][super::super::client::MigrationService::list_locations] calls.
+    /// The request builder for [MigrationService::list_locations][crate::client::MigrationService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -34979,7 +34979,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::get_location][super::super::client::MigrationService::get_location] calls.
+    /// The request builder for [MigrationService::get_location][crate::client::MigrationService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35040,7 +35040,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::set_iam_policy][super::super::client::MigrationService::set_iam_policy] calls.
+    /// The request builder for [MigrationService::set_iam_policy][crate::client::MigrationService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35143,7 +35143,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::get_iam_policy][super::super::client::MigrationService::get_iam_policy] calls.
+    /// The request builder for [MigrationService::get_iam_policy][crate::client::MigrationService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35224,7 +35224,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::test_iam_permissions][super::super::client::MigrationService::test_iam_permissions] calls.
+    /// The request builder for [MigrationService::test_iam_permissions][crate::client::MigrationService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35303,7 +35303,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::list_operations][super::super::client::MigrationService::list_operations] calls.
+    /// The request builder for [MigrationService::list_operations][crate::client::MigrationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35415,7 +35415,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::get_operation][super::super::client::MigrationService::get_operation] calls.
+    /// The request builder for [MigrationService::get_operation][crate::client::MigrationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35479,7 +35479,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::delete_operation][super::super::client::MigrationService::delete_operation] calls.
+    /// The request builder for [MigrationService::delete_operation][crate::client::MigrationService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35543,7 +35543,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::cancel_operation][super::super::client::MigrationService::cancel_operation] calls.
+    /// The request builder for [MigrationService::cancel_operation][crate::client::MigrationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35607,7 +35607,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::wait_operation][super::super::client::MigrationService::wait_operation] calls.
+    /// The request builder for [MigrationService::wait_operation][crate::client::MigrationService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35695,7 +35695,7 @@ pub mod migration_service {
 pub mod model_garden_service {
     use crate::Result;
 
-    /// A builder for [ModelGardenService][super::super::client::ModelGardenService].
+    /// A builder for [ModelGardenService][crate::client::ModelGardenService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -35723,7 +35723,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ModelGardenService] request builders.
+    /// Common implementation for [crate::client::ModelGardenService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ModelGardenService>,
@@ -35746,7 +35746,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::get_publisher_model][super::super::client::ModelGardenService::get_publisher_model] calls.
+    /// The request builder for [ModelGardenService::get_publisher_model][crate::client::ModelGardenService::get_publisher_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35836,7 +35836,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::list_locations][super::super::client::ModelGardenService::list_locations] calls.
+    /// The request builder for [ModelGardenService::list_locations][crate::client::ModelGardenService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -35946,7 +35946,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::get_location][super::super::client::ModelGardenService::get_location] calls.
+    /// The request builder for [ModelGardenService::get_location][crate::client::ModelGardenService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36007,7 +36007,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::set_iam_policy][super::super::client::ModelGardenService::set_iam_policy] calls.
+    /// The request builder for [ModelGardenService::set_iam_policy][crate::client::ModelGardenService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36110,7 +36110,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::get_iam_policy][super::super::client::ModelGardenService::get_iam_policy] calls.
+    /// The request builder for [ModelGardenService::get_iam_policy][crate::client::ModelGardenService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36191,7 +36191,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::test_iam_permissions][super::super::client::ModelGardenService::test_iam_permissions] calls.
+    /// The request builder for [ModelGardenService::test_iam_permissions][crate::client::ModelGardenService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36270,7 +36270,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::list_operations][super::super::client::ModelGardenService::list_operations] calls.
+    /// The request builder for [ModelGardenService::list_operations][crate::client::ModelGardenService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36382,7 +36382,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::get_operation][super::super::client::ModelGardenService::get_operation] calls.
+    /// The request builder for [ModelGardenService::get_operation][crate::client::ModelGardenService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36446,7 +36446,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::delete_operation][super::super::client::ModelGardenService::delete_operation] calls.
+    /// The request builder for [ModelGardenService::delete_operation][crate::client::ModelGardenService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36510,7 +36510,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::cancel_operation][super::super::client::ModelGardenService::cancel_operation] calls.
+    /// The request builder for [ModelGardenService::cancel_operation][crate::client::ModelGardenService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36574,7 +36574,7 @@ pub mod model_garden_service {
         }
     }
 
-    /// The request builder for [ModelGardenService::wait_operation][super::super::client::ModelGardenService::wait_operation] calls.
+    /// The request builder for [ModelGardenService::wait_operation][crate::client::ModelGardenService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36662,7 +36662,7 @@ pub mod model_garden_service {
 pub mod model_service {
     use crate::Result;
 
-    /// A builder for [ModelService][super::super::client::ModelService].
+    /// A builder for [ModelService][crate::client::ModelService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -36690,7 +36690,7 @@ pub mod model_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ModelService] request builders.
+    /// Common implementation for [crate::client::ModelService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ModelService>,
@@ -36713,7 +36713,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::upload_model][super::super::client::ModelService::upload_model] calls.
+    /// The request builder for [ModelService::upload_model][crate::client::ModelService::upload_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36758,7 +36758,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upload_model][super::super::client::ModelService::upload_model].
+        /// on [upload_model][crate::client::ModelService::upload_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upload_model(self.0.request, self.0.options)
@@ -36860,7 +36860,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
+    /// The request builder for [ModelService::get_model][crate::client::ModelService::get_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -36923,7 +36923,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
+    /// The request builder for [ModelService::list_models][crate::client::ModelService::list_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37056,7 +37056,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_model_versions][super::super::client::ModelService::list_model_versions] calls.
+    /// The request builder for [ModelService::list_model_versions][crate::client::ModelService::list_model_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37192,7 +37192,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_model_version_checkpoints][super::super::client::ModelService::list_model_version_checkpoints] calls.
+    /// The request builder for [ModelService::list_model_version_checkpoints][crate::client::ModelService::list_model_version_checkpoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37304,7 +37304,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::update_model][super::super::client::ModelService::update_model] calls.
+    /// The request builder for [ModelService::update_model][crate::client::ModelService::update_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37403,7 +37403,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::update_explanation_dataset][super::super::client::ModelService::update_explanation_dataset] calls.
+    /// The request builder for [ModelService::update_explanation_dataset][crate::client::ModelService::update_explanation_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37453,7 +37453,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_explanation_dataset][super::super::client::ModelService::update_explanation_dataset].
+        /// on [update_explanation_dataset][crate::client::ModelService::update_explanation_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_explanation_dataset(self.0.request, self.0.options)
@@ -37533,7 +37533,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
+    /// The request builder for [ModelService::delete_model][crate::client::ModelService::delete_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37578,7 +37578,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_model][super::super::client::ModelService::delete_model].
+        /// on [delete_model][crate::client::ModelService::delete_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_model(self.0.request, self.0.options)
@@ -37638,7 +37638,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::delete_model_version][super::super::client::ModelService::delete_model_version] calls.
+    /// The request builder for [ModelService::delete_model_version][crate::client::ModelService::delete_model_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37686,7 +37686,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_model_version][super::super::client::ModelService::delete_model_version].
+        /// on [delete_model_version][crate::client::ModelService::delete_model_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_model_version(self.0.request, self.0.options)
@@ -37746,7 +37746,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::merge_version_aliases][super::super::client::ModelService::merge_version_aliases] calls.
+    /// The request builder for [ModelService::merge_version_aliases][crate::client::ModelService::merge_version_aliases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37825,7 +37825,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::export_model][super::super::client::ModelService::export_model] calls.
+    /// The request builder for [ModelService::export_model][crate::client::ModelService::export_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37870,7 +37870,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_model][super::super::client::ModelService::export_model].
+        /// on [export_model][crate::client::ModelService::export_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_model(self.0.request, self.0.options)
@@ -37954,7 +37954,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::copy_model][super::super::client::ModelService::copy_model] calls.
+    /// The request builder for [ModelService::copy_model][crate::client::ModelService::copy_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -37999,7 +37999,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [copy_model][super::super::client::ModelService::copy_model].
+        /// on [copy_model][crate::client::ModelService::copy_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .copy_model(self.0.request, self.0.options)
@@ -38122,7 +38122,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::import_model_evaluation][super::super::client::ModelService::import_model_evaluation] calls.
+    /// The request builder for [ModelService::import_model_evaluation][crate::client::ModelService::import_model_evaluation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38210,7 +38210,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::batch_import_model_evaluation_slices][super::super::client::ModelService::batch_import_model_evaluation_slices] calls.
+    /// The request builder for [ModelService::batch_import_model_evaluation_slices][crate::client::ModelService::batch_import_model_evaluation_slices] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38291,7 +38291,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::batch_import_evaluated_annotations][super::super::client::ModelService::batch_import_evaluated_annotations] calls.
+    /// The request builder for [ModelService::batch_import_evaluated_annotations][crate::client::ModelService::batch_import_evaluated_annotations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38372,7 +38372,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_model_evaluation][super::super::client::ModelService::get_model_evaluation] calls.
+    /// The request builder for [ModelService::get_model_evaluation][crate::client::ModelService::get_model_evaluation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38438,7 +38438,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_model_evaluations][super::super::client::ModelService::list_model_evaluations] calls.
+    /// The request builder for [ModelService::list_model_evaluations][crate::client::ModelService::list_model_evaluations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38570,7 +38570,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_model_evaluation_slice][super::super::client::ModelService::get_model_evaluation_slice] calls.
+    /// The request builder for [ModelService::get_model_evaluation_slice][crate::client::ModelService::get_model_evaluation_slice] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38638,7 +38638,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_model_evaluation_slices][super::super::client::ModelService::list_model_evaluation_slices] calls.
+    /// The request builder for [ModelService::list_model_evaluation_slices][crate::client::ModelService::list_model_evaluation_slices] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38774,7 +38774,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_locations][super::super::client::ModelService::list_locations] calls.
+    /// The request builder for [ModelService::list_locations][crate::client::ModelService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38884,7 +38884,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_location][super::super::client::ModelService::get_location] calls.
+    /// The request builder for [ModelService::get_location][crate::client::ModelService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -38945,7 +38945,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::set_iam_policy][super::super::client::ModelService::set_iam_policy] calls.
+    /// The request builder for [ModelService::set_iam_policy][crate::client::ModelService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39048,7 +39048,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_iam_policy][super::super::client::ModelService::get_iam_policy] calls.
+    /// The request builder for [ModelService::get_iam_policy][crate::client::ModelService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39129,7 +39129,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::test_iam_permissions][super::super::client::ModelService::test_iam_permissions] calls.
+    /// The request builder for [ModelService::test_iam_permissions][crate::client::ModelService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39208,7 +39208,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_operations][super::super::client::ModelService::list_operations] calls.
+    /// The request builder for [ModelService::list_operations][crate::client::ModelService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39320,7 +39320,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_operation][super::super::client::ModelService::get_operation] calls.
+    /// The request builder for [ModelService::get_operation][crate::client::ModelService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39384,7 +39384,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::delete_operation][super::super::client::ModelService::delete_operation] calls.
+    /// The request builder for [ModelService::delete_operation][crate::client::ModelService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39448,7 +39448,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::cancel_operation][super::super::client::ModelService::cancel_operation] calls.
+    /// The request builder for [ModelService::cancel_operation][crate::client::ModelService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39512,7 +39512,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::wait_operation][super::super::client::ModelService::wait_operation] calls.
+    /// The request builder for [ModelService::wait_operation][crate::client::ModelService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39600,7 +39600,7 @@ pub mod model_service {
 pub mod notebook_service {
     use crate::Result;
 
-    /// A builder for [NotebookService][super::super::client::NotebookService].
+    /// A builder for [NotebookService][crate::client::NotebookService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -39628,7 +39628,7 @@ pub mod notebook_service {
         }
     }
 
-    /// Common implementation for [super::super::client::NotebookService] request builders.
+    /// Common implementation for [crate::client::NotebookService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::NotebookService>,
@@ -39651,7 +39651,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::create_notebook_runtime_template][super::super::client::NotebookService::create_notebook_runtime_template] calls.
+    /// The request builder for [NotebookService::create_notebook_runtime_template][crate::client::NotebookService::create_notebook_runtime_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39701,7 +39701,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_notebook_runtime_template][super::super::client::NotebookService::create_notebook_runtime_template].
+        /// on [create_notebook_runtime_template][crate::client::NotebookService::create_notebook_runtime_template].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_notebook_runtime_template(self.0.request, self.0.options)
@@ -39797,7 +39797,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_notebook_runtime_template][super::super::client::NotebookService::get_notebook_runtime_template] calls.
+    /// The request builder for [NotebookService::get_notebook_runtime_template][crate::client::NotebookService::get_notebook_runtime_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -39865,7 +39865,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_notebook_runtime_templates][super::super::client::NotebookService::list_notebook_runtime_templates] calls.
+    /// The request builder for [NotebookService::list_notebook_runtime_templates][crate::client::NotebookService::list_notebook_runtime_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40007,7 +40007,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::delete_notebook_runtime_template][super::super::client::NotebookService::delete_notebook_runtime_template] calls.
+    /// The request builder for [NotebookService::delete_notebook_runtime_template][crate::client::NotebookService::delete_notebook_runtime_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40057,7 +40057,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_notebook_runtime_template][super::super::client::NotebookService::delete_notebook_runtime_template].
+        /// on [delete_notebook_runtime_template][crate::client::NotebookService::delete_notebook_runtime_template].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_notebook_runtime_template(self.0.request, self.0.options)
@@ -40117,7 +40117,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::update_notebook_runtime_template][super::super::client::NotebookService::update_notebook_runtime_template] calls.
+    /// The request builder for [NotebookService::update_notebook_runtime_template][crate::client::NotebookService::update_notebook_runtime_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40224,7 +40224,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::assign_notebook_runtime][super::super::client::NotebookService::assign_notebook_runtime] calls.
+    /// The request builder for [NotebookService::assign_notebook_runtime][crate::client::NotebookService::assign_notebook_runtime] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40272,7 +40272,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [assign_notebook_runtime][super::super::client::NotebookService::assign_notebook_runtime].
+        /// on [assign_notebook_runtime][crate::client::NotebookService::assign_notebook_runtime].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .assign_notebook_runtime(self.0.request, self.0.options)
@@ -40370,7 +40370,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_notebook_runtime][super::super::client::NotebookService::get_notebook_runtime] calls.
+    /// The request builder for [NotebookService::get_notebook_runtime][crate::client::NotebookService::get_notebook_runtime] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40436,7 +40436,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_notebook_runtimes][super::super::client::NotebookService::list_notebook_runtimes] calls.
+    /// The request builder for [NotebookService::list_notebook_runtimes][crate::client::NotebookService::list_notebook_runtimes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40574,7 +40574,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::delete_notebook_runtime][super::super::client::NotebookService::delete_notebook_runtime] calls.
+    /// The request builder for [NotebookService::delete_notebook_runtime][crate::client::NotebookService::delete_notebook_runtime] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40622,7 +40622,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_notebook_runtime][super::super::client::NotebookService::delete_notebook_runtime].
+        /// on [delete_notebook_runtime][crate::client::NotebookService::delete_notebook_runtime].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_notebook_runtime(self.0.request, self.0.options)
@@ -40682,7 +40682,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::upgrade_notebook_runtime][super::super::client::NotebookService::upgrade_notebook_runtime] calls.
+    /// The request builder for [NotebookService::upgrade_notebook_runtime][crate::client::NotebookService::upgrade_notebook_runtime] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40730,7 +40730,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upgrade_notebook_runtime][super::super::client::NotebookService::upgrade_notebook_runtime].
+        /// on [upgrade_notebook_runtime][crate::client::NotebookService::upgrade_notebook_runtime].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upgrade_notebook_runtime(self.0.request, self.0.options)
@@ -40792,7 +40792,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::start_notebook_runtime][super::super::client::NotebookService::start_notebook_runtime] calls.
+    /// The request builder for [NotebookService::start_notebook_runtime][crate::client::NotebookService::start_notebook_runtime] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40840,7 +40840,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_notebook_runtime][super::super::client::NotebookService::start_notebook_runtime].
+        /// on [start_notebook_runtime][crate::client::NotebookService::start_notebook_runtime].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_notebook_runtime(self.0.request, self.0.options)
@@ -40902,7 +40902,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::stop_notebook_runtime][super::super::client::NotebookService::stop_notebook_runtime] calls.
+    /// The request builder for [NotebookService::stop_notebook_runtime][crate::client::NotebookService::stop_notebook_runtime] calls.
     ///
     /// # Example
     /// ```no_run
@@ -40950,7 +40950,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_notebook_runtime][super::super::client::NotebookService::stop_notebook_runtime].
+        /// on [stop_notebook_runtime][crate::client::NotebookService::stop_notebook_runtime].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_notebook_runtime(self.0.request, self.0.options)
@@ -41012,7 +41012,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::create_notebook_execution_job][super::super::client::NotebookService::create_notebook_execution_job] calls.
+    /// The request builder for [NotebookService::create_notebook_execution_job][crate::client::NotebookService::create_notebook_execution_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41062,7 +41062,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_notebook_execution_job][super::super::client::NotebookService::create_notebook_execution_job].
+        /// on [create_notebook_execution_job][crate::client::NotebookService::create_notebook_execution_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_notebook_execution_job(self.0.request, self.0.options)
@@ -41152,7 +41152,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_notebook_execution_job][super::super::client::NotebookService::get_notebook_execution_job] calls.
+    /// The request builder for [NotebookService::get_notebook_execution_job][crate::client::NotebookService::get_notebook_execution_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41226,7 +41226,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_notebook_execution_jobs][super::super::client::NotebookService::list_notebook_execution_jobs] calls.
+    /// The request builder for [NotebookService::list_notebook_execution_jobs][crate::client::NotebookService::list_notebook_execution_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41356,7 +41356,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::delete_notebook_execution_job][super::super::client::NotebookService::delete_notebook_execution_job] calls.
+    /// The request builder for [NotebookService::delete_notebook_execution_job][crate::client::NotebookService::delete_notebook_execution_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41406,7 +41406,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_notebook_execution_job][super::super::client::NotebookService::delete_notebook_execution_job].
+        /// on [delete_notebook_execution_job][crate::client::NotebookService::delete_notebook_execution_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_notebook_execution_job(self.0.request, self.0.options)
@@ -41466,7 +41466,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_locations][super::super::client::NotebookService::list_locations] calls.
+    /// The request builder for [NotebookService::list_locations][crate::client::NotebookService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41576,7 +41576,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_location][super::super::client::NotebookService::get_location] calls.
+    /// The request builder for [NotebookService::get_location][crate::client::NotebookService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41637,7 +41637,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::set_iam_policy][super::super::client::NotebookService::set_iam_policy] calls.
+    /// The request builder for [NotebookService::set_iam_policy][crate::client::NotebookService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41740,7 +41740,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_iam_policy][super::super::client::NotebookService::get_iam_policy] calls.
+    /// The request builder for [NotebookService::get_iam_policy][crate::client::NotebookService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41821,7 +41821,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::test_iam_permissions][super::super::client::NotebookService::test_iam_permissions] calls.
+    /// The request builder for [NotebookService::test_iam_permissions][crate::client::NotebookService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -41900,7 +41900,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_operations][super::super::client::NotebookService::list_operations] calls.
+    /// The request builder for [NotebookService::list_operations][crate::client::NotebookService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42012,7 +42012,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_operation][super::super::client::NotebookService::get_operation] calls.
+    /// The request builder for [NotebookService::get_operation][crate::client::NotebookService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42076,7 +42076,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::delete_operation][super::super::client::NotebookService::delete_operation] calls.
+    /// The request builder for [NotebookService::delete_operation][crate::client::NotebookService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42140,7 +42140,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::cancel_operation][super::super::client::NotebookService::cancel_operation] calls.
+    /// The request builder for [NotebookService::cancel_operation][crate::client::NotebookService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42204,7 +42204,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::wait_operation][super::super::client::NotebookService::wait_operation] calls.
+    /// The request builder for [NotebookService::wait_operation][crate::client::NotebookService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42292,7 +42292,7 @@ pub mod notebook_service {
 pub mod persistent_resource_service {
     use crate::Result;
 
-    /// A builder for [PersistentResourceService][super::super::client::PersistentResourceService].
+    /// A builder for [PersistentResourceService][crate::client::PersistentResourceService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -42320,7 +42320,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// Common implementation for [super::super::client::PersistentResourceService] request builders.
+    /// Common implementation for [crate::client::PersistentResourceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PersistentResourceService>,
@@ -42343,7 +42343,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::create_persistent_resource][super::super::client::PersistentResourceService::create_persistent_resource] calls.
+    /// The request builder for [PersistentResourceService::create_persistent_resource][crate::client::PersistentResourceService::create_persistent_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42393,7 +42393,7 @@ pub mod persistent_resource_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_persistent_resource][super::super::client::PersistentResourceService::create_persistent_resource].
+        /// on [create_persistent_resource][crate::client::PersistentResourceService::create_persistent_resource].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_persistent_resource(self.0.request, self.0.options)
@@ -42485,7 +42485,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::get_persistent_resource][super::super::client::PersistentResourceService::get_persistent_resource] calls.
+    /// The request builder for [PersistentResourceService::get_persistent_resource][crate::client::PersistentResourceService::get_persistent_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42551,7 +42551,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::list_persistent_resources][super::super::client::PersistentResourceService::list_persistent_resources] calls.
+    /// The request builder for [PersistentResourceService::list_persistent_resources][crate::client::PersistentResourceService::list_persistent_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42663,7 +42663,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::delete_persistent_resource][super::super::client::PersistentResourceService::delete_persistent_resource] calls.
+    /// The request builder for [PersistentResourceService::delete_persistent_resource][crate::client::PersistentResourceService::delete_persistent_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42713,7 +42713,7 @@ pub mod persistent_resource_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_persistent_resource][super::super::client::PersistentResourceService::delete_persistent_resource].
+        /// on [delete_persistent_resource][crate::client::PersistentResourceService::delete_persistent_resource].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_persistent_resource(self.0.request, self.0.options)
@@ -42773,7 +42773,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::update_persistent_resource][super::super::client::PersistentResourceService::update_persistent_resource] calls.
+    /// The request builder for [PersistentResourceService::update_persistent_resource][crate::client::PersistentResourceService::update_persistent_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42823,7 +42823,7 @@ pub mod persistent_resource_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_persistent_resource][super::super::client::PersistentResourceService::update_persistent_resource].
+        /// on [update_persistent_resource][crate::client::PersistentResourceService::update_persistent_resource].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_persistent_resource(self.0.request, self.0.options)
@@ -42921,7 +42921,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::reboot_persistent_resource][super::super::client::PersistentResourceService::reboot_persistent_resource] calls.
+    /// The request builder for [PersistentResourceService::reboot_persistent_resource][crate::client::PersistentResourceService::reboot_persistent_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -42971,7 +42971,7 @@ pub mod persistent_resource_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reboot_persistent_resource][super::super::client::PersistentResourceService::reboot_persistent_resource].
+        /// on [reboot_persistent_resource][crate::client::PersistentResourceService::reboot_persistent_resource].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reboot_persistent_resource(self.0.request, self.0.options)
@@ -43033,7 +43033,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::list_locations][super::super::client::PersistentResourceService::list_locations] calls.
+    /// The request builder for [PersistentResourceService::list_locations][crate::client::PersistentResourceService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43143,7 +43143,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::get_location][super::super::client::PersistentResourceService::get_location] calls.
+    /// The request builder for [PersistentResourceService::get_location][crate::client::PersistentResourceService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43204,7 +43204,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::set_iam_policy][super::super::client::PersistentResourceService::set_iam_policy] calls.
+    /// The request builder for [PersistentResourceService::set_iam_policy][crate::client::PersistentResourceService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43307,7 +43307,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::get_iam_policy][super::super::client::PersistentResourceService::get_iam_policy] calls.
+    /// The request builder for [PersistentResourceService::get_iam_policy][crate::client::PersistentResourceService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43388,7 +43388,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::test_iam_permissions][super::super::client::PersistentResourceService::test_iam_permissions] calls.
+    /// The request builder for [PersistentResourceService::test_iam_permissions][crate::client::PersistentResourceService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43467,7 +43467,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::list_operations][super::super::client::PersistentResourceService::list_operations] calls.
+    /// The request builder for [PersistentResourceService::list_operations][crate::client::PersistentResourceService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43579,7 +43579,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::get_operation][super::super::client::PersistentResourceService::get_operation] calls.
+    /// The request builder for [PersistentResourceService::get_operation][crate::client::PersistentResourceService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43643,7 +43643,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::delete_operation][super::super::client::PersistentResourceService::delete_operation] calls.
+    /// The request builder for [PersistentResourceService::delete_operation][crate::client::PersistentResourceService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43707,7 +43707,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::cancel_operation][super::super::client::PersistentResourceService::cancel_operation] calls.
+    /// The request builder for [PersistentResourceService::cancel_operation][crate::client::PersistentResourceService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43771,7 +43771,7 @@ pub mod persistent_resource_service {
         }
     }
 
-    /// The request builder for [PersistentResourceService::wait_operation][super::super::client::PersistentResourceService::wait_operation] calls.
+    /// The request builder for [PersistentResourceService::wait_operation][crate::client::PersistentResourceService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43859,7 +43859,7 @@ pub mod persistent_resource_service {
 pub mod pipeline_service {
     use crate::Result;
 
-    /// A builder for [PipelineService][super::super::client::PipelineService].
+    /// A builder for [PipelineService][crate::client::PipelineService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -43887,7 +43887,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// Common implementation for [super::super::client::PipelineService] request builders.
+    /// Common implementation for [crate::client::PipelineService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PipelineService>,
@@ -43910,7 +43910,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::create_training_pipeline][super::super::client::PipelineService::create_training_pipeline] calls.
+    /// The request builder for [PipelineService::create_training_pipeline][crate::client::PipelineService::create_training_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -43998,7 +43998,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::get_training_pipeline][super::super::client::PipelineService::get_training_pipeline] calls.
+    /// The request builder for [PipelineService::get_training_pipeline][crate::client::PipelineService::get_training_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44064,7 +44064,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::list_training_pipelines][super::super::client::PipelineService::list_training_pipelines] calls.
+    /// The request builder for [PipelineService::list_training_pipelines][crate::client::PipelineService::list_training_pipelines] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44196,7 +44196,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::delete_training_pipeline][super::super::client::PipelineService::delete_training_pipeline] calls.
+    /// The request builder for [PipelineService::delete_training_pipeline][crate::client::PipelineService::delete_training_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44244,7 +44244,7 @@ pub mod pipeline_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_training_pipeline][super::super::client::PipelineService::delete_training_pipeline].
+        /// on [delete_training_pipeline][crate::client::PipelineService::delete_training_pipeline].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_training_pipeline(self.0.request, self.0.options)
@@ -44304,7 +44304,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::cancel_training_pipeline][super::super::client::PipelineService::cancel_training_pipeline] calls.
+    /// The request builder for [PipelineService::cancel_training_pipeline][crate::client::PipelineService::cancel_training_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44370,7 +44370,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::create_pipeline_job][super::super::client::PipelineService::create_pipeline_job] calls.
+    /// The request builder for [PipelineService::create_pipeline_job][crate::client::PipelineService::create_pipeline_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44464,7 +44464,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::get_pipeline_job][super::super::client::PipelineService::get_pipeline_job] calls.
+    /// The request builder for [PipelineService::get_pipeline_job][crate::client::PipelineService::get_pipeline_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44527,7 +44527,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::list_pipeline_jobs][super::super::client::PipelineService::list_pipeline_jobs] calls.
+    /// The request builder for [PipelineService::list_pipeline_jobs][crate::client::PipelineService::list_pipeline_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44663,7 +44663,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::delete_pipeline_job][super::super::client::PipelineService::delete_pipeline_job] calls.
+    /// The request builder for [PipelineService::delete_pipeline_job][crate::client::PipelineService::delete_pipeline_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44711,7 +44711,7 @@ pub mod pipeline_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_pipeline_job][super::super::client::PipelineService::delete_pipeline_job].
+        /// on [delete_pipeline_job][crate::client::PipelineService::delete_pipeline_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_pipeline_job(self.0.request, self.0.options)
@@ -44771,7 +44771,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::batch_delete_pipeline_jobs][super::super::client::PipelineService::batch_delete_pipeline_jobs] calls.
+    /// The request builder for [PipelineService::batch_delete_pipeline_jobs][crate::client::PipelineService::batch_delete_pipeline_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44821,7 +44821,7 @@ pub mod pipeline_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_delete_pipeline_jobs][super::super::client::PipelineService::batch_delete_pipeline_jobs].
+        /// on [batch_delete_pipeline_jobs][crate::client::PipelineService::batch_delete_pipeline_jobs].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_delete_pipeline_jobs(self.0.request, self.0.options)
@@ -44896,7 +44896,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::cancel_pipeline_job][super::super::client::PipelineService::cancel_pipeline_job] calls.
+    /// The request builder for [PipelineService::cancel_pipeline_job][crate::client::PipelineService::cancel_pipeline_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -44962,7 +44962,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::batch_cancel_pipeline_jobs][super::super::client::PipelineService::batch_cancel_pipeline_jobs] calls.
+    /// The request builder for [PipelineService::batch_cancel_pipeline_jobs][crate::client::PipelineService::batch_cancel_pipeline_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45012,7 +45012,7 @@ pub mod pipeline_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_cancel_pipeline_jobs][super::super::client::PipelineService::batch_cancel_pipeline_jobs].
+        /// on [batch_cancel_pipeline_jobs][crate::client::PipelineService::batch_cancel_pipeline_jobs].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_cancel_pipeline_jobs(self.0.request, self.0.options)
@@ -45087,7 +45087,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::list_locations][super::super::client::PipelineService::list_locations] calls.
+    /// The request builder for [PipelineService::list_locations][crate::client::PipelineService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45197,7 +45197,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::get_location][super::super::client::PipelineService::get_location] calls.
+    /// The request builder for [PipelineService::get_location][crate::client::PipelineService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45258,7 +45258,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::set_iam_policy][super::super::client::PipelineService::set_iam_policy] calls.
+    /// The request builder for [PipelineService::set_iam_policy][crate::client::PipelineService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45361,7 +45361,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::get_iam_policy][super::super::client::PipelineService::get_iam_policy] calls.
+    /// The request builder for [PipelineService::get_iam_policy][crate::client::PipelineService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45442,7 +45442,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::test_iam_permissions][super::super::client::PipelineService::test_iam_permissions] calls.
+    /// The request builder for [PipelineService::test_iam_permissions][crate::client::PipelineService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45521,7 +45521,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::list_operations][super::super::client::PipelineService::list_operations] calls.
+    /// The request builder for [PipelineService::list_operations][crate::client::PipelineService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45633,7 +45633,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::get_operation][super::super::client::PipelineService::get_operation] calls.
+    /// The request builder for [PipelineService::get_operation][crate::client::PipelineService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45697,7 +45697,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::delete_operation][super::super::client::PipelineService::delete_operation] calls.
+    /// The request builder for [PipelineService::delete_operation][crate::client::PipelineService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45761,7 +45761,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::cancel_operation][super::super::client::PipelineService::cancel_operation] calls.
+    /// The request builder for [PipelineService::cancel_operation][crate::client::PipelineService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45825,7 +45825,7 @@ pub mod pipeline_service {
         }
     }
 
-    /// The request builder for [PipelineService::wait_operation][super::super::client::PipelineService::wait_operation] calls.
+    /// The request builder for [PipelineService::wait_operation][crate::client::PipelineService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -45913,7 +45913,7 @@ pub mod pipeline_service {
 pub mod prediction_service {
     use crate::Result;
 
-    /// A builder for [PredictionService][super::super::client::PredictionService].
+    /// A builder for [PredictionService][crate::client::PredictionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45941,7 +45941,7 @@ pub mod prediction_service {
         }
     }
 
-    /// Common implementation for [super::super::client::PredictionService] request builders.
+    /// Common implementation for [crate::client::PredictionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PredictionService>,
@@ -45964,7 +45964,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::predict][super::super::client::PredictionService::predict] calls.
+    /// The request builder for [PredictionService::predict][crate::client::PredictionService::predict] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46058,7 +46058,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::raw_predict][super::super::client::PredictionService::raw_predict] calls.
+    /// The request builder for [PredictionService::raw_predict][crate::client::PredictionService::raw_predict] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46139,7 +46139,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::direct_predict][super::super::client::PredictionService::direct_predict] calls.
+    /// The request builder for [PredictionService::direct_predict][crate::client::PredictionService::direct_predict] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46231,7 +46231,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::direct_raw_predict][super::super::client::PredictionService::direct_raw_predict] calls.
+    /// The request builder for [PredictionService::direct_raw_predict][crate::client::PredictionService::direct_raw_predict] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46309,7 +46309,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::explain][super::super::client::PredictionService::explain] calls.
+    /// The request builder for [PredictionService::explain][crate::client::PredictionService::explain] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46430,7 +46430,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::generate_content][super::super::client::PredictionService::generate_content] calls.
+    /// The request builder for [PredictionService::generate_content][crate::client::PredictionService::generate_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46599,7 +46599,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::list_locations][super::super::client::PredictionService::list_locations] calls.
+    /// The request builder for [PredictionService::list_locations][crate::client::PredictionService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46709,7 +46709,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::get_location][super::super::client::PredictionService::get_location] calls.
+    /// The request builder for [PredictionService::get_location][crate::client::PredictionService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46770,7 +46770,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::set_iam_policy][super::super::client::PredictionService::set_iam_policy] calls.
+    /// The request builder for [PredictionService::set_iam_policy][crate::client::PredictionService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46873,7 +46873,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::get_iam_policy][super::super::client::PredictionService::get_iam_policy] calls.
+    /// The request builder for [PredictionService::get_iam_policy][crate::client::PredictionService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -46954,7 +46954,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::test_iam_permissions][super::super::client::PredictionService::test_iam_permissions] calls.
+    /// The request builder for [PredictionService::test_iam_permissions][crate::client::PredictionService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47033,7 +47033,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::list_operations][super::super::client::PredictionService::list_operations] calls.
+    /// The request builder for [PredictionService::list_operations][crate::client::PredictionService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47145,7 +47145,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::get_operation][super::super::client::PredictionService::get_operation] calls.
+    /// The request builder for [PredictionService::get_operation][crate::client::PredictionService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47209,7 +47209,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::delete_operation][super::super::client::PredictionService::delete_operation] calls.
+    /// The request builder for [PredictionService::delete_operation][crate::client::PredictionService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47273,7 +47273,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::cancel_operation][super::super::client::PredictionService::cancel_operation] calls.
+    /// The request builder for [PredictionService::cancel_operation][crate::client::PredictionService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47337,7 +47337,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::wait_operation][super::super::client::PredictionService::wait_operation] calls.
+    /// The request builder for [PredictionService::wait_operation][crate::client::PredictionService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47425,7 +47425,7 @@ pub mod prediction_service {
 pub mod reasoning_engine_execution_service {
     use crate::Result;
 
-    /// A builder for [ReasoningEngineExecutionService][super::super::client::ReasoningEngineExecutionService].
+    /// A builder for [ReasoningEngineExecutionService][crate::client::ReasoningEngineExecutionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -47453,7 +47453,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ReasoningEngineExecutionService] request builders.
+    /// Common implementation for [crate::client::ReasoningEngineExecutionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ReasoningEngineExecutionService>,
@@ -47476,7 +47476,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::query_reasoning_engine][super::super::client::ReasoningEngineExecutionService::query_reasoning_engine] calls.
+    /// The request builder for [ReasoningEngineExecutionService::query_reasoning_engine][crate::client::ReasoningEngineExecutionService::query_reasoning_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47566,7 +47566,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::list_locations][super::super::client::ReasoningEngineExecutionService::list_locations] calls.
+    /// The request builder for [ReasoningEngineExecutionService::list_locations][crate::client::ReasoningEngineExecutionService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47676,7 +47676,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::get_location][super::super::client::ReasoningEngineExecutionService::get_location] calls.
+    /// The request builder for [ReasoningEngineExecutionService::get_location][crate::client::ReasoningEngineExecutionService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47737,7 +47737,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::set_iam_policy][super::super::client::ReasoningEngineExecutionService::set_iam_policy] calls.
+    /// The request builder for [ReasoningEngineExecutionService::set_iam_policy][crate::client::ReasoningEngineExecutionService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47840,7 +47840,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::get_iam_policy][super::super::client::ReasoningEngineExecutionService::get_iam_policy] calls.
+    /// The request builder for [ReasoningEngineExecutionService::get_iam_policy][crate::client::ReasoningEngineExecutionService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -47921,7 +47921,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::test_iam_permissions][super::super::client::ReasoningEngineExecutionService::test_iam_permissions] calls.
+    /// The request builder for [ReasoningEngineExecutionService::test_iam_permissions][crate::client::ReasoningEngineExecutionService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48000,7 +48000,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::list_operations][super::super::client::ReasoningEngineExecutionService::list_operations] calls.
+    /// The request builder for [ReasoningEngineExecutionService::list_operations][crate::client::ReasoningEngineExecutionService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48112,7 +48112,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::get_operation][super::super::client::ReasoningEngineExecutionService::get_operation] calls.
+    /// The request builder for [ReasoningEngineExecutionService::get_operation][crate::client::ReasoningEngineExecutionService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48176,7 +48176,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::delete_operation][super::super::client::ReasoningEngineExecutionService::delete_operation] calls.
+    /// The request builder for [ReasoningEngineExecutionService::delete_operation][crate::client::ReasoningEngineExecutionService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48240,7 +48240,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::cancel_operation][super::super::client::ReasoningEngineExecutionService::cancel_operation] calls.
+    /// The request builder for [ReasoningEngineExecutionService::cancel_operation][crate::client::ReasoningEngineExecutionService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48304,7 +48304,7 @@ pub mod reasoning_engine_execution_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineExecutionService::wait_operation][super::super::client::ReasoningEngineExecutionService::wait_operation] calls.
+    /// The request builder for [ReasoningEngineExecutionService::wait_operation][crate::client::ReasoningEngineExecutionService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48392,7 +48392,7 @@ pub mod reasoning_engine_execution_service {
 pub mod reasoning_engine_service {
     use crate::Result;
 
-    /// A builder for [ReasoningEngineService][super::super::client::ReasoningEngineService].
+    /// A builder for [ReasoningEngineService][crate::client::ReasoningEngineService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -48420,7 +48420,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ReasoningEngineService] request builders.
+    /// Common implementation for [crate::client::ReasoningEngineService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ReasoningEngineService>,
@@ -48443,7 +48443,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::create_reasoning_engine][super::super::client::ReasoningEngineService::create_reasoning_engine] calls.
+    /// The request builder for [ReasoningEngineService::create_reasoning_engine][crate::client::ReasoningEngineService::create_reasoning_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48491,7 +48491,7 @@ pub mod reasoning_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_reasoning_engine][super::super::client::ReasoningEngineService::create_reasoning_engine].
+        /// on [create_reasoning_engine][crate::client::ReasoningEngineService::create_reasoning_engine].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_reasoning_engine(self.0.request, self.0.options)
@@ -48575,7 +48575,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::get_reasoning_engine][super::super::client::ReasoningEngineService::get_reasoning_engine] calls.
+    /// The request builder for [ReasoningEngineService::get_reasoning_engine][crate::client::ReasoningEngineService::get_reasoning_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48641,7 +48641,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::list_reasoning_engines][super::super::client::ReasoningEngineService::list_reasoning_engines] calls.
+    /// The request builder for [ReasoningEngineService::list_reasoning_engines][crate::client::ReasoningEngineService::list_reasoning_engines] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48755,7 +48755,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::update_reasoning_engine][super::super::client::ReasoningEngineService::update_reasoning_engine] calls.
+    /// The request builder for [ReasoningEngineService::update_reasoning_engine][crate::client::ReasoningEngineService::update_reasoning_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48803,7 +48803,7 @@ pub mod reasoning_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_reasoning_engine][super::super::client::ReasoningEngineService::update_reasoning_engine].
+        /// on [update_reasoning_engine][crate::client::ReasoningEngineService::update_reasoning_engine].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_reasoning_engine(self.0.request, self.0.options)
@@ -48897,7 +48897,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::delete_reasoning_engine][super::super::client::ReasoningEngineService::delete_reasoning_engine] calls.
+    /// The request builder for [ReasoningEngineService::delete_reasoning_engine][crate::client::ReasoningEngineService::delete_reasoning_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -48945,7 +48945,7 @@ pub mod reasoning_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_reasoning_engine][super::super::client::ReasoningEngineService::delete_reasoning_engine].
+        /// on [delete_reasoning_engine][crate::client::ReasoningEngineService::delete_reasoning_engine].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_reasoning_engine(self.0.request, self.0.options)
@@ -49011,7 +49011,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::list_locations][super::super::client::ReasoningEngineService::list_locations] calls.
+    /// The request builder for [ReasoningEngineService::list_locations][crate::client::ReasoningEngineService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49121,7 +49121,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::get_location][super::super::client::ReasoningEngineService::get_location] calls.
+    /// The request builder for [ReasoningEngineService::get_location][crate::client::ReasoningEngineService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49182,7 +49182,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::set_iam_policy][super::super::client::ReasoningEngineService::set_iam_policy] calls.
+    /// The request builder for [ReasoningEngineService::set_iam_policy][crate::client::ReasoningEngineService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49285,7 +49285,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::get_iam_policy][super::super::client::ReasoningEngineService::get_iam_policy] calls.
+    /// The request builder for [ReasoningEngineService::get_iam_policy][crate::client::ReasoningEngineService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49366,7 +49366,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::test_iam_permissions][super::super::client::ReasoningEngineService::test_iam_permissions] calls.
+    /// The request builder for [ReasoningEngineService::test_iam_permissions][crate::client::ReasoningEngineService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49445,7 +49445,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::list_operations][super::super::client::ReasoningEngineService::list_operations] calls.
+    /// The request builder for [ReasoningEngineService::list_operations][crate::client::ReasoningEngineService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49557,7 +49557,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::get_operation][super::super::client::ReasoningEngineService::get_operation] calls.
+    /// The request builder for [ReasoningEngineService::get_operation][crate::client::ReasoningEngineService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49621,7 +49621,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::delete_operation][super::super::client::ReasoningEngineService::delete_operation] calls.
+    /// The request builder for [ReasoningEngineService::delete_operation][crate::client::ReasoningEngineService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49685,7 +49685,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::cancel_operation][super::super::client::ReasoningEngineService::cancel_operation] calls.
+    /// The request builder for [ReasoningEngineService::cancel_operation][crate::client::ReasoningEngineService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49749,7 +49749,7 @@ pub mod reasoning_engine_service {
         }
     }
 
-    /// The request builder for [ReasoningEngineService::wait_operation][super::super::client::ReasoningEngineService::wait_operation] calls.
+    /// The request builder for [ReasoningEngineService::wait_operation][crate::client::ReasoningEngineService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49837,7 +49837,7 @@ pub mod reasoning_engine_service {
 pub mod schedule_service {
     use crate::Result;
 
-    /// A builder for [ScheduleService][super::super::client::ScheduleService].
+    /// A builder for [ScheduleService][crate::client::ScheduleService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -49865,7 +49865,7 @@ pub mod schedule_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ScheduleService] request builders.
+    /// Common implementation for [crate::client::ScheduleService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ScheduleService>,
@@ -49888,7 +49888,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::create_schedule][super::super::client::ScheduleService::create_schedule] calls.
+    /// The request builder for [ScheduleService::create_schedule][crate::client::ScheduleService::create_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -49973,7 +49973,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::delete_schedule][super::super::client::ScheduleService::delete_schedule] calls.
+    /// The request builder for [ScheduleService::delete_schedule][crate::client::ScheduleService::delete_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50018,7 +50018,7 @@ pub mod schedule_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_schedule][super::super::client::ScheduleService::delete_schedule].
+        /// on [delete_schedule][crate::client::ScheduleService::delete_schedule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_schedule(self.0.request, self.0.options)
@@ -50078,7 +50078,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::get_schedule][super::super::client::ScheduleService::get_schedule] calls.
+    /// The request builder for [ScheduleService::get_schedule][crate::client::ScheduleService::get_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50141,7 +50141,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::list_schedules][super::super::client::ScheduleService::list_schedules] calls.
+    /// The request builder for [ScheduleService::list_schedules][crate::client::ScheduleService::list_schedules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50256,7 +50256,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::pause_schedule][super::super::client::ScheduleService::pause_schedule] calls.
+    /// The request builder for [ScheduleService::pause_schedule][crate::client::ScheduleService::pause_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50319,7 +50319,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::resume_schedule][super::super::client::ScheduleService::resume_schedule] calls.
+    /// The request builder for [ScheduleService::resume_schedule][crate::client::ScheduleService::resume_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50388,7 +50388,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::update_schedule][super::super::client::ScheduleService::update_schedule] calls.
+    /// The request builder for [ScheduleService::update_schedule][crate::client::ScheduleService::update_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50487,7 +50487,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::list_locations][super::super::client::ScheduleService::list_locations] calls.
+    /// The request builder for [ScheduleService::list_locations][crate::client::ScheduleService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50597,7 +50597,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::get_location][super::super::client::ScheduleService::get_location] calls.
+    /// The request builder for [ScheduleService::get_location][crate::client::ScheduleService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50658,7 +50658,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::set_iam_policy][super::super::client::ScheduleService::set_iam_policy] calls.
+    /// The request builder for [ScheduleService::set_iam_policy][crate::client::ScheduleService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50761,7 +50761,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::get_iam_policy][super::super::client::ScheduleService::get_iam_policy] calls.
+    /// The request builder for [ScheduleService::get_iam_policy][crate::client::ScheduleService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50842,7 +50842,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::test_iam_permissions][super::super::client::ScheduleService::test_iam_permissions] calls.
+    /// The request builder for [ScheduleService::test_iam_permissions][crate::client::ScheduleService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -50921,7 +50921,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::list_operations][super::super::client::ScheduleService::list_operations] calls.
+    /// The request builder for [ScheduleService::list_operations][crate::client::ScheduleService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51033,7 +51033,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::get_operation][super::super::client::ScheduleService::get_operation] calls.
+    /// The request builder for [ScheduleService::get_operation][crate::client::ScheduleService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51097,7 +51097,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::delete_operation][super::super::client::ScheduleService::delete_operation] calls.
+    /// The request builder for [ScheduleService::delete_operation][crate::client::ScheduleService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51161,7 +51161,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::cancel_operation][super::super::client::ScheduleService::cancel_operation] calls.
+    /// The request builder for [ScheduleService::cancel_operation][crate::client::ScheduleService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51225,7 +51225,7 @@ pub mod schedule_service {
         }
     }
 
-    /// The request builder for [ScheduleService::wait_operation][super::super::client::ScheduleService::wait_operation] calls.
+    /// The request builder for [ScheduleService::wait_operation][crate::client::ScheduleService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51313,7 +51313,7 @@ pub mod schedule_service {
 pub mod specialist_pool_service {
     use crate::Result;
 
-    /// A builder for [SpecialistPoolService][super::super::client::SpecialistPoolService].
+    /// A builder for [SpecialistPoolService][crate::client::SpecialistPoolService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -51341,7 +51341,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SpecialistPoolService] request builders.
+    /// Common implementation for [crate::client::SpecialistPoolService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SpecialistPoolService>,
@@ -51364,7 +51364,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::create_specialist_pool][super::super::client::SpecialistPoolService::create_specialist_pool] calls.
+    /// The request builder for [SpecialistPoolService::create_specialist_pool][crate::client::SpecialistPoolService::create_specialist_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51412,7 +51412,7 @@ pub mod specialist_pool_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_specialist_pool][super::super::client::SpecialistPoolService::create_specialist_pool].
+        /// on [create_specialist_pool][crate::client::SpecialistPoolService::create_specialist_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_specialist_pool(self.0.request, self.0.options)
@@ -51496,7 +51496,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::get_specialist_pool][super::super::client::SpecialistPoolService::get_specialist_pool] calls.
+    /// The request builder for [SpecialistPoolService::get_specialist_pool][crate::client::SpecialistPoolService::get_specialist_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51562,7 +51562,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::list_specialist_pools][super::super::client::SpecialistPoolService::list_specialist_pools] calls.
+    /// The request builder for [SpecialistPoolService::list_specialist_pools][crate::client::SpecialistPoolService::list_specialist_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51688,7 +51688,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::delete_specialist_pool][super::super::client::SpecialistPoolService::delete_specialist_pool] calls.
+    /// The request builder for [SpecialistPoolService::delete_specialist_pool][crate::client::SpecialistPoolService::delete_specialist_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51736,7 +51736,7 @@ pub mod specialist_pool_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_specialist_pool][super::super::client::SpecialistPoolService::delete_specialist_pool].
+        /// on [delete_specialist_pool][crate::client::SpecialistPoolService::delete_specialist_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_specialist_pool(self.0.request, self.0.options)
@@ -51802,7 +51802,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::update_specialist_pool][super::super::client::SpecialistPoolService::update_specialist_pool] calls.
+    /// The request builder for [SpecialistPoolService::update_specialist_pool][crate::client::SpecialistPoolService::update_specialist_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -51850,7 +51850,7 @@ pub mod specialist_pool_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_specialist_pool][super::super::client::SpecialistPoolService::update_specialist_pool].
+        /// on [update_specialist_pool][crate::client::SpecialistPoolService::update_specialist_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_specialist_pool(self.0.request, self.0.options)
@@ -51948,7 +51948,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::list_locations][super::super::client::SpecialistPoolService::list_locations] calls.
+    /// The request builder for [SpecialistPoolService::list_locations][crate::client::SpecialistPoolService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52058,7 +52058,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::get_location][super::super::client::SpecialistPoolService::get_location] calls.
+    /// The request builder for [SpecialistPoolService::get_location][crate::client::SpecialistPoolService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52119,7 +52119,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::set_iam_policy][super::super::client::SpecialistPoolService::set_iam_policy] calls.
+    /// The request builder for [SpecialistPoolService::set_iam_policy][crate::client::SpecialistPoolService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52222,7 +52222,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::get_iam_policy][super::super::client::SpecialistPoolService::get_iam_policy] calls.
+    /// The request builder for [SpecialistPoolService::get_iam_policy][crate::client::SpecialistPoolService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52303,7 +52303,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::test_iam_permissions][super::super::client::SpecialistPoolService::test_iam_permissions] calls.
+    /// The request builder for [SpecialistPoolService::test_iam_permissions][crate::client::SpecialistPoolService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52382,7 +52382,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::list_operations][super::super::client::SpecialistPoolService::list_operations] calls.
+    /// The request builder for [SpecialistPoolService::list_operations][crate::client::SpecialistPoolService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52494,7 +52494,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::get_operation][super::super::client::SpecialistPoolService::get_operation] calls.
+    /// The request builder for [SpecialistPoolService::get_operation][crate::client::SpecialistPoolService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52558,7 +52558,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::delete_operation][super::super::client::SpecialistPoolService::delete_operation] calls.
+    /// The request builder for [SpecialistPoolService::delete_operation][crate::client::SpecialistPoolService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52622,7 +52622,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::cancel_operation][super::super::client::SpecialistPoolService::cancel_operation] calls.
+    /// The request builder for [SpecialistPoolService::cancel_operation][crate::client::SpecialistPoolService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52686,7 +52686,7 @@ pub mod specialist_pool_service {
         }
     }
 
-    /// The request builder for [SpecialistPoolService::wait_operation][super::super::client::SpecialistPoolService::wait_operation] calls.
+    /// The request builder for [SpecialistPoolService::wait_operation][crate::client::SpecialistPoolService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52774,7 +52774,7 @@ pub mod specialist_pool_service {
 pub mod tensorboard_service {
     use crate::Result;
 
-    /// A builder for [TensorboardService][super::super::client::TensorboardService].
+    /// A builder for [TensorboardService][crate::client::TensorboardService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -52802,7 +52802,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// Common implementation for [super::super::client::TensorboardService] request builders.
+    /// Common implementation for [crate::client::TensorboardService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TensorboardService>,
@@ -52825,7 +52825,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::create_tensorboard][super::super::client::TensorboardService::create_tensorboard] calls.
+    /// The request builder for [TensorboardService::create_tensorboard][crate::client::TensorboardService::create_tensorboard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -52873,7 +52873,7 @@ pub mod tensorboard_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_tensorboard][super::super::client::TensorboardService::create_tensorboard].
+        /// on [create_tensorboard][crate::client::TensorboardService::create_tensorboard].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_tensorboard(self.0.request, self.0.options)
@@ -52955,7 +52955,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::get_tensorboard][super::super::client::TensorboardService::get_tensorboard] calls.
+    /// The request builder for [TensorboardService::get_tensorboard][crate::client::TensorboardService::get_tensorboard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53018,7 +53018,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::update_tensorboard][super::super::client::TensorboardService::update_tensorboard] calls.
+    /// The request builder for [TensorboardService::update_tensorboard][crate::client::TensorboardService::update_tensorboard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53066,7 +53066,7 @@ pub mod tensorboard_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_tensorboard][super::super::client::TensorboardService::update_tensorboard].
+        /// on [update_tensorboard][crate::client::TensorboardService::update_tensorboard].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_tensorboard(self.0.request, self.0.options)
@@ -53162,7 +53162,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::list_tensorboards][super::super::client::TensorboardService::list_tensorboards] calls.
+    /// The request builder for [TensorboardService::list_tensorboards][crate::client::TensorboardService::list_tensorboards] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53298,7 +53298,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::delete_tensorboard][super::super::client::TensorboardService::delete_tensorboard] calls.
+    /// The request builder for [TensorboardService::delete_tensorboard][crate::client::TensorboardService::delete_tensorboard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53346,7 +53346,7 @@ pub mod tensorboard_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tensorboard][super::super::client::TensorboardService::delete_tensorboard].
+        /// on [delete_tensorboard][crate::client::TensorboardService::delete_tensorboard].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tensorboard(self.0.request, self.0.options)
@@ -53406,7 +53406,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::read_tensorboard_usage][super::super::client::TensorboardService::read_tensorboard_usage] calls.
+    /// The request builder for [TensorboardService::read_tensorboard_usage][crate::client::TensorboardService::read_tensorboard_usage] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53472,7 +53472,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::read_tensorboard_size][super::super::client::TensorboardService::read_tensorboard_size] calls.
+    /// The request builder for [TensorboardService::read_tensorboard_size][crate::client::TensorboardService::read_tensorboard_size] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53538,7 +53538,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::create_tensorboard_experiment][super::super::client::TensorboardService::create_tensorboard_experiment] calls.
+    /// The request builder for [TensorboardService::create_tensorboard_experiment][crate::client::TensorboardService::create_tensorboard_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53632,7 +53632,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::get_tensorboard_experiment][super::super::client::TensorboardService::get_tensorboard_experiment] calls.
+    /// The request builder for [TensorboardService::get_tensorboard_experiment][crate::client::TensorboardService::get_tensorboard_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53700,7 +53700,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::update_tensorboard_experiment][super::super::client::TensorboardService::update_tensorboard_experiment] calls.
+    /// The request builder for [TensorboardService::update_tensorboard_experiment][crate::client::TensorboardService::update_tensorboard_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53804,7 +53804,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::list_tensorboard_experiments][super::super::client::TensorboardService::list_tensorboard_experiments] calls.
+    /// The request builder for [TensorboardService::list_tensorboard_experiments][crate::client::TensorboardService::list_tensorboard_experiments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53946,7 +53946,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::delete_tensorboard_experiment][super::super::client::TensorboardService::delete_tensorboard_experiment] calls.
+    /// The request builder for [TensorboardService::delete_tensorboard_experiment][crate::client::TensorboardService::delete_tensorboard_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -53996,7 +53996,7 @@ pub mod tensorboard_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tensorboard_experiment][super::super::client::TensorboardService::delete_tensorboard_experiment].
+        /// on [delete_tensorboard_experiment][crate::client::TensorboardService::delete_tensorboard_experiment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tensorboard_experiment(self.0.request, self.0.options)
@@ -54056,7 +54056,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::create_tensorboard_run][super::super::client::TensorboardService::create_tensorboard_run] calls.
+    /// The request builder for [TensorboardService::create_tensorboard_run][crate::client::TensorboardService::create_tensorboard_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54152,7 +54152,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::batch_create_tensorboard_runs][super::super::client::TensorboardService::batch_create_tensorboard_runs] calls.
+    /// The request builder for [TensorboardService::batch_create_tensorboard_runs][crate::client::TensorboardService::batch_create_tensorboard_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54233,7 +54233,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::get_tensorboard_run][super::super::client::TensorboardService::get_tensorboard_run] calls.
+    /// The request builder for [TensorboardService::get_tensorboard_run][crate::client::TensorboardService::get_tensorboard_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54299,7 +54299,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::update_tensorboard_run][super::super::client::TensorboardService::update_tensorboard_run] calls.
+    /// The request builder for [TensorboardService::update_tensorboard_run][crate::client::TensorboardService::update_tensorboard_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54401,7 +54401,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::list_tensorboard_runs][super::super::client::TensorboardService::list_tensorboard_runs] calls.
+    /// The request builder for [TensorboardService::list_tensorboard_runs][crate::client::TensorboardService::list_tensorboard_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54539,7 +54539,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::delete_tensorboard_run][super::super::client::TensorboardService::delete_tensorboard_run] calls.
+    /// The request builder for [TensorboardService::delete_tensorboard_run][crate::client::TensorboardService::delete_tensorboard_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54587,7 +54587,7 @@ pub mod tensorboard_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tensorboard_run][super::super::client::TensorboardService::delete_tensorboard_run].
+        /// on [delete_tensorboard_run][crate::client::TensorboardService::delete_tensorboard_run].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tensorboard_run(self.0.request, self.0.options)
@@ -54647,7 +54647,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::batch_create_tensorboard_time_series][super::super::client::TensorboardService::batch_create_tensorboard_time_series] calls.
+    /// The request builder for [TensorboardService::batch_create_tensorboard_time_series][crate::client::TensorboardService::batch_create_tensorboard_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54728,7 +54728,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::create_tensorboard_time_series][super::super::client::TensorboardService::create_tensorboard_time_series] calls.
+    /// The request builder for [TensorboardService::create_tensorboard_time_series][crate::client::TensorboardService::create_tensorboard_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54827,7 +54827,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::get_tensorboard_time_series][super::super::client::TensorboardService::get_tensorboard_time_series] calls.
+    /// The request builder for [TensorboardService::get_tensorboard_time_series][crate::client::TensorboardService::get_tensorboard_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54895,7 +54895,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::update_tensorboard_time_series][super::super::client::TensorboardService::update_tensorboard_time_series] calls.
+    /// The request builder for [TensorboardService::update_tensorboard_time_series][crate::client::TensorboardService::update_tensorboard_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -54999,7 +54999,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::list_tensorboard_time_series][super::super::client::TensorboardService::list_tensorboard_time_series] calls.
+    /// The request builder for [TensorboardService::list_tensorboard_time_series][crate::client::TensorboardService::list_tensorboard_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55141,7 +55141,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::delete_tensorboard_time_series][super::super::client::TensorboardService::delete_tensorboard_time_series] calls.
+    /// The request builder for [TensorboardService::delete_tensorboard_time_series][crate::client::TensorboardService::delete_tensorboard_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55191,7 +55191,7 @@ pub mod tensorboard_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tensorboard_time_series][super::super::client::TensorboardService::delete_tensorboard_time_series].
+        /// on [delete_tensorboard_time_series][crate::client::TensorboardService::delete_tensorboard_time_series].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tensorboard_time_series(self.0.request, self.0.options)
@@ -55251,7 +55251,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::batch_read_tensorboard_time_series_data][super::super::client::TensorboardService::batch_read_tensorboard_time_series_data] calls.
+    /// The request builder for [TensorboardService::batch_read_tensorboard_time_series_data][crate::client::TensorboardService::batch_read_tensorboard_time_series_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55334,7 +55334,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::read_tensorboard_time_series_data][super::super::client::TensorboardService::read_tensorboard_time_series_data] calls.
+    /// The request builder for [TensorboardService::read_tensorboard_time_series_data][crate::client::TensorboardService::read_tensorboard_time_series_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55414,7 +55414,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::write_tensorboard_experiment_data][super::super::client::TensorboardService::write_tensorboard_experiment_data] calls.
+    /// The request builder for [TensorboardService::write_tensorboard_experiment_data][crate::client::TensorboardService::write_tensorboard_experiment_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55495,7 +55495,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::write_tensorboard_run_data][super::super::client::TensorboardService::write_tensorboard_run_data] calls.
+    /// The request builder for [TensorboardService::write_tensorboard_run_data][crate::client::TensorboardService::write_tensorboard_run_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55576,7 +55576,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::export_tensorboard_time_series_data][super::super::client::TensorboardService::export_tensorboard_time_series_data] calls.
+    /// The request builder for [TensorboardService::export_tensorboard_time_series_data][crate::client::TensorboardService::export_tensorboard_time_series_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55700,7 +55700,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::list_locations][super::super::client::TensorboardService::list_locations] calls.
+    /// The request builder for [TensorboardService::list_locations][crate::client::TensorboardService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55810,7 +55810,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::get_location][super::super::client::TensorboardService::get_location] calls.
+    /// The request builder for [TensorboardService::get_location][crate::client::TensorboardService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55871,7 +55871,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::set_iam_policy][super::super::client::TensorboardService::set_iam_policy] calls.
+    /// The request builder for [TensorboardService::set_iam_policy][crate::client::TensorboardService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -55974,7 +55974,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::get_iam_policy][super::super::client::TensorboardService::get_iam_policy] calls.
+    /// The request builder for [TensorboardService::get_iam_policy][crate::client::TensorboardService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56055,7 +56055,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::test_iam_permissions][super::super::client::TensorboardService::test_iam_permissions] calls.
+    /// The request builder for [TensorboardService::test_iam_permissions][crate::client::TensorboardService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56134,7 +56134,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::list_operations][super::super::client::TensorboardService::list_operations] calls.
+    /// The request builder for [TensorboardService::list_operations][crate::client::TensorboardService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56246,7 +56246,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::get_operation][super::super::client::TensorboardService::get_operation] calls.
+    /// The request builder for [TensorboardService::get_operation][crate::client::TensorboardService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56310,7 +56310,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::delete_operation][super::super::client::TensorboardService::delete_operation] calls.
+    /// The request builder for [TensorboardService::delete_operation][crate::client::TensorboardService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56374,7 +56374,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::cancel_operation][super::super::client::TensorboardService::cancel_operation] calls.
+    /// The request builder for [TensorboardService::cancel_operation][crate::client::TensorboardService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56438,7 +56438,7 @@ pub mod tensorboard_service {
         }
     }
 
-    /// The request builder for [TensorboardService::wait_operation][super::super::client::TensorboardService::wait_operation] calls.
+    /// The request builder for [TensorboardService::wait_operation][crate::client::TensorboardService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56526,7 +56526,7 @@ pub mod tensorboard_service {
 pub mod vertex_rag_data_service {
     use crate::Result;
 
-    /// A builder for [VertexRagDataService][super::super::client::VertexRagDataService].
+    /// A builder for [VertexRagDataService][crate::client::VertexRagDataService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -56554,7 +56554,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// Common implementation for [super::super::client::VertexRagDataService] request builders.
+    /// Common implementation for [crate::client::VertexRagDataService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VertexRagDataService>,
@@ -56577,7 +56577,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::create_rag_corpus][super::super::client::VertexRagDataService::create_rag_corpus] calls.
+    /// The request builder for [VertexRagDataService::create_rag_corpus][crate::client::VertexRagDataService::create_rag_corpus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56622,7 +56622,7 @@ pub mod vertex_rag_data_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_rag_corpus][super::super::client::VertexRagDataService::create_rag_corpus].
+        /// on [create_rag_corpus][crate::client::VertexRagDataService::create_rag_corpus].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_rag_corpus(self.0.request, self.0.options)
@@ -56704,7 +56704,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::update_rag_corpus][super::super::client::VertexRagDataService::update_rag_corpus] calls.
+    /// The request builder for [VertexRagDataService::update_rag_corpus][crate::client::VertexRagDataService::update_rag_corpus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56749,7 +56749,7 @@ pub mod vertex_rag_data_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_rag_corpus][super::super::client::VertexRagDataService::update_rag_corpus].
+        /// on [update_rag_corpus][crate::client::VertexRagDataService::update_rag_corpus].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_rag_corpus(self.0.request, self.0.options)
@@ -56823,7 +56823,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::get_rag_corpus][super::super::client::VertexRagDataService::get_rag_corpus] calls.
+    /// The request builder for [VertexRagDataService::get_rag_corpus][crate::client::VertexRagDataService::get_rag_corpus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56886,7 +56886,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::list_rag_corpora][super::super::client::VertexRagDataService::list_rag_corpora] calls.
+    /// The request builder for [VertexRagDataService::list_rag_corpora][crate::client::VertexRagDataService::list_rag_corpora] calls.
     ///
     /// # Example
     /// ```no_run
@@ -56989,7 +56989,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::delete_rag_corpus][super::super::client::VertexRagDataService::delete_rag_corpus] calls.
+    /// The request builder for [VertexRagDataService::delete_rag_corpus][crate::client::VertexRagDataService::delete_rag_corpus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57034,7 +57034,7 @@ pub mod vertex_rag_data_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_rag_corpus][super::super::client::VertexRagDataService::delete_rag_corpus].
+        /// on [delete_rag_corpus][crate::client::VertexRagDataService::delete_rag_corpus].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_rag_corpus(self.0.request, self.0.options)
@@ -57100,7 +57100,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::upload_rag_file][super::super::client::VertexRagDataService::upload_rag_file] calls.
+    /// The request builder for [VertexRagDataService::upload_rag_file][crate::client::VertexRagDataService::upload_rag_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57207,7 +57207,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::import_rag_files][super::super::client::VertexRagDataService::import_rag_files] calls.
+    /// The request builder for [VertexRagDataService::import_rag_files][crate::client::VertexRagDataService::import_rag_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57252,7 +57252,7 @@ pub mod vertex_rag_data_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_rag_files][super::super::client::VertexRagDataService::import_rag_files].
+        /// on [import_rag_files][crate::client::VertexRagDataService::import_rag_files].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_rag_files(self.0.request, self.0.options)
@@ -57336,7 +57336,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::get_rag_file][super::super::client::VertexRagDataService::get_rag_file] calls.
+    /// The request builder for [VertexRagDataService::get_rag_file][crate::client::VertexRagDataService::get_rag_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57399,7 +57399,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::list_rag_files][super::super::client::VertexRagDataService::list_rag_files] calls.
+    /// The request builder for [VertexRagDataService::list_rag_files][crate::client::VertexRagDataService::list_rag_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57502,7 +57502,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::delete_rag_file][super::super::client::VertexRagDataService::delete_rag_file] calls.
+    /// The request builder for [VertexRagDataService::delete_rag_file][crate::client::VertexRagDataService::delete_rag_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57547,7 +57547,7 @@ pub mod vertex_rag_data_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_rag_file][super::super::client::VertexRagDataService::delete_rag_file].
+        /// on [delete_rag_file][crate::client::VertexRagDataService::delete_rag_file].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_rag_file(self.0.request, self.0.options)
@@ -57607,7 +57607,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::list_locations][super::super::client::VertexRagDataService::list_locations] calls.
+    /// The request builder for [VertexRagDataService::list_locations][crate::client::VertexRagDataService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57717,7 +57717,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::get_location][super::super::client::VertexRagDataService::get_location] calls.
+    /// The request builder for [VertexRagDataService::get_location][crate::client::VertexRagDataService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57778,7 +57778,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::set_iam_policy][super::super::client::VertexRagDataService::set_iam_policy] calls.
+    /// The request builder for [VertexRagDataService::set_iam_policy][crate::client::VertexRagDataService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57881,7 +57881,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::get_iam_policy][super::super::client::VertexRagDataService::get_iam_policy] calls.
+    /// The request builder for [VertexRagDataService::get_iam_policy][crate::client::VertexRagDataService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -57962,7 +57962,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::test_iam_permissions][super::super::client::VertexRagDataService::test_iam_permissions] calls.
+    /// The request builder for [VertexRagDataService::test_iam_permissions][crate::client::VertexRagDataService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58041,7 +58041,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::list_operations][super::super::client::VertexRagDataService::list_operations] calls.
+    /// The request builder for [VertexRagDataService::list_operations][crate::client::VertexRagDataService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58153,7 +58153,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::get_operation][super::super::client::VertexRagDataService::get_operation] calls.
+    /// The request builder for [VertexRagDataService::get_operation][crate::client::VertexRagDataService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58217,7 +58217,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::delete_operation][super::super::client::VertexRagDataService::delete_operation] calls.
+    /// The request builder for [VertexRagDataService::delete_operation][crate::client::VertexRagDataService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58281,7 +58281,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::cancel_operation][super::super::client::VertexRagDataService::cancel_operation] calls.
+    /// The request builder for [VertexRagDataService::cancel_operation][crate::client::VertexRagDataService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58345,7 +58345,7 @@ pub mod vertex_rag_data_service {
         }
     }
 
-    /// The request builder for [VertexRagDataService::wait_operation][super::super::client::VertexRagDataService::wait_operation] calls.
+    /// The request builder for [VertexRagDataService::wait_operation][crate::client::VertexRagDataService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58433,7 +58433,7 @@ pub mod vertex_rag_data_service {
 pub mod vertex_rag_service {
     use crate::Result;
 
-    /// A builder for [VertexRagService][super::super::client::VertexRagService].
+    /// A builder for [VertexRagService][crate::client::VertexRagService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -58461,7 +58461,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// Common implementation for [super::super::client::VertexRagService] request builders.
+    /// Common implementation for [crate::client::VertexRagService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VertexRagService>,
@@ -58484,7 +58484,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::retrieve_contexts][super::super::client::VertexRagService::retrieve_contexts] calls.
+    /// The request builder for [VertexRagService::retrieve_contexts][crate::client::VertexRagService::retrieve_contexts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58603,7 +58603,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::augment_prompt][super::super::client::VertexRagService::augment_prompt] calls.
+    /// The request builder for [VertexRagService::augment_prompt][crate::client::VertexRagService::augment_prompt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58724,7 +58724,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::corroborate_content][super::super::client::VertexRagService::corroborate_content] calls.
+    /// The request builder for [VertexRagService::corroborate_content][crate::client::VertexRagService::corroborate_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58837,7 +58837,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::list_locations][super::super::client::VertexRagService::list_locations] calls.
+    /// The request builder for [VertexRagService::list_locations][crate::client::VertexRagService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -58947,7 +58947,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::get_location][super::super::client::VertexRagService::get_location] calls.
+    /// The request builder for [VertexRagService::get_location][crate::client::VertexRagService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59008,7 +59008,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::set_iam_policy][super::super::client::VertexRagService::set_iam_policy] calls.
+    /// The request builder for [VertexRagService::set_iam_policy][crate::client::VertexRagService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59111,7 +59111,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::get_iam_policy][super::super::client::VertexRagService::get_iam_policy] calls.
+    /// The request builder for [VertexRagService::get_iam_policy][crate::client::VertexRagService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59192,7 +59192,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::test_iam_permissions][super::super::client::VertexRagService::test_iam_permissions] calls.
+    /// The request builder for [VertexRagService::test_iam_permissions][crate::client::VertexRagService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59271,7 +59271,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::list_operations][super::super::client::VertexRagService::list_operations] calls.
+    /// The request builder for [VertexRagService::list_operations][crate::client::VertexRagService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59383,7 +59383,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::get_operation][super::super::client::VertexRagService::get_operation] calls.
+    /// The request builder for [VertexRagService::get_operation][crate::client::VertexRagService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59447,7 +59447,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::delete_operation][super::super::client::VertexRagService::delete_operation] calls.
+    /// The request builder for [VertexRagService::delete_operation][crate::client::VertexRagService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59511,7 +59511,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::cancel_operation][super::super::client::VertexRagService::cancel_operation] calls.
+    /// The request builder for [VertexRagService::cancel_operation][crate::client::VertexRagService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59575,7 +59575,7 @@ pub mod vertex_rag_service {
         }
     }
 
-    /// The request builder for [VertexRagService::wait_operation][super::super::client::VertexRagService::wait_operation] calls.
+    /// The request builder for [VertexRagService::wait_operation][crate::client::VertexRagService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59663,7 +59663,7 @@ pub mod vertex_rag_service {
 pub mod vizier_service {
     use crate::Result;
 
-    /// A builder for [VizierService][super::super::client::VizierService].
+    /// A builder for [VizierService][crate::client::VizierService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -59691,7 +59691,7 @@ pub mod vizier_service {
         }
     }
 
-    /// Common implementation for [super::super::client::VizierService] request builders.
+    /// Common implementation for [crate::client::VizierService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VizierService>,
@@ -59714,7 +59714,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::create_study][super::super::client::VizierService::create_study] calls.
+    /// The request builder for [VizierService::create_study][crate::client::VizierService::create_study] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59799,7 +59799,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::get_study][super::super::client::VizierService::get_study] calls.
+    /// The request builder for [VizierService::get_study][crate::client::VizierService::get_study] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59862,7 +59862,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::list_studies][super::super::client::VizierService::list_studies] calls.
+    /// The request builder for [VizierService::list_studies][crate::client::VizierService::list_studies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -59965,7 +59965,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::delete_study][super::super::client::VizierService::delete_study] calls.
+    /// The request builder for [VizierService::delete_study][crate::client::VizierService::delete_study] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60028,7 +60028,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::lookup_study][super::super::client::VizierService::lookup_study] calls.
+    /// The request builder for [VizierService::lookup_study][crate::client::VizierService::lookup_study] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60099,7 +60099,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::suggest_trials][super::super::client::VizierService::suggest_trials] calls.
+    /// The request builder for [VizierService::suggest_trials][crate::client::VizierService::suggest_trials] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60144,7 +60144,7 @@ pub mod vizier_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [suggest_trials][super::super::client::VizierService::suggest_trials].
+        /// on [suggest_trials][crate::client::VizierService::suggest_trials].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .suggest_trials(self.0.request, self.0.options)
@@ -60231,7 +60231,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::create_trial][super::super::client::VizierService::create_trial] calls.
+    /// The request builder for [VizierService::create_trial][crate::client::VizierService::create_trial] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60316,7 +60316,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::get_trial][super::super::client::VizierService::get_trial] calls.
+    /// The request builder for [VizierService::get_trial][crate::client::VizierService::get_trial] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60379,7 +60379,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::list_trials][super::super::client::VizierService::list_trials] calls.
+    /// The request builder for [VizierService::list_trials][crate::client::VizierService::list_trials] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60482,7 +60482,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::add_trial_measurement][super::super::client::VizierService::add_trial_measurement] calls.
+    /// The request builder for [VizierService::add_trial_measurement][crate::client::VizierService::add_trial_measurement] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60570,7 +60570,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::complete_trial][super::super::client::VizierService::complete_trial] calls.
+    /// The request builder for [VizierService::complete_trial][crate::client::VizierService::complete_trial] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60663,7 +60663,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::delete_trial][super::super::client::VizierService::delete_trial] calls.
+    /// The request builder for [VizierService::delete_trial][crate::client::VizierService::delete_trial] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60726,7 +60726,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::check_trial_early_stopping_state][super::super::client::VizierService::check_trial_early_stopping_state] calls.
+    /// The request builder for [VizierService::check_trial_early_stopping_state][crate::client::VizierService::check_trial_early_stopping_state] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60776,7 +60776,7 @@ pub mod vizier_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [check_trial_early_stopping_state][super::super::client::VizierService::check_trial_early_stopping_state].
+        /// on [check_trial_early_stopping_state][crate::client::VizierService::check_trial_early_stopping_state].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .check_trial_early_stopping_state(self.0.request, self.0.options)
@@ -60838,7 +60838,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::stop_trial][super::super::client::VizierService::stop_trial] calls.
+    /// The request builder for [VizierService::stop_trial][crate::client::VizierService::stop_trial] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60901,7 +60901,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::list_optimal_trials][super::super::client::VizierService::list_optimal_trials] calls.
+    /// The request builder for [VizierService::list_optimal_trials][crate::client::VizierService::list_optimal_trials] calls.
     ///
     /// # Example
     /// ```no_run
@@ -60967,7 +60967,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::list_locations][super::super::client::VizierService::list_locations] calls.
+    /// The request builder for [VizierService::list_locations][crate::client::VizierService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61077,7 +61077,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::get_location][super::super::client::VizierService::get_location] calls.
+    /// The request builder for [VizierService::get_location][crate::client::VizierService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61138,7 +61138,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::set_iam_policy][super::super::client::VizierService::set_iam_policy] calls.
+    /// The request builder for [VizierService::set_iam_policy][crate::client::VizierService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61241,7 +61241,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::get_iam_policy][super::super::client::VizierService::get_iam_policy] calls.
+    /// The request builder for [VizierService::get_iam_policy][crate::client::VizierService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61322,7 +61322,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::test_iam_permissions][super::super::client::VizierService::test_iam_permissions] calls.
+    /// The request builder for [VizierService::test_iam_permissions][crate::client::VizierService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61401,7 +61401,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::list_operations][super::super::client::VizierService::list_operations] calls.
+    /// The request builder for [VizierService::list_operations][crate::client::VizierService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61513,7 +61513,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::get_operation][super::super::client::VizierService::get_operation] calls.
+    /// The request builder for [VizierService::get_operation][crate::client::VizierService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61577,7 +61577,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::delete_operation][super::super::client::VizierService::delete_operation] calls.
+    /// The request builder for [VizierService::delete_operation][crate::client::VizierService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61641,7 +61641,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::cancel_operation][super::super::client::VizierService::cancel_operation] calls.
+    /// The request builder for [VizierService::cancel_operation][crate::client::VizierService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -61705,7 +61705,7 @@ pub mod vizier_service {
         }
     }
 
-    /// The request builder for [VizierService::wait_operation][super::super::client::VizierService::wait_operation] calls.
+    /// The request builder for [VizierService::wait_operation][crate::client::VizierService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/alloydb/v1/src/builder.rs
+++ b/src/generated/cloud/alloydb/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod alloy_dbcsql_admin {
     use crate::Result;
 
-    /// A builder for [AlloyDBCSQLAdmin][super::super::client::AlloyDBCSQLAdmin].
+    /// A builder for [AlloyDBCSQLAdmin][crate::client::AlloyDBCSQLAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::AlloyDBCSQLAdmin] request builders.
+    /// Common implementation for [crate::client::AlloyDBCSQLAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AlloyDBCSQLAdmin>,
@@ -68,7 +68,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// The request builder for [AlloyDBCSQLAdmin::restore_from_cloud_sql][super::super::client::AlloyDBCSQLAdmin::restore_from_cloud_sql] calls.
+    /// The request builder for [AlloyDBCSQLAdmin::restore_from_cloud_sql][crate::client::AlloyDBCSQLAdmin::restore_from_cloud_sql] calls.
     ///
     /// # Example
     /// ```no_run
@@ -116,7 +116,7 @@ pub mod alloy_dbcsql_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_from_cloud_sql][super::super::client::AlloyDBCSQLAdmin::restore_from_cloud_sql].
+        /// on [restore_from_cloud_sql][crate::client::AlloyDBCSQLAdmin::restore_from_cloud_sql].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_from_cloud_sql(self.0.request, self.0.options)
@@ -230,7 +230,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// The request builder for [AlloyDBCSQLAdmin::list_locations][super::super::client::AlloyDBCSQLAdmin::list_locations] calls.
+    /// The request builder for [AlloyDBCSQLAdmin::list_locations][crate::client::AlloyDBCSQLAdmin::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -340,7 +340,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// The request builder for [AlloyDBCSQLAdmin::get_location][super::super::client::AlloyDBCSQLAdmin::get_location] calls.
+    /// The request builder for [AlloyDBCSQLAdmin::get_location][crate::client::AlloyDBCSQLAdmin::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -401,7 +401,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// The request builder for [AlloyDBCSQLAdmin::list_operations][super::super::client::AlloyDBCSQLAdmin::list_operations] calls.
+    /// The request builder for [AlloyDBCSQLAdmin::list_operations][crate::client::AlloyDBCSQLAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -513,7 +513,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// The request builder for [AlloyDBCSQLAdmin::get_operation][super::super::client::AlloyDBCSQLAdmin::get_operation] calls.
+    /// The request builder for [AlloyDBCSQLAdmin::get_operation][crate::client::AlloyDBCSQLAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -577,7 +577,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// The request builder for [AlloyDBCSQLAdmin::delete_operation][super::super::client::AlloyDBCSQLAdmin::delete_operation] calls.
+    /// The request builder for [AlloyDBCSQLAdmin::delete_operation][crate::client::AlloyDBCSQLAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -641,7 +641,7 @@ pub mod alloy_dbcsql_admin {
         }
     }
 
-    /// The request builder for [AlloyDBCSQLAdmin::cancel_operation][super::super::client::AlloyDBCSQLAdmin::cancel_operation] calls.
+    /// The request builder for [AlloyDBCSQLAdmin::cancel_operation][crate::client::AlloyDBCSQLAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -709,7 +709,7 @@ pub mod alloy_dbcsql_admin {
 pub mod alloy_db_admin {
     use crate::Result;
 
-    /// A builder for [AlloyDBAdmin][super::super::client::AlloyDBAdmin].
+    /// A builder for [AlloyDBAdmin][crate::client::AlloyDBAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -737,7 +737,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::AlloyDBAdmin] request builders.
+    /// Common implementation for [crate::client::AlloyDBAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AlloyDBAdmin>,
@@ -760,7 +760,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_clusters][super::super::client::AlloyDBAdmin::list_clusters] calls.
+    /// The request builder for [AlloyDBAdmin::list_clusters][crate::client::AlloyDBAdmin::list_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -875,7 +875,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::get_cluster][super::super::client::AlloyDBAdmin::get_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::get_cluster][crate::client::AlloyDBAdmin::get_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -944,7 +944,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::create_cluster][super::super::client::AlloyDBAdmin::create_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::create_cluster][crate::client::AlloyDBAdmin::create_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -989,7 +989,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cluster][super::super::client::AlloyDBAdmin::create_cluster].
+        /// on [create_cluster][crate::client::AlloyDBAdmin::create_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cluster(self.0.request, self.0.options)
@@ -1088,7 +1088,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::update_cluster][super::super::client::AlloyDBAdmin::update_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::update_cluster][crate::client::AlloyDBAdmin::update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1133,7 +1133,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_cluster][super::super::client::AlloyDBAdmin::update_cluster].
+        /// on [update_cluster][crate::client::AlloyDBAdmin::update_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_cluster(self.0.request, self.0.options)
@@ -1240,7 +1240,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::export_cluster][super::super::client::AlloyDBAdmin::export_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::export_cluster][crate::client::AlloyDBAdmin::export_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1285,7 +1285,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_cluster][super::super::client::AlloyDBAdmin::export_cluster].
+        /// on [export_cluster][crate::client::AlloyDBAdmin::export_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_cluster(self.0.request, self.0.options)
@@ -1430,7 +1430,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::import_cluster][super::super::client::AlloyDBAdmin::import_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::import_cluster][crate::client::AlloyDBAdmin::import_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1475,7 +1475,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_cluster][super::super::client::AlloyDBAdmin::import_cluster].
+        /// on [import_cluster][crate::client::AlloyDBAdmin::import_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_cluster(self.0.request, self.0.options)
@@ -1603,7 +1603,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::upgrade_cluster][super::super::client::AlloyDBAdmin::upgrade_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::upgrade_cluster][crate::client::AlloyDBAdmin::upgrade_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1648,7 +1648,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upgrade_cluster][super::super::client::AlloyDBAdmin::upgrade_cluster].
+        /// on [upgrade_cluster][crate::client::AlloyDBAdmin::upgrade_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upgrade_cluster(self.0.request, self.0.options)
@@ -1734,7 +1734,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::delete_cluster][super::super::client::AlloyDBAdmin::delete_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::delete_cluster][crate::client::AlloyDBAdmin::delete_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1779,7 +1779,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cluster][super::super::client::AlloyDBAdmin::delete_cluster].
+        /// on [delete_cluster][crate::client::AlloyDBAdmin::delete_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cluster(self.0.request, self.0.options)
@@ -1862,7 +1862,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::promote_cluster][super::super::client::AlloyDBAdmin::promote_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::promote_cluster][crate::client::AlloyDBAdmin::promote_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1907,7 +1907,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [promote_cluster][super::super::client::AlloyDBAdmin::promote_cluster].
+        /// on [promote_cluster][crate::client::AlloyDBAdmin::promote_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .promote_cluster(self.0.request, self.0.options)
@@ -1982,7 +1982,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::switchover_cluster][super::super::client::AlloyDBAdmin::switchover_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::switchover_cluster][crate::client::AlloyDBAdmin::switchover_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2030,7 +2030,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [switchover_cluster][super::super::client::AlloyDBAdmin::switchover_cluster].
+        /// on [switchover_cluster][crate::client::AlloyDBAdmin::switchover_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .switchover_cluster(self.0.request, self.0.options)
@@ -2099,7 +2099,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::restore_cluster][super::super::client::AlloyDBAdmin::restore_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::restore_cluster][crate::client::AlloyDBAdmin::restore_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2144,7 +2144,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_cluster][super::super::client::AlloyDBAdmin::restore_cluster].
+        /// on [restore_cluster][crate::client::AlloyDBAdmin::restore_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_cluster(self.0.request, self.0.options)
@@ -2285,7 +2285,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::create_secondary_cluster][super::super::client::AlloyDBAdmin::create_secondary_cluster] calls.
+    /// The request builder for [AlloyDBAdmin::create_secondary_cluster][crate::client::AlloyDBAdmin::create_secondary_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2333,7 +2333,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_secondary_cluster][super::super::client::AlloyDBAdmin::create_secondary_cluster].
+        /// on [create_secondary_cluster][crate::client::AlloyDBAdmin::create_secondary_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_secondary_cluster(self.0.request, self.0.options)
@@ -2432,7 +2432,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_instances][super::super::client::AlloyDBAdmin::list_instances] calls.
+    /// The request builder for [AlloyDBAdmin::list_instances][crate::client::AlloyDBAdmin::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2547,7 +2547,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::get_instance][super::super::client::AlloyDBAdmin::get_instance] calls.
+    /// The request builder for [AlloyDBAdmin::get_instance][crate::client::AlloyDBAdmin::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2616,7 +2616,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::create_instance][super::super::client::AlloyDBAdmin::create_instance] calls.
+    /// The request builder for [AlloyDBAdmin::create_instance][crate::client::AlloyDBAdmin::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2661,7 +2661,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::AlloyDBAdmin::create_instance].
+        /// on [create_instance][crate::client::AlloyDBAdmin::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -2760,7 +2760,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::create_secondary_instance][super::super::client::AlloyDBAdmin::create_secondary_instance] calls.
+    /// The request builder for [AlloyDBAdmin::create_secondary_instance][crate::client::AlloyDBAdmin::create_secondary_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2810,7 +2810,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_secondary_instance][super::super::client::AlloyDBAdmin::create_secondary_instance].
+        /// on [create_secondary_instance][crate::client::AlloyDBAdmin::create_secondary_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_secondary_instance(self.0.request, self.0.options)
@@ -2909,7 +2909,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::batch_create_instances][super::super::client::AlloyDBAdmin::batch_create_instances] calls.
+    /// The request builder for [AlloyDBAdmin::batch_create_instances][crate::client::AlloyDBAdmin::batch_create_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2957,7 +2957,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_create_instances][super::super::client::AlloyDBAdmin::batch_create_instances].
+        /// on [batch_create_instances][crate::client::AlloyDBAdmin::batch_create_instances].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_create_instances(self.0.request, self.0.options)
@@ -3045,7 +3045,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::update_instance][super::super::client::AlloyDBAdmin::update_instance] calls.
+    /// The request builder for [AlloyDBAdmin::update_instance][crate::client::AlloyDBAdmin::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3090,7 +3090,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::AlloyDBAdmin::update_instance].
+        /// on [update_instance][crate::client::AlloyDBAdmin::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -3197,7 +3197,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::delete_instance][super::super::client::AlloyDBAdmin::delete_instance] calls.
+    /// The request builder for [AlloyDBAdmin::delete_instance][crate::client::AlloyDBAdmin::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3242,7 +3242,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::AlloyDBAdmin::delete_instance].
+        /// on [delete_instance][crate::client::AlloyDBAdmin::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -3319,7 +3319,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::failover_instance][super::super::client::AlloyDBAdmin::failover_instance] calls.
+    /// The request builder for [AlloyDBAdmin::failover_instance][crate::client::AlloyDBAdmin::failover_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3367,7 +3367,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [failover_instance][super::super::client::AlloyDBAdmin::failover_instance].
+        /// on [failover_instance][crate::client::AlloyDBAdmin::failover_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .failover_instance(self.0.request, self.0.options)
@@ -3436,7 +3436,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::inject_fault][super::super::client::AlloyDBAdmin::inject_fault] calls.
+    /// The request builder for [AlloyDBAdmin::inject_fault][crate::client::AlloyDBAdmin::inject_fault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3481,7 +3481,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [inject_fault][super::super::client::AlloyDBAdmin::inject_fault].
+        /// on [inject_fault][crate::client::AlloyDBAdmin::inject_fault].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .inject_fault(self.0.request, self.0.options)
@@ -3561,7 +3561,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::restart_instance][super::super::client::AlloyDBAdmin::restart_instance] calls.
+    /// The request builder for [AlloyDBAdmin::restart_instance][crate::client::AlloyDBAdmin::restart_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3606,7 +3606,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restart_instance][super::super::client::AlloyDBAdmin::restart_instance].
+        /// on [restart_instance][crate::client::AlloyDBAdmin::restart_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restart_instance(self.0.request, self.0.options)
@@ -3686,7 +3686,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::execute_sql][super::super::client::AlloyDBAdmin::execute_sql] calls.
+    /// The request builder for [AlloyDBAdmin::execute_sql][crate::client::AlloyDBAdmin::execute_sql] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3795,7 +3795,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_backups][super::super::client::AlloyDBAdmin::list_backups] calls.
+    /// The request builder for [AlloyDBAdmin::list_backups][crate::client::AlloyDBAdmin::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3910,7 +3910,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::get_backup][super::super::client::AlloyDBAdmin::get_backup] calls.
+    /// The request builder for [AlloyDBAdmin::get_backup][crate::client::AlloyDBAdmin::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3973,7 +3973,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::create_backup][super::super::client::AlloyDBAdmin::create_backup] calls.
+    /// The request builder for [AlloyDBAdmin::create_backup][crate::client::AlloyDBAdmin::create_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4018,7 +4018,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup][super::super::client::AlloyDBAdmin::create_backup].
+        /// on [create_backup][crate::client::AlloyDBAdmin::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
@@ -4117,7 +4117,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::update_backup][super::super::client::AlloyDBAdmin::update_backup] calls.
+    /// The request builder for [AlloyDBAdmin::update_backup][crate::client::AlloyDBAdmin::update_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4162,7 +4162,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup][super::super::client::AlloyDBAdmin::update_backup].
+        /// on [update_backup][crate::client::AlloyDBAdmin::update_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup(self.0.request, self.0.options)
@@ -4269,7 +4269,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::delete_backup][super::super::client::AlloyDBAdmin::delete_backup] calls.
+    /// The request builder for [AlloyDBAdmin::delete_backup][crate::client::AlloyDBAdmin::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4314,7 +4314,7 @@ pub mod alloy_db_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::AlloyDBAdmin::delete_backup].
+        /// on [delete_backup][crate::client::AlloyDBAdmin::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -4391,7 +4391,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_supported_database_flags][super::super::client::AlloyDBAdmin::list_supported_database_flags] calls.
+    /// The request builder for [AlloyDBAdmin::list_supported_database_flags][crate::client::AlloyDBAdmin::list_supported_database_flags] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4512,7 +4512,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::generate_client_certificate][super::super::client::AlloyDBAdmin::generate_client_certificate] calls.
+    /// The request builder for [AlloyDBAdmin::generate_client_certificate][crate::client::AlloyDBAdmin::generate_client_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4616,7 +4616,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::get_connection_info][super::super::client::AlloyDBAdmin::get_connection_info] calls.
+    /// The request builder for [AlloyDBAdmin::get_connection_info][crate::client::AlloyDBAdmin::get_connection_info] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4688,7 +4688,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_users][super::super::client::AlloyDBAdmin::list_users] calls.
+    /// The request builder for [AlloyDBAdmin::list_users][crate::client::AlloyDBAdmin::list_users] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4803,7 +4803,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::get_user][super::super::client::AlloyDBAdmin::get_user] calls.
+    /// The request builder for [AlloyDBAdmin::get_user][crate::client::AlloyDBAdmin::get_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4866,7 +4866,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::create_user][super::super::client::AlloyDBAdmin::create_user] calls.
+    /// The request builder for [AlloyDBAdmin::create_user][crate::client::AlloyDBAdmin::create_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4971,7 +4971,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::update_user][super::super::client::AlloyDBAdmin::update_user] calls.
+    /// The request builder for [AlloyDBAdmin::update_user][crate::client::AlloyDBAdmin::update_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5084,7 +5084,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::delete_user][super::super::client::AlloyDBAdmin::delete_user] calls.
+    /// The request builder for [AlloyDBAdmin::delete_user][crate::client::AlloyDBAdmin::delete_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5159,7 +5159,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_databases][super::super::client::AlloyDBAdmin::list_databases] calls.
+    /// The request builder for [AlloyDBAdmin::list_databases][crate::client::AlloyDBAdmin::list_databases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5268,7 +5268,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_locations][super::super::client::AlloyDBAdmin::list_locations] calls.
+    /// The request builder for [AlloyDBAdmin::list_locations][crate::client::AlloyDBAdmin::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5378,7 +5378,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::get_location][super::super::client::AlloyDBAdmin::get_location] calls.
+    /// The request builder for [AlloyDBAdmin::get_location][crate::client::AlloyDBAdmin::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5439,7 +5439,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::list_operations][super::super::client::AlloyDBAdmin::list_operations] calls.
+    /// The request builder for [AlloyDBAdmin::list_operations][crate::client::AlloyDBAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5551,7 +5551,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::get_operation][super::super::client::AlloyDBAdmin::get_operation] calls.
+    /// The request builder for [AlloyDBAdmin::get_operation][crate::client::AlloyDBAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5615,7 +5615,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::delete_operation][super::super::client::AlloyDBAdmin::delete_operation] calls.
+    /// The request builder for [AlloyDBAdmin::delete_operation][crate::client::AlloyDBAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5679,7 +5679,7 @@ pub mod alloy_db_admin {
         }
     }
 
-    /// The request builder for [AlloyDBAdmin::cancel_operation][super::super::client::AlloyDBAdmin::cancel_operation] calls.
+    /// The request builder for [AlloyDBAdmin::cancel_operation][crate::client::AlloyDBAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/apigateway/v1/src/builder.rs
+++ b/src/generated/cloud/apigateway/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod api_gateway_service {
     use crate::Result;
 
-    /// A builder for [ApiGatewayService][super::super::client::ApiGatewayService].
+    /// A builder for [ApiGatewayService][crate::client::ApiGatewayService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ApiGatewayService] request builders.
+    /// Common implementation for [crate::client::ApiGatewayService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ApiGatewayService>,
@@ -68,7 +68,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::list_gateways][super::super::client::ApiGatewayService::list_gateways] calls.
+    /// The request builder for [ApiGatewayService::list_gateways][crate::client::ApiGatewayService::list_gateways] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::get_gateway][super::super::client::ApiGatewayService::get_gateway] calls.
+    /// The request builder for [ApiGatewayService::get_gateway][crate::client::ApiGatewayService::get_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::create_gateway][super::super::client::ApiGatewayService::create_gateway] calls.
+    /// The request builder for [ApiGatewayService::create_gateway][crate::client::ApiGatewayService::create_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_gateway][super::super::client::ApiGatewayService::create_gateway].
+        /// on [create_gateway][crate::client::ApiGatewayService::create_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_gateway(self.0.request, self.0.options)
@@ -378,7 +378,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::update_gateway][super::super::client::ApiGatewayService::update_gateway] calls.
+    /// The request builder for [ApiGatewayService::update_gateway][crate::client::ApiGatewayService::update_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -423,7 +423,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_gateway][super::super::client::ApiGatewayService::update_gateway].
+        /// on [update_gateway][crate::client::ApiGatewayService::update_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_gateway(self.0.request, self.0.options)
@@ -512,7 +512,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::delete_gateway][super::super::client::ApiGatewayService::delete_gateway] calls.
+    /// The request builder for [ApiGatewayService::delete_gateway][crate::client::ApiGatewayService::delete_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -557,7 +557,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_gateway][super::super::client::ApiGatewayService::delete_gateway].
+        /// on [delete_gateway][crate::client::ApiGatewayService::delete_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_gateway(self.0.request, self.0.options)
@@ -616,7 +616,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::list_apis][super::super::client::ApiGatewayService::list_apis] calls.
+    /// The request builder for [ApiGatewayService::list_apis][crate::client::ApiGatewayService::list_apis] calls.
     ///
     /// # Example
     /// ```no_run
@@ -731,7 +731,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::get_api][super::super::client::ApiGatewayService::get_api] calls.
+    /// The request builder for [ApiGatewayService::get_api][crate::client::ApiGatewayService::get_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -794,7 +794,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::create_api][super::super::client::ApiGatewayService::create_api] calls.
+    /// The request builder for [ApiGatewayService::create_api][crate::client::ApiGatewayService::create_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -839,7 +839,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_api][super::super::client::ApiGatewayService::create_api].
+        /// on [create_api][crate::client::ApiGatewayService::create_api].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_api(self.0.request, self.0.options)
@@ -926,7 +926,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::update_api][super::super::client::ApiGatewayService::update_api] calls.
+    /// The request builder for [ApiGatewayService::update_api][crate::client::ApiGatewayService::update_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -971,7 +971,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_api][super::super::client::ApiGatewayService::update_api].
+        /// on [update_api][crate::client::ApiGatewayService::update_api].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_api(self.0.request, self.0.options)
@@ -1060,7 +1060,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::delete_api][super::super::client::ApiGatewayService::delete_api] calls.
+    /// The request builder for [ApiGatewayService::delete_api][crate::client::ApiGatewayService::delete_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1105,7 +1105,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_api][super::super::client::ApiGatewayService::delete_api].
+        /// on [delete_api][crate::client::ApiGatewayService::delete_api].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_api(self.0.request, self.0.options)
@@ -1164,7 +1164,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::list_api_configs][super::super::client::ApiGatewayService::list_api_configs] calls.
+    /// The request builder for [ApiGatewayService::list_api_configs][crate::client::ApiGatewayService::list_api_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1279,7 +1279,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::get_api_config][super::super::client::ApiGatewayService::get_api_config] calls.
+    /// The request builder for [ApiGatewayService::get_api_config][crate::client::ApiGatewayService::get_api_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1351,7 +1351,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::create_api_config][super::super::client::ApiGatewayService::create_api_config] calls.
+    /// The request builder for [ApiGatewayService::create_api_config][crate::client::ApiGatewayService::create_api_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1396,7 +1396,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_api_config][super::super::client::ApiGatewayService::create_api_config].
+        /// on [create_api_config][crate::client::ApiGatewayService::create_api_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_api_config(self.0.request, self.0.options)
@@ -1483,7 +1483,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::update_api_config][super::super::client::ApiGatewayService::update_api_config] calls.
+    /// The request builder for [ApiGatewayService::update_api_config][crate::client::ApiGatewayService::update_api_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1528,7 +1528,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_api_config][super::super::client::ApiGatewayService::update_api_config].
+        /// on [update_api_config][crate::client::ApiGatewayService::update_api_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_api_config(self.0.request, self.0.options)
@@ -1617,7 +1617,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::delete_api_config][super::super::client::ApiGatewayService::delete_api_config] calls.
+    /// The request builder for [ApiGatewayService::delete_api_config][crate::client::ApiGatewayService::delete_api_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1662,7 +1662,7 @@ pub mod api_gateway_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_api_config][super::super::client::ApiGatewayService::delete_api_config].
+        /// on [delete_api_config][crate::client::ApiGatewayService::delete_api_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_api_config(self.0.request, self.0.options)
@@ -1721,7 +1721,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::list_operations][super::super::client::ApiGatewayService::list_operations] calls.
+    /// The request builder for [ApiGatewayService::list_operations][crate::client::ApiGatewayService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1833,7 +1833,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::get_operation][super::super::client::ApiGatewayService::get_operation] calls.
+    /// The request builder for [ApiGatewayService::get_operation][crate::client::ApiGatewayService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1897,7 +1897,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::delete_operation][super::super::client::ApiGatewayService::delete_operation] calls.
+    /// The request builder for [ApiGatewayService::delete_operation][crate::client::ApiGatewayService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1961,7 +1961,7 @@ pub mod api_gateway_service {
         }
     }
 
-    /// The request builder for [ApiGatewayService::cancel_operation][super::super::client::ApiGatewayService::cancel_operation] calls.
+    /// The request builder for [ApiGatewayService::cancel_operation][crate::client::ApiGatewayService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/apigeeconnect/v1/src/builder.rs
+++ b/src/generated/cloud/apigeeconnect/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod connection_service {
     use crate::Result;
 
-    /// A builder for [ConnectionService][super::super::client::ConnectionService].
+    /// A builder for [ConnectionService][crate::client::ConnectionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod connection_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ConnectionService] request builders.
+    /// Common implementation for [crate::client::ConnectionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConnectionService>,
@@ -68,7 +68,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::list_connections][super::super::client::ConnectionService::list_connections] calls.
+    /// The request builder for [ConnectionService::list_connections][crate::client::ConnectionService::list_connections] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/apihub/v1/src/builder.rs
+++ b/src/generated/cloud/apihub/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod api_hub {
     use crate::Result;
 
-    /// A builder for [ApiHub][super::super::client::ApiHub].
+    /// A builder for [ApiHub][crate::client::ApiHub].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod api_hub {
         }
     }
 
-    /// Common implementation for [super::super::client::ApiHub] request builders.
+    /// Common implementation for [crate::client::ApiHub] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ApiHub>,
@@ -66,7 +66,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::create_api][super::super::client::ApiHub::create_api] calls.
+    /// The request builder for [ApiHub::create_api][crate::client::ApiHub::create_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -155,7 +155,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_api][super::super::client::ApiHub::get_api] calls.
+    /// The request builder for [ApiHub::get_api][crate::client::ApiHub::get_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -216,7 +216,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_apis][super::super::client::ApiHub::list_apis] calls.
+    /// The request builder for [ApiHub::list_apis][crate::client::ApiHub::list_apis] calls.
     ///
     /// # Example
     /// ```no_run
@@ -323,7 +323,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::update_api][super::super::client::ApiHub::update_api] calls.
+    /// The request builder for [ApiHub::update_api][crate::client::ApiHub::update_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -420,7 +420,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::delete_api][super::super::client::ApiHub::delete_api] calls.
+    /// The request builder for [ApiHub::delete_api][crate::client::ApiHub::delete_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -487,7 +487,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::create_version][super::super::client::ApiHub::create_version] calls.
+    /// The request builder for [ApiHub::create_version][crate::client::ApiHub::create_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -576,7 +576,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_version][super::super::client::ApiHub::get_version] calls.
+    /// The request builder for [ApiHub::get_version][crate::client::ApiHub::get_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -637,7 +637,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_versions][super::super::client::ApiHub::list_versions] calls.
+    /// The request builder for [ApiHub::list_versions][crate::client::ApiHub::list_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -744,7 +744,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::update_version][super::super::client::ApiHub::update_version] calls.
+    /// The request builder for [ApiHub::update_version][crate::client::ApiHub::update_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -841,7 +841,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::delete_version][super::super::client::ApiHub::delete_version] calls.
+    /// The request builder for [ApiHub::delete_version][crate::client::ApiHub::delete_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -908,7 +908,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::create_spec][super::super::client::ApiHub::create_spec] calls.
+    /// The request builder for [ApiHub::create_spec][crate::client::ApiHub::create_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -997,7 +997,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_spec][super::super::client::ApiHub::get_spec] calls.
+    /// The request builder for [ApiHub::get_spec][crate::client::ApiHub::get_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1058,7 +1058,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_spec_contents][super::super::client::ApiHub::get_spec_contents] calls.
+    /// The request builder for [ApiHub::get_spec_contents][crate::client::ApiHub::get_spec_contents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1119,7 +1119,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_specs][super::super::client::ApiHub::list_specs] calls.
+    /// The request builder for [ApiHub::list_specs][crate::client::ApiHub::list_specs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1226,7 +1226,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::update_spec][super::super::client::ApiHub::update_spec] calls.
+    /// The request builder for [ApiHub::update_spec][crate::client::ApiHub::update_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1323,7 +1323,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::delete_spec][super::super::client::ApiHub::delete_spec] calls.
+    /// The request builder for [ApiHub::delete_spec][crate::client::ApiHub::delete_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1384,7 +1384,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_api_operation][super::super::client::ApiHub::get_api_operation] calls.
+    /// The request builder for [ApiHub::get_api_operation][crate::client::ApiHub::get_api_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1445,7 +1445,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_api_operations][super::super::client::ApiHub::list_api_operations] calls.
+    /// The request builder for [ApiHub::list_api_operations][crate::client::ApiHub::list_api_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1555,7 +1555,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_definition][super::super::client::ApiHub::get_definition] calls.
+    /// The request builder for [ApiHub::get_definition][crate::client::ApiHub::get_definition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1616,7 +1616,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::create_deployment][super::super::client::ApiHub::create_deployment] calls.
+    /// The request builder for [ApiHub::create_deployment][crate::client::ApiHub::create_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1708,7 +1708,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_deployment][super::super::client::ApiHub::get_deployment] calls.
+    /// The request builder for [ApiHub::get_deployment][crate::client::ApiHub::get_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1769,7 +1769,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_deployments][super::super::client::ApiHub::list_deployments] calls.
+    /// The request builder for [ApiHub::list_deployments][crate::client::ApiHub::list_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1876,7 +1876,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::update_deployment][super::super::client::ApiHub::update_deployment] calls.
+    /// The request builder for [ApiHub::update_deployment][crate::client::ApiHub::update_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1976,7 +1976,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::delete_deployment][super::super::client::ApiHub::delete_deployment] calls.
+    /// The request builder for [ApiHub::delete_deployment][crate::client::ApiHub::delete_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2040,7 +2040,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::create_attribute][super::super::client::ApiHub::create_attribute] calls.
+    /// The request builder for [ApiHub::create_attribute][crate::client::ApiHub::create_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2129,7 +2129,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_attribute][super::super::client::ApiHub::get_attribute] calls.
+    /// The request builder for [ApiHub::get_attribute][crate::client::ApiHub::get_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2190,7 +2190,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::update_attribute][super::super::client::ApiHub::update_attribute] calls.
+    /// The request builder for [ApiHub::update_attribute][crate::client::ApiHub::update_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2287,7 +2287,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::delete_attribute][super::super::client::ApiHub::delete_attribute] calls.
+    /// The request builder for [ApiHub::delete_attribute][crate::client::ApiHub::delete_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2348,7 +2348,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_attributes][super::super::client::ApiHub::list_attributes] calls.
+    /// The request builder for [ApiHub::list_attributes][crate::client::ApiHub::list_attributes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2455,7 +2455,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::search_resources][super::super::client::ApiHub::search_resources] calls.
+    /// The request builder for [ApiHub::search_resources][crate::client::ApiHub::search_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2570,7 +2570,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::create_external_api][super::super::client::ApiHub::create_external_api] calls.
+    /// The request builder for [ApiHub::create_external_api][crate::client::ApiHub::create_external_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2662,7 +2662,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_external_api][super::super::client::ApiHub::get_external_api] calls.
+    /// The request builder for [ApiHub::get_external_api][crate::client::ApiHub::get_external_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2723,7 +2723,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::update_external_api][super::super::client::ApiHub::update_external_api] calls.
+    /// The request builder for [ApiHub::update_external_api][crate::client::ApiHub::update_external_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2823,7 +2823,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::delete_external_api][super::super::client::ApiHub::delete_external_api] calls.
+    /// The request builder for [ApiHub::delete_external_api][crate::client::ApiHub::delete_external_api] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2887,7 +2887,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_external_apis][super::super::client::ApiHub::list_external_apis] calls.
+    /// The request builder for [ApiHub::list_external_apis][crate::client::ApiHub::list_external_apis] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2991,7 +2991,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_locations][super::super::client::ApiHub::list_locations] calls.
+    /// The request builder for [ApiHub::list_locations][crate::client::ApiHub::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3099,7 +3099,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_location][super::super::client::ApiHub::get_location] calls.
+    /// The request builder for [ApiHub::get_location][crate::client::ApiHub::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3158,7 +3158,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::list_operations][super::super::client::ApiHub::list_operations] calls.
+    /// The request builder for [ApiHub::list_operations][crate::client::ApiHub::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3268,7 +3268,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::get_operation][super::super::client::ApiHub::get_operation] calls.
+    /// The request builder for [ApiHub::get_operation][crate::client::ApiHub::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3330,7 +3330,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::delete_operation][super::super::client::ApiHub::delete_operation] calls.
+    /// The request builder for [ApiHub::delete_operation][crate::client::ApiHub::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3392,7 +3392,7 @@ pub mod api_hub {
         }
     }
 
-    /// The request builder for [ApiHub::cancel_operation][super::super::client::ApiHub::cancel_operation] calls.
+    /// The request builder for [ApiHub::cancel_operation][crate::client::ApiHub::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3458,7 +3458,7 @@ pub mod api_hub {
 pub mod api_hub_dependencies {
     use crate::Result;
 
-    /// A builder for [ApiHubDependencies][super::super::client::ApiHubDependencies].
+    /// A builder for [ApiHubDependencies][crate::client::ApiHubDependencies].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3486,7 +3486,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// Common implementation for [super::super::client::ApiHubDependencies] request builders.
+    /// Common implementation for [crate::client::ApiHubDependencies] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ApiHubDependencies>,
@@ -3509,7 +3509,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::create_dependency][super::super::client::ApiHubDependencies::create_dependency] calls.
+    /// The request builder for [ApiHubDependencies::create_dependency][crate::client::ApiHubDependencies::create_dependency] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3603,7 +3603,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::get_dependency][super::super::client::ApiHubDependencies::get_dependency] calls.
+    /// The request builder for [ApiHubDependencies::get_dependency][crate::client::ApiHubDependencies::get_dependency] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3666,7 +3666,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::update_dependency][super::super::client::ApiHubDependencies::update_dependency] calls.
+    /// The request builder for [ApiHubDependencies::update_dependency][crate::client::ApiHubDependencies::update_dependency] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3768,7 +3768,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::delete_dependency][super::super::client::ApiHubDependencies::delete_dependency] calls.
+    /// The request builder for [ApiHubDependencies::delete_dependency][crate::client::ApiHubDependencies::delete_dependency] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3834,7 +3834,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::list_dependencies][super::super::client::ApiHubDependencies::list_dependencies] calls.
+    /// The request builder for [ApiHubDependencies::list_dependencies][crate::client::ApiHubDependencies::list_dependencies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3946,7 +3946,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::list_locations][super::super::client::ApiHubDependencies::list_locations] calls.
+    /// The request builder for [ApiHubDependencies::list_locations][crate::client::ApiHubDependencies::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4056,7 +4056,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::get_location][super::super::client::ApiHubDependencies::get_location] calls.
+    /// The request builder for [ApiHubDependencies::get_location][crate::client::ApiHubDependencies::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4117,7 +4117,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::list_operations][super::super::client::ApiHubDependencies::list_operations] calls.
+    /// The request builder for [ApiHubDependencies::list_operations][crate::client::ApiHubDependencies::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4229,7 +4229,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::get_operation][super::super::client::ApiHubDependencies::get_operation] calls.
+    /// The request builder for [ApiHubDependencies::get_operation][crate::client::ApiHubDependencies::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4293,7 +4293,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::delete_operation][super::super::client::ApiHubDependencies::delete_operation] calls.
+    /// The request builder for [ApiHubDependencies::delete_operation][crate::client::ApiHubDependencies::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4357,7 +4357,7 @@ pub mod api_hub_dependencies {
         }
     }
 
-    /// The request builder for [ApiHubDependencies::cancel_operation][super::super::client::ApiHubDependencies::cancel_operation] calls.
+    /// The request builder for [ApiHubDependencies::cancel_operation][crate::client::ApiHubDependencies::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4425,7 +4425,7 @@ pub mod api_hub_dependencies {
 pub mod host_project_registration_service {
     use crate::Result;
 
-    /// A builder for [HostProjectRegistrationService][super::super::client::HostProjectRegistrationService].
+    /// A builder for [HostProjectRegistrationService][crate::client::HostProjectRegistrationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4453,7 +4453,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// Common implementation for [super::super::client::HostProjectRegistrationService] request builders.
+    /// Common implementation for [crate::client::HostProjectRegistrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::HostProjectRegistrationService>,
@@ -4476,7 +4476,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::create_host_project_registration][super::super::client::HostProjectRegistrationService::create_host_project_registration] calls.
+    /// The request builder for [HostProjectRegistrationService::create_host_project_registration][crate::client::HostProjectRegistrationService::create_host_project_registration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4580,7 +4580,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::get_host_project_registration][super::super::client::HostProjectRegistrationService::get_host_project_registration] calls.
+    /// The request builder for [HostProjectRegistrationService::get_host_project_registration][crate::client::HostProjectRegistrationService::get_host_project_registration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4648,7 +4648,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::list_host_project_registrations][super::super::client::HostProjectRegistrationService::list_host_project_registrations] calls.
+    /// The request builder for [HostProjectRegistrationService::list_host_project_registrations][crate::client::HostProjectRegistrationService::list_host_project_registrations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4772,7 +4772,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::list_locations][super::super::client::HostProjectRegistrationService::list_locations] calls.
+    /// The request builder for [HostProjectRegistrationService::list_locations][crate::client::HostProjectRegistrationService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4882,7 +4882,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::get_location][super::super::client::HostProjectRegistrationService::get_location] calls.
+    /// The request builder for [HostProjectRegistrationService::get_location][crate::client::HostProjectRegistrationService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4943,7 +4943,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::list_operations][super::super::client::HostProjectRegistrationService::list_operations] calls.
+    /// The request builder for [HostProjectRegistrationService::list_operations][crate::client::HostProjectRegistrationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5055,7 +5055,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::get_operation][super::super::client::HostProjectRegistrationService::get_operation] calls.
+    /// The request builder for [HostProjectRegistrationService::get_operation][crate::client::HostProjectRegistrationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5119,7 +5119,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::delete_operation][super::super::client::HostProjectRegistrationService::delete_operation] calls.
+    /// The request builder for [HostProjectRegistrationService::delete_operation][crate::client::HostProjectRegistrationService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5183,7 +5183,7 @@ pub mod host_project_registration_service {
         }
     }
 
-    /// The request builder for [HostProjectRegistrationService::cancel_operation][super::super::client::HostProjectRegistrationService::cancel_operation] calls.
+    /// The request builder for [HostProjectRegistrationService::cancel_operation][crate::client::HostProjectRegistrationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5251,7 +5251,7 @@ pub mod host_project_registration_service {
 pub mod linting_service {
     use crate::Result;
 
-    /// A builder for [LintingService][super::super::client::LintingService].
+    /// A builder for [LintingService][crate::client::LintingService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5279,7 +5279,7 @@ pub mod linting_service {
         }
     }
 
-    /// Common implementation for [super::super::client::LintingService] request builders.
+    /// Common implementation for [crate::client::LintingService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LintingService>,
@@ -5302,7 +5302,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::get_style_guide][super::super::client::LintingService::get_style_guide] calls.
+    /// The request builder for [LintingService::get_style_guide][crate::client::LintingService::get_style_guide] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5365,7 +5365,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::update_style_guide][super::super::client::LintingService::update_style_guide] calls.
+    /// The request builder for [LintingService::update_style_guide][crate::client::LintingService::update_style_guide] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5463,7 +5463,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::get_style_guide_contents][super::super::client::LintingService::get_style_guide_contents] calls.
+    /// The request builder for [LintingService::get_style_guide_contents][crate::client::LintingService::get_style_guide_contents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5529,7 +5529,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::lint_spec][super::super::client::LintingService::lint_spec] calls.
+    /// The request builder for [LintingService::lint_spec][crate::client::LintingService::lint_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5592,7 +5592,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::list_locations][super::super::client::LintingService::list_locations] calls.
+    /// The request builder for [LintingService::list_locations][crate::client::LintingService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5702,7 +5702,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::get_location][super::super::client::LintingService::get_location] calls.
+    /// The request builder for [LintingService::get_location][crate::client::LintingService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5763,7 +5763,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::list_operations][super::super::client::LintingService::list_operations] calls.
+    /// The request builder for [LintingService::list_operations][crate::client::LintingService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5875,7 +5875,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::get_operation][super::super::client::LintingService::get_operation] calls.
+    /// The request builder for [LintingService::get_operation][crate::client::LintingService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5939,7 +5939,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::delete_operation][super::super::client::LintingService::delete_operation] calls.
+    /// The request builder for [LintingService::delete_operation][crate::client::LintingService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6003,7 +6003,7 @@ pub mod linting_service {
         }
     }
 
-    /// The request builder for [LintingService::cancel_operation][super::super::client::LintingService::cancel_operation] calls.
+    /// The request builder for [LintingService::cancel_operation][crate::client::LintingService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6071,7 +6071,7 @@ pub mod linting_service {
 pub mod api_hub_plugin {
     use crate::Result;
 
-    /// A builder for [ApiHubPlugin][super::super::client::ApiHubPlugin].
+    /// A builder for [ApiHubPlugin][crate::client::ApiHubPlugin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6099,7 +6099,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// Common implementation for [super::super::client::ApiHubPlugin] request builders.
+    /// Common implementation for [crate::client::ApiHubPlugin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ApiHubPlugin>,
@@ -6122,7 +6122,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::get_plugin][super::super::client::ApiHubPlugin::get_plugin] calls.
+    /// The request builder for [ApiHubPlugin::get_plugin][crate::client::ApiHubPlugin::get_plugin] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6185,7 +6185,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::enable_plugin][super::super::client::ApiHubPlugin::enable_plugin] calls.
+    /// The request builder for [ApiHubPlugin::enable_plugin][crate::client::ApiHubPlugin::enable_plugin] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6248,7 +6248,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::disable_plugin][super::super::client::ApiHubPlugin::disable_plugin] calls.
+    /// The request builder for [ApiHubPlugin::disable_plugin][crate::client::ApiHubPlugin::disable_plugin] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6311,7 +6311,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::list_locations][super::super::client::ApiHubPlugin::list_locations] calls.
+    /// The request builder for [ApiHubPlugin::list_locations][crate::client::ApiHubPlugin::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6421,7 +6421,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::get_location][super::super::client::ApiHubPlugin::get_location] calls.
+    /// The request builder for [ApiHubPlugin::get_location][crate::client::ApiHubPlugin::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6482,7 +6482,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::list_operations][super::super::client::ApiHubPlugin::list_operations] calls.
+    /// The request builder for [ApiHubPlugin::list_operations][crate::client::ApiHubPlugin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6594,7 +6594,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::get_operation][super::super::client::ApiHubPlugin::get_operation] calls.
+    /// The request builder for [ApiHubPlugin::get_operation][crate::client::ApiHubPlugin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6658,7 +6658,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::delete_operation][super::super::client::ApiHubPlugin::delete_operation] calls.
+    /// The request builder for [ApiHubPlugin::delete_operation][crate::client::ApiHubPlugin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6722,7 +6722,7 @@ pub mod api_hub_plugin {
         }
     }
 
-    /// The request builder for [ApiHubPlugin::cancel_operation][super::super::client::ApiHubPlugin::cancel_operation] calls.
+    /// The request builder for [ApiHubPlugin::cancel_operation][crate::client::ApiHubPlugin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6790,7 +6790,7 @@ pub mod api_hub_plugin {
 pub mod provisioning {
     use crate::Result;
 
-    /// A builder for [Provisioning][super::super::client::Provisioning].
+    /// A builder for [Provisioning][crate::client::Provisioning].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6818,7 +6818,7 @@ pub mod provisioning {
         }
     }
 
-    /// Common implementation for [super::super::client::Provisioning] request builders.
+    /// Common implementation for [crate::client::Provisioning] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Provisioning>,
@@ -6841,7 +6841,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::create_api_hub_instance][super::super::client::Provisioning::create_api_hub_instance] calls.
+    /// The request builder for [Provisioning::create_api_hub_instance][crate::client::Provisioning::create_api_hub_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6889,7 +6889,7 @@ pub mod provisioning {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_api_hub_instance][super::super::client::Provisioning::create_api_hub_instance].
+        /// on [create_api_hub_instance][crate::client::Provisioning::create_api_hub_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_api_hub_instance(self.0.request, self.0.options)
@@ -6977,7 +6977,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::get_api_hub_instance][super::super::client::Provisioning::get_api_hub_instance] calls.
+    /// The request builder for [Provisioning::get_api_hub_instance][crate::client::Provisioning::get_api_hub_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7043,7 +7043,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::lookup_api_hub_instance][super::super::client::Provisioning::lookup_api_hub_instance] calls.
+    /// The request builder for [Provisioning::lookup_api_hub_instance][crate::client::Provisioning::lookup_api_hub_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7109,7 +7109,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::list_locations][super::super::client::Provisioning::list_locations] calls.
+    /// The request builder for [Provisioning::list_locations][crate::client::Provisioning::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7219,7 +7219,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::get_location][super::super::client::Provisioning::get_location] calls.
+    /// The request builder for [Provisioning::get_location][crate::client::Provisioning::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7280,7 +7280,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::list_operations][super::super::client::Provisioning::list_operations] calls.
+    /// The request builder for [Provisioning::list_operations][crate::client::Provisioning::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7392,7 +7392,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::get_operation][super::super::client::Provisioning::get_operation] calls.
+    /// The request builder for [Provisioning::get_operation][crate::client::Provisioning::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7456,7 +7456,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::delete_operation][super::super::client::Provisioning::delete_operation] calls.
+    /// The request builder for [Provisioning::delete_operation][crate::client::Provisioning::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7520,7 +7520,7 @@ pub mod provisioning {
         }
     }
 
-    /// The request builder for [Provisioning::cancel_operation][super::super::client::Provisioning::cancel_operation] calls.
+    /// The request builder for [Provisioning::cancel_operation][crate::client::Provisioning::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7588,7 +7588,7 @@ pub mod provisioning {
 pub mod runtime_project_attachment_service {
     use crate::Result;
 
-    /// A builder for [RuntimeProjectAttachmentService][super::super::client::RuntimeProjectAttachmentService].
+    /// A builder for [RuntimeProjectAttachmentService][crate::client::RuntimeProjectAttachmentService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7616,7 +7616,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RuntimeProjectAttachmentService] request builders.
+    /// Common implementation for [crate::client::RuntimeProjectAttachmentService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RuntimeProjectAttachmentService>,
@@ -7639,7 +7639,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::create_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::create_runtime_project_attachment] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::create_runtime_project_attachment][crate::client::RuntimeProjectAttachmentService::create_runtime_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7743,7 +7743,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::get_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::get_runtime_project_attachment] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::get_runtime_project_attachment][crate::client::RuntimeProjectAttachmentService::get_runtime_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7811,7 +7811,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::list_runtime_project_attachments][super::super::client::RuntimeProjectAttachmentService::list_runtime_project_attachments] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::list_runtime_project_attachments][crate::client::RuntimeProjectAttachmentService::list_runtime_project_attachments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7935,7 +7935,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::delete_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::delete_runtime_project_attachment] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::delete_runtime_project_attachment][crate::client::RuntimeProjectAttachmentService::delete_runtime_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8003,7 +8003,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::lookup_runtime_project_attachment][super::super::client::RuntimeProjectAttachmentService::lookup_runtime_project_attachment] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::lookup_runtime_project_attachment][crate::client::RuntimeProjectAttachmentService::lookup_runtime_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8071,7 +8071,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::list_locations][super::super::client::RuntimeProjectAttachmentService::list_locations] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::list_locations][crate::client::RuntimeProjectAttachmentService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8181,7 +8181,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::get_location][super::super::client::RuntimeProjectAttachmentService::get_location] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::get_location][crate::client::RuntimeProjectAttachmentService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8242,7 +8242,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::list_operations][super::super::client::RuntimeProjectAttachmentService::list_operations] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::list_operations][crate::client::RuntimeProjectAttachmentService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8354,7 +8354,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::get_operation][super::super::client::RuntimeProjectAttachmentService::get_operation] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::get_operation][crate::client::RuntimeProjectAttachmentService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8418,7 +8418,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::delete_operation][super::super::client::RuntimeProjectAttachmentService::delete_operation] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::delete_operation][crate::client::RuntimeProjectAttachmentService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8482,7 +8482,7 @@ pub mod runtime_project_attachment_service {
         }
     }
 
-    /// The request builder for [RuntimeProjectAttachmentService::cancel_operation][super::super::client::RuntimeProjectAttachmentService::cancel_operation] calls.
+    /// The request builder for [RuntimeProjectAttachmentService::cancel_operation][crate::client::RuntimeProjectAttachmentService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/apphub/v1/src/builder.rs
+++ b/src/generated/cloud/apphub/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod app_hub {
     use crate::Result;
 
-    /// A builder for [AppHub][super::super::client::AppHub].
+    /// A builder for [AppHub][crate::client::AppHub].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod app_hub {
         }
     }
 
-    /// Common implementation for [super::super::client::AppHub] request builders.
+    /// Common implementation for [crate::client::AppHub] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AppHub>,
@@ -66,7 +66,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::lookup_service_project_attachment][super::super::client::AppHub::lookup_service_project_attachment] calls.
+    /// The request builder for [AppHub::lookup_service_project_attachment][crate::client::AppHub::lookup_service_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -132,7 +132,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_service_project_attachments][super::super::client::AppHub::list_service_project_attachments] calls.
+    /// The request builder for [AppHub::list_service_project_attachments][crate::client::AppHub::list_service_project_attachments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::create_service_project_attachment][super::super::client::AppHub::create_service_project_attachment] calls.
+    /// The request builder for [AppHub::create_service_project_attachment][crate::client::AppHub::create_service_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -302,7 +302,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service_project_attachment][super::super::client::AppHub::create_service_project_attachment].
+        /// on [create_service_project_attachment][crate::client::AppHub::create_service_project_attachment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service_project_attachment(self.0.request, self.0.options)
@@ -404,7 +404,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_service_project_attachment][super::super::client::AppHub::get_service_project_attachment] calls.
+    /// The request builder for [AppHub::get_service_project_attachment][crate::client::AppHub::get_service_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -470,7 +470,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::delete_service_project_attachment][super::super::client::AppHub::delete_service_project_attachment] calls.
+    /// The request builder for [AppHub::delete_service_project_attachment][crate::client::AppHub::delete_service_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -518,7 +518,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service_project_attachment][super::super::client::AppHub::delete_service_project_attachment].
+        /// on [delete_service_project_attachment][crate::client::AppHub::delete_service_project_attachment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service_project_attachment(self.0.request, self.0.options)
@@ -583,7 +583,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::detach_service_project_attachment][super::super::client::AppHub::detach_service_project_attachment] calls.
+    /// The request builder for [AppHub::detach_service_project_attachment][crate::client::AppHub::detach_service_project_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -649,7 +649,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_discovered_services][super::super::client::AppHub::list_discovered_services] calls.
+    /// The request builder for [AppHub::list_discovered_services][crate::client::AppHub::list_discovered_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -769,7 +769,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_discovered_service][super::super::client::AppHub::get_discovered_service] calls.
+    /// The request builder for [AppHub::get_discovered_service][crate::client::AppHub::get_discovered_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -833,7 +833,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::lookup_discovered_service][super::super::client::AppHub::lookup_discovered_service] calls.
+    /// The request builder for [AppHub::lookup_discovered_service][crate::client::AppHub::lookup_discovered_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -907,7 +907,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_services][super::super::client::AppHub::list_services] calls.
+    /// The request builder for [AppHub::list_services][crate::client::AppHub::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1020,7 +1020,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::create_service][super::super::client::AppHub::create_service] calls.
+    /// The request builder for [AppHub::create_service][crate::client::AppHub::create_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1063,7 +1063,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service][super::super::client::AppHub::create_service].
+        /// on [create_service][crate::client::AppHub::create_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service(self.0.request, self.0.options)
@@ -1156,7 +1156,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_service][super::super::client::AppHub::get_service] calls.
+    /// The request builder for [AppHub::get_service][crate::client::AppHub::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1217,7 +1217,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::update_service][super::super::client::AppHub::update_service] calls.
+    /// The request builder for [AppHub::update_service][crate::client::AppHub::update_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1260,7 +1260,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service][super::super::client::AppHub::update_service].
+        /// on [update_service][crate::client::AppHub::update_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service(self.0.request, self.0.options)
@@ -1359,7 +1359,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::delete_service][super::super::client::AppHub::delete_service] calls.
+    /// The request builder for [AppHub::delete_service][crate::client::AppHub::delete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1402,7 +1402,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service][super::super::client::AppHub::delete_service].
+        /// on [delete_service][crate::client::AppHub::delete_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service(self.0.request, self.0.options)
@@ -1467,7 +1467,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_discovered_workloads][super::super::client::AppHub::list_discovered_workloads] calls.
+    /// The request builder for [AppHub::list_discovered_workloads][crate::client::AppHub::list_discovered_workloads] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1589,7 +1589,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_discovered_workload][super::super::client::AppHub::get_discovered_workload] calls.
+    /// The request builder for [AppHub::get_discovered_workload][crate::client::AppHub::get_discovered_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1653,7 +1653,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::lookup_discovered_workload][super::super::client::AppHub::lookup_discovered_workload] calls.
+    /// The request builder for [AppHub::lookup_discovered_workload][crate::client::AppHub::lookup_discovered_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1727,7 +1727,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_workloads][super::super::client::AppHub::list_workloads] calls.
+    /// The request builder for [AppHub::list_workloads][crate::client::AppHub::list_workloads] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1840,7 +1840,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::create_workload][super::super::client::AppHub::create_workload] calls.
+    /// The request builder for [AppHub::create_workload][crate::client::AppHub::create_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1883,7 +1883,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_workload][super::super::client::AppHub::create_workload].
+        /// on [create_workload][crate::client::AppHub::create_workload].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_workload(self.0.request, self.0.options)
@@ -1976,7 +1976,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_workload][super::super::client::AppHub::get_workload] calls.
+    /// The request builder for [AppHub::get_workload][crate::client::AppHub::get_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2037,7 +2037,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::update_workload][super::super::client::AppHub::update_workload] calls.
+    /// The request builder for [AppHub::update_workload][crate::client::AppHub::update_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2080,7 +2080,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_workload][super::super::client::AppHub::update_workload].
+        /// on [update_workload][crate::client::AppHub::update_workload].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_workload(self.0.request, self.0.options)
@@ -2179,7 +2179,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::delete_workload][super::super::client::AppHub::delete_workload] calls.
+    /// The request builder for [AppHub::delete_workload][crate::client::AppHub::delete_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2222,7 +2222,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_workload][super::super::client::AppHub::delete_workload].
+        /// on [delete_workload][crate::client::AppHub::delete_workload].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_workload(self.0.request, self.0.options)
@@ -2287,7 +2287,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_applications][super::super::client::AppHub::list_applications] calls.
+    /// The request builder for [AppHub::list_applications][crate::client::AppHub::list_applications] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2403,7 +2403,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::create_application][super::super::client::AppHub::create_application] calls.
+    /// The request builder for [AppHub::create_application][crate::client::AppHub::create_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2449,7 +2449,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_application][super::super::client::AppHub::create_application].
+        /// on [create_application][crate::client::AppHub::create_application].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_application(self.0.request, self.0.options)
@@ -2544,7 +2544,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_application][super::super::client::AppHub::get_application] calls.
+    /// The request builder for [AppHub::get_application][crate::client::AppHub::get_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2605,7 +2605,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::update_application][super::super::client::AppHub::update_application] calls.
+    /// The request builder for [AppHub::update_application][crate::client::AppHub::update_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2651,7 +2651,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_application][super::super::client::AppHub::update_application].
+        /// on [update_application][crate::client::AppHub::update_application].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_application(self.0.request, self.0.options)
@@ -2752,7 +2752,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::delete_application][super::super::client::AppHub::delete_application] calls.
+    /// The request builder for [AppHub::delete_application][crate::client::AppHub::delete_application] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2798,7 +2798,7 @@ pub mod app_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_application][super::super::client::AppHub::delete_application].
+        /// on [delete_application][crate::client::AppHub::delete_application].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_application(self.0.request, self.0.options)
@@ -2863,7 +2863,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_locations][super::super::client::AppHub::list_locations] calls.
+    /// The request builder for [AppHub::list_locations][crate::client::AppHub::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2971,7 +2971,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_location][super::super::client::AppHub::get_location] calls.
+    /// The request builder for [AppHub::get_location][crate::client::AppHub::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3030,7 +3030,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::set_iam_policy][super::super::client::AppHub::set_iam_policy] calls.
+    /// The request builder for [AppHub::set_iam_policy][crate::client::AppHub::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3131,7 +3131,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_iam_policy][super::super::client::AppHub::get_iam_policy] calls.
+    /// The request builder for [AppHub::get_iam_policy][crate::client::AppHub::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3210,7 +3210,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::test_iam_permissions][super::super::client::AppHub::test_iam_permissions] calls.
+    /// The request builder for [AppHub::test_iam_permissions][crate::client::AppHub::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3287,7 +3287,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::list_operations][super::super::client::AppHub::list_operations] calls.
+    /// The request builder for [AppHub::list_operations][crate::client::AppHub::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3397,7 +3397,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::get_operation][super::super::client::AppHub::get_operation] calls.
+    /// The request builder for [AppHub::get_operation][crate::client::AppHub::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3459,7 +3459,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::delete_operation][super::super::client::AppHub::delete_operation] calls.
+    /// The request builder for [AppHub::delete_operation][crate::client::AppHub::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3521,7 +3521,7 @@ pub mod app_hub {
         }
     }
 
-    /// The request builder for [AppHub::cancel_operation][super::super::client::AppHub::cancel_operation] calls.
+    /// The request builder for [AppHub::cancel_operation][crate::client::AppHub::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/asset/v1/src/builder.rs
+++ b/src/generated/cloud/asset/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod asset_service {
     use crate::Result;
 
-    /// A builder for [AssetService][super::super::client::AssetService].
+    /// A builder for [AssetService][crate::client::AssetService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod asset_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AssetService] request builders.
+    /// Common implementation for [crate::client::AssetService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AssetService>,
@@ -68,7 +68,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::export_assets][super::super::client::AssetService::export_assets] calls.
+    /// The request builder for [AssetService::export_assets][crate::client::AssetService::export_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod asset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_assets][super::super::client::AssetService::export_assets].
+        /// on [export_assets][crate::client::AssetService::export_assets].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_assets(self.0.request, self.0.options)
@@ -241,7 +241,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::list_assets][super::super::client::AssetService::list_assets] calls.
+    /// The request builder for [AssetService::list_assets][crate::client::AssetService::list_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -390,7 +390,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::batch_get_assets_history][super::super::client::AssetService::batch_get_assets_history] calls.
+    /// The request builder for [AssetService::batch_get_assets_history][crate::client::AssetService::batch_get_assets_history] calls.
     ///
     /// # Example
     /// ```no_run
@@ -502,7 +502,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::create_feed][super::super::client::AssetService::create_feed] calls.
+    /// The request builder for [AssetService::create_feed][crate::client::AssetService::create_feed] calls.
     ///
     /// # Example
     /// ```no_run
@@ -595,7 +595,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::get_feed][super::super::client::AssetService::get_feed] calls.
+    /// The request builder for [AssetService::get_feed][crate::client::AssetService::get_feed] calls.
     ///
     /// # Example
     /// ```no_run
@@ -658,7 +658,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::list_feeds][super::super::client::AssetService::list_feeds] calls.
+    /// The request builder for [AssetService::list_feeds][crate::client::AssetService::list_feeds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -721,7 +721,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::update_feed][super::super::client::AssetService::update_feed] calls.
+    /// The request builder for [AssetService::update_feed][crate::client::AssetService::update_feed] calls.
     ///
     /// # Example
     /// ```no_run
@@ -820,7 +820,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::delete_feed][super::super::client::AssetService::delete_feed] calls.
+    /// The request builder for [AssetService::delete_feed][crate::client::AssetService::delete_feed] calls.
     ///
     /// # Example
     /// ```no_run
@@ -883,7 +883,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::search_all_resources][super::super::client::AssetService::search_all_resources] calls.
+    /// The request builder for [AssetService::search_all_resources][crate::client::AssetService::search_all_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1032,7 +1032,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::search_all_iam_policies][super::super::client::AssetService::search_all_iam_policies] calls.
+    /// The request builder for [AssetService::search_all_iam_policies][crate::client::AssetService::search_all_iam_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1163,7 +1163,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::analyze_iam_policy][super::super::client::AssetService::analyze_iam_policy] calls.
+    /// The request builder for [AssetService::analyze_iam_policy][crate::client::AssetService::analyze_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1267,7 +1267,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::analyze_iam_policy_longrunning][super::super::client::AssetService::analyze_iam_policy_longrunning] calls.
+    /// The request builder for [AssetService::analyze_iam_policy_longrunning][crate::client::AssetService::analyze_iam_policy_longrunning] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1317,7 +1317,7 @@ pub mod asset_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [analyze_iam_policy_longrunning][super::super::client::AssetService::analyze_iam_policy_longrunning].
+        /// on [analyze_iam_policy_longrunning][crate::client::AssetService::analyze_iam_policy_longrunning].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .analyze_iam_policy_longrunning(self.0.request, self.0.options)
@@ -1421,7 +1421,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::analyze_move][super::super::client::AssetService::analyze_move] calls.
+    /// The request builder for [AssetService::analyze_move][crate::client::AssetService::analyze_move] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1501,7 +1501,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::query_assets][super::super::client::AssetService::query_assets] calls.
+    /// The request builder for [AssetService::query_assets][crate::client::AssetService::query_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1687,7 +1687,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::create_saved_query][super::super::client::AssetService::create_saved_query] calls.
+    /// The request builder for [AssetService::create_saved_query][crate::client::AssetService::create_saved_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1783,7 +1783,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::get_saved_query][super::super::client::AssetService::get_saved_query] calls.
+    /// The request builder for [AssetService::get_saved_query][crate::client::AssetService::get_saved_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1846,7 +1846,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::list_saved_queries][super::super::client::AssetService::list_saved_queries] calls.
+    /// The request builder for [AssetService::list_saved_queries][crate::client::AssetService::list_saved_queries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1958,7 +1958,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::update_saved_query][super::super::client::AssetService::update_saved_query] calls.
+    /// The request builder for [AssetService::update_saved_query][crate::client::AssetService::update_saved_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2060,7 +2060,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::delete_saved_query][super::super::client::AssetService::delete_saved_query] calls.
+    /// The request builder for [AssetService::delete_saved_query][crate::client::AssetService::delete_saved_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2126,7 +2126,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::batch_get_effective_iam_policies][super::super::client::AssetService::batch_get_effective_iam_policies] calls.
+    /// The request builder for [AssetService::batch_get_effective_iam_policies][crate::client::AssetService::batch_get_effective_iam_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2207,7 +2207,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::analyze_org_policies][super::super::client::AssetService::analyze_org_policies] calls.
+    /// The request builder for [AssetService::analyze_org_policies][crate::client::AssetService::analyze_org_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2341,7 +2341,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::analyze_org_policy_governed_containers][super::super::client::AssetService::analyze_org_policy_governed_containers] calls.
+    /// The request builder for [AssetService::analyze_org_policy_governed_containers][crate::client::AssetService::analyze_org_policy_governed_containers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2481,7 +2481,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::analyze_org_policy_governed_assets][super::super::client::AssetService::analyze_org_policy_governed_assets] calls.
+    /// The request builder for [AssetService::analyze_org_policy_governed_assets][crate::client::AssetService::analyze_org_policy_governed_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2619,7 +2619,7 @@ pub mod asset_service {
         }
     }
 
-    /// The request builder for [AssetService::get_operation][super::super::client::AssetService::get_operation] calls.
+    /// The request builder for [AssetService::get_operation][crate::client::AssetService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/assuredworkloads/v1/src/builder.rs
+++ b/src/generated/cloud/assuredworkloads/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod assured_workloads_service {
     use crate::Result;
 
-    /// A builder for [AssuredWorkloadsService][super::super::client::AssuredWorkloadsService].
+    /// A builder for [AssuredWorkloadsService][crate::client::AssuredWorkloadsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AssuredWorkloadsService] request builders.
+    /// Common implementation for [crate::client::AssuredWorkloadsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AssuredWorkloadsService>,
@@ -68,7 +68,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::create_workload][super::super::client::AssuredWorkloadsService::create_workload] calls.
+    /// The request builder for [AssuredWorkloadsService::create_workload][crate::client::AssuredWorkloadsService::create_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod assured_workloads_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_workload][super::super::client::AssuredWorkloadsService::create_workload].
+        /// on [create_workload][crate::client::AssuredWorkloadsService::create_workload].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_workload(self.0.request, self.0.options)
@@ -201,7 +201,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::update_workload][super::super::client::AssuredWorkloadsService::update_workload] calls.
+    /// The request builder for [AssuredWorkloadsService::update_workload][crate::client::AssuredWorkloadsService::update_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -300,7 +300,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::restrict_allowed_resources][super::super::client::AssuredWorkloadsService::restrict_allowed_resources] calls.
+    /// The request builder for [AssuredWorkloadsService::restrict_allowed_resources][crate::client::AssuredWorkloadsService::restrict_allowed_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -381,7 +381,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::delete_workload][super::super::client::AssuredWorkloadsService::delete_workload] calls.
+    /// The request builder for [AssuredWorkloadsService::delete_workload][crate::client::AssuredWorkloadsService::delete_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -450,7 +450,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::get_workload][super::super::client::AssuredWorkloadsService::get_workload] calls.
+    /// The request builder for [AssuredWorkloadsService::get_workload][crate::client::AssuredWorkloadsService::get_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -513,7 +513,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::list_workloads][super::super::client::AssuredWorkloadsService::list_workloads] calls.
+    /// The request builder for [AssuredWorkloadsService::list_workloads][crate::client::AssuredWorkloadsService::list_workloads] calls.
     ///
     /// # Example
     /// ```no_run
@@ -622,7 +622,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::list_operations][super::super::client::AssuredWorkloadsService::list_operations] calls.
+    /// The request builder for [AssuredWorkloadsService::list_operations][crate::client::AssuredWorkloadsService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -734,7 +734,7 @@ pub mod assured_workloads_service {
         }
     }
 
-    /// The request builder for [AssuredWorkloadsService::get_operation][super::super::client::AssuredWorkloadsService::get_operation] calls.
+    /// The request builder for [AssuredWorkloadsService::get_operation][crate::client::AssuredWorkloadsService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/backupdr/v1/src/builder.rs
+++ b/src/generated/cloud/backupdr/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod backup_dr {
     use crate::Result;
 
-    /// A builder for [BackupDR][super::super::client::BackupDR].
+    /// A builder for [BackupDR][crate::client::BackupDR].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod backup_dr {
         }
     }
 
-    /// Common implementation for [super::super::client::BackupDR] request builders.
+    /// Common implementation for [crate::client::BackupDR] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::BackupDR>,
@@ -66,7 +66,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_management_servers][super::super::client::BackupDR::list_management_servers] calls.
+    /// The request builder for [BackupDR::list_management_servers][crate::client::BackupDR::list_management_servers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -208,7 +208,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_management_server][super::super::client::BackupDR::get_management_server] calls.
+    /// The request builder for [BackupDR::get_management_server][crate::client::BackupDR::get_management_server] calls.
     ///
     /// # Example
     /// ```no_run
@@ -272,7 +272,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::create_management_server][super::super::client::BackupDR::create_management_server] calls.
+    /// The request builder for [BackupDR::create_management_server][crate::client::BackupDR::create_management_server] calls.
     ///
     /// # Example
     /// ```no_run
@@ -318,7 +318,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_management_server][super::super::client::BackupDR::create_management_server].
+        /// on [create_management_server][crate::client::BackupDR::create_management_server].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_management_server(self.0.request, self.0.options)
@@ -414,7 +414,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::delete_management_server][super::super::client::BackupDR::delete_management_server] calls.
+    /// The request builder for [BackupDR::delete_management_server][crate::client::BackupDR::delete_management_server] calls.
     ///
     /// # Example
     /// ```no_run
@@ -460,7 +460,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_management_server][super::super::client::BackupDR::delete_management_server].
+        /// on [delete_management_server][crate::client::BackupDR::delete_management_server].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_management_server(self.0.request, self.0.options)
@@ -525,7 +525,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::create_backup_vault][super::super::client::BackupDR::create_backup_vault] calls.
+    /// The request builder for [BackupDR::create_backup_vault][crate::client::BackupDR::create_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -571,7 +571,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup_vault][super::super::client::BackupDR::create_backup_vault].
+        /// on [create_backup_vault][crate::client::BackupDR::create_backup_vault].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup_vault(self.0.request, self.0.options)
@@ -672,7 +672,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_backup_vaults][super::super::client::BackupDR::list_backup_vaults] calls.
+    /// The request builder for [BackupDR::list_backup_vaults][crate::client::BackupDR::list_backup_vaults] calls.
     ///
     /// # Example
     /// ```no_run
@@ -794,7 +794,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::fetch_usable_backup_vaults][super::super::client::BackupDR::fetch_usable_backup_vaults] calls.
+    /// The request builder for [BackupDR::fetch_usable_backup_vaults][crate::client::BackupDR::fetch_usable_backup_vaults] calls.
     ///
     /// # Example
     /// ```no_run
@@ -916,7 +916,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_backup_vault][super::super::client::BackupDR::get_backup_vault] calls.
+    /// The request builder for [BackupDR::get_backup_vault][crate::client::BackupDR::get_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -983,7 +983,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::update_backup_vault][super::super::client::BackupDR::update_backup_vault] calls.
+    /// The request builder for [BackupDR::update_backup_vault][crate::client::BackupDR::update_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1029,7 +1029,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup_vault][super::super::client::BackupDR::update_backup_vault].
+        /// on [update_backup_vault][crate::client::BackupDR::update_backup_vault].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup_vault(self.0.request, self.0.options)
@@ -1142,7 +1142,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::delete_backup_vault][super::super::client::BackupDR::delete_backup_vault] calls.
+    /// The request builder for [BackupDR::delete_backup_vault][crate::client::BackupDR::delete_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1188,7 +1188,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup_vault][super::super::client::BackupDR::delete_backup_vault].
+        /// on [delete_backup_vault][crate::client::BackupDR::delete_backup_vault].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup_vault(self.0.request, self.0.options)
@@ -1283,7 +1283,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_data_sources][super::super::client::BackupDR::list_data_sources] calls.
+    /// The request builder for [BackupDR::list_data_sources][crate::client::BackupDR::list_data_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1396,7 +1396,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_data_source][super::super::client::BackupDR::get_data_source] calls.
+    /// The request builder for [BackupDR::get_data_source][crate::client::BackupDR::get_data_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1457,7 +1457,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::update_data_source][super::super::client::BackupDR::update_data_source] calls.
+    /// The request builder for [BackupDR::update_data_source][crate::client::BackupDR::update_data_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1503,7 +1503,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_data_source][super::super::client::BackupDR::update_data_source].
+        /// on [update_data_source][crate::client::BackupDR::update_data_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_data_source(self.0.request, self.0.options)
@@ -1608,7 +1608,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_backups][super::super::client::BackupDR::list_backups] calls.
+    /// The request builder for [BackupDR::list_backups][crate::client::BackupDR::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1727,7 +1727,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_backup][super::super::client::BackupDR::get_backup] calls.
+    /// The request builder for [BackupDR::get_backup][crate::client::BackupDR::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1794,7 +1794,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::update_backup][super::super::client::BackupDR::update_backup] calls.
+    /// The request builder for [BackupDR::update_backup][crate::client::BackupDR::update_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1837,7 +1837,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup][super::super::client::BackupDR::update_backup].
+        /// on [update_backup][crate::client::BackupDR::update_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup(self.0.request, self.0.options)
@@ -1936,7 +1936,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::delete_backup][super::super::client::BackupDR::delete_backup] calls.
+    /// The request builder for [BackupDR::delete_backup][crate::client::BackupDR::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1979,7 +1979,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::BackupDR::delete_backup].
+        /// on [delete_backup][crate::client::BackupDR::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -2042,7 +2042,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::restore_backup][super::super::client::BackupDR::restore_backup] calls.
+    /// The request builder for [BackupDR::restore_backup][crate::client::BackupDR::restore_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2085,7 +2085,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_backup][super::super::client::BackupDR::restore_backup].
+        /// on [restore_backup][crate::client::BackupDR::restore_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_backup(self.0.request, self.0.options)
@@ -2209,7 +2209,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::create_backup_plan][super::super::client::BackupDR::create_backup_plan] calls.
+    /// The request builder for [BackupDR::create_backup_plan][crate::client::BackupDR::create_backup_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2255,7 +2255,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup_plan][super::super::client::BackupDR::create_backup_plan].
+        /// on [create_backup_plan][crate::client::BackupDR::create_backup_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup_plan(self.0.request, self.0.options)
@@ -2348,7 +2348,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_backup_plan][super::super::client::BackupDR::get_backup_plan] calls.
+    /// The request builder for [BackupDR::get_backup_plan][crate::client::BackupDR::get_backup_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2409,7 +2409,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_backup_plans][super::super::client::BackupDR::list_backup_plans] calls.
+    /// The request builder for [BackupDR::list_backup_plans][crate::client::BackupDR::list_backup_plans] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2522,7 +2522,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::delete_backup_plan][super::super::client::BackupDR::delete_backup_plan] calls.
+    /// The request builder for [BackupDR::delete_backup_plan][crate::client::BackupDR::delete_backup_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2568,7 +2568,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup_plan][super::super::client::BackupDR::delete_backup_plan].
+        /// on [delete_backup_plan][crate::client::BackupDR::delete_backup_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup_plan(self.0.request, self.0.options)
@@ -2633,7 +2633,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::create_backup_plan_association][super::super::client::BackupDR::create_backup_plan_association] calls.
+    /// The request builder for [BackupDR::create_backup_plan_association][crate::client::BackupDR::create_backup_plan_association] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2681,7 +2681,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup_plan_association][super::super::client::BackupDR::create_backup_plan_association].
+        /// on [create_backup_plan_association][crate::client::BackupDR::create_backup_plan_association].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup_plan_association(self.0.request, self.0.options)
@@ -2780,7 +2780,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_backup_plan_association][super::super::client::BackupDR::get_backup_plan_association] calls.
+    /// The request builder for [BackupDR::get_backup_plan_association][crate::client::BackupDR::get_backup_plan_association] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2846,7 +2846,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_backup_plan_associations][super::super::client::BackupDR::list_backup_plan_associations] calls.
+    /// The request builder for [BackupDR::list_backup_plan_associations][crate::client::BackupDR::list_backup_plan_associations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2962,7 +2962,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::delete_backup_plan_association][super::super::client::BackupDR::delete_backup_plan_association] calls.
+    /// The request builder for [BackupDR::delete_backup_plan_association][crate::client::BackupDR::delete_backup_plan_association] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3010,7 +3010,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup_plan_association][super::super::client::BackupDR::delete_backup_plan_association].
+        /// on [delete_backup_plan_association][crate::client::BackupDR::delete_backup_plan_association].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup_plan_association(self.0.request, self.0.options)
@@ -3075,7 +3075,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::trigger_backup][super::super::client::BackupDR::trigger_backup] calls.
+    /// The request builder for [BackupDR::trigger_backup][crate::client::BackupDR::trigger_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3118,7 +3118,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [trigger_backup][super::super::client::BackupDR::trigger_backup].
+        /// on [trigger_backup][crate::client::BackupDR::trigger_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .trigger_backup(self.0.request, self.0.options)
@@ -3192,7 +3192,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::initialize_service][super::super::client::BackupDR::initialize_service] calls.
+    /// The request builder for [BackupDR::initialize_service][crate::client::BackupDR::initialize_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3238,7 +3238,7 @@ pub mod backup_dr {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [initialize_service][super::super::client::BackupDR::initialize_service].
+        /// on [initialize_service][crate::client::BackupDR::initialize_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .initialize_service(self.0.request, self.0.options)
@@ -3312,7 +3312,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_locations][super::super::client::BackupDR::list_locations] calls.
+    /// The request builder for [BackupDR::list_locations][crate::client::BackupDR::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3420,7 +3420,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_location][super::super::client::BackupDR::get_location] calls.
+    /// The request builder for [BackupDR::get_location][crate::client::BackupDR::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3479,7 +3479,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::set_iam_policy][super::super::client::BackupDR::set_iam_policy] calls.
+    /// The request builder for [BackupDR::set_iam_policy][crate::client::BackupDR::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3580,7 +3580,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_iam_policy][super::super::client::BackupDR::get_iam_policy] calls.
+    /// The request builder for [BackupDR::get_iam_policy][crate::client::BackupDR::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3659,7 +3659,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::test_iam_permissions][super::super::client::BackupDR::test_iam_permissions] calls.
+    /// The request builder for [BackupDR::test_iam_permissions][crate::client::BackupDR::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3736,7 +3736,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::list_operations][super::super::client::BackupDR::list_operations] calls.
+    /// The request builder for [BackupDR::list_operations][crate::client::BackupDR::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3846,7 +3846,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::get_operation][super::super::client::BackupDR::get_operation] calls.
+    /// The request builder for [BackupDR::get_operation][crate::client::BackupDR::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3908,7 +3908,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::delete_operation][super::super::client::BackupDR::delete_operation] calls.
+    /// The request builder for [BackupDR::delete_operation][crate::client::BackupDR::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3970,7 +3970,7 @@ pub mod backup_dr {
         }
     }
 
-    /// The request builder for [BackupDR::cancel_operation][super::super::client::BackupDR::cancel_operation] calls.
+    /// The request builder for [BackupDR::cancel_operation][crate::client::BackupDR::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/baremetalsolution/v2/src/builder.rs
+++ b/src/generated/cloud/baremetalsolution/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod bare_metal_solution {
     use crate::Result;
 
-    /// A builder for [BareMetalSolution][super::super::client::BareMetalSolution].
+    /// A builder for [BareMetalSolution][crate::client::BareMetalSolution].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// Common implementation for [super::super::client::BareMetalSolution] request builders.
+    /// Common implementation for [crate::client::BareMetalSolution] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::BareMetalSolution>,
@@ -68,7 +68,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_instances][super::super::client::BareMetalSolution::list_instances] calls.
+    /// The request builder for [BareMetalSolution::list_instances][crate::client::BareMetalSolution::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -177,7 +177,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_instance][super::super::client::BareMetalSolution::get_instance] calls.
+    /// The request builder for [BareMetalSolution::get_instance][crate::client::BareMetalSolution::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::update_instance][super::super::client::BareMetalSolution::update_instance] calls.
+    /// The request builder for [BareMetalSolution::update_instance][crate::client::BareMetalSolution::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -285,7 +285,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::BareMetalSolution::update_instance].
+        /// on [update_instance][crate::client::BareMetalSolution::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -374,7 +374,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::rename_instance][super::super::client::BareMetalSolution::rename_instance] calls.
+    /// The request builder for [BareMetalSolution::rename_instance][crate::client::BareMetalSolution::rename_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -445,7 +445,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::reset_instance][super::super::client::BareMetalSolution::reset_instance] calls.
+    /// The request builder for [BareMetalSolution::reset_instance][crate::client::BareMetalSolution::reset_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -490,7 +490,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reset_instance][super::super::client::BareMetalSolution::reset_instance].
+        /// on [reset_instance][crate::client::BareMetalSolution::reset_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reset_instance(self.0.request, self.0.options)
@@ -550,7 +550,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::start_instance][super::super::client::BareMetalSolution::start_instance] calls.
+    /// The request builder for [BareMetalSolution::start_instance][crate::client::BareMetalSolution::start_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -595,7 +595,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_instance][super::super::client::BareMetalSolution::start_instance].
+        /// on [start_instance][crate::client::BareMetalSolution::start_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_instance(self.0.request, self.0.options)
@@ -655,7 +655,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::stop_instance][super::super::client::BareMetalSolution::stop_instance] calls.
+    /// The request builder for [BareMetalSolution::stop_instance][crate::client::BareMetalSolution::stop_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -700,7 +700,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_instance][super::super::client::BareMetalSolution::stop_instance].
+        /// on [stop_instance][crate::client::BareMetalSolution::stop_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_instance(self.0.request, self.0.options)
@@ -760,7 +760,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::enable_interactive_serial_console][super::super::client::BareMetalSolution::enable_interactive_serial_console] calls.
+    /// The request builder for [BareMetalSolution::enable_interactive_serial_console][crate::client::BareMetalSolution::enable_interactive_serial_console] calls.
     ///
     /// # Example
     /// ```no_run
@@ -810,7 +810,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [enable_interactive_serial_console][super::super::client::BareMetalSolution::enable_interactive_serial_console].
+        /// on [enable_interactive_serial_console][crate::client::BareMetalSolution::enable_interactive_serial_console].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .enable_interactive_serial_console(self.0.request, self.0.options)
@@ -872,7 +872,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::disable_interactive_serial_console][super::super::client::BareMetalSolution::disable_interactive_serial_console] calls.
+    /// The request builder for [BareMetalSolution::disable_interactive_serial_console][crate::client::BareMetalSolution::disable_interactive_serial_console] calls.
     ///
     /// # Example
     /// ```no_run
@@ -922,7 +922,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [disable_interactive_serial_console][super::super::client::BareMetalSolution::disable_interactive_serial_console].
+        /// on [disable_interactive_serial_console][crate::client::BareMetalSolution::disable_interactive_serial_console].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .disable_interactive_serial_console(self.0.request, self.0.options)
@@ -984,7 +984,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::detach_lun][super::super::client::BareMetalSolution::detach_lun] calls.
+    /// The request builder for [BareMetalSolution::detach_lun][crate::client::BareMetalSolution::detach_lun] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1029,7 +1029,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [detach_lun][super::super::client::BareMetalSolution::detach_lun].
+        /// on [detach_lun][crate::client::BareMetalSolution::detach_lun].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .detach_lun(self.0.request, self.0.options)
@@ -1100,7 +1100,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_ssh_keys][super::super::client::BareMetalSolution::list_ssh_keys] calls.
+    /// The request builder for [BareMetalSolution::list_ssh_keys][crate::client::BareMetalSolution::list_ssh_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1203,7 +1203,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::create_ssh_key][super::super::client::BareMetalSolution::create_ssh_key] calls.
+    /// The request builder for [BareMetalSolution::create_ssh_key][crate::client::BareMetalSolution::create_ssh_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1296,7 +1296,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::delete_ssh_key][super::super::client::BareMetalSolution::delete_ssh_key] calls.
+    /// The request builder for [BareMetalSolution::delete_ssh_key][crate::client::BareMetalSolution::delete_ssh_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1359,7 +1359,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_volumes][super::super::client::BareMetalSolution::list_volumes] calls.
+    /// The request builder for [BareMetalSolution::list_volumes][crate::client::BareMetalSolution::list_volumes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1468,7 +1468,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_volume][super::super::client::BareMetalSolution::get_volume] calls.
+    /// The request builder for [BareMetalSolution::get_volume][crate::client::BareMetalSolution::get_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1531,7 +1531,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::update_volume][super::super::client::BareMetalSolution::update_volume] calls.
+    /// The request builder for [BareMetalSolution::update_volume][crate::client::BareMetalSolution::update_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1576,7 +1576,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_volume][super::super::client::BareMetalSolution::update_volume].
+        /// on [update_volume][crate::client::BareMetalSolution::update_volume].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_volume(self.0.request, self.0.options)
@@ -1665,7 +1665,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::rename_volume][super::super::client::BareMetalSolution::rename_volume] calls.
+    /// The request builder for [BareMetalSolution::rename_volume][crate::client::BareMetalSolution::rename_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1736,7 +1736,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::evict_volume][super::super::client::BareMetalSolution::evict_volume] calls.
+    /// The request builder for [BareMetalSolution::evict_volume][crate::client::BareMetalSolution::evict_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1781,7 +1781,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [evict_volume][super::super::client::BareMetalSolution::evict_volume].
+        /// on [evict_volume][crate::client::BareMetalSolution::evict_volume].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .evict_volume(self.0.request, self.0.options)
@@ -1840,7 +1840,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::resize_volume][super::super::client::BareMetalSolution::resize_volume] calls.
+    /// The request builder for [BareMetalSolution::resize_volume][crate::client::BareMetalSolution::resize_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1885,7 +1885,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [resize_volume][super::super::client::BareMetalSolution::resize_volume].
+        /// on [resize_volume][crate::client::BareMetalSolution::resize_volume].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .resize_volume(self.0.request, self.0.options)
@@ -1948,7 +1948,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_networks][super::super::client::BareMetalSolution::list_networks] calls.
+    /// The request builder for [BareMetalSolution::list_networks][crate::client::BareMetalSolution::list_networks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2057,7 +2057,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_network_usage][super::super::client::BareMetalSolution::list_network_usage] calls.
+    /// The request builder for [BareMetalSolution::list_network_usage][crate::client::BareMetalSolution::list_network_usage] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2123,7 +2123,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_network][super::super::client::BareMetalSolution::get_network] calls.
+    /// The request builder for [BareMetalSolution::get_network][crate::client::BareMetalSolution::get_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2186,7 +2186,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::update_network][super::super::client::BareMetalSolution::update_network] calls.
+    /// The request builder for [BareMetalSolution::update_network][crate::client::BareMetalSolution::update_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2231,7 +2231,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_network][super::super::client::BareMetalSolution::update_network].
+        /// on [update_network][crate::client::BareMetalSolution::update_network].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_network(self.0.request, self.0.options)
@@ -2320,7 +2320,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::create_volume_snapshot][super::super::client::BareMetalSolution::create_volume_snapshot] calls.
+    /// The request builder for [BareMetalSolution::create_volume_snapshot][crate::client::BareMetalSolution::create_volume_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2408,7 +2408,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::restore_volume_snapshot][super::super::client::BareMetalSolution::restore_volume_snapshot] calls.
+    /// The request builder for [BareMetalSolution::restore_volume_snapshot][crate::client::BareMetalSolution::restore_volume_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2456,7 +2456,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_volume_snapshot][super::super::client::BareMetalSolution::restore_volume_snapshot].
+        /// on [restore_volume_snapshot][crate::client::BareMetalSolution::restore_volume_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_volume_snapshot(self.0.request, self.0.options)
@@ -2516,7 +2516,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::delete_volume_snapshot][super::super::client::BareMetalSolution::delete_volume_snapshot] calls.
+    /// The request builder for [BareMetalSolution::delete_volume_snapshot][crate::client::BareMetalSolution::delete_volume_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2582,7 +2582,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_volume_snapshot][super::super::client::BareMetalSolution::get_volume_snapshot] calls.
+    /// The request builder for [BareMetalSolution::get_volume_snapshot][crate::client::BareMetalSolution::get_volume_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2648,7 +2648,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_volume_snapshots][super::super::client::BareMetalSolution::list_volume_snapshots] calls.
+    /// The request builder for [BareMetalSolution::list_volume_snapshots][crate::client::BareMetalSolution::list_volume_snapshots] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2756,7 +2756,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_lun][super::super::client::BareMetalSolution::get_lun] calls.
+    /// The request builder for [BareMetalSolution::get_lun][crate::client::BareMetalSolution::get_lun] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2819,7 +2819,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_luns][super::super::client::BareMetalSolution::list_luns] calls.
+    /// The request builder for [BareMetalSolution::list_luns][crate::client::BareMetalSolution::list_luns] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2922,7 +2922,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::evict_lun][super::super::client::BareMetalSolution::evict_lun] calls.
+    /// The request builder for [BareMetalSolution::evict_lun][crate::client::BareMetalSolution::evict_lun] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2967,7 +2967,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [evict_lun][super::super::client::BareMetalSolution::evict_lun].
+        /// on [evict_lun][crate::client::BareMetalSolution::evict_lun].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .evict_lun(self.0.request, self.0.options)
@@ -3026,7 +3026,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_nfs_share][super::super::client::BareMetalSolution::get_nfs_share] calls.
+    /// The request builder for [BareMetalSolution::get_nfs_share][crate::client::BareMetalSolution::get_nfs_share] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3089,7 +3089,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_nfs_shares][super::super::client::BareMetalSolution::list_nfs_shares] calls.
+    /// The request builder for [BareMetalSolution::list_nfs_shares][crate::client::BareMetalSolution::list_nfs_shares] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3198,7 +3198,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::update_nfs_share][super::super::client::BareMetalSolution::update_nfs_share] calls.
+    /// The request builder for [BareMetalSolution::update_nfs_share][crate::client::BareMetalSolution::update_nfs_share] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3243,7 +3243,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_nfs_share][super::super::client::BareMetalSolution::update_nfs_share].
+        /// on [update_nfs_share][crate::client::BareMetalSolution::update_nfs_share].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_nfs_share(self.0.request, self.0.options)
@@ -3332,7 +3332,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::create_nfs_share][super::super::client::BareMetalSolution::create_nfs_share] calls.
+    /// The request builder for [BareMetalSolution::create_nfs_share][crate::client::BareMetalSolution::create_nfs_share] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3377,7 +3377,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_nfs_share][super::super::client::BareMetalSolution::create_nfs_share].
+        /// on [create_nfs_share][crate::client::BareMetalSolution::create_nfs_share].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_nfs_share(self.0.request, self.0.options)
@@ -3456,7 +3456,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::rename_nfs_share][super::super::client::BareMetalSolution::rename_nfs_share] calls.
+    /// The request builder for [BareMetalSolution::rename_nfs_share][crate::client::BareMetalSolution::rename_nfs_share] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3527,7 +3527,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::delete_nfs_share][super::super::client::BareMetalSolution::delete_nfs_share] calls.
+    /// The request builder for [BareMetalSolution::delete_nfs_share][crate::client::BareMetalSolution::delete_nfs_share] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3572,7 +3572,7 @@ pub mod bare_metal_solution {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_nfs_share][super::super::client::BareMetalSolution::delete_nfs_share].
+        /// on [delete_nfs_share][crate::client::BareMetalSolution::delete_nfs_share].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_nfs_share(self.0.request, self.0.options)
@@ -3631,7 +3631,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_provisioning_quotas][super::super::client::BareMetalSolution::list_provisioning_quotas] calls.
+    /// The request builder for [BareMetalSolution::list_provisioning_quotas][crate::client::BareMetalSolution::list_provisioning_quotas] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3741,7 +3741,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::submit_provisioning_config][super::super::client::BareMetalSolution::submit_provisioning_config] calls.
+    /// The request builder for [BareMetalSolution::submit_provisioning_config][crate::client::BareMetalSolution::submit_provisioning_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3837,7 +3837,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_provisioning_config][super::super::client::BareMetalSolution::get_provisioning_config] calls.
+    /// The request builder for [BareMetalSolution::get_provisioning_config][crate::client::BareMetalSolution::get_provisioning_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3903,7 +3903,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::create_provisioning_config][super::super::client::BareMetalSolution::create_provisioning_config] calls.
+    /// The request builder for [BareMetalSolution::create_provisioning_config][crate::client::BareMetalSolution::create_provisioning_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3999,7 +3999,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::update_provisioning_config][super::super::client::BareMetalSolution::update_provisioning_config] calls.
+    /// The request builder for [BareMetalSolution::update_provisioning_config][crate::client::BareMetalSolution::update_provisioning_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4109,7 +4109,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::rename_network][super::super::client::BareMetalSolution::rename_network] calls.
+    /// The request builder for [BareMetalSolution::rename_network][crate::client::BareMetalSolution::rename_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4180,7 +4180,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_os_images][super::super::client::BareMetalSolution::list_os_images] calls.
+    /// The request builder for [BareMetalSolution::list_os_images][crate::client::BareMetalSolution::list_os_images] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4283,7 +4283,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::list_locations][super::super::client::BareMetalSolution::list_locations] calls.
+    /// The request builder for [BareMetalSolution::list_locations][crate::client::BareMetalSolution::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4393,7 +4393,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_location][super::super::client::BareMetalSolution::get_location] calls.
+    /// The request builder for [BareMetalSolution::get_location][crate::client::BareMetalSolution::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4454,7 +4454,7 @@ pub mod bare_metal_solution {
         }
     }
 
-    /// The request builder for [BareMetalSolution::get_operation][super::super::client::BareMetalSolution::get_operation] calls.
+    /// The request builder for [BareMetalSolution::get_operation][crate::client::BareMetalSolution::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnections/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod app_connections_service {
     use crate::Result;
 
-    /// A builder for [AppConnectionsService][super::super::client::AppConnectionsService].
+    /// A builder for [AppConnectionsService][crate::client::AppConnectionsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AppConnectionsService] request builders.
+    /// Common implementation for [crate::client::AppConnectionsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AppConnectionsService>,
@@ -68,7 +68,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::list_app_connections][super::super::client::AppConnectionsService::list_app_connections] calls.
+    /// The request builder for [AppConnectionsService::list_app_connections][crate::client::AppConnectionsService::list_app_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -188,7 +188,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::get_app_connection][super::super::client::AppConnectionsService::get_app_connection] calls.
+    /// The request builder for [AppConnectionsService::get_app_connection][crate::client::AppConnectionsService::get_app_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::create_app_connection][super::super::client::AppConnectionsService::create_app_connection] calls.
+    /// The request builder for [AppConnectionsService::create_app_connection][crate::client::AppConnectionsService::create_app_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -302,7 +302,7 @@ pub mod app_connections_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_app_connection][super::super::client::AppConnectionsService::create_app_connection].
+        /// on [create_app_connection][crate::client::AppConnectionsService::create_app_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_app_connection(self.0.request, self.0.options)
@@ -402,7 +402,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::update_app_connection][super::super::client::AppConnectionsService::update_app_connection] calls.
+    /// The request builder for [AppConnectionsService::update_app_connection][crate::client::AppConnectionsService::update_app_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -450,7 +450,7 @@ pub mod app_connections_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_app_connection][super::super::client::AppConnectionsService::update_app_connection].
+        /// on [update_app_connection][crate::client::AppConnectionsService::update_app_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_app_connection(self.0.request, self.0.options)
@@ -564,7 +564,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::delete_app_connection][super::super::client::AppConnectionsService::delete_app_connection] calls.
+    /// The request builder for [AppConnectionsService::delete_app_connection][crate::client::AppConnectionsService::delete_app_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -612,7 +612,7 @@ pub mod app_connections_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_app_connection][super::super::client::AppConnectionsService::delete_app_connection].
+        /// on [delete_app_connection][crate::client::AppConnectionsService::delete_app_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_app_connection(self.0.request, self.0.options)
@@ -684,7 +684,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::resolve_app_connections][super::super::client::AppConnectionsService::resolve_app_connections] calls.
+    /// The request builder for [AppConnectionsService::resolve_app_connections][crate::client::AppConnectionsService::resolve_app_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -800,7 +800,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::list_locations][super::super::client::AppConnectionsService::list_locations] calls.
+    /// The request builder for [AppConnectionsService::list_locations][crate::client::AppConnectionsService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -910,7 +910,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::get_location][super::super::client::AppConnectionsService::get_location] calls.
+    /// The request builder for [AppConnectionsService::get_location][crate::client::AppConnectionsService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -971,7 +971,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::set_iam_policy][super::super::client::AppConnectionsService::set_iam_policy] calls.
+    /// The request builder for [AppConnectionsService::set_iam_policy][crate::client::AppConnectionsService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1074,7 +1074,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::get_iam_policy][super::super::client::AppConnectionsService::get_iam_policy] calls.
+    /// The request builder for [AppConnectionsService::get_iam_policy][crate::client::AppConnectionsService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1155,7 +1155,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::test_iam_permissions][super::super::client::AppConnectionsService::test_iam_permissions] calls.
+    /// The request builder for [AppConnectionsService::test_iam_permissions][crate::client::AppConnectionsService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1234,7 +1234,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::list_operations][super::super::client::AppConnectionsService::list_operations] calls.
+    /// The request builder for [AppConnectionsService::list_operations][crate::client::AppConnectionsService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1346,7 +1346,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::get_operation][super::super::client::AppConnectionsService::get_operation] calls.
+    /// The request builder for [AppConnectionsService::get_operation][crate::client::AppConnectionsService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1410,7 +1410,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::delete_operation][super::super::client::AppConnectionsService::delete_operation] calls.
+    /// The request builder for [AppConnectionsService::delete_operation][crate::client::AppConnectionsService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1474,7 +1474,7 @@ pub mod app_connections_service {
         }
     }
 
-    /// The request builder for [AppConnectionsService::cancel_operation][super::super::client::AppConnectionsService::cancel_operation] calls.
+    /// The request builder for [AppConnectionsService::cancel_operation][crate::client::AppConnectionsService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appconnectors/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod app_connectors_service {
     use crate::Result;
 
-    /// A builder for [AppConnectorsService][super::super::client::AppConnectorsService].
+    /// A builder for [AppConnectorsService][crate::client::AppConnectorsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AppConnectorsService] request builders.
+    /// Common implementation for [crate::client::AppConnectorsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AppConnectorsService>,
@@ -68,7 +68,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::list_app_connectors][super::super::client::AppConnectorsService::list_app_connectors] calls.
+    /// The request builder for [AppConnectorsService::list_app_connectors][crate::client::AppConnectorsService::list_app_connectors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::get_app_connector][super::super::client::AppConnectorsService::get_app_connector] calls.
+    /// The request builder for [AppConnectorsService::get_app_connector][crate::client::AppConnectorsService::get_app_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -249,7 +249,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::create_app_connector][super::super::client::AppConnectorsService::create_app_connector] calls.
+    /// The request builder for [AppConnectorsService::create_app_connector][crate::client::AppConnectorsService::create_app_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod app_connectors_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_app_connector][super::super::client::AppConnectorsService::create_app_connector].
+        /// on [create_app_connector][crate::client::AppConnectorsService::create_app_connector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_app_connector(self.0.request, self.0.options)
@@ -397,7 +397,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::update_app_connector][super::super::client::AppConnectorsService::update_app_connector] calls.
+    /// The request builder for [AppConnectorsService::update_app_connector][crate::client::AppConnectorsService::update_app_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -445,7 +445,7 @@ pub mod app_connectors_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_app_connector][super::super::client::AppConnectorsService::update_app_connector].
+        /// on [update_app_connector][crate::client::AppConnectorsService::update_app_connector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_app_connector(self.0.request, self.0.options)
@@ -553,7 +553,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::delete_app_connector][super::super::client::AppConnectorsService::delete_app_connector] calls.
+    /// The request builder for [AppConnectorsService::delete_app_connector][crate::client::AppConnectorsService::delete_app_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -601,7 +601,7 @@ pub mod app_connectors_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_app_connector][super::super::client::AppConnectorsService::delete_app_connector].
+        /// on [delete_app_connector][crate::client::AppConnectorsService::delete_app_connector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_app_connector(self.0.request, self.0.options)
@@ -673,7 +673,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::report_status][super::super::client::AppConnectorsService::report_status] calls.
+    /// The request builder for [AppConnectorsService::report_status][crate::client::AppConnectorsService::report_status] calls.
     ///
     /// # Example
     /// ```no_run
@@ -718,7 +718,7 @@ pub mod app_connectors_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [report_status][super::super::client::AppConnectorsService::report_status].
+        /// on [report_status][crate::client::AppConnectorsService::report_status].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .report_status(self.0.request, self.0.options)
@@ -812,7 +812,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::list_locations][super::super::client::AppConnectorsService::list_locations] calls.
+    /// The request builder for [AppConnectorsService::list_locations][crate::client::AppConnectorsService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -922,7 +922,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::get_location][super::super::client::AppConnectorsService::get_location] calls.
+    /// The request builder for [AppConnectorsService::get_location][crate::client::AppConnectorsService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -983,7 +983,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::set_iam_policy][super::super::client::AppConnectorsService::set_iam_policy] calls.
+    /// The request builder for [AppConnectorsService::set_iam_policy][crate::client::AppConnectorsService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1086,7 +1086,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::get_iam_policy][super::super::client::AppConnectorsService::get_iam_policy] calls.
+    /// The request builder for [AppConnectorsService::get_iam_policy][crate::client::AppConnectorsService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1167,7 +1167,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::test_iam_permissions][super::super::client::AppConnectorsService::test_iam_permissions] calls.
+    /// The request builder for [AppConnectorsService::test_iam_permissions][crate::client::AppConnectorsService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1246,7 +1246,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::list_operations][super::super::client::AppConnectorsService::list_operations] calls.
+    /// The request builder for [AppConnectorsService::list_operations][crate::client::AppConnectorsService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1358,7 +1358,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::get_operation][super::super::client::AppConnectorsService::get_operation] calls.
+    /// The request builder for [AppConnectorsService::get_operation][crate::client::AppConnectorsService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1422,7 +1422,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::delete_operation][super::super::client::AppConnectorsService::delete_operation] calls.
+    /// The request builder for [AppConnectorsService::delete_operation][crate::client::AppConnectorsService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1486,7 +1486,7 @@ pub mod app_connectors_service {
         }
     }
 
-    /// The request builder for [AppConnectorsService::cancel_operation][super::super::client::AppConnectorsService::cancel_operation] calls.
+    /// The request builder for [AppConnectorsService::cancel_operation][crate::client::AppConnectorsService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/appgateways/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod app_gateways_service {
     use crate::Result;
 
-    /// A builder for [AppGatewaysService][super::super::client::AppGatewaysService].
+    /// A builder for [AppGatewaysService][crate::client::AppGatewaysService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AppGatewaysService] request builders.
+    /// Common implementation for [crate::client::AppGatewaysService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AppGatewaysService>,
@@ -68,7 +68,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::list_app_gateways][super::super::client::AppGatewaysService::list_app_gateways] calls.
+    /// The request builder for [AppGatewaysService::list_app_gateways][crate::client::AppGatewaysService::list_app_gateways] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::get_app_gateway][super::super::client::AppGatewaysService::get_app_gateway] calls.
+    /// The request builder for [AppGatewaysService::get_app_gateway][crate::client::AppGatewaysService::get_app_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::create_app_gateway][super::super::client::AppGatewaysService::create_app_gateway] calls.
+    /// The request builder for [AppGatewaysService::create_app_gateway][crate::client::AppGatewaysService::create_app_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -294,7 +294,7 @@ pub mod app_gateways_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_app_gateway][super::super::client::AppGatewaysService::create_app_gateway].
+        /// on [create_app_gateway][crate::client::AppGatewaysService::create_app_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_app_gateway(self.0.request, self.0.options)
@@ -394,7 +394,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::delete_app_gateway][super::super::client::AppGatewaysService::delete_app_gateway] calls.
+    /// The request builder for [AppGatewaysService::delete_app_gateway][crate::client::AppGatewaysService::delete_app_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -442,7 +442,7 @@ pub mod app_gateways_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_app_gateway][super::super::client::AppGatewaysService::delete_app_gateway].
+        /// on [delete_app_gateway][crate::client::AppGatewaysService::delete_app_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_app_gateway(self.0.request, self.0.options)
@@ -514,7 +514,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::list_locations][super::super::client::AppGatewaysService::list_locations] calls.
+    /// The request builder for [AppGatewaysService::list_locations][crate::client::AppGatewaysService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -624,7 +624,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::get_location][super::super::client::AppGatewaysService::get_location] calls.
+    /// The request builder for [AppGatewaysService::get_location][crate::client::AppGatewaysService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -685,7 +685,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::set_iam_policy][super::super::client::AppGatewaysService::set_iam_policy] calls.
+    /// The request builder for [AppGatewaysService::set_iam_policy][crate::client::AppGatewaysService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -788,7 +788,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::get_iam_policy][super::super::client::AppGatewaysService::get_iam_policy] calls.
+    /// The request builder for [AppGatewaysService::get_iam_policy][crate::client::AppGatewaysService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -869,7 +869,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::test_iam_permissions][super::super::client::AppGatewaysService::test_iam_permissions] calls.
+    /// The request builder for [AppGatewaysService::test_iam_permissions][crate::client::AppGatewaysService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -948,7 +948,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::list_operations][super::super::client::AppGatewaysService::list_operations] calls.
+    /// The request builder for [AppGatewaysService::list_operations][crate::client::AppGatewaysService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1060,7 +1060,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::get_operation][super::super::client::AppGatewaysService::get_operation] calls.
+    /// The request builder for [AppGatewaysService::get_operation][crate::client::AppGatewaysService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1124,7 +1124,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::delete_operation][super::super::client::AppGatewaysService::delete_operation] calls.
+    /// The request builder for [AppGatewaysService::delete_operation][crate::client::AppGatewaysService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1188,7 +1188,7 @@ pub mod app_gateways_service {
         }
     }
 
-    /// The request builder for [AppGatewaysService::cancel_operation][super::super::client::AppGatewaysService::cancel_operation] calls.
+    /// The request builder for [AppGatewaysService::cancel_operation][crate::client::AppGatewaysService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientconnectorservices/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod client_connector_services_service {
     use crate::Result;
 
-    /// A builder for [ClientConnectorServicesService][super::super::client::ClientConnectorServicesService].
+    /// A builder for [ClientConnectorServicesService][crate::client::ClientConnectorServicesService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ClientConnectorServicesService] request builders.
+    /// Common implementation for [crate::client::ClientConnectorServicesService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ClientConnectorServicesService>,
@@ -68,7 +68,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::list_client_connector_services][super::super::client::ClientConnectorServicesService::list_client_connector_services] calls.
+    /// The request builder for [ClientConnectorServicesService::list_client_connector_services][crate::client::ClientConnectorServicesService::list_client_connector_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -192,7 +192,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::get_client_connector_service][super::super::client::ClientConnectorServicesService::get_client_connector_service] calls.
+    /// The request builder for [ClientConnectorServicesService::get_client_connector_service][crate::client::ClientConnectorServicesService::get_client_connector_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -260,7 +260,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::create_client_connector_service][super::super::client::ClientConnectorServicesService::create_client_connector_service] calls.
+    /// The request builder for [ClientConnectorServicesService::create_client_connector_service][crate::client::ClientConnectorServicesService::create_client_connector_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -310,7 +310,7 @@ pub mod client_connector_services_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_client_connector_service][super::super::client::ClientConnectorServicesService::create_client_connector_service].
+        /// on [create_client_connector_service][crate::client::ClientConnectorServicesService::create_client_connector_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_client_connector_service(self.0.request, self.0.options)
@@ -415,7 +415,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::update_client_connector_service][super::super::client::ClientConnectorServicesService::update_client_connector_service] calls.
+    /// The request builder for [ClientConnectorServicesService::update_client_connector_service][crate::client::ClientConnectorServicesService::update_client_connector_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -465,7 +465,7 @@ pub mod client_connector_services_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_client_connector_service][super::super::client::ClientConnectorServicesService::update_client_connector_service].
+        /// on [update_client_connector_service][crate::client::ClientConnectorServicesService::update_client_connector_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_client_connector_service(self.0.request, self.0.options)
@@ -581,7 +581,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::delete_client_connector_service][super::super::client::ClientConnectorServicesService::delete_client_connector_service] calls.
+    /// The request builder for [ClientConnectorServicesService::delete_client_connector_service][crate::client::ClientConnectorServicesService::delete_client_connector_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -631,7 +631,7 @@ pub mod client_connector_services_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_client_connector_service][super::super::client::ClientConnectorServicesService::delete_client_connector_service].
+        /// on [delete_client_connector_service][crate::client::ClientConnectorServicesService::delete_client_connector_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_client_connector_service(self.0.request, self.0.options)
@@ -707,7 +707,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::list_locations][super::super::client::ClientConnectorServicesService::list_locations] calls.
+    /// The request builder for [ClientConnectorServicesService::list_locations][crate::client::ClientConnectorServicesService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -817,7 +817,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::get_location][super::super::client::ClientConnectorServicesService::get_location] calls.
+    /// The request builder for [ClientConnectorServicesService::get_location][crate::client::ClientConnectorServicesService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -878,7 +878,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::set_iam_policy][super::super::client::ClientConnectorServicesService::set_iam_policy] calls.
+    /// The request builder for [ClientConnectorServicesService::set_iam_policy][crate::client::ClientConnectorServicesService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -981,7 +981,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::get_iam_policy][super::super::client::ClientConnectorServicesService::get_iam_policy] calls.
+    /// The request builder for [ClientConnectorServicesService::get_iam_policy][crate::client::ClientConnectorServicesService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1062,7 +1062,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::test_iam_permissions][super::super::client::ClientConnectorServicesService::test_iam_permissions] calls.
+    /// The request builder for [ClientConnectorServicesService::test_iam_permissions][crate::client::ClientConnectorServicesService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1141,7 +1141,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::list_operations][super::super::client::ClientConnectorServicesService::list_operations] calls.
+    /// The request builder for [ClientConnectorServicesService::list_operations][crate::client::ClientConnectorServicesService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1253,7 +1253,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::get_operation][super::super::client::ClientConnectorServicesService::get_operation] calls.
+    /// The request builder for [ClientConnectorServicesService::get_operation][crate::client::ClientConnectorServicesService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1317,7 +1317,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::delete_operation][super::super::client::ClientConnectorServicesService::delete_operation] calls.
+    /// The request builder for [ClientConnectorServicesService::delete_operation][crate::client::ClientConnectorServicesService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1381,7 +1381,7 @@ pub mod client_connector_services_service {
         }
     }
 
-    /// The request builder for [ClientConnectorServicesService::cancel_operation][super::super::client::ClientConnectorServicesService::cancel_operation] calls.
+    /// The request builder for [ClientConnectorServicesService::cancel_operation][crate::client::ClientConnectorServicesService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
+++ b/src/generated/cloud/beyondcorp/clientgateways/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod client_gateways_service {
     use crate::Result;
 
-    /// A builder for [ClientGatewaysService][super::super::client::ClientGatewaysService].
+    /// A builder for [ClientGatewaysService][crate::client::ClientGatewaysService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ClientGatewaysService] request builders.
+    /// Common implementation for [crate::client::ClientGatewaysService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ClientGatewaysService>,
@@ -68,7 +68,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::list_client_gateways][super::super::client::ClientGatewaysService::list_client_gateways] calls.
+    /// The request builder for [ClientGatewaysService::list_client_gateways][crate::client::ClientGatewaysService::list_client_gateways] calls.
     ///
     /// # Example
     /// ```no_run
@@ -188,7 +188,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::get_client_gateway][super::super::client::ClientGatewaysService::get_client_gateway] calls.
+    /// The request builder for [ClientGatewaysService::get_client_gateway][crate::client::ClientGatewaysService::get_client_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::create_client_gateway][super::super::client::ClientGatewaysService::create_client_gateway] calls.
+    /// The request builder for [ClientGatewaysService::create_client_gateway][crate::client::ClientGatewaysService::create_client_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -302,7 +302,7 @@ pub mod client_gateways_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_client_gateway][super::super::client::ClientGatewaysService::create_client_gateway].
+        /// on [create_client_gateway][crate::client::ClientGatewaysService::create_client_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_client_gateway(self.0.request, self.0.options)
@@ -402,7 +402,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::delete_client_gateway][super::super::client::ClientGatewaysService::delete_client_gateway] calls.
+    /// The request builder for [ClientGatewaysService::delete_client_gateway][crate::client::ClientGatewaysService::delete_client_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -450,7 +450,7 @@ pub mod client_gateways_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_client_gateway][super::super::client::ClientGatewaysService::delete_client_gateway].
+        /// on [delete_client_gateway][crate::client::ClientGatewaysService::delete_client_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_client_gateway(self.0.request, self.0.options)
@@ -522,7 +522,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::list_locations][super::super::client::ClientGatewaysService::list_locations] calls.
+    /// The request builder for [ClientGatewaysService::list_locations][crate::client::ClientGatewaysService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -632,7 +632,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::get_location][super::super::client::ClientGatewaysService::get_location] calls.
+    /// The request builder for [ClientGatewaysService::get_location][crate::client::ClientGatewaysService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -693,7 +693,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::set_iam_policy][super::super::client::ClientGatewaysService::set_iam_policy] calls.
+    /// The request builder for [ClientGatewaysService::set_iam_policy][crate::client::ClientGatewaysService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -796,7 +796,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::get_iam_policy][super::super::client::ClientGatewaysService::get_iam_policy] calls.
+    /// The request builder for [ClientGatewaysService::get_iam_policy][crate::client::ClientGatewaysService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -877,7 +877,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::test_iam_permissions][super::super::client::ClientGatewaysService::test_iam_permissions] calls.
+    /// The request builder for [ClientGatewaysService::test_iam_permissions][crate::client::ClientGatewaysService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -956,7 +956,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::list_operations][super::super::client::ClientGatewaysService::list_operations] calls.
+    /// The request builder for [ClientGatewaysService::list_operations][crate::client::ClientGatewaysService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1068,7 +1068,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::get_operation][super::super::client::ClientGatewaysService::get_operation] calls.
+    /// The request builder for [ClientGatewaysService::get_operation][crate::client::ClientGatewaysService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1132,7 +1132,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::delete_operation][super::super::client::ClientGatewaysService::delete_operation] calls.
+    /// The request builder for [ClientGatewaysService::delete_operation][crate::client::ClientGatewaysService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1196,7 +1196,7 @@ pub mod client_gateways_service {
         }
     }
 
-    /// The request builder for [ClientGatewaysService::cancel_operation][super::super::client::ClientGatewaysService::cancel_operation] calls.
+    /// The request builder for [ClientGatewaysService::cancel_operation][crate::client::ClientGatewaysService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/analyticshub/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod analytics_hub_service {
     use crate::Result;
 
-    /// A builder for [AnalyticsHubService][super::super::client::AnalyticsHubService].
+    /// A builder for [AnalyticsHubService][crate::client::AnalyticsHubService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AnalyticsHubService] request builders.
+    /// Common implementation for [crate::client::AnalyticsHubService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AnalyticsHubService>,
@@ -68,7 +68,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::list_data_exchanges][super::super::client::AnalyticsHubService::list_data_exchanges] calls.
+    /// The request builder for [AnalyticsHubService::list_data_exchanges][crate::client::AnalyticsHubService::list_data_exchanges] calls.
     ///
     /// # Example
     /// ```no_run
@@ -174,7 +174,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::list_org_data_exchanges][super::super::client::AnalyticsHubService::list_org_data_exchanges] calls.
+    /// The request builder for [AnalyticsHubService::list_org_data_exchanges][crate::client::AnalyticsHubService::list_org_data_exchanges] calls.
     ///
     /// # Example
     /// ```no_run
@@ -282,7 +282,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::get_data_exchange][super::super::client::AnalyticsHubService::get_data_exchange] calls.
+    /// The request builder for [AnalyticsHubService::get_data_exchange][crate::client::AnalyticsHubService::get_data_exchange] calls.
     ///
     /// # Example
     /// ```no_run
@@ -345,7 +345,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::create_data_exchange][super::super::client::AnalyticsHubService::create_data_exchange] calls.
+    /// The request builder for [AnalyticsHubService::create_data_exchange][crate::client::AnalyticsHubService::create_data_exchange] calls.
     ///
     /// # Example
     /// ```no_run
@@ -441,7 +441,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::update_data_exchange][super::super::client::AnalyticsHubService::update_data_exchange] calls.
+    /// The request builder for [AnalyticsHubService::update_data_exchange][crate::client::AnalyticsHubService::update_data_exchange] calls.
     ///
     /// # Example
     /// ```no_run
@@ -543,7 +543,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::delete_data_exchange][super::super::client::AnalyticsHubService::delete_data_exchange] calls.
+    /// The request builder for [AnalyticsHubService::delete_data_exchange][crate::client::AnalyticsHubService::delete_data_exchange] calls.
     ///
     /// # Example
     /// ```no_run
@@ -609,7 +609,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::list_listings][super::super::client::AnalyticsHubService::list_listings] calls.
+    /// The request builder for [AnalyticsHubService::list_listings][crate::client::AnalyticsHubService::list_listings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -712,7 +712,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::get_listing][super::super::client::AnalyticsHubService::get_listing] calls.
+    /// The request builder for [AnalyticsHubService::get_listing][crate::client::AnalyticsHubService::get_listing] calls.
     ///
     /// # Example
     /// ```no_run
@@ -775,7 +775,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::create_listing][super::super::client::AnalyticsHubService::create_listing] calls.
+    /// The request builder for [AnalyticsHubService::create_listing][crate::client::AnalyticsHubService::create_listing] calls.
     ///
     /// # Example
     /// ```no_run
@@ -868,7 +868,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::update_listing][super::super::client::AnalyticsHubService::update_listing] calls.
+    /// The request builder for [AnalyticsHubService::update_listing][crate::client::AnalyticsHubService::update_listing] calls.
     ///
     /// # Example
     /// ```no_run
@@ -967,7 +967,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::delete_listing][super::super::client::AnalyticsHubService::delete_listing] calls.
+    /// The request builder for [AnalyticsHubService::delete_listing][crate::client::AnalyticsHubService::delete_listing] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1036,7 +1036,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::subscribe_listing][super::super::client::AnalyticsHubService::subscribe_listing] calls.
+    /// The request builder for [AnalyticsHubService::subscribe_listing][crate::client::AnalyticsHubService::subscribe_listing] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1146,7 +1146,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::subscribe_data_exchange][super::super::client::AnalyticsHubService::subscribe_data_exchange] calls.
+    /// The request builder for [AnalyticsHubService::subscribe_data_exchange][crate::client::AnalyticsHubService::subscribe_data_exchange] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1194,7 +1194,7 @@ pub mod analytics_hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [subscribe_data_exchange][super::super::client::AnalyticsHubService::subscribe_data_exchange].
+        /// on [subscribe_data_exchange][crate::client::AnalyticsHubService::subscribe_data_exchange].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .subscribe_data_exchange(self.0.request, self.0.options)
@@ -1294,7 +1294,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::refresh_subscription][super::super::client::AnalyticsHubService::refresh_subscription] calls.
+    /// The request builder for [AnalyticsHubService::refresh_subscription][crate::client::AnalyticsHubService::refresh_subscription] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1342,7 +1342,7 @@ pub mod analytics_hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [refresh_subscription][super::super::client::AnalyticsHubService::refresh_subscription].
+        /// on [refresh_subscription][crate::client::AnalyticsHubService::refresh_subscription].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .refresh_subscription(self.0.request, self.0.options)
@@ -1402,7 +1402,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::get_subscription][super::super::client::AnalyticsHubService::get_subscription] calls.
+    /// The request builder for [AnalyticsHubService::get_subscription][crate::client::AnalyticsHubService::get_subscription] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1465,7 +1465,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::list_subscriptions][super::super::client::AnalyticsHubService::list_subscriptions] calls.
+    /// The request builder for [AnalyticsHubService::list_subscriptions][crate::client::AnalyticsHubService::list_subscriptions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1577,7 +1577,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::list_shared_resource_subscriptions][super::super::client::AnalyticsHubService::list_shared_resource_subscriptions] calls.
+    /// The request builder for [AnalyticsHubService::list_shared_resource_subscriptions][crate::client::AnalyticsHubService::list_shared_resource_subscriptions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1695,7 +1695,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::revoke_subscription][super::super::client::AnalyticsHubService::revoke_subscription] calls.
+    /// The request builder for [AnalyticsHubService::revoke_subscription][crate::client::AnalyticsHubService::revoke_subscription] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1767,7 +1767,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::delete_subscription][super::super::client::AnalyticsHubService::delete_subscription] calls.
+    /// The request builder for [AnalyticsHubService::delete_subscription][crate::client::AnalyticsHubService::delete_subscription] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1815,7 +1815,7 @@ pub mod analytics_hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_subscription][super::super::client::AnalyticsHubService::delete_subscription].
+        /// on [delete_subscription][crate::client::AnalyticsHubService::delete_subscription].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_subscription(self.0.request, self.0.options)
@@ -1874,7 +1874,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::get_iam_policy][super::super::client::AnalyticsHubService::get_iam_policy] calls.
+    /// The request builder for [AnalyticsHubService::get_iam_policy][crate::client::AnalyticsHubService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1955,7 +1955,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::set_iam_policy][super::super::client::AnalyticsHubService::set_iam_policy] calls.
+    /// The request builder for [AnalyticsHubService::set_iam_policy][crate::client::AnalyticsHubService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2058,7 +2058,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::test_iam_permissions][super::super::client::AnalyticsHubService::test_iam_permissions] calls.
+    /// The request builder for [AnalyticsHubService::test_iam_permissions][crate::client::AnalyticsHubService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2137,7 +2137,7 @@ pub mod analytics_hub_service {
         }
     }
 
-    /// The request builder for [AnalyticsHubService::get_operation][super::super::client::AnalyticsHubService::get_operation] calls.
+    /// The request builder for [AnalyticsHubService::get_operation][crate::client::AnalyticsHubService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/bigquery/connection/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/connection/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod connection_service {
     use crate::Result;
 
-    /// A builder for [ConnectionService][super::super::client::ConnectionService].
+    /// A builder for [ConnectionService][crate::client::ConnectionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod connection_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ConnectionService] request builders.
+    /// Common implementation for [crate::client::ConnectionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConnectionService>,
@@ -68,7 +68,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::create_connection][super::super::client::ConnectionService::create_connection] calls.
+    /// The request builder for [ConnectionService::create_connection][crate::client::ConnectionService::create_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -162,7 +162,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::get_connection][super::super::client::ConnectionService::get_connection] calls.
+    /// The request builder for [ConnectionService::get_connection][crate::client::ConnectionService::get_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -225,7 +225,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::list_connections][super::super::client::ConnectionService::list_connections] calls.
+    /// The request builder for [ConnectionService::list_connections][crate::client::ConnectionService::list_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -330,7 +330,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::update_connection][super::super::client::ConnectionService::update_connection] calls.
+    /// The request builder for [ConnectionService::update_connection][crate::client::ConnectionService::update_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -440,7 +440,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::delete_connection][super::super::client::ConnectionService::delete_connection] calls.
+    /// The request builder for [ConnectionService::delete_connection][crate::client::ConnectionService::delete_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -506,7 +506,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::get_iam_policy][super::super::client::ConnectionService::get_iam_policy] calls.
+    /// The request builder for [ConnectionService::get_iam_policy][crate::client::ConnectionService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -587,7 +587,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::set_iam_policy][super::super::client::ConnectionService::set_iam_policy] calls.
+    /// The request builder for [ConnectionService::set_iam_policy][crate::client::ConnectionService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -690,7 +690,7 @@ pub mod connection_service {
         }
     }
 
-    /// The request builder for [ConnectionService::test_iam_permissions][super::super::client::ConnectionService::test_iam_permissions] calls.
+    /// The request builder for [ConnectionService::test_iam_permissions][crate::client::ConnectionService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datapolicies/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod data_policy_service {
     use crate::Result;
 
-    /// A builder for [DataPolicyService][super::super::client::DataPolicyService].
+    /// A builder for [DataPolicyService][crate::client::DataPolicyService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataPolicyService] request builders.
+    /// Common implementation for [crate::client::DataPolicyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataPolicyService>,
@@ -68,7 +68,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::create_data_policy][super::super::client::DataPolicyService::create_data_policy] calls.
+    /// The request builder for [DataPolicyService::create_data_policy][crate::client::DataPolicyService::create_data_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -156,7 +156,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::update_data_policy][super::super::client::DataPolicyService::update_data_policy] calls.
+    /// The request builder for [DataPolicyService::update_data_policy][crate::client::DataPolicyService::update_data_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::rename_data_policy][super::super::client::DataPolicyService::rename_data_policy] calls.
+    /// The request builder for [DataPolicyService::rename_data_policy][crate::client::DataPolicyService::rename_data_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -328,7 +328,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::delete_data_policy][super::super::client::DataPolicyService::delete_data_policy] calls.
+    /// The request builder for [DataPolicyService::delete_data_policy][crate::client::DataPolicyService::delete_data_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -394,7 +394,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::get_data_policy][super::super::client::DataPolicyService::get_data_policy] calls.
+    /// The request builder for [DataPolicyService::get_data_policy][crate::client::DataPolicyService::get_data_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -457,7 +457,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::list_data_policies][super::super::client::DataPolicyService::list_data_policies] calls.
+    /// The request builder for [DataPolicyService::list_data_policies][crate::client::DataPolicyService::list_data_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -569,7 +569,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::get_iam_policy][super::super::client::DataPolicyService::get_iam_policy] calls.
+    /// The request builder for [DataPolicyService::get_iam_policy][crate::client::DataPolicyService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -650,7 +650,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::set_iam_policy][super::super::client::DataPolicyService::set_iam_policy] calls.
+    /// The request builder for [DataPolicyService::set_iam_policy][crate::client::DataPolicyService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -753,7 +753,7 @@ pub mod data_policy_service {
         }
     }
 
-    /// The request builder for [DataPolicyService::test_iam_permissions][super::super::client::DataPolicyService::test_iam_permissions] calls.
+    /// The request builder for [DataPolicyService::test_iam_permissions][crate::client::DataPolicyService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/datatransfer/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod data_transfer_service {
     use crate::Result;
 
-    /// A builder for [DataTransferService][super::super::client::DataTransferService].
+    /// A builder for [DataTransferService][crate::client::DataTransferService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataTransferService] request builders.
+    /// Common implementation for [crate::client::DataTransferService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataTransferService>,
@@ -68,7 +68,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::get_data_source][super::super::client::DataTransferService::get_data_source] calls.
+    /// The request builder for [DataTransferService::get_data_source][crate::client::DataTransferService::get_data_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::list_data_sources][super::super::client::DataTransferService::list_data_sources] calls.
+    /// The request builder for [DataTransferService::list_data_sources][crate::client::DataTransferService::list_data_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -234,7 +234,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::create_transfer_config][super::super::client::DataTransferService::create_transfer_config] calls.
+    /// The request builder for [DataTransferService::create_transfer_config][crate::client::DataTransferService::create_transfer_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -341,7 +341,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::update_transfer_config][super::super::client::DataTransferService::update_transfer_config] calls.
+    /// The request builder for [DataTransferService::update_transfer_config][crate::client::DataTransferService::update_transfer_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -462,7 +462,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::delete_transfer_config][super::super::client::DataTransferService::delete_transfer_config] calls.
+    /// The request builder for [DataTransferService::delete_transfer_config][crate::client::DataTransferService::delete_transfer_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -528,7 +528,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::get_transfer_config][super::super::client::DataTransferService::get_transfer_config] calls.
+    /// The request builder for [DataTransferService::get_transfer_config][crate::client::DataTransferService::get_transfer_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -594,7 +594,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::list_transfer_configs][super::super::client::DataTransferService::list_transfer_configs] calls.
+    /// The request builder for [DataTransferService::list_transfer_configs][crate::client::DataTransferService::list_transfer_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -713,7 +713,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::schedule_transfer_runs][super::super::client::DataTransferService::schedule_transfer_runs] calls.
+    /// The request builder for [DataTransferService::schedule_transfer_runs][crate::client::DataTransferService::schedule_transfer_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -823,7 +823,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::start_manual_transfer_runs][super::super::client::DataTransferService::start_manual_transfer_runs] calls.
+    /// The request builder for [DataTransferService::start_manual_transfer_runs][crate::client::DataTransferService::start_manual_transfer_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -933,7 +933,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::get_transfer_run][super::super::client::DataTransferService::get_transfer_run] calls.
+    /// The request builder for [DataTransferService::get_transfer_run][crate::client::DataTransferService::get_transfer_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -996,7 +996,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::delete_transfer_run][super::super::client::DataTransferService::delete_transfer_run] calls.
+    /// The request builder for [DataTransferService::delete_transfer_run][crate::client::DataTransferService::delete_transfer_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1062,7 +1062,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::list_transfer_runs][super::super::client::DataTransferService::list_transfer_runs] calls.
+    /// The request builder for [DataTransferService::list_transfer_runs][crate::client::DataTransferService::list_transfer_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1188,7 +1188,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::list_transfer_logs][super::super::client::DataTransferService::list_transfer_logs] calls.
+    /// The request builder for [DataTransferService::list_transfer_logs][crate::client::DataTransferService::list_transfer_logs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1305,7 +1305,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::check_valid_creds][super::super::client::DataTransferService::check_valid_creds] calls.
+    /// The request builder for [DataTransferService::check_valid_creds][crate::client::DataTransferService::check_valid_creds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1368,7 +1368,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::enroll_data_sources][super::super::client::DataTransferService::enroll_data_sources] calls.
+    /// The request builder for [DataTransferService::enroll_data_sources][crate::client::DataTransferService::enroll_data_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1445,7 +1445,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::unenroll_data_sources][super::super::client::DataTransferService::unenroll_data_sources] calls.
+    /// The request builder for [DataTransferService::unenroll_data_sources][crate::client::DataTransferService::unenroll_data_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1522,7 +1522,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::list_locations][super::super::client::DataTransferService::list_locations] calls.
+    /// The request builder for [DataTransferService::list_locations][crate::client::DataTransferService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1632,7 +1632,7 @@ pub mod data_transfer_service {
         }
     }
 
-    /// The request builder for [DataTransferService::get_location][super::super::client::DataTransferService::get_location] calls.
+    /// The request builder for [DataTransferService::get_location][crate::client::DataTransferService::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/bigquery/migration/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/migration/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod migration_service {
     use crate::Result;
 
-    /// A builder for [MigrationService][super::super::client::MigrationService].
+    /// A builder for [MigrationService][crate::client::MigrationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod migration_service {
         }
     }
 
-    /// Common implementation for [super::super::client::MigrationService] request builders.
+    /// Common implementation for [crate::client::MigrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MigrationService>,
@@ -68,7 +68,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::create_migration_workflow][super::super::client::MigrationService::create_migration_workflow] calls.
+    /// The request builder for [MigrationService::create_migration_workflow][crate::client::MigrationService::create_migration_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -158,7 +158,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::get_migration_workflow][super::super::client::MigrationService::get_migration_workflow] calls.
+    /// The request builder for [MigrationService::get_migration_workflow][crate::client::MigrationService::get_migration_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -242,7 +242,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::list_migration_workflows][super::super::client::MigrationService::list_migration_workflows] calls.
+    /// The request builder for [MigrationService::list_migration_workflows][crate::client::MigrationService::list_migration_workflows] calls.
     ///
     /// # Example
     /// ```no_run
@@ -370,7 +370,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::delete_migration_workflow][super::super::client::MigrationService::delete_migration_workflow] calls.
+    /// The request builder for [MigrationService::delete_migration_workflow][crate::client::MigrationService::delete_migration_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -438,7 +438,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::start_migration_workflow][super::super::client::MigrationService::start_migration_workflow] calls.
+    /// The request builder for [MigrationService::start_migration_workflow][crate::client::MigrationService::start_migration_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -504,7 +504,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::get_migration_subtask][super::super::client::MigrationService::get_migration_subtask] calls.
+    /// The request builder for [MigrationService::get_migration_subtask][crate::client::MigrationService::get_migration_subtask] calls.
     ///
     /// # Example
     /// ```no_run
@@ -588,7 +588,7 @@ pub mod migration_service {
         }
     }
 
-    /// The request builder for [MigrationService::list_migration_subtasks][super::super::client::MigrationService::list_migration_subtasks] calls.
+    /// The request builder for [MigrationService::list_migration_subtasks][crate::client::MigrationService::list_migration_subtasks] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
+++ b/src/generated/cloud/bigquery/reservation/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod reservation_service {
     use crate::Result;
 
-    /// A builder for [ReservationService][super::super::client::ReservationService].
+    /// A builder for [ReservationService][crate::client::ReservationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod reservation_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ReservationService] request builders.
+    /// Common implementation for [crate::client::ReservationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ReservationService>,
@@ -68,7 +68,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::create_reservation][super::super::client::ReservationService::create_reservation] calls.
+    /// The request builder for [ReservationService::create_reservation][crate::client::ReservationService::create_reservation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -158,7 +158,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::list_reservations][super::super::client::ReservationService::list_reservations] calls.
+    /// The request builder for [ReservationService::list_reservations][crate::client::ReservationService::list_reservations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -264,7 +264,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::get_reservation][super::super::client::ReservationService::get_reservation] calls.
+    /// The request builder for [ReservationService::get_reservation][crate::client::ReservationService::get_reservation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -327,7 +327,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::delete_reservation][super::super::client::ReservationService::delete_reservation] calls.
+    /// The request builder for [ReservationService::delete_reservation][crate::client::ReservationService::delete_reservation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -393,7 +393,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::update_reservation][super::super::client::ReservationService::update_reservation] calls.
+    /// The request builder for [ReservationService::update_reservation][crate::client::ReservationService::update_reservation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -487,7 +487,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::failover_reservation][super::super::client::ReservationService::failover_reservation] calls.
+    /// The request builder for [ReservationService::failover_reservation][crate::client::ReservationService::failover_reservation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -553,7 +553,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::create_capacity_commitment][super::super::client::ReservationService::create_capacity_commitment] calls.
+    /// The request builder for [ReservationService::create_capacity_commitment][crate::client::ReservationService::create_capacity_commitment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -651,7 +651,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::list_capacity_commitments][super::super::client::ReservationService::list_capacity_commitments] calls.
+    /// The request builder for [ReservationService::list_capacity_commitments][crate::client::ReservationService::list_capacity_commitments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -763,7 +763,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::get_capacity_commitment][super::super::client::ReservationService::get_capacity_commitment] calls.
+    /// The request builder for [ReservationService::get_capacity_commitment][crate::client::ReservationService::get_capacity_commitment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -829,7 +829,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::delete_capacity_commitment][super::super::client::ReservationService::delete_capacity_commitment] calls.
+    /// The request builder for [ReservationService::delete_capacity_commitment][crate::client::ReservationService::delete_capacity_commitment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -903,7 +903,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::update_capacity_commitment][super::super::client::ReservationService::update_capacity_commitment] calls.
+    /// The request builder for [ReservationService::update_capacity_commitment][crate::client::ReservationService::update_capacity_commitment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -999,7 +999,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::split_capacity_commitment][super::super::client::ReservationService::split_capacity_commitment] calls.
+    /// The request builder for [ReservationService::split_capacity_commitment][crate::client::ReservationService::split_capacity_commitment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1073,7 +1073,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::merge_capacity_commitments][super::super::client::ReservationService::merge_capacity_commitments] calls.
+    /// The request builder for [ReservationService::merge_capacity_commitments][crate::client::ReservationService::merge_capacity_commitments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1150,7 +1150,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::create_assignment][super::super::client::ReservationService::create_assignment] calls.
+    /// The request builder for [ReservationService::create_assignment][crate::client::ReservationService::create_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1240,7 +1240,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::list_assignments][super::super::client::ReservationService::list_assignments] calls.
+    /// The request builder for [ReservationService::list_assignments][crate::client::ReservationService::list_assignments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1343,7 +1343,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::delete_assignment][super::super::client::ReservationService::delete_assignment] calls.
+    /// The request builder for [ReservationService::delete_assignment][crate::client::ReservationService::delete_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1409,7 +1409,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::search_assignments][super::super::client::ReservationService::search_assignments] calls.
+    /// The request builder for [ReservationService::search_assignments][crate::client::ReservationService::search_assignments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1521,7 +1521,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::search_all_assignments][super::super::client::ReservationService::search_all_assignments] calls.
+    /// The request builder for [ReservationService::search_all_assignments][crate::client::ReservationService::search_all_assignments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1635,7 +1635,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::move_assignment][super::super::client::ReservationService::move_assignment] calls.
+    /// The request builder for [ReservationService::move_assignment][crate::client::ReservationService::move_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1710,7 +1710,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::update_assignment][super::super::client::ReservationService::update_assignment] calls.
+    /// The request builder for [ReservationService::update_assignment][crate::client::ReservationService::update_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1804,7 +1804,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::get_bi_reservation][super::super::client::ReservationService::get_bi_reservation] calls.
+    /// The request builder for [ReservationService::get_bi_reservation][crate::client::ReservationService::get_bi_reservation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1870,7 +1870,7 @@ pub mod reservation_service {
         }
     }
 
-    /// The request builder for [ReservationService::update_bi_reservation][super::super::client::ReservationService::update_bi_reservation] calls.
+    /// The request builder for [ReservationService::update_bi_reservation][crate::client::ReservationService::update_bi_reservation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/bigquery/v2/src/builder.rs
+++ b/src/generated/cloud/bigquery/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod dataset_service {
     use crate::Result;
 
-    /// A builder for [DatasetService][super::super::client::DatasetService].
+    /// A builder for [DatasetService][crate::client::DatasetService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod dataset_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DatasetService] request builders.
+    /// Common implementation for [crate::client::DatasetService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DatasetService>,
@@ -68,7 +68,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::get_dataset][super::super::client::DatasetService::get_dataset] calls.
+    /// The request builder for [DatasetService::get_dataset][crate::client::DatasetService::get_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -154,7 +154,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::insert_dataset][super::super::client::DatasetService::insert_dataset] calls.
+    /// The request builder for [DatasetService::insert_dataset][crate::client::DatasetService::insert_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -245,7 +245,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::patch_dataset][super::super::client::DatasetService::patch_dataset] calls.
+    /// The request builder for [DatasetService::patch_dataset][crate::client::DatasetService::patch_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -358,7 +358,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::update_dataset][super::super::client::DatasetService::update_dataset] calls.
+    /// The request builder for [DatasetService::update_dataset][crate::client::DatasetService::update_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -471,7 +471,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::delete_dataset][super::super::client::DatasetService::delete_dataset] calls.
+    /// The request builder for [DatasetService::delete_dataset][crate::client::DatasetService::delete_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -548,7 +548,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::list_datasets][super::super::client::DatasetService::list_datasets] calls.
+    /// The request builder for [DatasetService::list_datasets][crate::client::DatasetService::list_datasets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -647,7 +647,7 @@ pub mod dataset_service {
         }
     }
 
-    /// The request builder for [DatasetService::undelete_dataset][super::super::client::DatasetService::undelete_dataset] calls.
+    /// The request builder for [DatasetService::undelete_dataset][crate::client::DatasetService::undelete_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -740,7 +740,7 @@ pub mod dataset_service {
 pub mod model_service {
     use crate::Result;
 
-    /// A builder for [ModelService][super::super::client::ModelService].
+    /// A builder for [ModelService][crate::client::ModelService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -768,7 +768,7 @@ pub mod model_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ModelService] request builders.
+    /// Common implementation for [crate::client::ModelService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ModelService>,
@@ -791,7 +791,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
+    /// The request builder for [ModelService::get_model][crate::client::ModelService::get_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -870,7 +870,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
+    /// The request builder for [ModelService::list_models][crate::client::ModelService::list_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -965,7 +965,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::patch_model][super::super::client::ModelService::patch_model] calls.
+    /// The request builder for [ModelService::patch_model][crate::client::ModelService::patch_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1066,7 +1066,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
+    /// The request builder for [ModelService::delete_model][crate::client::ModelService::delete_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1149,7 +1149,7 @@ pub mod model_service {
 pub mod project_service {
     use crate::Result;
 
-    /// A builder for [ProjectService][super::super::client::ProjectService].
+    /// A builder for [ProjectService][crate::client::ProjectService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1177,7 +1177,7 @@ pub mod project_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ProjectService] request builders.
+    /// Common implementation for [crate::client::ProjectService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ProjectService>,
@@ -1200,7 +1200,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for [ProjectService::get_service_account][super::super::client::ProjectService::get_service_account] calls.
+    /// The request builder for [ProjectService::get_service_account][crate::client::ProjectService::get_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1270,7 +1270,7 @@ pub mod project_service {
 pub mod routine_service {
     use crate::Result;
 
-    /// A builder for [RoutineService][super::super::client::RoutineService].
+    /// A builder for [RoutineService][crate::client::RoutineService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1298,7 +1298,7 @@ pub mod routine_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RoutineService] request builders.
+    /// Common implementation for [crate::client::RoutineService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RoutineService>,
@@ -1321,7 +1321,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for [RoutineService::get_routine][super::super::client::RoutineService::get_routine] calls.
+    /// The request builder for [RoutineService::get_routine][crate::client::RoutineService::get_routine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1400,7 +1400,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for [RoutineService::insert_routine][super::super::client::RoutineService::insert_routine] calls.
+    /// The request builder for [RoutineService::insert_routine][crate::client::RoutineService::insert_routine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1493,7 +1493,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for [RoutineService::update_routine][super::super::client::RoutineService::update_routine] calls.
+    /// The request builder for [RoutineService::update_routine][crate::client::RoutineService::update_routine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1594,7 +1594,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for [RoutineService::delete_routine][super::super::client::RoutineService::delete_routine] calls.
+    /// The request builder for [RoutineService::delete_routine][crate::client::RoutineService::delete_routine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1673,7 +1673,7 @@ pub mod routine_service {
         }
     }
 
-    /// The request builder for [RoutineService::list_routines][super::super::client::RoutineService::list_routines] calls.
+    /// The request builder for [RoutineService::list_routines][crate::client::RoutineService::list_routines] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1778,7 +1778,7 @@ pub mod routine_service {
 pub mod row_access_policy_service {
     use crate::Result;
 
-    /// A builder for [RowAccessPolicyService][super::super::client::RowAccessPolicyService].
+    /// A builder for [RowAccessPolicyService][crate::client::RowAccessPolicyService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1806,7 +1806,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RowAccessPolicyService] request builders.
+    /// Common implementation for [crate::client::RowAccessPolicyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RowAccessPolicyService>,
@@ -1829,7 +1829,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for [RowAccessPolicyService::list_row_access_policies][super::super::client::RowAccessPolicyService::list_row_access_policies] calls.
+    /// The request builder for [RowAccessPolicyService::list_row_access_policies][crate::client::RowAccessPolicyService::list_row_access_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1953,7 +1953,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for [RowAccessPolicyService::get_row_access_policy][super::super::client::RowAccessPolicyService::get_row_access_policy] calls.
+    /// The request builder for [RowAccessPolicyService::get_row_access_policy][crate::client::RowAccessPolicyService::get_row_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2043,7 +2043,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for [RowAccessPolicyService::create_row_access_policy][super::super::client::RowAccessPolicyService::create_row_access_policy] calls.
+    /// The request builder for [RowAccessPolicyService::create_row_access_policy][crate::client::RowAccessPolicyService::create_row_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2147,7 +2147,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for [RowAccessPolicyService::update_row_access_policy][super::super::client::RowAccessPolicyService::update_row_access_policy] calls.
+    /// The request builder for [RowAccessPolicyService::update_row_access_policy][crate::client::RowAccessPolicyService::update_row_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2259,7 +2259,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for [RowAccessPolicyService::delete_row_access_policy][super::super::client::RowAccessPolicyService::delete_row_access_policy] calls.
+    /// The request builder for [RowAccessPolicyService::delete_row_access_policy][crate::client::RowAccessPolicyService::delete_row_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2367,7 +2367,7 @@ pub mod row_access_policy_service {
         }
     }
 
-    /// The request builder for [RowAccessPolicyService::batch_delete_row_access_policies][super::super::client::RowAccessPolicyService::batch_delete_row_access_policies] calls.
+    /// The request builder for [RowAccessPolicyService::batch_delete_row_access_policies][crate::client::RowAccessPolicyService::batch_delete_row_access_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2486,7 +2486,7 @@ pub mod row_access_policy_service {
 pub mod table_service {
     use crate::Result;
 
-    /// A builder for [TableService][super::super::client::TableService].
+    /// A builder for [TableService][crate::client::TableService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2514,7 +2514,7 @@ pub mod table_service {
         }
     }
 
-    /// Common implementation for [super::super::client::TableService] request builders.
+    /// Common implementation for [crate::client::TableService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TableService>,
@@ -2537,7 +2537,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for [TableService::get_table][super::super::client::TableService::get_table] calls.
+    /// The request builder for [TableService::get_table][crate::client::TableService::get_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2631,7 +2631,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for [TableService::insert_table][super::super::client::TableService::insert_table] calls.
+    /// The request builder for [TableService::insert_table][crate::client::TableService::insert_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2724,7 +2724,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for [TableService::patch_table][super::super::client::TableService::patch_table] calls.
+    /// The request builder for [TableService::patch_table][crate::client::TableService::patch_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2834,7 +2834,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for [TableService::update_table][super::super::client::TableService::update_table] calls.
+    /// The request builder for [TableService::update_table][crate::client::TableService::update_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2944,7 +2944,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for [TableService::delete_table][super::super::client::TableService::delete_table] calls.
+    /// The request builder for [TableService::delete_table][crate::client::TableService::delete_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3023,7 +3023,7 @@ pub mod table_service {
         }
     }
 
-    /// The request builder for [TableService::list_tables][super::super::client::TableService::list_tables] calls.
+    /// The request builder for [TableService::list_tables][crate::client::TableService::list_tables] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/billing/v1/src/builder.rs
+++ b/src/generated/cloud/billing/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_billing {
     use crate::Result;
 
-    /// A builder for [CloudBilling][super::super::client::CloudBilling].
+    /// A builder for [CloudBilling][crate::client::CloudBilling].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudBilling] request builders.
+    /// Common implementation for [crate::client::CloudBilling] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudBilling>,
@@ -68,7 +68,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::get_billing_account][super::super::client::CloudBilling::get_billing_account] calls.
+    /// The request builder for [CloudBilling::get_billing_account][crate::client::CloudBilling::get_billing_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -134,7 +134,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::list_billing_accounts][super::super::client::CloudBilling::list_billing_accounts] calls.
+    /// The request builder for [CloudBilling::list_billing_accounts][crate::client::CloudBilling::list_billing_accounts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::update_billing_account][super::super::client::CloudBilling::update_billing_account] calls.
+    /// The request builder for [CloudBilling::update_billing_account][crate::client::CloudBilling::update_billing_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -352,7 +352,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::create_billing_account][super::super::client::CloudBilling::create_billing_account] calls.
+    /// The request builder for [CloudBilling::create_billing_account][crate::client::CloudBilling::create_billing_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -438,7 +438,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::list_project_billing_info][super::super::client::CloudBilling::list_project_billing_info] calls.
+    /// The request builder for [CloudBilling::list_project_billing_info][crate::client::CloudBilling::list_project_billing_info] calls.
     ///
     /// # Example
     /// ```no_run
@@ -548,7 +548,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::get_project_billing_info][super::super::client::CloudBilling::get_project_billing_info] calls.
+    /// The request builder for [CloudBilling::get_project_billing_info][crate::client::CloudBilling::get_project_billing_info] calls.
     ///
     /// # Example
     /// ```no_run
@@ -614,7 +614,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::update_project_billing_info][super::super::client::CloudBilling::update_project_billing_info] calls.
+    /// The request builder for [CloudBilling::update_project_billing_info][crate::client::CloudBilling::update_project_billing_info] calls.
     ///
     /// # Example
     /// ```no_run
@@ -700,7 +700,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::get_iam_policy][super::super::client::CloudBilling::get_iam_policy] calls.
+    /// The request builder for [CloudBilling::get_iam_policy][crate::client::CloudBilling::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -781,7 +781,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::set_iam_policy][super::super::client::CloudBilling::set_iam_policy] calls.
+    /// The request builder for [CloudBilling::set_iam_policy][crate::client::CloudBilling::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -884,7 +884,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::test_iam_permissions][super::super::client::CloudBilling::test_iam_permissions] calls.
+    /// The request builder for [CloudBilling::test_iam_permissions][crate::client::CloudBilling::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -963,7 +963,7 @@ pub mod cloud_billing {
         }
     }
 
-    /// The request builder for [CloudBilling::move_billing_account][super::super::client::CloudBilling::move_billing_account] calls.
+    /// The request builder for [CloudBilling::move_billing_account][crate::client::CloudBilling::move_billing_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1041,7 +1041,7 @@ pub mod cloud_billing {
 pub mod cloud_catalog {
     use crate::Result;
 
-    /// A builder for [CloudCatalog][super::super::client::CloudCatalog].
+    /// A builder for [CloudCatalog][crate::client::CloudCatalog].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1069,7 +1069,7 @@ pub mod cloud_catalog {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudCatalog] request builders.
+    /// Common implementation for [crate::client::CloudCatalog] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudCatalog>,
@@ -1092,7 +1092,7 @@ pub mod cloud_catalog {
         }
     }
 
-    /// The request builder for [CloudCatalog::list_services][super::super::client::CloudCatalog::list_services] calls.
+    /// The request builder for [CloudCatalog::list_services][crate::client::CloudCatalog::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1187,7 +1187,7 @@ pub mod cloud_catalog {
         }
     }
 
-    /// The request builder for [CloudCatalog::list_skus][super::super::client::CloudCatalog::list_skus] calls.
+    /// The request builder for [CloudCatalog::list_skus][crate::client::CloudCatalog::list_skus] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/binaryauthorization/v1/src/builder.rs
+++ b/src/generated/cloud/binaryauthorization/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod binauthz_management_service_v_1 {
     use crate::Result;
 
-    /// A builder for [BinauthzManagementServiceV1][super::super::client::BinauthzManagementServiceV1].
+    /// A builder for [BinauthzManagementServiceV1][crate::client::BinauthzManagementServiceV1].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// Common implementation for [super::super::client::BinauthzManagementServiceV1] request builders.
+    /// Common implementation for [crate::client::BinauthzManagementServiceV1] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::BinauthzManagementServiceV1>,
@@ -68,7 +68,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for [BinauthzManagementServiceV1::get_policy][super::super::client::BinauthzManagementServiceV1::get_policy] calls.
+    /// The request builder for [BinauthzManagementServiceV1::get_policy][crate::client::BinauthzManagementServiceV1::get_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for [BinauthzManagementServiceV1::update_policy][super::super::client::BinauthzManagementServiceV1::update_policy] calls.
+    /// The request builder for [BinauthzManagementServiceV1::update_policy][crate::client::BinauthzManagementServiceV1::update_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -208,7 +208,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for [BinauthzManagementServiceV1::create_attestor][super::super::client::BinauthzManagementServiceV1::create_attestor] calls.
+    /// The request builder for [BinauthzManagementServiceV1::create_attestor][crate::client::BinauthzManagementServiceV1::create_attestor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -301,7 +301,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for [BinauthzManagementServiceV1::get_attestor][super::super::client::BinauthzManagementServiceV1::get_attestor] calls.
+    /// The request builder for [BinauthzManagementServiceV1::get_attestor][crate::client::BinauthzManagementServiceV1::get_attestor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -364,7 +364,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for [BinauthzManagementServiceV1::update_attestor][super::super::client::BinauthzManagementServiceV1::update_attestor] calls.
+    /// The request builder for [BinauthzManagementServiceV1::update_attestor][crate::client::BinauthzManagementServiceV1::update_attestor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -441,7 +441,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for [BinauthzManagementServiceV1::list_attestors][super::super::client::BinauthzManagementServiceV1::list_attestors] calls.
+    /// The request builder for [BinauthzManagementServiceV1::list_attestors][crate::client::BinauthzManagementServiceV1::list_attestors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -544,7 +544,7 @@ pub mod binauthz_management_service_v_1 {
         }
     }
 
-    /// The request builder for [BinauthzManagementServiceV1::delete_attestor][super::super::client::BinauthzManagementServiceV1::delete_attestor] calls.
+    /// The request builder for [BinauthzManagementServiceV1::delete_attestor][crate::client::BinauthzManagementServiceV1::delete_attestor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -611,7 +611,7 @@ pub mod binauthz_management_service_v_1 {
 pub mod system_policy_v_1 {
     use crate::Result;
 
-    /// A builder for [SystemPolicyV1][super::super::client::SystemPolicyV1].
+    /// A builder for [SystemPolicyV1][crate::client::SystemPolicyV1].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -639,7 +639,7 @@ pub mod system_policy_v_1 {
         }
     }
 
-    /// Common implementation for [super::super::client::SystemPolicyV1] request builders.
+    /// Common implementation for [crate::client::SystemPolicyV1] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SystemPolicyV1>,
@@ -662,7 +662,7 @@ pub mod system_policy_v_1 {
         }
     }
 
-    /// The request builder for [SystemPolicyV1::get_system_policy][super::super::client::SystemPolicyV1::get_system_policy] calls.
+    /// The request builder for [SystemPolicyV1::get_system_policy][crate::client::SystemPolicyV1::get_system_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -729,7 +729,7 @@ pub mod system_policy_v_1 {
 pub mod validation_helper_v_1 {
     use crate::Result;
 
-    /// A builder for [ValidationHelperV1][super::super::client::ValidationHelperV1].
+    /// A builder for [ValidationHelperV1][crate::client::ValidationHelperV1].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -757,7 +757,7 @@ pub mod validation_helper_v_1 {
         }
     }
 
-    /// Common implementation for [super::super::client::ValidationHelperV1] request builders.
+    /// Common implementation for [crate::client::ValidationHelperV1] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ValidationHelperV1>,
@@ -780,7 +780,7 @@ pub mod validation_helper_v_1 {
         }
     }
 
-    /// The request builder for [ValidationHelperV1::validate_attestation_occurrence][super::super::client::ValidationHelperV1::validate_attestation_occurrence] calls.
+    /// The request builder for [ValidationHelperV1::validate_attestation_occurrence][crate::client::ValidationHelperV1::validate_attestation_occurrence] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/certificatemanager/v1/src/builder.rs
+++ b/src/generated/cloud/certificatemanager/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod certificate_manager {
     use crate::Result;
 
-    /// A builder for [CertificateManager][super::super::client::CertificateManager].
+    /// A builder for [CertificateManager][crate::client::CertificateManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::CertificateManager] request builders.
+    /// Common implementation for [crate::client::CertificateManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CertificateManager>,
@@ -68,7 +68,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_certificates][super::super::client::CertificateManager::list_certificates] calls.
+    /// The request builder for [CertificateManager::list_certificates][crate::client::CertificateManager::list_certificates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_certificate][super::super::client::CertificateManager::get_certificate] calls.
+    /// The request builder for [CertificateManager::get_certificate][crate::client::CertificateManager::get_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -249,7 +249,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::create_certificate][super::super::client::CertificateManager::create_certificate] calls.
+    /// The request builder for [CertificateManager::create_certificate][crate::client::CertificateManager::create_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_certificate][super::super::client::CertificateManager::create_certificate].
+        /// on [create_certificate][crate::client::CertificateManager::create_certificate].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_certificate(self.0.request, self.0.options)
@@ -386,7 +386,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::update_certificate][super::super::client::CertificateManager::update_certificate] calls.
+    /// The request builder for [CertificateManager::update_certificate][crate::client::CertificateManager::update_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -434,7 +434,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_certificate][super::super::client::CertificateManager::update_certificate].
+        /// on [update_certificate][crate::client::CertificateManager::update_certificate].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_certificate(self.0.request, self.0.options)
@@ -529,7 +529,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::delete_certificate][super::super::client::CertificateManager::delete_certificate] calls.
+    /// The request builder for [CertificateManager::delete_certificate][crate::client::CertificateManager::delete_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -577,7 +577,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_certificate][super::super::client::CertificateManager::delete_certificate].
+        /// on [delete_certificate][crate::client::CertificateManager::delete_certificate].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_certificate(self.0.request, self.0.options)
@@ -636,7 +636,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_certificate_maps][super::super::client::CertificateManager::list_certificate_maps] calls.
+    /// The request builder for [CertificateManager::list_certificate_maps][crate::client::CertificateManager::list_certificate_maps] calls.
     ///
     /// # Example
     /// ```no_run
@@ -756,7 +756,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_certificate_map][super::super::client::CertificateManager::get_certificate_map] calls.
+    /// The request builder for [CertificateManager::get_certificate_map][crate::client::CertificateManager::get_certificate_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -822,7 +822,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::create_certificate_map][super::super::client::CertificateManager::create_certificate_map] calls.
+    /// The request builder for [CertificateManager::create_certificate_map][crate::client::CertificateManager::create_certificate_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -870,7 +870,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_certificate_map][super::super::client::CertificateManager::create_certificate_map].
+        /// on [create_certificate_map][crate::client::CertificateManager::create_certificate_map].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_certificate_map(self.0.request, self.0.options)
@@ -960,7 +960,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::update_certificate_map][super::super::client::CertificateManager::update_certificate_map] calls.
+    /// The request builder for [CertificateManager::update_certificate_map][crate::client::CertificateManager::update_certificate_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1008,7 +1008,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_certificate_map][super::super::client::CertificateManager::update_certificate_map].
+        /// on [update_certificate_map][crate::client::CertificateManager::update_certificate_map].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_certificate_map(self.0.request, self.0.options)
@@ -1104,7 +1104,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::delete_certificate_map][super::super::client::CertificateManager::delete_certificate_map] calls.
+    /// The request builder for [CertificateManager::delete_certificate_map][crate::client::CertificateManager::delete_certificate_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1152,7 +1152,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_certificate_map][super::super::client::CertificateManager::delete_certificate_map].
+        /// on [delete_certificate_map][crate::client::CertificateManager::delete_certificate_map].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_certificate_map(self.0.request, self.0.options)
@@ -1211,7 +1211,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_certificate_map_entries][super::super::client::CertificateManager::list_certificate_map_entries] calls.
+    /// The request builder for [CertificateManager::list_certificate_map_entries][crate::client::CertificateManager::list_certificate_map_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1335,7 +1335,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_certificate_map_entry][super::super::client::CertificateManager::get_certificate_map_entry] calls.
+    /// The request builder for [CertificateManager::get_certificate_map_entry][crate::client::CertificateManager::get_certificate_map_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1401,7 +1401,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::create_certificate_map_entry][super::super::client::CertificateManager::create_certificate_map_entry] calls.
+    /// The request builder for [CertificateManager::create_certificate_map_entry][crate::client::CertificateManager::create_certificate_map_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1451,7 +1451,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_certificate_map_entry][super::super::client::CertificateManager::create_certificate_map_entry].
+        /// on [create_certificate_map_entry][crate::client::CertificateManager::create_certificate_map_entry].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_certificate_map_entry(self.0.request, self.0.options)
@@ -1541,7 +1541,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::update_certificate_map_entry][super::super::client::CertificateManager::update_certificate_map_entry] calls.
+    /// The request builder for [CertificateManager::update_certificate_map_entry][crate::client::CertificateManager::update_certificate_map_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1591,7 +1591,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_certificate_map_entry][super::super::client::CertificateManager::update_certificate_map_entry].
+        /// on [update_certificate_map_entry][crate::client::CertificateManager::update_certificate_map_entry].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_certificate_map_entry(self.0.request, self.0.options)
@@ -1687,7 +1687,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::delete_certificate_map_entry][super::super::client::CertificateManager::delete_certificate_map_entry] calls.
+    /// The request builder for [CertificateManager::delete_certificate_map_entry][crate::client::CertificateManager::delete_certificate_map_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1737,7 +1737,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_certificate_map_entry][super::super::client::CertificateManager::delete_certificate_map_entry].
+        /// on [delete_certificate_map_entry][crate::client::CertificateManager::delete_certificate_map_entry].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_certificate_map_entry(self.0.request, self.0.options)
@@ -1796,7 +1796,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_dns_authorizations][super::super::client::CertificateManager::list_dns_authorizations] calls.
+    /// The request builder for [CertificateManager::list_dns_authorizations][crate::client::CertificateManager::list_dns_authorizations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1916,7 +1916,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_dns_authorization][super::super::client::CertificateManager::get_dns_authorization] calls.
+    /// The request builder for [CertificateManager::get_dns_authorization][crate::client::CertificateManager::get_dns_authorization] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1982,7 +1982,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::create_dns_authorization][super::super::client::CertificateManager::create_dns_authorization] calls.
+    /// The request builder for [CertificateManager::create_dns_authorization][crate::client::CertificateManager::create_dns_authorization] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2030,7 +2030,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_dns_authorization][super::super::client::CertificateManager::create_dns_authorization].
+        /// on [create_dns_authorization][crate::client::CertificateManager::create_dns_authorization].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_dns_authorization(self.0.request, self.0.options)
@@ -2120,7 +2120,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::update_dns_authorization][super::super::client::CertificateManager::update_dns_authorization] calls.
+    /// The request builder for [CertificateManager::update_dns_authorization][crate::client::CertificateManager::update_dns_authorization] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2168,7 +2168,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_dns_authorization][super::super::client::CertificateManager::update_dns_authorization].
+        /// on [update_dns_authorization][crate::client::CertificateManager::update_dns_authorization].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_dns_authorization(self.0.request, self.0.options)
@@ -2264,7 +2264,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::delete_dns_authorization][super::super::client::CertificateManager::delete_dns_authorization] calls.
+    /// The request builder for [CertificateManager::delete_dns_authorization][crate::client::CertificateManager::delete_dns_authorization] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2312,7 +2312,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_dns_authorization][super::super::client::CertificateManager::delete_dns_authorization].
+        /// on [delete_dns_authorization][crate::client::CertificateManager::delete_dns_authorization].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_dns_authorization(self.0.request, self.0.options)
@@ -2371,7 +2371,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_certificate_issuance_configs][super::super::client::CertificateManager::list_certificate_issuance_configs] calls.
+    /// The request builder for [CertificateManager::list_certificate_issuance_configs][crate::client::CertificateManager::list_certificate_issuance_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2495,7 +2495,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_certificate_issuance_config][super::super::client::CertificateManager::get_certificate_issuance_config] calls.
+    /// The request builder for [CertificateManager::get_certificate_issuance_config][crate::client::CertificateManager::get_certificate_issuance_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2563,7 +2563,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::create_certificate_issuance_config][super::super::client::CertificateManager::create_certificate_issuance_config] calls.
+    /// The request builder for [CertificateManager::create_certificate_issuance_config][crate::client::CertificateManager::create_certificate_issuance_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2613,7 +2613,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_certificate_issuance_config][super::super::client::CertificateManager::create_certificate_issuance_config].
+        /// on [create_certificate_issuance_config][crate::client::CertificateManager::create_certificate_issuance_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_certificate_issuance_config(self.0.request, self.0.options)
@@ -2709,7 +2709,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::delete_certificate_issuance_config][super::super::client::CertificateManager::delete_certificate_issuance_config] calls.
+    /// The request builder for [CertificateManager::delete_certificate_issuance_config][crate::client::CertificateManager::delete_certificate_issuance_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2759,7 +2759,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_certificate_issuance_config][super::super::client::CertificateManager::delete_certificate_issuance_config].
+        /// on [delete_certificate_issuance_config][crate::client::CertificateManager::delete_certificate_issuance_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_certificate_issuance_config(self.0.request, self.0.options)
@@ -2818,7 +2818,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_trust_configs][super::super::client::CertificateManager::list_trust_configs] calls.
+    /// The request builder for [CertificateManager::list_trust_configs][crate::client::CertificateManager::list_trust_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2936,7 +2936,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_trust_config][super::super::client::CertificateManager::get_trust_config] calls.
+    /// The request builder for [CertificateManager::get_trust_config][crate::client::CertificateManager::get_trust_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2999,7 +2999,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::create_trust_config][super::super::client::CertificateManager::create_trust_config] calls.
+    /// The request builder for [CertificateManager::create_trust_config][crate::client::CertificateManager::create_trust_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3047,7 +3047,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_trust_config][super::super::client::CertificateManager::create_trust_config].
+        /// on [create_trust_config][crate::client::CertificateManager::create_trust_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_trust_config(self.0.request, self.0.options)
@@ -3136,7 +3136,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::update_trust_config][super::super::client::CertificateManager::update_trust_config] calls.
+    /// The request builder for [CertificateManager::update_trust_config][crate::client::CertificateManager::update_trust_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3184,7 +3184,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_trust_config][super::super::client::CertificateManager::update_trust_config].
+        /// on [update_trust_config][crate::client::CertificateManager::update_trust_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_trust_config(self.0.request, self.0.options)
@@ -3279,7 +3279,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::delete_trust_config][super::super::client::CertificateManager::delete_trust_config] calls.
+    /// The request builder for [CertificateManager::delete_trust_config][crate::client::CertificateManager::delete_trust_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3327,7 +3327,7 @@ pub mod certificate_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_trust_config][super::super::client::CertificateManager::delete_trust_config].
+        /// on [delete_trust_config][crate::client::CertificateManager::delete_trust_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_trust_config(self.0.request, self.0.options)
@@ -3392,7 +3392,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_locations][super::super::client::CertificateManager::list_locations] calls.
+    /// The request builder for [CertificateManager::list_locations][crate::client::CertificateManager::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3502,7 +3502,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_location][super::super::client::CertificateManager::get_location] calls.
+    /// The request builder for [CertificateManager::get_location][crate::client::CertificateManager::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3563,7 +3563,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::list_operations][super::super::client::CertificateManager::list_operations] calls.
+    /// The request builder for [CertificateManager::list_operations][crate::client::CertificateManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3675,7 +3675,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::get_operation][super::super::client::CertificateManager::get_operation] calls.
+    /// The request builder for [CertificateManager::get_operation][crate::client::CertificateManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3739,7 +3739,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::delete_operation][super::super::client::CertificateManager::delete_operation] calls.
+    /// The request builder for [CertificateManager::delete_operation][crate::client::CertificateManager::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3803,7 +3803,7 @@ pub mod certificate_manager {
         }
     }
 
-    /// The request builder for [CertificateManager::cancel_operation][super::super::client::CertificateManager::cancel_operation] calls.
+    /// The request builder for [CertificateManager::cancel_operation][crate::client::CertificateManager::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/chronicle/v1/src/builder.rs
+++ b/src/generated/cloud/chronicle/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod data_access_control_service {
     use crate::Result;
 
-    /// A builder for [DataAccessControlService][super::super::client::DataAccessControlService].
+    /// A builder for [DataAccessControlService][crate::client::DataAccessControlService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataAccessControlService] request builders.
+    /// Common implementation for [crate::client::DataAccessControlService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataAccessControlService>,
@@ -68,7 +68,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::create_data_access_label][super::super::client::DataAccessControlService::create_data_access_label] calls.
+    /// The request builder for [DataAccessControlService::create_data_access_label][crate::client::DataAccessControlService::create_data_access_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -164,7 +164,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::get_data_access_label][super::super::client::DataAccessControlService::get_data_access_label] calls.
+    /// The request builder for [DataAccessControlService::get_data_access_label][crate::client::DataAccessControlService::get_data_access_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -230,7 +230,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::list_data_access_labels][super::super::client::DataAccessControlService::list_data_access_labels] calls.
+    /// The request builder for [DataAccessControlService::list_data_access_labels][crate::client::DataAccessControlService::list_data_access_labels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -344,7 +344,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::update_data_access_label][super::super::client::DataAccessControlService::update_data_access_label] calls.
+    /// The request builder for [DataAccessControlService::update_data_access_label][crate::client::DataAccessControlService::update_data_access_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -442,7 +442,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::delete_data_access_label][super::super::client::DataAccessControlService::delete_data_access_label] calls.
+    /// The request builder for [DataAccessControlService::delete_data_access_label][crate::client::DataAccessControlService::delete_data_access_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -508,7 +508,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::create_data_access_scope][super::super::client::DataAccessControlService::create_data_access_scope] calls.
+    /// The request builder for [DataAccessControlService::create_data_access_scope][crate::client::DataAccessControlService::create_data_access_scope] calls.
     ///
     /// # Example
     /// ```no_run
@@ -604,7 +604,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::get_data_access_scope][super::super::client::DataAccessControlService::get_data_access_scope] calls.
+    /// The request builder for [DataAccessControlService::get_data_access_scope][crate::client::DataAccessControlService::get_data_access_scope] calls.
     ///
     /// # Example
     /// ```no_run
@@ -670,7 +670,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::list_data_access_scopes][super::super::client::DataAccessControlService::list_data_access_scopes] calls.
+    /// The request builder for [DataAccessControlService::list_data_access_scopes][crate::client::DataAccessControlService::list_data_access_scopes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -784,7 +784,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::update_data_access_scope][super::super::client::DataAccessControlService::update_data_access_scope] calls.
+    /// The request builder for [DataAccessControlService::update_data_access_scope][crate::client::DataAccessControlService::update_data_access_scope] calls.
     ///
     /// # Example
     /// ```no_run
@@ -882,7 +882,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::delete_data_access_scope][super::super::client::DataAccessControlService::delete_data_access_scope] calls.
+    /// The request builder for [DataAccessControlService::delete_data_access_scope][crate::client::DataAccessControlService::delete_data_access_scope] calls.
     ///
     /// # Example
     /// ```no_run
@@ -948,7 +948,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::list_operations][super::super::client::DataAccessControlService::list_operations] calls.
+    /// The request builder for [DataAccessControlService::list_operations][crate::client::DataAccessControlService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1060,7 +1060,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::get_operation][super::super::client::DataAccessControlService::get_operation] calls.
+    /// The request builder for [DataAccessControlService::get_operation][crate::client::DataAccessControlService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1124,7 +1124,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::delete_operation][super::super::client::DataAccessControlService::delete_operation] calls.
+    /// The request builder for [DataAccessControlService::delete_operation][crate::client::DataAccessControlService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1188,7 +1188,7 @@ pub mod data_access_control_service {
         }
     }
 
-    /// The request builder for [DataAccessControlService::cancel_operation][super::super::client::DataAccessControlService::cancel_operation] calls.
+    /// The request builder for [DataAccessControlService::cancel_operation][crate::client::DataAccessControlService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1256,7 +1256,7 @@ pub mod data_access_control_service {
 pub mod entity_service {
     use crate::Result;
 
-    /// A builder for [EntityService][super::super::client::EntityService].
+    /// A builder for [EntityService][crate::client::EntityService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1284,7 +1284,7 @@ pub mod entity_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EntityService] request builders.
+    /// Common implementation for [crate::client::EntityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EntityService>,
@@ -1307,7 +1307,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::get_watchlist][super::super::client::EntityService::get_watchlist] calls.
+    /// The request builder for [EntityService::get_watchlist][crate::client::EntityService::get_watchlist] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1370,7 +1370,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::list_watchlists][super::super::client::EntityService::list_watchlists] calls.
+    /// The request builder for [EntityService::list_watchlists][crate::client::EntityService::list_watchlists] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1479,7 +1479,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::create_watchlist][super::super::client::EntityService::create_watchlist] calls.
+    /// The request builder for [EntityService::create_watchlist][crate::client::EntityService::create_watchlist] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1570,7 +1570,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::update_watchlist][super::super::client::EntityService::update_watchlist] calls.
+    /// The request builder for [EntityService::update_watchlist][crate::client::EntityService::update_watchlist] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1665,7 +1665,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::delete_watchlist][super::super::client::EntityService::delete_watchlist] calls.
+    /// The request builder for [EntityService::delete_watchlist][crate::client::EntityService::delete_watchlist] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1734,7 +1734,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::list_operations][super::super::client::EntityService::list_operations] calls.
+    /// The request builder for [EntityService::list_operations][crate::client::EntityService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1846,7 +1846,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::get_operation][super::super::client::EntityService::get_operation] calls.
+    /// The request builder for [EntityService::get_operation][crate::client::EntityService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1910,7 +1910,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::delete_operation][super::super::client::EntityService::delete_operation] calls.
+    /// The request builder for [EntityService::delete_operation][crate::client::EntityService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1974,7 +1974,7 @@ pub mod entity_service {
         }
     }
 
-    /// The request builder for [EntityService::cancel_operation][super::super::client::EntityService::cancel_operation] calls.
+    /// The request builder for [EntityService::cancel_operation][crate::client::EntityService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2042,7 +2042,7 @@ pub mod entity_service {
 pub mod instance_service {
     use crate::Result;
 
-    /// A builder for [InstanceService][super::super::client::InstanceService].
+    /// A builder for [InstanceService][crate::client::InstanceService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2070,7 +2070,7 @@ pub mod instance_service {
         }
     }
 
-    /// Common implementation for [super::super::client::InstanceService] request builders.
+    /// Common implementation for [crate::client::InstanceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::InstanceService>,
@@ -2093,7 +2093,7 @@ pub mod instance_service {
         }
     }
 
-    /// The request builder for [InstanceService::get_instance][super::super::client::InstanceService::get_instance] calls.
+    /// The request builder for [InstanceService::get_instance][crate::client::InstanceService::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2156,7 +2156,7 @@ pub mod instance_service {
         }
     }
 
-    /// The request builder for [InstanceService::list_operations][super::super::client::InstanceService::list_operations] calls.
+    /// The request builder for [InstanceService::list_operations][crate::client::InstanceService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2268,7 +2268,7 @@ pub mod instance_service {
         }
     }
 
-    /// The request builder for [InstanceService::get_operation][super::super::client::InstanceService::get_operation] calls.
+    /// The request builder for [InstanceService::get_operation][crate::client::InstanceService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2332,7 +2332,7 @@ pub mod instance_service {
         }
     }
 
-    /// The request builder for [InstanceService::delete_operation][super::super::client::InstanceService::delete_operation] calls.
+    /// The request builder for [InstanceService::delete_operation][crate::client::InstanceService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2396,7 +2396,7 @@ pub mod instance_service {
         }
     }
 
-    /// The request builder for [InstanceService::cancel_operation][super::super::client::InstanceService::cancel_operation] calls.
+    /// The request builder for [InstanceService::cancel_operation][crate::client::InstanceService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2464,7 +2464,7 @@ pub mod instance_service {
 pub mod reference_list_service {
     use crate::Result;
 
-    /// A builder for [ReferenceListService][super::super::client::ReferenceListService].
+    /// A builder for [ReferenceListService][crate::client::ReferenceListService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2492,7 +2492,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ReferenceListService] request builders.
+    /// Common implementation for [crate::client::ReferenceListService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ReferenceListService>,
@@ -2515,7 +2515,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::get_reference_list][super::super::client::ReferenceListService::get_reference_list] calls.
+    /// The request builder for [ReferenceListService::get_reference_list][crate::client::ReferenceListService::get_reference_list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2587,7 +2587,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::list_reference_lists][super::super::client::ReferenceListService::list_reference_lists] calls.
+    /// The request builder for [ReferenceListService::list_reference_lists][crate::client::ReferenceListService::list_reference_lists] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2701,7 +2701,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::create_reference_list][super::super::client::ReferenceListService::create_reference_list] calls.
+    /// The request builder for [ReferenceListService::create_reference_list][crate::client::ReferenceListService::create_reference_list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2797,7 +2797,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::update_reference_list][super::super::client::ReferenceListService::update_reference_list] calls.
+    /// The request builder for [ReferenceListService::update_reference_list][crate::client::ReferenceListService::update_reference_list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2895,7 +2895,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::list_operations][super::super::client::ReferenceListService::list_operations] calls.
+    /// The request builder for [ReferenceListService::list_operations][crate::client::ReferenceListService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3007,7 +3007,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::get_operation][super::super::client::ReferenceListService::get_operation] calls.
+    /// The request builder for [ReferenceListService::get_operation][crate::client::ReferenceListService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3071,7 +3071,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::delete_operation][super::super::client::ReferenceListService::delete_operation] calls.
+    /// The request builder for [ReferenceListService::delete_operation][crate::client::ReferenceListService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3135,7 +3135,7 @@ pub mod reference_list_service {
         }
     }
 
-    /// The request builder for [ReferenceListService::cancel_operation][super::super::client::ReferenceListService::cancel_operation] calls.
+    /// The request builder for [ReferenceListService::cancel_operation][crate::client::ReferenceListService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3203,7 +3203,7 @@ pub mod reference_list_service {
 pub mod rule_service {
     use crate::Result;
 
-    /// A builder for [RuleService][super::super::client::RuleService].
+    /// A builder for [RuleService][crate::client::RuleService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3231,7 +3231,7 @@ pub mod rule_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RuleService] request builders.
+    /// Common implementation for [crate::client::RuleService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RuleService>,
@@ -3254,7 +3254,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::create_rule][super::super::client::RuleService::create_rule] calls.
+    /// The request builder for [RuleService::create_rule][crate::client::RuleService::create_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3339,7 +3339,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::get_rule][super::super::client::RuleService::get_rule] calls.
+    /// The request builder for [RuleService::get_rule][crate::client::RuleService::get_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3408,7 +3408,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::list_rules][super::super::client::RuleService::list_rules] calls.
+    /// The request builder for [RuleService::list_rules][crate::client::RuleService::list_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3523,7 +3523,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::update_rule][super::super::client::RuleService::update_rule] calls.
+    /// The request builder for [RuleService::update_rule][crate::client::RuleService::update_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3618,7 +3618,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::delete_rule][super::super::client::RuleService::delete_rule] calls.
+    /// The request builder for [RuleService::delete_rule][crate::client::RuleService::delete_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3687,7 +3687,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::list_rule_revisions][super::super::client::RuleService::list_rule_revisions] calls.
+    /// The request builder for [RuleService::list_rule_revisions][crate::client::RuleService::list_rule_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3799,7 +3799,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::create_retrohunt][super::super::client::RuleService::create_retrohunt] calls.
+    /// The request builder for [RuleService::create_retrohunt][crate::client::RuleService::create_retrohunt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3844,7 +3844,7 @@ pub mod rule_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_retrohunt][super::super::client::RuleService::create_retrohunt].
+        /// on [create_retrohunt][crate::client::RuleService::create_retrohunt].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_retrohunt(self.0.request, self.0.options)
@@ -3923,7 +3923,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::get_retrohunt][super::super::client::RuleService::get_retrohunt] calls.
+    /// The request builder for [RuleService::get_retrohunt][crate::client::RuleService::get_retrohunt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3986,7 +3986,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::list_retrohunts][super::super::client::RuleService::list_retrohunts] calls.
+    /// The request builder for [RuleService::list_retrohunts][crate::client::RuleService::list_retrohunts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4095,7 +4095,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::get_rule_deployment][super::super::client::RuleService::get_rule_deployment] calls.
+    /// The request builder for [RuleService::get_rule_deployment][crate::client::RuleService::get_rule_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4161,7 +4161,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::list_rule_deployments][super::super::client::RuleService::list_rule_deployments] calls.
+    /// The request builder for [RuleService::list_rule_deployments][crate::client::RuleService::list_rule_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4275,7 +4275,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::update_rule_deployment][super::super::client::RuleService::update_rule_deployment] calls.
+    /// The request builder for [RuleService::update_rule_deployment][crate::client::RuleService::update_rule_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4377,7 +4377,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::list_operations][super::super::client::RuleService::list_operations] calls.
+    /// The request builder for [RuleService::list_operations][crate::client::RuleService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4489,7 +4489,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::get_operation][super::super::client::RuleService::get_operation] calls.
+    /// The request builder for [RuleService::get_operation][crate::client::RuleService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4553,7 +4553,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::delete_operation][super::super::client::RuleService::delete_operation] calls.
+    /// The request builder for [RuleService::delete_operation][crate::client::RuleService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4617,7 +4617,7 @@ pub mod rule_service {
         }
     }
 
-    /// The request builder for [RuleService::cancel_operation][super::super::client::RuleService::cancel_operation] calls.
+    /// The request builder for [RuleService::cancel_operation][crate::client::RuleService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
+++ b/src/generated/cloud/cloudcontrolspartner/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_controls_partner_core {
     use crate::Result;
 
-    /// A builder for [CloudControlsPartnerCore][super::super::client::CloudControlsPartnerCore].
+    /// A builder for [CloudControlsPartnerCore][crate::client::CloudControlsPartnerCore].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudControlsPartnerCore] request builders.
+    /// Common implementation for [crate::client::CloudControlsPartnerCore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudControlsPartnerCore>,
@@ -68,7 +68,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::get_workload][super::super::client::CloudControlsPartnerCore::get_workload] calls.
+    /// The request builder for [CloudControlsPartnerCore::get_workload][crate::client::CloudControlsPartnerCore::get_workload] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::list_workloads][super::super::client::CloudControlsPartnerCore::list_workloads] calls.
+    /// The request builder for [CloudControlsPartnerCore::list_workloads][crate::client::CloudControlsPartnerCore::list_workloads] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::get_customer][super::super::client::CloudControlsPartnerCore::get_customer] calls.
+    /// The request builder for [CloudControlsPartnerCore::get_customer][crate::client::CloudControlsPartnerCore::get_customer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -309,7 +309,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::list_customers][super::super::client::CloudControlsPartnerCore::list_customers] calls.
+    /// The request builder for [CloudControlsPartnerCore::list_customers][crate::client::CloudControlsPartnerCore::list_customers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -424,7 +424,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::get_ekm_connections][super::super::client::CloudControlsPartnerCore::get_ekm_connections] calls.
+    /// The request builder for [CloudControlsPartnerCore::get_ekm_connections][crate::client::CloudControlsPartnerCore::get_ekm_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -490,7 +490,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::get_partner_permissions][super::super::client::CloudControlsPartnerCore::get_partner_permissions] calls.
+    /// The request builder for [CloudControlsPartnerCore::get_partner_permissions][crate::client::CloudControlsPartnerCore::get_partner_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -556,7 +556,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::list_access_approval_requests][super::super::client::CloudControlsPartnerCore::list_access_approval_requests] calls.
+    /// The request builder for [CloudControlsPartnerCore::list_access_approval_requests][crate::client::CloudControlsPartnerCore::list_access_approval_requests] calls.
     ///
     /// # Example
     /// ```no_run
@@ -680,7 +680,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::get_partner][super::super::client::CloudControlsPartnerCore::get_partner] calls.
+    /// The request builder for [CloudControlsPartnerCore::get_partner][crate::client::CloudControlsPartnerCore::get_partner] calls.
     ///
     /// # Example
     /// ```no_run
@@ -743,7 +743,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::create_customer][super::super::client::CloudControlsPartnerCore::create_customer] calls.
+    /// The request builder for [CloudControlsPartnerCore::create_customer][crate::client::CloudControlsPartnerCore::create_customer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -836,7 +836,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::update_customer][super::super::client::CloudControlsPartnerCore::update_customer] calls.
+    /// The request builder for [CloudControlsPartnerCore::update_customer][crate::client::CloudControlsPartnerCore::update_customer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -931,7 +931,7 @@ pub mod cloud_controls_partner_core {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerCore::delete_customer][super::super::client::CloudControlsPartnerCore::delete_customer] calls.
+    /// The request builder for [CloudControlsPartnerCore::delete_customer][crate::client::CloudControlsPartnerCore::delete_customer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -998,7 +998,7 @@ pub mod cloud_controls_partner_core {
 pub mod cloud_controls_partner_monitoring {
     use crate::Result;
 
-    /// A builder for [CloudControlsPartnerMonitoring][super::super::client::CloudControlsPartnerMonitoring].
+    /// A builder for [CloudControlsPartnerMonitoring][crate::client::CloudControlsPartnerMonitoring].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1026,7 +1026,7 @@ pub mod cloud_controls_partner_monitoring {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudControlsPartnerMonitoring] request builders.
+    /// Common implementation for [crate::client::CloudControlsPartnerMonitoring] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudControlsPartnerMonitoring>,
@@ -1049,7 +1049,7 @@ pub mod cloud_controls_partner_monitoring {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerMonitoring::list_violations][super::super::client::CloudControlsPartnerMonitoring::list_violations] calls.
+    /// The request builder for [CloudControlsPartnerMonitoring::list_violations][crate::client::CloudControlsPartnerMonitoring::list_violations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1182,7 +1182,7 @@ pub mod cloud_controls_partner_monitoring {
         }
     }
 
-    /// The request builder for [CloudControlsPartnerMonitoring::get_violation][super::super::client::CloudControlsPartnerMonitoring::get_violation] calls.
+    /// The request builder for [CloudControlsPartnerMonitoring::get_violation][crate::client::CloudControlsPartnerMonitoring::get_violation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/clouddms/v1/src/builder.rs
+++ b/src/generated/cloud/clouddms/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod data_migration_service {
     use crate::Result;
 
-    /// A builder for [DataMigrationService][super::super::client::DataMigrationService].
+    /// A builder for [DataMigrationService][crate::client::DataMigrationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataMigrationService] request builders.
+    /// Common implementation for [crate::client::DataMigrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataMigrationService>,
@@ -68,7 +68,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::list_migration_jobs][super::super::client::DataMigrationService::list_migration_jobs] calls.
+    /// The request builder for [DataMigrationService::list_migration_jobs][crate::client::DataMigrationService::list_migration_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_migration_job][super::super::client::DataMigrationService::get_migration_job] calls.
+    /// The request builder for [DataMigrationService::get_migration_job][crate::client::DataMigrationService::get_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -249,7 +249,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::create_migration_job][super::super::client::DataMigrationService::create_migration_job] calls.
+    /// The request builder for [DataMigrationService::create_migration_job][crate::client::DataMigrationService::create_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_migration_job][super::super::client::DataMigrationService::create_migration_job].
+        /// on [create_migration_job][crate::client::DataMigrationService::create_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_migration_job(self.0.request, self.0.options)
@@ -392,7 +392,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::update_migration_job][super::super::client::DataMigrationService::update_migration_job] calls.
+    /// The request builder for [DataMigrationService::update_migration_job][crate::client::DataMigrationService::update_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -440,7 +440,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_migration_job][super::super::client::DataMigrationService::update_migration_job].
+        /// on [update_migration_job][crate::client::DataMigrationService::update_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_migration_job(self.0.request, self.0.options)
@@ -541,7 +541,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::delete_migration_job][super::super::client::DataMigrationService::delete_migration_job] calls.
+    /// The request builder for [DataMigrationService::delete_migration_job][crate::client::DataMigrationService::delete_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -589,7 +589,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_migration_job][super::super::client::DataMigrationService::delete_migration_job].
+        /// on [delete_migration_job][crate::client::DataMigrationService::delete_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_migration_job(self.0.request, self.0.options)
@@ -660,7 +660,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::start_migration_job][super::super::client::DataMigrationService::start_migration_job] calls.
+    /// The request builder for [DataMigrationService::start_migration_job][crate::client::DataMigrationService::start_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -708,7 +708,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_migration_job][super::super::client::DataMigrationService::start_migration_job].
+        /// on [start_migration_job][crate::client::DataMigrationService::start_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_migration_job(self.0.request, self.0.options)
@@ -771,7 +771,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::stop_migration_job][super::super::client::DataMigrationService::stop_migration_job] calls.
+    /// The request builder for [DataMigrationService::stop_migration_job][crate::client::DataMigrationService::stop_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -819,7 +819,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_migration_job][super::super::client::DataMigrationService::stop_migration_job].
+        /// on [stop_migration_job][crate::client::DataMigrationService::stop_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_migration_job(self.0.request, self.0.options)
@@ -876,7 +876,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::resume_migration_job][super::super::client::DataMigrationService::resume_migration_job] calls.
+    /// The request builder for [DataMigrationService::resume_migration_job][crate::client::DataMigrationService::resume_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -924,7 +924,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [resume_migration_job][super::super::client::DataMigrationService::resume_migration_job].
+        /// on [resume_migration_job][crate::client::DataMigrationService::resume_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .resume_migration_job(self.0.request, self.0.options)
@@ -981,7 +981,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::promote_migration_job][super::super::client::DataMigrationService::promote_migration_job] calls.
+    /// The request builder for [DataMigrationService::promote_migration_job][crate::client::DataMigrationService::promote_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1029,7 +1029,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [promote_migration_job][super::super::client::DataMigrationService::promote_migration_job].
+        /// on [promote_migration_job][crate::client::DataMigrationService::promote_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .promote_migration_job(self.0.request, self.0.options)
@@ -1086,7 +1086,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::verify_migration_job][super::super::client::DataMigrationService::verify_migration_job] calls.
+    /// The request builder for [DataMigrationService::verify_migration_job][crate::client::DataMigrationService::verify_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1134,7 +1134,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [verify_migration_job][super::super::client::DataMigrationService::verify_migration_job].
+        /// on [verify_migration_job][crate::client::DataMigrationService::verify_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .verify_migration_job(self.0.request, self.0.options)
@@ -1227,7 +1227,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::restart_migration_job][super::super::client::DataMigrationService::restart_migration_job] calls.
+    /// The request builder for [DataMigrationService::restart_migration_job][crate::client::DataMigrationService::restart_migration_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1275,7 +1275,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restart_migration_job][super::super::client::DataMigrationService::restart_migration_job].
+        /// on [restart_migration_job][crate::client::DataMigrationService::restart_migration_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restart_migration_job(self.0.request, self.0.options)
@@ -1338,7 +1338,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::generate_ssh_script][super::super::client::DataMigrationService::generate_ssh_script] calls.
+    /// The request builder for [DataMigrationService::generate_ssh_script][crate::client::DataMigrationService::generate_ssh_script] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1460,7 +1460,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::generate_tcp_proxy_script][super::super::client::DataMigrationService::generate_tcp_proxy_script] calls.
+    /// The request builder for [DataMigrationService::generate_tcp_proxy_script][crate::client::DataMigrationService::generate_tcp_proxy_script] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1554,7 +1554,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::list_connection_profiles][super::super::client::DataMigrationService::list_connection_profiles] calls.
+    /// The request builder for [DataMigrationService::list_connection_profiles][crate::client::DataMigrationService::list_connection_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1676,7 +1676,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_connection_profile][super::super::client::DataMigrationService::get_connection_profile] calls.
+    /// The request builder for [DataMigrationService::get_connection_profile][crate::client::DataMigrationService::get_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1742,7 +1742,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::create_connection_profile][super::super::client::DataMigrationService::create_connection_profile] calls.
+    /// The request builder for [DataMigrationService::create_connection_profile][crate::client::DataMigrationService::create_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1792,7 +1792,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_connection_profile][super::super::client::DataMigrationService::create_connection_profile].
+        /// on [create_connection_profile][crate::client::DataMigrationService::create_connection_profile].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_connection_profile(self.0.request, self.0.options)
@@ -1900,7 +1900,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::update_connection_profile][super::super::client::DataMigrationService::update_connection_profile] calls.
+    /// The request builder for [DataMigrationService::update_connection_profile][crate::client::DataMigrationService::update_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1950,7 +1950,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_connection_profile][super::super::client::DataMigrationService::update_connection_profile].
+        /// on [update_connection_profile][crate::client::DataMigrationService::update_connection_profile].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_connection_profile(self.0.request, self.0.options)
@@ -2064,7 +2064,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::delete_connection_profile][super::super::client::DataMigrationService::delete_connection_profile] calls.
+    /// The request builder for [DataMigrationService::delete_connection_profile][crate::client::DataMigrationService::delete_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2114,7 +2114,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_connection_profile][super::super::client::DataMigrationService::delete_connection_profile].
+        /// on [delete_connection_profile][crate::client::DataMigrationService::delete_connection_profile].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_connection_profile(self.0.request, self.0.options)
@@ -2185,7 +2185,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::create_private_connection][super::super::client::DataMigrationService::create_private_connection] calls.
+    /// The request builder for [DataMigrationService::create_private_connection][crate::client::DataMigrationService::create_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2235,7 +2235,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_private_connection][super::super::client::DataMigrationService::create_private_connection].
+        /// on [create_private_connection][crate::client::DataMigrationService::create_private_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_private_connection(self.0.request, self.0.options)
@@ -2337,7 +2337,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_private_connection][super::super::client::DataMigrationService::get_private_connection] calls.
+    /// The request builder for [DataMigrationService::get_private_connection][crate::client::DataMigrationService::get_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2403,7 +2403,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::list_private_connections][super::super::client::DataMigrationService::list_private_connections] calls.
+    /// The request builder for [DataMigrationService::list_private_connections][crate::client::DataMigrationService::list_private_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2525,7 +2525,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::delete_private_connection][super::super::client::DataMigrationService::delete_private_connection] calls.
+    /// The request builder for [DataMigrationService::delete_private_connection][crate::client::DataMigrationService::delete_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2575,7 +2575,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_private_connection][super::super::client::DataMigrationService::delete_private_connection].
+        /// on [delete_private_connection][crate::client::DataMigrationService::delete_private_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_private_connection(self.0.request, self.0.options)
@@ -2640,7 +2640,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_conversion_workspace][super::super::client::DataMigrationService::get_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::get_conversion_workspace][crate::client::DataMigrationService::get_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2706,7 +2706,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::list_conversion_workspaces][super::super::client::DataMigrationService::list_conversion_workspaces] calls.
+    /// The request builder for [DataMigrationService::list_conversion_workspaces][crate::client::DataMigrationService::list_conversion_workspaces] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2824,7 +2824,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::create_conversion_workspace][super::super::client::DataMigrationService::create_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::create_conversion_workspace][crate::client::DataMigrationService::create_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2874,7 +2874,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_conversion_workspace][super::super::client::DataMigrationService::create_conversion_workspace].
+        /// on [create_conversion_workspace][crate::client::DataMigrationService::create_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_conversion_workspace(self.0.request, self.0.options)
@@ -2970,7 +2970,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::update_conversion_workspace][super::super::client::DataMigrationService::update_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::update_conversion_workspace][crate::client::DataMigrationService::update_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3020,7 +3020,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_conversion_workspace][super::super::client::DataMigrationService::update_conversion_workspace].
+        /// on [update_conversion_workspace][crate::client::DataMigrationService::update_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_conversion_workspace(self.0.request, self.0.options)
@@ -3122,7 +3122,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::delete_conversion_workspace][super::super::client::DataMigrationService::delete_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::delete_conversion_workspace][crate::client::DataMigrationService::delete_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3172,7 +3172,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_conversion_workspace][super::super::client::DataMigrationService::delete_conversion_workspace].
+        /// on [delete_conversion_workspace][crate::client::DataMigrationService::delete_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_conversion_workspace(self.0.request, self.0.options)
@@ -3243,7 +3243,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::create_mapping_rule][super::super::client::DataMigrationService::create_mapping_rule] calls.
+    /// The request builder for [DataMigrationService::create_mapping_rule][crate::client::DataMigrationService::create_mapping_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3345,7 +3345,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::delete_mapping_rule][super::super::client::DataMigrationService::delete_mapping_rule] calls.
+    /// The request builder for [DataMigrationService::delete_mapping_rule][crate::client::DataMigrationService::delete_mapping_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3417,7 +3417,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::list_mapping_rules][super::super::client::DataMigrationService::list_mapping_rules] calls.
+    /// The request builder for [DataMigrationService::list_mapping_rules][crate::client::DataMigrationService::list_mapping_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3523,7 +3523,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_mapping_rule][super::super::client::DataMigrationService::get_mapping_rule] calls.
+    /// The request builder for [DataMigrationService::get_mapping_rule][crate::client::DataMigrationService::get_mapping_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3586,7 +3586,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::seed_conversion_workspace][super::super::client::DataMigrationService::seed_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::seed_conversion_workspace][crate::client::DataMigrationService::seed_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3636,7 +3636,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [seed_conversion_workspace][super::super::client::DataMigrationService::seed_conversion_workspace].
+        /// on [seed_conversion_workspace][crate::client::DataMigrationService::seed_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .seed_conversion_workspace(self.0.request, self.0.options)
@@ -3740,7 +3740,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::import_mapping_rules][super::super::client::DataMigrationService::import_mapping_rules] calls.
+    /// The request builder for [DataMigrationService::import_mapping_rules][crate::client::DataMigrationService::import_mapping_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3788,7 +3788,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_mapping_rules][super::super::client::DataMigrationService::import_mapping_rules].
+        /// on [import_mapping_rules][crate::client::DataMigrationService::import_mapping_rules].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_mapping_rules(self.0.request, self.0.options)
@@ -3880,7 +3880,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::convert_conversion_workspace][super::super::client::DataMigrationService::convert_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::convert_conversion_workspace][crate::client::DataMigrationService::convert_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3930,7 +3930,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [convert_conversion_workspace][super::super::client::DataMigrationService::convert_conversion_workspace].
+        /// on [convert_conversion_workspace][crate::client::DataMigrationService::convert_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .convert_conversion_workspace(self.0.request, self.0.options)
@@ -4006,7 +4006,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::commit_conversion_workspace][super::super::client::DataMigrationService::commit_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::commit_conversion_workspace][crate::client::DataMigrationService::commit_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4056,7 +4056,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [commit_conversion_workspace][super::super::client::DataMigrationService::commit_conversion_workspace].
+        /// on [commit_conversion_workspace][crate::client::DataMigrationService::commit_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .commit_conversion_workspace(self.0.request, self.0.options)
@@ -4122,7 +4122,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::rollback_conversion_workspace][super::super::client::DataMigrationService::rollback_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::rollback_conversion_workspace][crate::client::DataMigrationService::rollback_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4172,7 +4172,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [rollback_conversion_workspace][super::super::client::DataMigrationService::rollback_conversion_workspace].
+        /// on [rollback_conversion_workspace][crate::client::DataMigrationService::rollback_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .rollback_conversion_workspace(self.0.request, self.0.options)
@@ -4232,7 +4232,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::apply_conversion_workspace][super::super::client::DataMigrationService::apply_conversion_workspace] calls.
+    /// The request builder for [DataMigrationService::apply_conversion_workspace][crate::client::DataMigrationService::apply_conversion_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4282,7 +4282,7 @@ pub mod data_migration_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [apply_conversion_workspace][super::super::client::DataMigrationService::apply_conversion_workspace].
+        /// on [apply_conversion_workspace][crate::client::DataMigrationService::apply_conversion_workspace].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .apply_conversion_workspace(self.0.request, self.0.options)
@@ -4387,7 +4387,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::describe_database_entities][super::super::client::DataMigrationService::describe_database_entities] calls.
+    /// The request builder for [DataMigrationService::describe_database_entities][crate::client::DataMigrationService::describe_database_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4534,7 +4534,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::search_background_jobs][super::super::client::DataMigrationService::search_background_jobs] calls.
+    /// The request builder for [DataMigrationService::search_background_jobs][crate::client::DataMigrationService::search_background_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4630,7 +4630,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::describe_conversion_workspace_revisions][super::super::client::DataMigrationService::describe_conversion_workspace_revisions] calls.
+    /// The request builder for [DataMigrationService::describe_conversion_workspace_revisions][crate::client::DataMigrationService::describe_conversion_workspace_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4706,7 +4706,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::fetch_static_ips][super::super::client::DataMigrationService::fetch_static_ips] calls.
+    /// The request builder for [DataMigrationService::fetch_static_ips][crate::client::DataMigrationService::fetch_static_ips] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4781,7 +4781,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::list_locations][super::super::client::DataMigrationService::list_locations] calls.
+    /// The request builder for [DataMigrationService::list_locations][crate::client::DataMigrationService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4891,7 +4891,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_location][super::super::client::DataMigrationService::get_location] calls.
+    /// The request builder for [DataMigrationService::get_location][crate::client::DataMigrationService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4952,7 +4952,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::set_iam_policy][super::super::client::DataMigrationService::set_iam_policy] calls.
+    /// The request builder for [DataMigrationService::set_iam_policy][crate::client::DataMigrationService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5055,7 +5055,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_iam_policy][super::super::client::DataMigrationService::get_iam_policy] calls.
+    /// The request builder for [DataMigrationService::get_iam_policy][crate::client::DataMigrationService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5136,7 +5136,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::test_iam_permissions][super::super::client::DataMigrationService::test_iam_permissions] calls.
+    /// The request builder for [DataMigrationService::test_iam_permissions][crate::client::DataMigrationService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5215,7 +5215,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::list_operations][super::super::client::DataMigrationService::list_operations] calls.
+    /// The request builder for [DataMigrationService::list_operations][crate::client::DataMigrationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5327,7 +5327,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::get_operation][super::super::client::DataMigrationService::get_operation] calls.
+    /// The request builder for [DataMigrationService::get_operation][crate::client::DataMigrationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5391,7 +5391,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::delete_operation][super::super::client::DataMigrationService::delete_operation] calls.
+    /// The request builder for [DataMigrationService::delete_operation][crate::client::DataMigrationService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5455,7 +5455,7 @@ pub mod data_migration_service {
         }
     }
 
-    /// The request builder for [DataMigrationService::cancel_operation][super::super::client::DataMigrationService::cancel_operation] calls.
+    /// The request builder for [DataMigrationService::cancel_operation][crate::client::DataMigrationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
+++ b/src/generated/cloud/commerce/consumer/procurement/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod license_management_service {
     use crate::Result;
 
-    /// A builder for [LicenseManagementService][super::super::client::LicenseManagementService].
+    /// A builder for [LicenseManagementService][crate::client::LicenseManagementService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod license_management_service {
         }
     }
 
-    /// Common implementation for [super::super::client::LicenseManagementService] request builders.
+    /// Common implementation for [crate::client::LicenseManagementService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LicenseManagementService>,
@@ -68,7 +68,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for [LicenseManagementService::get_license_pool][super::super::client::LicenseManagementService::get_license_pool] calls.
+    /// The request builder for [LicenseManagementService::get_license_pool][crate::client::LicenseManagementService::get_license_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for [LicenseManagementService::update_license_pool][super::super::client::LicenseManagementService::update_license_pool] calls.
+    /// The request builder for [LicenseManagementService::update_license_pool][crate::client::LicenseManagementService::update_license_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -233,7 +233,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for [LicenseManagementService::assign][super::super::client::LicenseManagementService::assign] calls.
+    /// The request builder for [LicenseManagementService::assign][crate::client::LicenseManagementService::assign] calls.
     ///
     /// # Example
     /// ```no_run
@@ -309,7 +309,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for [LicenseManagementService::unassign][super::super::client::LicenseManagementService::unassign] calls.
+    /// The request builder for [LicenseManagementService::unassign][crate::client::LicenseManagementService::unassign] calls.
     ///
     /// # Example
     /// ```no_run
@@ -385,7 +385,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for [LicenseManagementService::enumerate_licensed_users][super::super::client::LicenseManagementService::enumerate_licensed_users] calls.
+    /// The request builder for [LicenseManagementService::enumerate_licensed_users][crate::client::LicenseManagementService::enumerate_licensed_users] calls.
     ///
     /// # Example
     /// ```no_run
@@ -495,7 +495,7 @@ pub mod license_management_service {
         }
     }
 
-    /// The request builder for [LicenseManagementService::get_operation][super::super::client::LicenseManagementService::get_operation] calls.
+    /// The request builder for [LicenseManagementService::get_operation][crate::client::LicenseManagementService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -563,7 +563,7 @@ pub mod license_management_service {
 pub mod consumer_procurement_service {
     use crate::Result;
 
-    /// A builder for [ConsumerProcurementService][super::super::client::ConsumerProcurementService].
+    /// A builder for [ConsumerProcurementService][crate::client::ConsumerProcurementService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -591,7 +591,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ConsumerProcurementService] request builders.
+    /// Common implementation for [crate::client::ConsumerProcurementService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConsumerProcurementService>,
@@ -614,7 +614,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for [ConsumerProcurementService::place_order][super::super::client::ConsumerProcurementService::place_order] calls.
+    /// The request builder for [ConsumerProcurementService::place_order][crate::client::ConsumerProcurementService::place_order] calls.
     ///
     /// # Example
     /// ```no_run
@@ -659,7 +659,7 @@ pub mod consumer_procurement_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [place_order][super::super::client::ConsumerProcurementService::place_order].
+        /// on [place_order][crate::client::ConsumerProcurementService::place_order].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .place_order(self.0.request, self.0.options)
@@ -741,7 +741,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for [ConsumerProcurementService::get_order][super::super::client::ConsumerProcurementService::get_order] calls.
+    /// The request builder for [ConsumerProcurementService::get_order][crate::client::ConsumerProcurementService::get_order] calls.
     ///
     /// # Example
     /// ```no_run
@@ -804,7 +804,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for [ConsumerProcurementService::list_orders][super::super::client::ConsumerProcurementService::list_orders] calls.
+    /// The request builder for [ConsumerProcurementService::list_orders][crate::client::ConsumerProcurementService::list_orders] calls.
     ///
     /// # Example
     /// ```no_run
@@ -913,7 +913,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for [ConsumerProcurementService::modify_order][super::super::client::ConsumerProcurementService::modify_order] calls.
+    /// The request builder for [ConsumerProcurementService::modify_order][crate::client::ConsumerProcurementService::modify_order] calls.
     ///
     /// # Example
     /// ```no_run
@@ -958,7 +958,7 @@ pub mod consumer_procurement_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [modify_order][super::super::client::ConsumerProcurementService::modify_order].
+        /// on [modify_order][crate::client::ConsumerProcurementService::modify_order].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .modify_order(self.0.request, self.0.options)
@@ -1038,7 +1038,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for [ConsumerProcurementService::cancel_order][super::super::client::ConsumerProcurementService::cancel_order] calls.
+    /// The request builder for [ConsumerProcurementService::cancel_order][crate::client::ConsumerProcurementService::cancel_order] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1083,7 +1083,7 @@ pub mod consumer_procurement_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [cancel_order][super::super::client::ConsumerProcurementService::cancel_order].
+        /// on [cancel_order][crate::client::ConsumerProcurementService::cancel_order].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .cancel_order(self.0.request, self.0.options)
@@ -1157,7 +1157,7 @@ pub mod consumer_procurement_service {
         }
     }
 
-    /// The request builder for [ConsumerProcurementService::get_operation][super::super::client::ConsumerProcurementService::get_operation] calls.
+    /// The request builder for [ConsumerProcurementService::get_operation][crate::client::ConsumerProcurementService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
+++ b/src/generated/cloud/confidentialcomputing/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod confidential_computing {
     use crate::Result;
 
-    /// A builder for [ConfidentialComputing][super::super::client::ConfidentialComputing].
+    /// A builder for [ConfidentialComputing][crate::client::ConfidentialComputing].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// Common implementation for [super::super::client::ConfidentialComputing] request builders.
+    /// Common implementation for [crate::client::ConfidentialComputing] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConfidentialComputing>,
@@ -68,7 +68,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for [ConfidentialComputing::create_challenge][super::super::client::ConfidentialComputing::create_challenge] calls.
+    /// The request builder for [ConfidentialComputing::create_challenge][crate::client::ConfidentialComputing::create_challenge] calls.
     ///
     /// # Example
     /// ```no_run
@@ -153,7 +153,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for [ConfidentialComputing::verify_attestation][super::super::client::ConfidentialComputing::verify_attestation] calls.
+    /// The request builder for [ConfidentialComputing::verify_attestation][crate::client::ConfidentialComputing::verify_attestation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -345,7 +345,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for [ConfidentialComputing::list_locations][super::super::client::ConfidentialComputing::list_locations] calls.
+    /// The request builder for [ConfidentialComputing::list_locations][crate::client::ConfidentialComputing::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -455,7 +455,7 @@ pub mod confidential_computing {
         }
     }
 
-    /// The request builder for [ConfidentialComputing::get_location][super::super::client::ConfidentialComputing::get_location] calls.
+    /// The request builder for [ConfidentialComputing::get_location][crate::client::ConfidentialComputing::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/config/v1/src/builder.rs
+++ b/src/generated/cloud/config/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod config {
     use crate::Result;
 
-    /// A builder for [Config][super::super::client::Config].
+    /// A builder for [Config][crate::client::Config].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod config {
         }
     }
 
-    /// Common implementation for [super::super::client::Config] request builders.
+    /// Common implementation for [crate::client::Config] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Config>,
@@ -66,7 +66,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::list_deployments][super::super::client::Config::list_deployments] calls.
+    /// The request builder for [Config::list_deployments][crate::client::Config::list_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -179,7 +179,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_deployment][super::super::client::Config::get_deployment] calls.
+    /// The request builder for [Config::get_deployment][crate::client::Config::get_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::create_deployment][super::super::client::Config::create_deployment] calls.
+    /// The request builder for [Config::create_deployment][crate::client::Config::create_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -286,7 +286,7 @@ pub mod config {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_deployment][super::super::client::Config::create_deployment].
+        /// on [create_deployment][crate::client::Config::create_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_deployment(self.0.request, self.0.options)
@@ -379,7 +379,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::update_deployment][super::super::client::Config::update_deployment] calls.
+    /// The request builder for [Config::update_deployment][crate::client::Config::update_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -425,7 +425,7 @@ pub mod config {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_deployment][super::super::client::Config::update_deployment].
+        /// on [update_deployment][crate::client::Config::update_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_deployment(self.0.request, self.0.options)
@@ -520,7 +520,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::delete_deployment][super::super::client::Config::delete_deployment] calls.
+    /// The request builder for [Config::delete_deployment][crate::client::Config::delete_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -566,7 +566,7 @@ pub mod config {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_deployment][super::super::client::Config::delete_deployment].
+        /// on [delete_deployment][crate::client::Config::delete_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_deployment(self.0.request, self.0.options)
@@ -644,7 +644,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::list_revisions][super::super::client::Config::list_revisions] calls.
+    /// The request builder for [Config::list_revisions][crate::client::Config::list_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -757,7 +757,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_revision][super::super::client::Config::get_revision] calls.
+    /// The request builder for [Config::get_revision][crate::client::Config::get_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -818,7 +818,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_resource][super::super::client::Config::get_resource] calls.
+    /// The request builder for [Config::get_resource][crate::client::Config::get_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -879,7 +879,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::list_resources][super::super::client::Config::list_resources] calls.
+    /// The request builder for [Config::list_resources][crate::client::Config::list_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -992,7 +992,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::export_deployment_statefile][super::super::client::Config::export_deployment_statefile] calls.
+    /// The request builder for [Config::export_deployment_statefile][crate::client::Config::export_deployment_statefile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1064,7 +1064,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::export_revision_statefile][super::super::client::Config::export_revision_statefile] calls.
+    /// The request builder for [Config::export_revision_statefile][crate::client::Config::export_revision_statefile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1130,7 +1130,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::import_statefile][super::super::client::Config::import_statefile] calls.
+    /// The request builder for [Config::import_statefile][crate::client::Config::import_statefile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1205,7 +1205,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::delete_statefile][super::super::client::Config::delete_statefile] calls.
+    /// The request builder for [Config::delete_statefile][crate::client::Config::delete_statefile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1274,7 +1274,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::lock_deployment][super::super::client::Config::lock_deployment] calls.
+    /// The request builder for [Config::lock_deployment][crate::client::Config::lock_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1317,7 +1317,7 @@ pub mod config {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [lock_deployment][super::super::client::Config::lock_deployment].
+        /// on [lock_deployment][crate::client::Config::lock_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .lock_deployment(self.0.request, self.0.options)
@@ -1374,7 +1374,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::unlock_deployment][super::super::client::Config::unlock_deployment] calls.
+    /// The request builder for [Config::unlock_deployment][crate::client::Config::unlock_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1420,7 +1420,7 @@ pub mod config {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [unlock_deployment][super::super::client::Config::unlock_deployment].
+        /// on [unlock_deployment][crate::client::Config::unlock_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .unlock_deployment(self.0.request, self.0.options)
@@ -1485,7 +1485,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::export_lock_info][super::super::client::Config::export_lock_info] calls.
+    /// The request builder for [Config::export_lock_info][crate::client::Config::export_lock_info] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1546,7 +1546,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::create_preview][super::super::client::Config::create_preview] calls.
+    /// The request builder for [Config::create_preview][crate::client::Config::create_preview] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1589,7 +1589,7 @@ pub mod config {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_preview][super::super::client::Config::create_preview].
+        /// on [create_preview][crate::client::Config::create_preview].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_preview(self.0.request, self.0.options)
@@ -1680,7 +1680,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_preview][super::super::client::Config::get_preview] calls.
+    /// The request builder for [Config::get_preview][crate::client::Config::get_preview] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1741,7 +1741,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::list_previews][super::super::client::Config::list_previews] calls.
+    /// The request builder for [Config::list_previews][crate::client::Config::list_previews] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1854,7 +1854,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::delete_preview][super::super::client::Config::delete_preview] calls.
+    /// The request builder for [Config::delete_preview][crate::client::Config::delete_preview] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1897,7 +1897,7 @@ pub mod config {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_preview][super::super::client::Config::delete_preview].
+        /// on [delete_preview][crate::client::Config::delete_preview].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_preview(self.0.request, self.0.options)
@@ -1960,7 +1960,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::export_preview_result][super::super::client::Config::export_preview_result] calls.
+    /// The request builder for [Config::export_preview_result][crate::client::Config::export_preview_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2024,7 +2024,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::list_terraform_versions][super::super::client::Config::list_terraform_versions] calls.
+    /// The request builder for [Config::list_terraform_versions][crate::client::Config::list_terraform_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2142,7 +2142,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_terraform_version][super::super::client::Config::get_terraform_version] calls.
+    /// The request builder for [Config::get_terraform_version][crate::client::Config::get_terraform_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2206,7 +2206,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::list_locations][super::super::client::Config::list_locations] calls.
+    /// The request builder for [Config::list_locations][crate::client::Config::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2314,7 +2314,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_location][super::super::client::Config::get_location] calls.
+    /// The request builder for [Config::get_location][crate::client::Config::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2373,7 +2373,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::set_iam_policy][super::super::client::Config::set_iam_policy] calls.
+    /// The request builder for [Config::set_iam_policy][crate::client::Config::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2474,7 +2474,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_iam_policy][super::super::client::Config::get_iam_policy] calls.
+    /// The request builder for [Config::get_iam_policy][crate::client::Config::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2553,7 +2553,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::test_iam_permissions][super::super::client::Config::test_iam_permissions] calls.
+    /// The request builder for [Config::test_iam_permissions][crate::client::Config::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2630,7 +2630,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::list_operations][super::super::client::Config::list_operations] calls.
+    /// The request builder for [Config::list_operations][crate::client::Config::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2740,7 +2740,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::get_operation][super::super::client::Config::get_operation] calls.
+    /// The request builder for [Config::get_operation][crate::client::Config::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2802,7 +2802,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::delete_operation][super::super::client::Config::delete_operation] calls.
+    /// The request builder for [Config::delete_operation][crate::client::Config::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2864,7 +2864,7 @@ pub mod config {
         }
     }
 
-    /// The request builder for [Config::cancel_operation][super::super::client::Config::cancel_operation] calls.
+    /// The request builder for [Config::cancel_operation][crate::client::Config::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/connectors/v1/src/builder.rs
+++ b/src/generated/cloud/connectors/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod connectors {
     use crate::Result;
 
-    /// A builder for [Connectors][super::super::client::Connectors].
+    /// A builder for [Connectors][crate::client::Connectors].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod connectors {
         }
     }
 
-    /// Common implementation for [super::super::client::Connectors] request builders.
+    /// Common implementation for [crate::client::Connectors] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Connectors>,
@@ -68,7 +68,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_connections][super::super::client::Connectors::list_connections] calls.
+    /// The request builder for [Connectors::list_connections][crate::client::Connectors::list_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -189,7 +189,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_connection][super::super::client::Connectors::get_connection] calls.
+    /// The request builder for [Connectors::get_connection][crate::client::Connectors::get_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -258,7 +258,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::create_connection][super::super::client::Connectors::create_connection] calls.
+    /// The request builder for [Connectors::create_connection][crate::client::Connectors::create_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -306,7 +306,7 @@ pub mod connectors {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_connection][super::super::client::Connectors::create_connection].
+        /// on [create_connection][crate::client::Connectors::create_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_connection(self.0.request, self.0.options)
@@ -393,7 +393,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::update_connection][super::super::client::Connectors::update_connection] calls.
+    /// The request builder for [Connectors::update_connection][crate::client::Connectors::update_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -441,7 +441,7 @@ pub mod connectors {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_connection][super::super::client::Connectors::update_connection].
+        /// on [update_connection][crate::client::Connectors::update_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_connection(self.0.request, self.0.options)
@@ -534,7 +534,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::delete_connection][super::super::client::Connectors::delete_connection] calls.
+    /// The request builder for [Connectors::delete_connection][crate::client::Connectors::delete_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -582,7 +582,7 @@ pub mod connectors {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_connection][super::super::client::Connectors::delete_connection].
+        /// on [delete_connection][crate::client::Connectors::delete_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_connection(self.0.request, self.0.options)
@@ -641,7 +641,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_providers][super::super::client::Connectors::list_providers] calls.
+    /// The request builder for [Connectors::list_providers][crate::client::Connectors::list_providers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -744,7 +744,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_provider][super::super::client::Connectors::get_provider] calls.
+    /// The request builder for [Connectors::get_provider][crate::client::Connectors::get_provider] calls.
     ///
     /// # Example
     /// ```no_run
@@ -807,7 +807,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_connectors][super::super::client::Connectors::list_connectors] calls.
+    /// The request builder for [Connectors::list_connectors][crate::client::Connectors::list_connectors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -910,7 +910,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_connector][super::super::client::Connectors::get_connector] calls.
+    /// The request builder for [Connectors::get_connector][crate::client::Connectors::get_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -973,7 +973,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_connector_versions][super::super::client::Connectors::list_connector_versions] calls.
+    /// The request builder for [Connectors::list_connector_versions][crate::client::Connectors::list_connector_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1087,7 +1087,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_connector_version][super::super::client::Connectors::get_connector_version] calls.
+    /// The request builder for [Connectors::get_connector_version][crate::client::Connectors::get_connector_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1159,7 +1159,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_connection_schema_metadata][super::super::client::Connectors::get_connection_schema_metadata] calls.
+    /// The request builder for [Connectors::get_connection_schema_metadata][crate::client::Connectors::get_connection_schema_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1227,7 +1227,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::refresh_connection_schema_metadata][super::super::client::Connectors::refresh_connection_schema_metadata] calls.
+    /// The request builder for [Connectors::refresh_connection_schema_metadata][crate::client::Connectors::refresh_connection_schema_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1277,7 +1277,7 @@ pub mod connectors {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [refresh_connection_schema_metadata][super::super::client::Connectors::refresh_connection_schema_metadata].
+        /// on [refresh_connection_schema_metadata][crate::client::Connectors::refresh_connection_schema_metadata].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .refresh_connection_schema_metadata(self.0.request, self.0.options)
@@ -1337,7 +1337,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_runtime_entity_schemas][super::super::client::Connectors::list_runtime_entity_schemas] calls.
+    /// The request builder for [Connectors::list_runtime_entity_schemas][crate::client::Connectors::list_runtime_entity_schemas] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1457,7 +1457,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_runtime_action_schemas][super::super::client::Connectors::list_runtime_action_schemas] calls.
+    /// The request builder for [Connectors::list_runtime_action_schemas][crate::client::Connectors::list_runtime_action_schemas] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1577,7 +1577,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_runtime_config][super::super::client::Connectors::get_runtime_config] calls.
+    /// The request builder for [Connectors::get_runtime_config][crate::client::Connectors::get_runtime_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1643,7 +1643,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_global_settings][super::super::client::Connectors::get_global_settings] calls.
+    /// The request builder for [Connectors::get_global_settings][crate::client::Connectors::get_global_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1709,7 +1709,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_locations][super::super::client::Connectors::list_locations] calls.
+    /// The request builder for [Connectors::list_locations][crate::client::Connectors::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1819,7 +1819,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_location][super::super::client::Connectors::get_location] calls.
+    /// The request builder for [Connectors::get_location][crate::client::Connectors::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1880,7 +1880,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::set_iam_policy][super::super::client::Connectors::set_iam_policy] calls.
+    /// The request builder for [Connectors::set_iam_policy][crate::client::Connectors::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1983,7 +1983,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_iam_policy][super::super::client::Connectors::get_iam_policy] calls.
+    /// The request builder for [Connectors::get_iam_policy][crate::client::Connectors::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2064,7 +2064,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::test_iam_permissions][super::super::client::Connectors::test_iam_permissions] calls.
+    /// The request builder for [Connectors::test_iam_permissions][crate::client::Connectors::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2143,7 +2143,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::list_operations][super::super::client::Connectors::list_operations] calls.
+    /// The request builder for [Connectors::list_operations][crate::client::Connectors::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2255,7 +2255,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::get_operation][super::super::client::Connectors::get_operation] calls.
+    /// The request builder for [Connectors::get_operation][crate::client::Connectors::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2319,7 +2319,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::delete_operation][super::super::client::Connectors::delete_operation] calls.
+    /// The request builder for [Connectors::delete_operation][crate::client::Connectors::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2383,7 +2383,7 @@ pub mod connectors {
         }
     }
 
-    /// The request builder for [Connectors::cancel_operation][super::super::client::Connectors::cancel_operation] calls.
+    /// The request builder for [Connectors::cancel_operation][crate::client::Connectors::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
+++ b/src/generated/cloud/contactcenterinsights/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod contact_center_insights {
     use crate::Result;
 
-    /// A builder for [ContactCenterInsights][super::super::client::ContactCenterInsights].
+    /// A builder for [ContactCenterInsights][crate::client::ContactCenterInsights].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// Common implementation for [super::super::client::ContactCenterInsights] request builders.
+    /// Common implementation for [crate::client::ContactCenterInsights] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ContactCenterInsights>,
@@ -68,7 +68,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_conversation][super::super::client::ContactCenterInsights::create_conversation] calls.
+    /// The request builder for [ContactCenterInsights::create_conversation][crate::client::ContactCenterInsights::create_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -162,7 +162,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::upload_conversation][super::super::client::ContactCenterInsights::upload_conversation] calls.
+    /// The request builder for [ContactCenterInsights::upload_conversation][crate::client::ContactCenterInsights::upload_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -210,7 +210,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upload_conversation][super::super::client::ContactCenterInsights::upload_conversation].
+        /// on [upload_conversation][crate::client::ContactCenterInsights::upload_conversation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upload_conversation(self.0.request, self.0.options)
@@ -334,7 +334,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_conversation][super::super::client::ContactCenterInsights::update_conversation] calls.
+    /// The request builder for [ContactCenterInsights::update_conversation][crate::client::ContactCenterInsights::update_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -432,7 +432,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_conversation][super::super::client::ContactCenterInsights::get_conversation] calls.
+    /// The request builder for [ContactCenterInsights::get_conversation][crate::client::ContactCenterInsights::get_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -501,7 +501,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_conversations][super::super::client::ContactCenterInsights::list_conversations] calls.
+    /// The request builder for [ContactCenterInsights::list_conversations][crate::client::ContactCenterInsights::list_conversations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -625,7 +625,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_conversation][super::super::client::ContactCenterInsights::delete_conversation] calls.
+    /// The request builder for [ContactCenterInsights::delete_conversation][crate::client::ContactCenterInsights::delete_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -697,7 +697,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_analysis][super::super::client::ContactCenterInsights::create_analysis] calls.
+    /// The request builder for [ContactCenterInsights::create_analysis][crate::client::ContactCenterInsights::create_analysis] calls.
     ///
     /// # Example
     /// ```no_run
@@ -742,7 +742,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_analysis][super::super::client::ContactCenterInsights::create_analysis].
+        /// on [create_analysis][crate::client::ContactCenterInsights::create_analysis].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_analysis(self.0.request, self.0.options)
@@ -824,7 +824,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_analysis][super::super::client::ContactCenterInsights::get_analysis] calls.
+    /// The request builder for [ContactCenterInsights::get_analysis][crate::client::ContactCenterInsights::get_analysis] calls.
     ///
     /// # Example
     /// ```no_run
@@ -887,7 +887,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_analyses][super::super::client::ContactCenterInsights::list_analyses] calls.
+    /// The request builder for [ContactCenterInsights::list_analyses][crate::client::ContactCenterInsights::list_analyses] calls.
     ///
     /// # Example
     /// ```no_run
@@ -996,7 +996,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_analysis][super::super::client::ContactCenterInsights::delete_analysis] calls.
+    /// The request builder for [ContactCenterInsights::delete_analysis][crate::client::ContactCenterInsights::delete_analysis] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1059,7 +1059,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::bulk_analyze_conversations][super::super::client::ContactCenterInsights::bulk_analyze_conversations] calls.
+    /// The request builder for [ContactCenterInsights::bulk_analyze_conversations][crate::client::ContactCenterInsights::bulk_analyze_conversations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1109,7 +1109,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [bulk_analyze_conversations][super::super::client::ContactCenterInsights::bulk_analyze_conversations].
+        /// on [bulk_analyze_conversations][crate::client::ContactCenterInsights::bulk_analyze_conversations].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .bulk_analyze_conversations(self.0.request, self.0.options)
@@ -1205,7 +1205,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::bulk_delete_conversations][super::super::client::ContactCenterInsights::bulk_delete_conversations] calls.
+    /// The request builder for [ContactCenterInsights::bulk_delete_conversations][crate::client::ContactCenterInsights::bulk_delete_conversations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1255,7 +1255,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [bulk_delete_conversations][super::super::client::ContactCenterInsights::bulk_delete_conversations].
+        /// on [bulk_delete_conversations][crate::client::ContactCenterInsights::bulk_delete_conversations].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .bulk_delete_conversations(self.0.request, self.0.options)
@@ -1335,7 +1335,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::ingest_conversations][super::super::client::ContactCenterInsights::ingest_conversations] calls.
+    /// The request builder for [ContactCenterInsights::ingest_conversations][crate::client::ContactCenterInsights::ingest_conversations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1383,7 +1383,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [ingest_conversations][super::super::client::ContactCenterInsights::ingest_conversations].
+        /// on [ingest_conversations][crate::client::ContactCenterInsights::ingest_conversations].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .ingest_conversations(self.0.request, self.0.options)
@@ -1579,7 +1579,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::export_insights_data][super::super::client::ContactCenterInsights::export_insights_data] calls.
+    /// The request builder for [ContactCenterInsights::export_insights_data][crate::client::ContactCenterInsights::export_insights_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1627,7 +1627,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_insights_data][super::super::client::ContactCenterInsights::export_insights_data].
+        /// on [export_insights_data][crate::client::ContactCenterInsights::export_insights_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_insights_data(self.0.request, self.0.options)
@@ -1745,7 +1745,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_issue_model][super::super::client::ContactCenterInsights::create_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::create_issue_model][crate::client::ContactCenterInsights::create_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1793,7 +1793,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_issue_model][super::super::client::ContactCenterInsights::create_issue_model].
+        /// on [create_issue_model][crate::client::ContactCenterInsights::create_issue_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_issue_model(self.0.request, self.0.options)
@@ -1875,7 +1875,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_issue_model][super::super::client::ContactCenterInsights::update_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::update_issue_model][crate::client::ContactCenterInsights::update_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1973,7 +1973,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_issue_model][super::super::client::ContactCenterInsights::get_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::get_issue_model][crate::client::ContactCenterInsights::get_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2036,7 +2036,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_issue_models][super::super::client::ContactCenterInsights::list_issue_models] calls.
+    /// The request builder for [ContactCenterInsights::list_issue_models][crate::client::ContactCenterInsights::list_issue_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2099,7 +2099,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_issue_model][super::super::client::ContactCenterInsights::delete_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::delete_issue_model][crate::client::ContactCenterInsights::delete_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2147,7 +2147,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_issue_model][super::super::client::ContactCenterInsights::delete_issue_model].
+        /// on [delete_issue_model][crate::client::ContactCenterInsights::delete_issue_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_issue_model(self.0.request, self.0.options)
@@ -2207,7 +2207,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::deploy_issue_model][super::super::client::ContactCenterInsights::deploy_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::deploy_issue_model][crate::client::ContactCenterInsights::deploy_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2255,7 +2255,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [deploy_issue_model][super::super::client::ContactCenterInsights::deploy_issue_model].
+        /// on [deploy_issue_model][crate::client::ContactCenterInsights::deploy_issue_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .deploy_issue_model(self.0.request, self.0.options)
@@ -2317,7 +2317,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::undeploy_issue_model][super::super::client::ContactCenterInsights::undeploy_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::undeploy_issue_model][crate::client::ContactCenterInsights::undeploy_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2365,7 +2365,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undeploy_issue_model][super::super::client::ContactCenterInsights::undeploy_issue_model].
+        /// on [undeploy_issue_model][crate::client::ContactCenterInsights::undeploy_issue_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undeploy_issue_model(self.0.request, self.0.options)
@@ -2427,7 +2427,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::export_issue_model][super::super::client::ContactCenterInsights::export_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::export_issue_model][crate::client::ContactCenterInsights::export_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2475,7 +2475,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_issue_model][super::super::client::ContactCenterInsights::export_issue_model].
+        /// on [export_issue_model][crate::client::ContactCenterInsights::export_issue_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_issue_model(self.0.request, self.0.options)
@@ -2568,7 +2568,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::import_issue_model][super::super::client::ContactCenterInsights::import_issue_model] calls.
+    /// The request builder for [ContactCenterInsights::import_issue_model][crate::client::ContactCenterInsights::import_issue_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2616,7 +2616,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_issue_model][super::super::client::ContactCenterInsights::import_issue_model].
+        /// on [import_issue_model][crate::client::ContactCenterInsights::import_issue_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_issue_model(self.0.request, self.0.options)
@@ -2713,7 +2713,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_issue][super::super::client::ContactCenterInsights::get_issue] calls.
+    /// The request builder for [ContactCenterInsights::get_issue][crate::client::ContactCenterInsights::get_issue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2776,7 +2776,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_issues][super::super::client::ContactCenterInsights::list_issues] calls.
+    /// The request builder for [ContactCenterInsights::list_issues][crate::client::ContactCenterInsights::list_issues] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2839,7 +2839,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_issue][super::super::client::ContactCenterInsights::update_issue] calls.
+    /// The request builder for [ContactCenterInsights::update_issue][crate::client::ContactCenterInsights::update_issue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2934,7 +2934,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_issue][super::super::client::ContactCenterInsights::delete_issue] calls.
+    /// The request builder for [ContactCenterInsights::delete_issue][crate::client::ContactCenterInsights::delete_issue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2997,7 +2997,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::calculate_issue_model_stats][super::super::client::ContactCenterInsights::calculate_issue_model_stats] calls.
+    /// The request builder for [ContactCenterInsights::calculate_issue_model_stats][crate::client::ContactCenterInsights::calculate_issue_model_stats] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3065,7 +3065,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_phrase_matcher][super::super::client::ContactCenterInsights::create_phrase_matcher] calls.
+    /// The request builder for [ContactCenterInsights::create_phrase_matcher][crate::client::ContactCenterInsights::create_phrase_matcher] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3153,7 +3153,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_phrase_matcher][super::super::client::ContactCenterInsights::get_phrase_matcher] calls.
+    /// The request builder for [ContactCenterInsights::get_phrase_matcher][crate::client::ContactCenterInsights::get_phrase_matcher] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3219,7 +3219,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_phrase_matchers][super::super::client::ContactCenterInsights::list_phrase_matchers] calls.
+    /// The request builder for [ContactCenterInsights::list_phrase_matchers][crate::client::ContactCenterInsights::list_phrase_matchers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3333,7 +3333,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_phrase_matcher][super::super::client::ContactCenterInsights::delete_phrase_matcher] calls.
+    /// The request builder for [ContactCenterInsights::delete_phrase_matcher][crate::client::ContactCenterInsights::delete_phrase_matcher] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3399,7 +3399,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_phrase_matcher][super::super::client::ContactCenterInsights::update_phrase_matcher] calls.
+    /// The request builder for [ContactCenterInsights::update_phrase_matcher][crate::client::ContactCenterInsights::update_phrase_matcher] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3497,7 +3497,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::calculate_stats][super::super::client::ContactCenterInsights::calculate_stats] calls.
+    /// The request builder for [ContactCenterInsights::calculate_stats][crate::client::ContactCenterInsights::calculate_stats] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3566,7 +3566,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_settings][super::super::client::ContactCenterInsights::get_settings] calls.
+    /// The request builder for [ContactCenterInsights::get_settings][crate::client::ContactCenterInsights::get_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3629,7 +3629,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_settings][super::super::client::ContactCenterInsights::update_settings] calls.
+    /// The request builder for [ContactCenterInsights::update_settings][crate::client::ContactCenterInsights::update_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3728,7 +3728,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_analysis_rule][super::super::client::ContactCenterInsights::create_analysis_rule] calls.
+    /// The request builder for [ContactCenterInsights::create_analysis_rule][crate::client::ContactCenterInsights::create_analysis_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3816,7 +3816,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_analysis_rule][super::super::client::ContactCenterInsights::get_analysis_rule] calls.
+    /// The request builder for [ContactCenterInsights::get_analysis_rule][crate::client::ContactCenterInsights::get_analysis_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3879,7 +3879,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_analysis_rules][super::super::client::ContactCenterInsights::list_analysis_rules] calls.
+    /// The request builder for [ContactCenterInsights::list_analysis_rules][crate::client::ContactCenterInsights::list_analysis_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3985,7 +3985,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_analysis_rule][super::super::client::ContactCenterInsights::update_analysis_rule] calls.
+    /// The request builder for [ContactCenterInsights::update_analysis_rule][crate::client::ContactCenterInsights::update_analysis_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4083,7 +4083,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_analysis_rule][super::super::client::ContactCenterInsights::delete_analysis_rule] calls.
+    /// The request builder for [ContactCenterInsights::delete_analysis_rule][crate::client::ContactCenterInsights::delete_analysis_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4149,7 +4149,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_encryption_spec][super::super::client::ContactCenterInsights::get_encryption_spec] calls.
+    /// The request builder for [ContactCenterInsights::get_encryption_spec][crate::client::ContactCenterInsights::get_encryption_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4215,7 +4215,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::initialize_encryption_spec][super::super::client::ContactCenterInsights::initialize_encryption_spec] calls.
+    /// The request builder for [ContactCenterInsights::initialize_encryption_spec][crate::client::ContactCenterInsights::initialize_encryption_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4265,7 +4265,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [initialize_encryption_spec][super::super::client::ContactCenterInsights::initialize_encryption_spec].
+        /// on [initialize_encryption_spec][crate::client::ContactCenterInsights::initialize_encryption_spec].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .initialize_encryption_spec(self.0.request, self.0.options)
@@ -4341,7 +4341,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_view][super::super::client::ContactCenterInsights::create_view] calls.
+    /// The request builder for [ContactCenterInsights::create_view][crate::client::ContactCenterInsights::create_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4426,7 +4426,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_view][super::super::client::ContactCenterInsights::get_view] calls.
+    /// The request builder for [ContactCenterInsights::get_view][crate::client::ContactCenterInsights::get_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4489,7 +4489,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_views][super::super::client::ContactCenterInsights::list_views] calls.
+    /// The request builder for [ContactCenterInsights::list_views][crate::client::ContactCenterInsights::list_views] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4592,7 +4592,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_view][super::super::client::ContactCenterInsights::update_view] calls.
+    /// The request builder for [ContactCenterInsights::update_view][crate::client::ContactCenterInsights::update_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4687,7 +4687,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_view][super::super::client::ContactCenterInsights::delete_view] calls.
+    /// The request builder for [ContactCenterInsights::delete_view][crate::client::ContactCenterInsights::delete_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4750,7 +4750,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::query_metrics][super::super::client::ContactCenterInsights::query_metrics] calls.
+    /// The request builder for [ContactCenterInsights::query_metrics][crate::client::ContactCenterInsights::query_metrics] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4795,7 +4795,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [query_metrics][super::super::client::ContactCenterInsights::query_metrics].
+        /// on [query_metrics][crate::client::ContactCenterInsights::query_metrics].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .query_metrics(self.0.request, self.0.options)
@@ -4903,7 +4903,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_qa_question][super::super::client::ContactCenterInsights::create_qa_question] calls.
+    /// The request builder for [ContactCenterInsights::create_qa_question][crate::client::ContactCenterInsights::create_qa_question] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4997,7 +4997,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_qa_question][super::super::client::ContactCenterInsights::get_qa_question] calls.
+    /// The request builder for [ContactCenterInsights::get_qa_question][crate::client::ContactCenterInsights::get_qa_question] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5060,7 +5060,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_qa_question][super::super::client::ContactCenterInsights::update_qa_question] calls.
+    /// The request builder for [ContactCenterInsights::update_qa_question][crate::client::ContactCenterInsights::update_qa_question] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5162,7 +5162,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_qa_question][super::super::client::ContactCenterInsights::delete_qa_question] calls.
+    /// The request builder for [ContactCenterInsights::delete_qa_question][crate::client::ContactCenterInsights::delete_qa_question] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5228,7 +5228,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_qa_questions][super::super::client::ContactCenterInsights::list_qa_questions] calls.
+    /// The request builder for [ContactCenterInsights::list_qa_questions][crate::client::ContactCenterInsights::list_qa_questions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5331,7 +5331,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_qa_scorecard][super::super::client::ContactCenterInsights::create_qa_scorecard] calls.
+    /// The request builder for [ContactCenterInsights::create_qa_scorecard][crate::client::ContactCenterInsights::create_qa_scorecard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5425,7 +5425,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_qa_scorecard][super::super::client::ContactCenterInsights::get_qa_scorecard] calls.
+    /// The request builder for [ContactCenterInsights::get_qa_scorecard][crate::client::ContactCenterInsights::get_qa_scorecard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5488,7 +5488,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_qa_scorecard][super::super::client::ContactCenterInsights::update_qa_scorecard] calls.
+    /// The request builder for [ContactCenterInsights::update_qa_scorecard][crate::client::ContactCenterInsights::update_qa_scorecard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5590,7 +5590,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_qa_scorecard][super::super::client::ContactCenterInsights::delete_qa_scorecard] calls.
+    /// The request builder for [ContactCenterInsights::delete_qa_scorecard][crate::client::ContactCenterInsights::delete_qa_scorecard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5662,7 +5662,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_qa_scorecards][super::super::client::ContactCenterInsights::list_qa_scorecards] calls.
+    /// The request builder for [ContactCenterInsights::list_qa_scorecards][crate::client::ContactCenterInsights::list_qa_scorecards] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5768,7 +5768,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_qa_scorecard_revision][super::super::client::ContactCenterInsights::create_qa_scorecard_revision] calls.
+    /// The request builder for [ContactCenterInsights::create_qa_scorecard_revision][crate::client::ContactCenterInsights::create_qa_scorecard_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5864,7 +5864,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_qa_scorecard_revision][super::super::client::ContactCenterInsights::get_qa_scorecard_revision] calls.
+    /// The request builder for [ContactCenterInsights::get_qa_scorecard_revision][crate::client::ContactCenterInsights::get_qa_scorecard_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5930,7 +5930,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::tune_qa_scorecard_revision][super::super::client::ContactCenterInsights::tune_qa_scorecard_revision] calls.
+    /// The request builder for [ContactCenterInsights::tune_qa_scorecard_revision][crate::client::ContactCenterInsights::tune_qa_scorecard_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5980,7 +5980,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [tune_qa_scorecard_revision][super::super::client::ContactCenterInsights::tune_qa_scorecard_revision].
+        /// on [tune_qa_scorecard_revision][crate::client::ContactCenterInsights::tune_qa_scorecard_revision].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .tune_qa_scorecard_revision(self.0.request, self.0.options)
@@ -6056,7 +6056,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::deploy_qa_scorecard_revision][super::super::client::ContactCenterInsights::deploy_qa_scorecard_revision] calls.
+    /// The request builder for [ContactCenterInsights::deploy_qa_scorecard_revision][crate::client::ContactCenterInsights::deploy_qa_scorecard_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6124,7 +6124,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::undeploy_qa_scorecard_revision][super::super::client::ContactCenterInsights::undeploy_qa_scorecard_revision] calls.
+    /// The request builder for [ContactCenterInsights::undeploy_qa_scorecard_revision][crate::client::ContactCenterInsights::undeploy_qa_scorecard_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6192,7 +6192,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_qa_scorecard_revision][super::super::client::ContactCenterInsights::delete_qa_scorecard_revision] calls.
+    /// The request builder for [ContactCenterInsights::delete_qa_scorecard_revision][crate::client::ContactCenterInsights::delete_qa_scorecard_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6266,7 +6266,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_qa_scorecard_revisions][super::super::client::ContactCenterInsights::list_qa_scorecard_revisions] calls.
+    /// The request builder for [ContactCenterInsights::list_qa_scorecard_revisions][crate::client::ContactCenterInsights::list_qa_scorecard_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6384,7 +6384,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::create_feedback_label][super::super::client::ContactCenterInsights::create_feedback_label] calls.
+    /// The request builder for [ContactCenterInsights::create_feedback_label][crate::client::ContactCenterInsights::create_feedback_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6478,7 +6478,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_feedback_labels][super::super::client::ContactCenterInsights::list_feedback_labels] calls.
+    /// The request builder for [ContactCenterInsights::list_feedback_labels][crate::client::ContactCenterInsights::list_feedback_labels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6592,7 +6592,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_feedback_label][super::super::client::ContactCenterInsights::get_feedback_label] calls.
+    /// The request builder for [ContactCenterInsights::get_feedback_label][crate::client::ContactCenterInsights::get_feedback_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6658,7 +6658,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::update_feedback_label][super::super::client::ContactCenterInsights::update_feedback_label] calls.
+    /// The request builder for [ContactCenterInsights::update_feedback_label][crate::client::ContactCenterInsights::update_feedback_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6760,7 +6760,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::delete_feedback_label][super::super::client::ContactCenterInsights::delete_feedback_label] calls.
+    /// The request builder for [ContactCenterInsights::delete_feedback_label][crate::client::ContactCenterInsights::delete_feedback_label] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6826,7 +6826,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_all_feedback_labels][super::super::client::ContactCenterInsights::list_all_feedback_labels] calls.
+    /// The request builder for [ContactCenterInsights::list_all_feedback_labels][crate::client::ContactCenterInsights::list_all_feedback_labels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6940,7 +6940,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::bulk_upload_feedback_labels][super::super::client::ContactCenterInsights::bulk_upload_feedback_labels] calls.
+    /// The request builder for [ContactCenterInsights::bulk_upload_feedback_labels][crate::client::ContactCenterInsights::bulk_upload_feedback_labels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6990,7 +6990,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [bulk_upload_feedback_labels][super::super::client::ContactCenterInsights::bulk_upload_feedback_labels].
+        /// on [bulk_upload_feedback_labels][crate::client::ContactCenterInsights::bulk_upload_feedback_labels].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .bulk_upload_feedback_labels(self.0.request, self.0.options)
@@ -7089,7 +7089,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::bulk_download_feedback_labels][super::super::client::ContactCenterInsights::bulk_download_feedback_labels] calls.
+    /// The request builder for [ContactCenterInsights::bulk_download_feedback_labels][crate::client::ContactCenterInsights::bulk_download_feedback_labels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7139,7 +7139,7 @@ pub mod contact_center_insights {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [bulk_download_feedback_labels][super::super::client::ContactCenterInsights::bulk_download_feedback_labels].
+        /// on [bulk_download_feedback_labels][crate::client::ContactCenterInsights::bulk_download_feedback_labels].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .bulk_download_feedback_labels(self.0.request, self.0.options)
@@ -7274,7 +7274,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::list_operations][super::super::client::ContactCenterInsights::list_operations] calls.
+    /// The request builder for [ContactCenterInsights::list_operations][crate::client::ContactCenterInsights::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7386,7 +7386,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::get_operation][super::super::client::ContactCenterInsights::get_operation] calls.
+    /// The request builder for [ContactCenterInsights::get_operation][crate::client::ContactCenterInsights::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7450,7 +7450,7 @@ pub mod contact_center_insights {
         }
     }
 
-    /// The request builder for [ContactCenterInsights::cancel_operation][super::super::client::ContactCenterInsights::cancel_operation] calls.
+    /// The request builder for [ContactCenterInsights::cancel_operation][crate::client::ContactCenterInsights::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/lineage/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod lineage {
     use crate::Result;
 
-    /// A builder for [Lineage][super::super::client::Lineage].
+    /// A builder for [Lineage][crate::client::Lineage].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod lineage {
         }
     }
 
-    /// Common implementation for [super::super::client::Lineage] request builders.
+    /// Common implementation for [crate::client::Lineage] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Lineage>,
@@ -66,7 +66,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::process_open_lineage_run_event][super::super::client::Lineage::process_open_lineage_run_event] calls.
+    /// The request builder for [Lineage::process_open_lineage_run_event][crate::client::Lineage::process_open_lineage_run_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -160,7 +160,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::create_process][super::super::client::Lineage::create_process] calls.
+    /// The request builder for [Lineage::create_process][crate::client::Lineage::create_process] calls.
     ///
     /// # Example
     /// ```no_run
@@ -249,7 +249,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::update_process][super::super::client::Lineage::update_process] calls.
+    /// The request builder for [Lineage::update_process][crate::client::Lineage::update_process] calls.
     ///
     /// # Example
     /// ```no_run
@@ -348,7 +348,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::get_process][super::super::client::Lineage::get_process] calls.
+    /// The request builder for [Lineage::get_process][crate::client::Lineage::get_process] calls.
     ///
     /// # Example
     /// ```no_run
@@ -409,7 +409,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::list_processes][super::super::client::Lineage::list_processes] calls.
+    /// The request builder for [Lineage::list_processes][crate::client::Lineage::list_processes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -510,7 +510,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::delete_process][super::super::client::Lineage::delete_process] calls.
+    /// The request builder for [Lineage::delete_process][crate::client::Lineage::delete_process] calls.
     ///
     /// # Example
     /// ```no_run
@@ -553,7 +553,7 @@ pub mod lineage {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_process][super::super::client::Lineage::delete_process].
+        /// on [delete_process][crate::client::Lineage::delete_process].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_process(self.0.request, self.0.options)
@@ -618,7 +618,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::create_run][super::super::client::Lineage::create_run] calls.
+    /// The request builder for [Lineage::create_run][crate::client::Lineage::create_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -707,7 +707,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::update_run][super::super::client::Lineage::update_run] calls.
+    /// The request builder for [Lineage::update_run][crate::client::Lineage::update_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -806,7 +806,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::get_run][super::super::client::Lineage::get_run] calls.
+    /// The request builder for [Lineage::get_run][crate::client::Lineage::get_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -867,7 +867,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::list_runs][super::super::client::Lineage::list_runs] calls.
+    /// The request builder for [Lineage::list_runs][crate::client::Lineage::list_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -968,7 +968,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::delete_run][super::super::client::Lineage::delete_run] calls.
+    /// The request builder for [Lineage::delete_run][crate::client::Lineage::delete_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1011,7 +1011,7 @@ pub mod lineage {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_run][super::super::client::Lineage::delete_run].
+        /// on [delete_run][crate::client::Lineage::delete_run].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_run(self.0.request, self.0.options)
@@ -1076,7 +1076,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::create_lineage_event][super::super::client::Lineage::create_lineage_event] calls.
+    /// The request builder for [Lineage::create_lineage_event][crate::client::Lineage::create_lineage_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1168,7 +1168,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::get_lineage_event][super::super::client::Lineage::get_lineage_event] calls.
+    /// The request builder for [Lineage::get_lineage_event][crate::client::Lineage::get_lineage_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1229,7 +1229,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::list_lineage_events][super::super::client::Lineage::list_lineage_events] calls.
+    /// The request builder for [Lineage::list_lineage_events][crate::client::Lineage::list_lineage_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1333,7 +1333,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::delete_lineage_event][super::super::client::Lineage::delete_lineage_event] calls.
+    /// The request builder for [Lineage::delete_lineage_event][crate::client::Lineage::delete_lineage_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1403,7 +1403,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::search_links][super::super::client::Lineage::search_links] calls.
+    /// The request builder for [Lineage::search_links][crate::client::Lineage::search_links] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1542,7 +1542,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::batch_search_link_processes][super::super::client::Lineage::batch_search_link_processes] calls.
+    /// The request builder for [Lineage::batch_search_link_processes][crate::client::Lineage::batch_search_link_processes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1665,7 +1665,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::list_operations][super::super::client::Lineage::list_operations] calls.
+    /// The request builder for [Lineage::list_operations][crate::client::Lineage::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1775,7 +1775,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::get_operation][super::super::client::Lineage::get_operation] calls.
+    /// The request builder for [Lineage::get_operation][crate::client::Lineage::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1837,7 +1837,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::delete_operation][super::super::client::Lineage::delete_operation] calls.
+    /// The request builder for [Lineage::delete_operation][crate::client::Lineage::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1899,7 +1899,7 @@ pub mod lineage {
         }
     }
 
-    /// The request builder for [Lineage::cancel_operation][super::super::client::Lineage::cancel_operation] calls.
+    /// The request builder for [Lineage::cancel_operation][crate::client::Lineage::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/datacatalog/v1/src/builder.rs
+++ b/src/generated/cloud/datacatalog/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod data_catalog {
     use crate::Result;
 
-    /// A builder for [DataCatalog][super::super::client::DataCatalog].
+    /// A builder for [DataCatalog][crate::client::DataCatalog].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod data_catalog {
         }
     }
 
-    /// Common implementation for [super::super::client::DataCatalog] request builders.
+    /// Common implementation for [crate::client::DataCatalog] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataCatalog>,
@@ -68,7 +68,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::search_catalog][super::super::client::DataCatalog::search_catalog] calls.
+    /// The request builder for [DataCatalog::search_catalog][crate::client::DataCatalog::search_catalog] calls.
     ///
     /// # Example
     /// ```no_run
@@ -203,7 +203,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::create_entry_group][super::super::client::DataCatalog::create_entry_group] calls.
+    /// The request builder for [DataCatalog::create_entry_group][crate::client::DataCatalog::create_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -295,7 +295,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::get_entry_group][super::super::client::DataCatalog::get_entry_group] calls.
+    /// The request builder for [DataCatalog::get_entry_group][crate::client::DataCatalog::get_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -376,7 +376,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::update_entry_group][super::super::client::DataCatalog::update_entry_group] calls.
+    /// The request builder for [DataCatalog::update_entry_group][crate::client::DataCatalog::update_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -474,7 +474,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::delete_entry_group][super::super::client::DataCatalog::delete_entry_group] calls.
+    /// The request builder for [DataCatalog::delete_entry_group][crate::client::DataCatalog::delete_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -546,7 +546,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::list_entry_groups][super::super::client::DataCatalog::list_entry_groups] calls.
+    /// The request builder for [DataCatalog::list_entry_groups][crate::client::DataCatalog::list_entry_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -649,7 +649,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::create_entry][super::super::client::DataCatalog::create_entry] calls.
+    /// The request builder for [DataCatalog::create_entry][crate::client::DataCatalog::create_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -742,7 +742,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::update_entry][super::super::client::DataCatalog::update_entry] calls.
+    /// The request builder for [DataCatalog::update_entry][crate::client::DataCatalog::update_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -837,7 +837,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::delete_entry][super::super::client::DataCatalog::delete_entry] calls.
+    /// The request builder for [DataCatalog::delete_entry][crate::client::DataCatalog::delete_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -900,7 +900,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::get_entry][super::super::client::DataCatalog::get_entry] calls.
+    /// The request builder for [DataCatalog::get_entry][crate::client::DataCatalog::get_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -963,7 +963,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::lookup_entry][super::super::client::DataCatalog::lookup_entry] calls.
+    /// The request builder for [DataCatalog::lookup_entry][crate::client::DataCatalog::lookup_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1081,7 +1081,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::list_entries][super::super::client::DataCatalog::list_entries] calls.
+    /// The request builder for [DataCatalog::list_entries][crate::client::DataCatalog::list_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1202,7 +1202,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::modify_entry_overview][super::super::client::DataCatalog::modify_entry_overview] calls.
+    /// The request builder for [DataCatalog::modify_entry_overview][crate::client::DataCatalog::modify_entry_overview] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1290,7 +1290,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::modify_entry_contacts][super::super::client::DataCatalog::modify_entry_contacts] calls.
+    /// The request builder for [DataCatalog::modify_entry_contacts][crate::client::DataCatalog::modify_entry_contacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1378,7 +1378,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::create_tag_template][super::super::client::DataCatalog::create_tag_template] calls.
+    /// The request builder for [DataCatalog::create_tag_template][crate::client::DataCatalog::create_tag_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1474,7 +1474,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::get_tag_template][super::super::client::DataCatalog::get_tag_template] calls.
+    /// The request builder for [DataCatalog::get_tag_template][crate::client::DataCatalog::get_tag_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1537,7 +1537,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::update_tag_template][super::super::client::DataCatalog::update_tag_template] calls.
+    /// The request builder for [DataCatalog::update_tag_template][crate::client::DataCatalog::update_tag_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1635,7 +1635,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::delete_tag_template][super::super::client::DataCatalog::delete_tag_template] calls.
+    /// The request builder for [DataCatalog::delete_tag_template][crate::client::DataCatalog::delete_tag_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1709,7 +1709,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::create_tag_template_field][super::super::client::DataCatalog::create_tag_template_field] calls.
+    /// The request builder for [DataCatalog::create_tag_template_field][crate::client::DataCatalog::create_tag_template_field] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1805,7 +1805,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::update_tag_template_field][super::super::client::DataCatalog::update_tag_template_field] calls.
+    /// The request builder for [DataCatalog::update_tag_template_field][crate::client::DataCatalog::update_tag_template_field] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1911,7 +1911,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::rename_tag_template_field][super::super::client::DataCatalog::rename_tag_template_field] calls.
+    /// The request builder for [DataCatalog::rename_tag_template_field][crate::client::DataCatalog::rename_tag_template_field] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1985,7 +1985,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::rename_tag_template_field_enum_value][super::super::client::DataCatalog::rename_tag_template_field_enum_value] calls.
+    /// The request builder for [DataCatalog::rename_tag_template_field_enum_value][crate::client::DataCatalog::rename_tag_template_field_enum_value] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2064,7 +2064,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::delete_tag_template_field][super::super::client::DataCatalog::delete_tag_template_field] calls.
+    /// The request builder for [DataCatalog::delete_tag_template_field][crate::client::DataCatalog::delete_tag_template_field] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2138,7 +2138,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::create_tag][super::super::client::DataCatalog::create_tag] calls.
+    /// The request builder for [DataCatalog::create_tag][crate::client::DataCatalog::create_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2223,7 +2223,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::update_tag][super::super::client::DataCatalog::update_tag] calls.
+    /// The request builder for [DataCatalog::update_tag][crate::client::DataCatalog::update_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2318,7 +2318,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::delete_tag][super::super::client::DataCatalog::delete_tag] calls.
+    /// The request builder for [DataCatalog::delete_tag][crate::client::DataCatalog::delete_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2381,7 +2381,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::list_tags][super::super::client::DataCatalog::list_tags] calls.
+    /// The request builder for [DataCatalog::list_tags][crate::client::DataCatalog::list_tags] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2484,7 +2484,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::reconcile_tags][super::super::client::DataCatalog::reconcile_tags] calls.
+    /// The request builder for [DataCatalog::reconcile_tags][crate::client::DataCatalog::reconcile_tags] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2529,7 +2529,7 @@ pub mod data_catalog {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reconcile_tags][super::super::client::DataCatalog::reconcile_tags].
+        /// on [reconcile_tags][crate::client::DataCatalog::reconcile_tags].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reconcile_tags(self.0.request, self.0.options)
@@ -2614,7 +2614,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::star_entry][super::super::client::DataCatalog::star_entry] calls.
+    /// The request builder for [DataCatalog::star_entry][crate::client::DataCatalog::star_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2677,7 +2677,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::unstar_entry][super::super::client::DataCatalog::unstar_entry] calls.
+    /// The request builder for [DataCatalog::unstar_entry][crate::client::DataCatalog::unstar_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2740,7 +2740,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::set_iam_policy][super::super::client::DataCatalog::set_iam_policy] calls.
+    /// The request builder for [DataCatalog::set_iam_policy][crate::client::DataCatalog::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2843,7 +2843,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::get_iam_policy][super::super::client::DataCatalog::get_iam_policy] calls.
+    /// The request builder for [DataCatalog::get_iam_policy][crate::client::DataCatalog::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2924,7 +2924,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::test_iam_permissions][super::super::client::DataCatalog::test_iam_permissions] calls.
+    /// The request builder for [DataCatalog::test_iam_permissions][crate::client::DataCatalog::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3003,7 +3003,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::import_entries][super::super::client::DataCatalog::import_entries] calls.
+    /// The request builder for [DataCatalog::import_entries][crate::client::DataCatalog::import_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3048,7 +3048,7 @@ pub mod data_catalog {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_entries][super::super::client::DataCatalog::import_entries].
+        /// on [import_entries][crate::client::DataCatalog::import_entries].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_entries(self.0.request, self.0.options)
@@ -3139,7 +3139,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::set_config][super::super::client::DataCatalog::set_config] calls.
+    /// The request builder for [DataCatalog::set_config][crate::client::DataCatalog::set_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3246,7 +3246,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::retrieve_config][super::super::client::DataCatalog::retrieve_config] calls.
+    /// The request builder for [DataCatalog::retrieve_config][crate::client::DataCatalog::retrieve_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3309,7 +3309,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::retrieve_effective_config][super::super::client::DataCatalog::retrieve_effective_config] calls.
+    /// The request builder for [DataCatalog::retrieve_effective_config][crate::client::DataCatalog::retrieve_effective_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3377,7 +3377,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::list_operations][super::super::client::DataCatalog::list_operations] calls.
+    /// The request builder for [DataCatalog::list_operations][crate::client::DataCatalog::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3489,7 +3489,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::get_operation][super::super::client::DataCatalog::get_operation] calls.
+    /// The request builder for [DataCatalog::get_operation][crate::client::DataCatalog::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3553,7 +3553,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::delete_operation][super::super::client::DataCatalog::delete_operation] calls.
+    /// The request builder for [DataCatalog::delete_operation][crate::client::DataCatalog::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3617,7 +3617,7 @@ pub mod data_catalog {
         }
     }
 
-    /// The request builder for [DataCatalog::cancel_operation][super::super::client::DataCatalog::cancel_operation] calls.
+    /// The request builder for [DataCatalog::cancel_operation][crate::client::DataCatalog::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3685,7 +3685,7 @@ pub mod data_catalog {
 pub mod policy_tag_manager {
     use crate::Result;
 
-    /// A builder for [PolicyTagManager][super::super::client::PolicyTagManager].
+    /// A builder for [PolicyTagManager][crate::client::PolicyTagManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3713,7 +3713,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::PolicyTagManager] request builders.
+    /// Common implementation for [crate::client::PolicyTagManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PolicyTagManager>,
@@ -3736,7 +3736,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::create_taxonomy][super::super::client::PolicyTagManager::create_taxonomy] calls.
+    /// The request builder for [PolicyTagManager::create_taxonomy][crate::client::PolicyTagManager::create_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3817,7 +3817,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::delete_taxonomy][super::super::client::PolicyTagManager::delete_taxonomy] calls.
+    /// The request builder for [PolicyTagManager::delete_taxonomy][crate::client::PolicyTagManager::delete_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3880,7 +3880,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::update_taxonomy][super::super::client::PolicyTagManager::update_taxonomy] calls.
+    /// The request builder for [PolicyTagManager::update_taxonomy][crate::client::PolicyTagManager::update_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3971,7 +3971,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::list_taxonomies][super::super::client::PolicyTagManager::list_taxonomies] calls.
+    /// The request builder for [PolicyTagManager::list_taxonomies][crate::client::PolicyTagManager::list_taxonomies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4080,7 +4080,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::get_taxonomy][super::super::client::PolicyTagManager::get_taxonomy] calls.
+    /// The request builder for [PolicyTagManager::get_taxonomy][crate::client::PolicyTagManager::get_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4143,7 +4143,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::create_policy_tag][super::super::client::PolicyTagManager::create_policy_tag] calls.
+    /// The request builder for [PolicyTagManager::create_policy_tag][crate::client::PolicyTagManager::create_policy_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4224,7 +4224,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::delete_policy_tag][super::super::client::PolicyTagManager::delete_policy_tag] calls.
+    /// The request builder for [PolicyTagManager::delete_policy_tag][crate::client::PolicyTagManager::delete_policy_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4287,7 +4287,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::update_policy_tag][super::super::client::PolicyTagManager::update_policy_tag] calls.
+    /// The request builder for [PolicyTagManager::update_policy_tag][crate::client::PolicyTagManager::update_policy_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4378,7 +4378,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::list_policy_tags][super::super::client::PolicyTagManager::list_policy_tags] calls.
+    /// The request builder for [PolicyTagManager::list_policy_tags][crate::client::PolicyTagManager::list_policy_tags] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4481,7 +4481,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::get_policy_tag][super::super::client::PolicyTagManager::get_policy_tag] calls.
+    /// The request builder for [PolicyTagManager::get_policy_tag][crate::client::PolicyTagManager::get_policy_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4544,7 +4544,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::get_iam_policy][super::super::client::PolicyTagManager::get_iam_policy] calls.
+    /// The request builder for [PolicyTagManager::get_iam_policy][crate::client::PolicyTagManager::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4625,7 +4625,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::set_iam_policy][super::super::client::PolicyTagManager::set_iam_policy] calls.
+    /// The request builder for [PolicyTagManager::set_iam_policy][crate::client::PolicyTagManager::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4728,7 +4728,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::test_iam_permissions][super::super::client::PolicyTagManager::test_iam_permissions] calls.
+    /// The request builder for [PolicyTagManager::test_iam_permissions][crate::client::PolicyTagManager::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4807,7 +4807,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::list_operations][super::super::client::PolicyTagManager::list_operations] calls.
+    /// The request builder for [PolicyTagManager::list_operations][crate::client::PolicyTagManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4919,7 +4919,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::get_operation][super::super::client::PolicyTagManager::get_operation] calls.
+    /// The request builder for [PolicyTagManager::get_operation][crate::client::PolicyTagManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4983,7 +4983,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::delete_operation][super::super::client::PolicyTagManager::delete_operation] calls.
+    /// The request builder for [PolicyTagManager::delete_operation][crate::client::PolicyTagManager::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5047,7 +5047,7 @@ pub mod policy_tag_manager {
         }
     }
 
-    /// The request builder for [PolicyTagManager::cancel_operation][super::super::client::PolicyTagManager::cancel_operation] calls.
+    /// The request builder for [PolicyTagManager::cancel_operation][crate::client::PolicyTagManager::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5115,7 +5115,7 @@ pub mod policy_tag_manager {
 pub mod policy_tag_manager_serialization {
     use crate::Result;
 
-    /// A builder for [PolicyTagManagerSerialization][super::super::client::PolicyTagManagerSerialization].
+    /// A builder for [PolicyTagManagerSerialization][crate::client::PolicyTagManagerSerialization].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5143,7 +5143,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// Common implementation for [super::super::client::PolicyTagManagerSerialization] request builders.
+    /// Common implementation for [crate::client::PolicyTagManagerSerialization] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PolicyTagManagerSerialization>,
@@ -5166,7 +5166,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for [PolicyTagManagerSerialization::replace_taxonomy][super::super::client::PolicyTagManagerSerialization::replace_taxonomy] calls.
+    /// The request builder for [PolicyTagManagerSerialization::replace_taxonomy][crate::client::PolicyTagManagerSerialization::replace_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5251,7 +5251,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for [PolicyTagManagerSerialization::import_taxonomies][super::super::client::PolicyTagManagerSerialization::import_taxonomies] calls.
+    /// The request builder for [PolicyTagManagerSerialization::import_taxonomies][crate::client::PolicyTagManagerSerialization::import_taxonomies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5359,7 +5359,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for [PolicyTagManagerSerialization::export_taxonomies][super::super::client::PolicyTagManagerSerialization::export_taxonomies] calls.
+    /// The request builder for [PolicyTagManagerSerialization::export_taxonomies][crate::client::PolicyTagManagerSerialization::export_taxonomies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5462,7 +5462,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for [PolicyTagManagerSerialization::list_operations][super::super::client::PolicyTagManagerSerialization::list_operations] calls.
+    /// The request builder for [PolicyTagManagerSerialization::list_operations][crate::client::PolicyTagManagerSerialization::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5574,7 +5574,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for [PolicyTagManagerSerialization::get_operation][super::super::client::PolicyTagManagerSerialization::get_operation] calls.
+    /// The request builder for [PolicyTagManagerSerialization::get_operation][crate::client::PolicyTagManagerSerialization::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5638,7 +5638,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for [PolicyTagManagerSerialization::delete_operation][super::super::client::PolicyTagManagerSerialization::delete_operation] calls.
+    /// The request builder for [PolicyTagManagerSerialization::delete_operation][crate::client::PolicyTagManagerSerialization::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5702,7 +5702,7 @@ pub mod policy_tag_manager_serialization {
         }
     }
 
-    /// The request builder for [PolicyTagManagerSerialization::cancel_operation][super::super::client::PolicyTagManagerSerialization::cancel_operation] calls.
+    /// The request builder for [PolicyTagManagerSerialization::cancel_operation][crate::client::PolicyTagManagerSerialization::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/dataform/v1/src/builder.rs
+++ b/src/generated/cloud/dataform/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod dataform {
     use crate::Result;
 
-    /// A builder for [Dataform][super::super::client::Dataform].
+    /// A builder for [Dataform][crate::client::Dataform].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod dataform {
         }
     }
 
-    /// Common implementation for [super::super::client::Dataform] request builders.
+    /// Common implementation for [crate::client::Dataform] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Dataform>,
@@ -66,7 +66,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::list_repositories][super::super::client::Dataform::list_repositories] calls.
+    /// The request builder for [Dataform::list_repositories][crate::client::Dataform::list_repositories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -182,7 +182,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_repository][super::super::client::Dataform::get_repository] calls.
+    /// The request builder for [Dataform::get_repository][crate::client::Dataform::get_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -243,7 +243,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::create_repository][super::super::client::Dataform::create_repository] calls.
+    /// The request builder for [Dataform::create_repository][crate::client::Dataform::create_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -337,7 +337,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::update_repository][super::super::client::Dataform::update_repository] calls.
+    /// The request builder for [Dataform::update_repository][crate::client::Dataform::update_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -433,7 +433,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::delete_repository][super::super::client::Dataform::delete_repository] calls.
+    /// The request builder for [Dataform::delete_repository][crate::client::Dataform::delete_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -503,7 +503,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::commit_repository_changes][super::super::client::Dataform::commit_repository_changes] calls.
+    /// The request builder for [Dataform::commit_repository_changes][crate::client::Dataform::commit_repository_changes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -609,7 +609,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::read_repository_file][super::super::client::Dataform::read_repository_file] calls.
+    /// The request builder for [Dataform::read_repository_file][crate::client::Dataform::read_repository_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -687,7 +687,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::query_repository_directory_contents][super::super::client::Dataform::query_repository_directory_contents] calls.
+    /// The request builder for [Dataform::query_repository_directory_contents][crate::client::Dataform::query_repository_directory_contents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -809,7 +809,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::fetch_repository_history][super::super::client::Dataform::fetch_repository_history] calls.
+    /// The request builder for [Dataform::fetch_repository_history][crate::client::Dataform::fetch_repository_history] calls.
     ///
     /// # Example
     /// ```no_run
@@ -917,7 +917,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::compute_repository_access_token_status][super::super::client::Dataform::compute_repository_access_token_status] calls.
+    /// The request builder for [Dataform::compute_repository_access_token_status][crate::client::Dataform::compute_repository_access_token_status] calls.
     ///
     /// # Example
     /// ```no_run
@@ -985,7 +985,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::fetch_remote_branches][super::super::client::Dataform::fetch_remote_branches] calls.
+    /// The request builder for [Dataform::fetch_remote_branches][crate::client::Dataform::fetch_remote_branches] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1049,7 +1049,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::list_workspaces][super::super::client::Dataform::list_workspaces] calls.
+    /// The request builder for [Dataform::list_workspaces][crate::client::Dataform::list_workspaces] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1162,7 +1162,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_workspace][super::super::client::Dataform::get_workspace] calls.
+    /// The request builder for [Dataform::get_workspace][crate::client::Dataform::get_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1223,7 +1223,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::create_workspace][super::super::client::Dataform::create_workspace] calls.
+    /// The request builder for [Dataform::create_workspace][crate::client::Dataform::create_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1314,7 +1314,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::delete_workspace][super::super::client::Dataform::delete_workspace] calls.
+    /// The request builder for [Dataform::delete_workspace][crate::client::Dataform::delete_workspace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1375,7 +1375,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::install_npm_packages][super::super::client::Dataform::install_npm_packages] calls.
+    /// The request builder for [Dataform::install_npm_packages][crate::client::Dataform::install_npm_packages] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1439,7 +1439,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::pull_git_commits][super::super::client::Dataform::pull_git_commits] calls.
+    /// The request builder for [Dataform::pull_git_commits][crate::client::Dataform::pull_git_commits] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1528,7 +1528,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::push_git_commits][super::super::client::Dataform::push_git_commits] calls.
+    /// The request builder for [Dataform::push_git_commits][crate::client::Dataform::push_git_commits] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1595,7 +1595,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::fetch_file_git_statuses][super::super::client::Dataform::fetch_file_git_statuses] calls.
+    /// The request builder for [Dataform::fetch_file_git_statuses][crate::client::Dataform::fetch_file_git_statuses] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1659,7 +1659,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::fetch_git_ahead_behind][super::super::client::Dataform::fetch_git_ahead_behind] calls.
+    /// The request builder for [Dataform::fetch_git_ahead_behind][crate::client::Dataform::fetch_git_ahead_behind] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1729,7 +1729,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::commit_workspace_changes][super::super::client::Dataform::commit_workspace_changes] calls.
+    /// The request builder for [Dataform::commit_workspace_changes][crate::client::Dataform::commit_workspace_changes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1832,7 +1832,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::reset_workspace_changes][super::super::client::Dataform::reset_workspace_changes] calls.
+    /// The request builder for [Dataform::reset_workspace_changes][crate::client::Dataform::reset_workspace_changes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1913,7 +1913,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::fetch_file_diff][super::super::client::Dataform::fetch_file_diff] calls.
+    /// The request builder for [Dataform::fetch_file_diff][crate::client::Dataform::fetch_file_diff] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1982,7 +1982,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::query_directory_contents][super::super::client::Dataform::query_directory_contents] calls.
+    /// The request builder for [Dataform::query_directory_contents][crate::client::Dataform::query_directory_contents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2096,7 +2096,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::search_files][super::super::client::Dataform::search_files] calls.
+    /// The request builder for [Dataform::search_files][crate::client::Dataform::search_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2203,7 +2203,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::make_directory][super::super::client::Dataform::make_directory] calls.
+    /// The request builder for [Dataform::make_directory][crate::client::Dataform::make_directory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2272,7 +2272,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::remove_directory][super::super::client::Dataform::remove_directory] calls.
+    /// The request builder for [Dataform::remove_directory][crate::client::Dataform::remove_directory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2341,7 +2341,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::move_directory][super::super::client::Dataform::move_directory] calls.
+    /// The request builder for [Dataform::move_directory][crate::client::Dataform::move_directory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2418,7 +2418,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::read_file][super::super::client::Dataform::read_file] calls.
+    /// The request builder for [Dataform::read_file][crate::client::Dataform::read_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2493,7 +2493,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::remove_file][super::super::client::Dataform::remove_file] calls.
+    /// The request builder for [Dataform::remove_file][crate::client::Dataform::remove_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2562,7 +2562,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::move_file][super::super::client::Dataform::move_file] calls.
+    /// The request builder for [Dataform::move_file][crate::client::Dataform::move_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2639,7 +2639,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::write_file][super::super::client::Dataform::write_file] calls.
+    /// The request builder for [Dataform::write_file][crate::client::Dataform::write_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2716,7 +2716,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::list_release_configs][super::super::client::Dataform::list_release_configs] calls.
+    /// The request builder for [Dataform::list_release_configs][crate::client::Dataform::list_release_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2822,7 +2822,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_release_config][super::super::client::Dataform::get_release_config] calls.
+    /// The request builder for [Dataform::get_release_config][crate::client::Dataform::get_release_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2886,7 +2886,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::create_release_config][super::super::client::Dataform::create_release_config] calls.
+    /// The request builder for [Dataform::create_release_config][crate::client::Dataform::create_release_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2980,7 +2980,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::update_release_config][super::super::client::Dataform::update_release_config] calls.
+    /// The request builder for [Dataform::update_release_config][crate::client::Dataform::update_release_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3076,7 +3076,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::delete_release_config][super::super::client::Dataform::delete_release_config] calls.
+    /// The request builder for [Dataform::delete_release_config][crate::client::Dataform::delete_release_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3140,7 +3140,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::list_compilation_results][super::super::client::Dataform::list_compilation_results] calls.
+    /// The request builder for [Dataform::list_compilation_results][crate::client::Dataform::list_compilation_results] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3260,7 +3260,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_compilation_result][super::super::client::Dataform::get_compilation_result] calls.
+    /// The request builder for [Dataform::get_compilation_result][crate::client::Dataform::get_compilation_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3324,7 +3324,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::create_compilation_result][super::super::client::Dataform::create_compilation_result] calls.
+    /// The request builder for [Dataform::create_compilation_result][crate::client::Dataform::create_compilation_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3412,7 +3412,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::query_compilation_result_actions][super::super::client::Dataform::query_compilation_result_actions] calls.
+    /// The request builder for [Dataform::query_compilation_result_actions][crate::client::Dataform::query_compilation_result_actions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3528,7 +3528,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::list_workflow_configs][super::super::client::Dataform::list_workflow_configs] calls.
+    /// The request builder for [Dataform::list_workflow_configs][crate::client::Dataform::list_workflow_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3634,7 +3634,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_workflow_config][super::super::client::Dataform::get_workflow_config] calls.
+    /// The request builder for [Dataform::get_workflow_config][crate::client::Dataform::get_workflow_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3698,7 +3698,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::create_workflow_config][super::super::client::Dataform::create_workflow_config] calls.
+    /// The request builder for [Dataform::create_workflow_config][crate::client::Dataform::create_workflow_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3792,7 +3792,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::update_workflow_config][super::super::client::Dataform::update_workflow_config] calls.
+    /// The request builder for [Dataform::update_workflow_config][crate::client::Dataform::update_workflow_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3888,7 +3888,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::delete_workflow_config][super::super::client::Dataform::delete_workflow_config] calls.
+    /// The request builder for [Dataform::delete_workflow_config][crate::client::Dataform::delete_workflow_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3952,7 +3952,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::list_workflow_invocations][super::super::client::Dataform::list_workflow_invocations] calls.
+    /// The request builder for [Dataform::list_workflow_invocations][crate::client::Dataform::list_workflow_invocations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4074,7 +4074,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_workflow_invocation][super::super::client::Dataform::get_workflow_invocation] calls.
+    /// The request builder for [Dataform::get_workflow_invocation][crate::client::Dataform::get_workflow_invocation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4138,7 +4138,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::create_workflow_invocation][super::super::client::Dataform::create_workflow_invocation] calls.
+    /// The request builder for [Dataform::create_workflow_invocation][crate::client::Dataform::create_workflow_invocation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4226,7 +4226,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::delete_workflow_invocation][super::super::client::Dataform::delete_workflow_invocation] calls.
+    /// The request builder for [Dataform::delete_workflow_invocation][crate::client::Dataform::delete_workflow_invocation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4292,7 +4292,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::cancel_workflow_invocation][super::super::client::Dataform::cancel_workflow_invocation] calls.
+    /// The request builder for [Dataform::cancel_workflow_invocation][crate::client::Dataform::cancel_workflow_invocation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4358,7 +4358,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::query_workflow_invocation_actions][super::super::client::Dataform::query_workflow_invocation_actions] calls.
+    /// The request builder for [Dataform::query_workflow_invocation_actions][crate::client::Dataform::query_workflow_invocation_actions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4468,7 +4468,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_config][super::super::client::Dataform::get_config] calls.
+    /// The request builder for [Dataform::get_config][crate::client::Dataform::get_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4529,7 +4529,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::update_config][super::super::client::Dataform::update_config] calls.
+    /// The request builder for [Dataform::update_config][crate::client::Dataform::update_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4622,7 +4622,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::list_locations][super::super::client::Dataform::list_locations] calls.
+    /// The request builder for [Dataform::list_locations][crate::client::Dataform::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4730,7 +4730,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_location][super::super::client::Dataform::get_location] calls.
+    /// The request builder for [Dataform::get_location][crate::client::Dataform::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4789,7 +4789,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::set_iam_policy][super::super::client::Dataform::set_iam_policy] calls.
+    /// The request builder for [Dataform::set_iam_policy][crate::client::Dataform::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4890,7 +4890,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::get_iam_policy][super::super::client::Dataform::get_iam_policy] calls.
+    /// The request builder for [Dataform::get_iam_policy][crate::client::Dataform::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4969,7 +4969,7 @@ pub mod dataform {
         }
     }
 
-    /// The request builder for [Dataform::test_iam_permissions][super::super::client::Dataform::test_iam_permissions] calls.
+    /// The request builder for [Dataform::test_iam_permissions][crate::client::Dataform::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/datafusion/v1/src/builder.rs
+++ b/src/generated/cloud/datafusion/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod data_fusion {
     use crate::Result;
 
-    /// A builder for [DataFusion][super::super::client::DataFusion].
+    /// A builder for [DataFusion][crate::client::DataFusion].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod data_fusion {
         }
     }
 
-    /// Common implementation for [super::super::client::DataFusion] request builders.
+    /// Common implementation for [crate::client::DataFusion] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataFusion>,
@@ -68,7 +68,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::list_available_versions][super::super::client::DataFusion::list_available_versions] calls.
+    /// The request builder for [DataFusion::list_available_versions][crate::client::DataFusion::list_available_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -182,7 +182,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::list_instances][super::super::client::DataFusion::list_instances] calls.
+    /// The request builder for [DataFusion::list_instances][crate::client::DataFusion::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::get_instance][super::super::client::DataFusion::get_instance] calls.
+    /// The request builder for [DataFusion::get_instance][crate::client::DataFusion::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -360,7 +360,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::create_instance][super::super::client::DataFusion::create_instance] calls.
+    /// The request builder for [DataFusion::create_instance][crate::client::DataFusion::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -405,7 +405,7 @@ pub mod data_fusion {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::DataFusion::create_instance].
+        /// on [create_instance][crate::client::DataFusion::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -488,7 +488,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::delete_instance][super::super::client::DataFusion::delete_instance] calls.
+    /// The request builder for [DataFusion::delete_instance][crate::client::DataFusion::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -533,7 +533,7 @@ pub mod data_fusion {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::DataFusion::delete_instance].
+        /// on [delete_instance][crate::client::DataFusion::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -592,7 +592,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::update_instance][super::super::client::DataFusion::update_instance] calls.
+    /// The request builder for [DataFusion::update_instance][crate::client::DataFusion::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -637,7 +637,7 @@ pub mod data_fusion {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::DataFusion::update_instance].
+        /// on [update_instance][crate::client::DataFusion::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -726,7 +726,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::restart_instance][super::super::client::DataFusion::restart_instance] calls.
+    /// The request builder for [DataFusion::restart_instance][crate::client::DataFusion::restart_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -771,7 +771,7 @@ pub mod data_fusion {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restart_instance][super::super::client::DataFusion::restart_instance].
+        /// on [restart_instance][crate::client::DataFusion::restart_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restart_instance(self.0.request, self.0.options)
@@ -828,7 +828,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::list_operations][super::super::client::DataFusion::list_operations] calls.
+    /// The request builder for [DataFusion::list_operations][crate::client::DataFusion::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -940,7 +940,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::get_operation][super::super::client::DataFusion::get_operation] calls.
+    /// The request builder for [DataFusion::get_operation][crate::client::DataFusion::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1004,7 +1004,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::delete_operation][super::super::client::DataFusion::delete_operation] calls.
+    /// The request builder for [DataFusion::delete_operation][crate::client::DataFusion::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1068,7 +1068,7 @@ pub mod data_fusion {
         }
     }
 
-    /// The request builder for [DataFusion::cancel_operation][super::super::client::DataFusion::cancel_operation] calls.
+    /// The request builder for [DataFusion::cancel_operation][crate::client::DataFusion::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/dataplex/v1/src/builder.rs
+++ b/src/generated/cloud/dataplex/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod catalog_service {
     use crate::Result;
 
-    /// A builder for [CatalogService][super::super::client::CatalogService].
+    /// A builder for [CatalogService][crate::client::CatalogService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod catalog_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CatalogService] request builders.
+    /// Common implementation for [crate::client::CatalogService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CatalogService>,
@@ -68,7 +68,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::create_entry_type][super::super::client::CatalogService::create_entry_type] calls.
+    /// The request builder for [CatalogService::create_entry_type][crate::client::CatalogService::create_entry_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_entry_type][super::super::client::CatalogService::create_entry_type].
+        /// on [create_entry_type][crate::client::CatalogService::create_entry_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_entry_type(self.0.request, self.0.options)
@@ -206,7 +206,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::update_entry_type][super::super::client::CatalogService::update_entry_type] calls.
+    /// The request builder for [CatalogService::update_entry_type][crate::client::CatalogService::update_entry_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -251,7 +251,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_entry_type][super::super::client::CatalogService::update_entry_type].
+        /// on [update_entry_type][crate::client::CatalogService::update_entry_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_entry_type(self.0.request, self.0.options)
@@ -350,7 +350,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::delete_entry_type][super::super::client::CatalogService::delete_entry_type] calls.
+    /// The request builder for [CatalogService::delete_entry_type][crate::client::CatalogService::delete_entry_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -395,7 +395,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_entry_type][super::super::client::CatalogService::delete_entry_type].
+        /// on [delete_entry_type][crate::client::CatalogService::delete_entry_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_entry_type(self.0.request, self.0.options)
@@ -460,7 +460,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_entry_types][super::super::client::CatalogService::list_entry_types] calls.
+    /// The request builder for [CatalogService::list_entry_types][crate::client::CatalogService::list_entry_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -575,7 +575,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_entry_type][super::super::client::CatalogService::get_entry_type] calls.
+    /// The request builder for [CatalogService::get_entry_type][crate::client::CatalogService::get_entry_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -638,7 +638,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::create_aspect_type][super::super::client::CatalogService::create_aspect_type] calls.
+    /// The request builder for [CatalogService::create_aspect_type][crate::client::CatalogService::create_aspect_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -686,7 +686,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_aspect_type][super::super::client::CatalogService::create_aspect_type].
+        /// on [create_aspect_type][crate::client::CatalogService::create_aspect_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_aspect_type(self.0.request, self.0.options)
@@ -779,7 +779,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::update_aspect_type][super::super::client::CatalogService::update_aspect_type] calls.
+    /// The request builder for [CatalogService::update_aspect_type][crate::client::CatalogService::update_aspect_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -827,7 +827,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_aspect_type][super::super::client::CatalogService::update_aspect_type].
+        /// on [update_aspect_type][crate::client::CatalogService::update_aspect_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_aspect_type(self.0.request, self.0.options)
@@ -926,7 +926,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::delete_aspect_type][super::super::client::CatalogService::delete_aspect_type] calls.
+    /// The request builder for [CatalogService::delete_aspect_type][crate::client::CatalogService::delete_aspect_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -974,7 +974,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_aspect_type][super::super::client::CatalogService::delete_aspect_type].
+        /// on [delete_aspect_type][crate::client::CatalogService::delete_aspect_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_aspect_type(self.0.request, self.0.options)
@@ -1039,7 +1039,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_aspect_types][super::super::client::CatalogService::list_aspect_types] calls.
+    /// The request builder for [CatalogService::list_aspect_types][crate::client::CatalogService::list_aspect_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1154,7 +1154,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_aspect_type][super::super::client::CatalogService::get_aspect_type] calls.
+    /// The request builder for [CatalogService::get_aspect_type][crate::client::CatalogService::get_aspect_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1217,7 +1217,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::create_entry_group][super::super::client::CatalogService::create_entry_group] calls.
+    /// The request builder for [CatalogService::create_entry_group][crate::client::CatalogService::create_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1265,7 +1265,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_entry_group][super::super::client::CatalogService::create_entry_group].
+        /// on [create_entry_group][crate::client::CatalogService::create_entry_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_entry_group(self.0.request, self.0.options)
@@ -1358,7 +1358,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::update_entry_group][super::super::client::CatalogService::update_entry_group] calls.
+    /// The request builder for [CatalogService::update_entry_group][crate::client::CatalogService::update_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1406,7 +1406,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_entry_group][super::super::client::CatalogService::update_entry_group].
+        /// on [update_entry_group][crate::client::CatalogService::update_entry_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_entry_group(self.0.request, self.0.options)
@@ -1505,7 +1505,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::delete_entry_group][super::super::client::CatalogService::delete_entry_group] calls.
+    /// The request builder for [CatalogService::delete_entry_group][crate::client::CatalogService::delete_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1553,7 +1553,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_entry_group][super::super::client::CatalogService::delete_entry_group].
+        /// on [delete_entry_group][crate::client::CatalogService::delete_entry_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_entry_group(self.0.request, self.0.options)
@@ -1618,7 +1618,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_entry_groups][super::super::client::CatalogService::list_entry_groups] calls.
+    /// The request builder for [CatalogService::list_entry_groups][crate::client::CatalogService::list_entry_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1733,7 +1733,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_entry_group][super::super::client::CatalogService::get_entry_group] calls.
+    /// The request builder for [CatalogService::get_entry_group][crate::client::CatalogService::get_entry_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1796,7 +1796,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::create_entry][super::super::client::CatalogService::create_entry] calls.
+    /// The request builder for [CatalogService::create_entry][crate::client::CatalogService::create_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1889,7 +1889,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::update_entry][super::super::client::CatalogService::update_entry] calls.
+    /// The request builder for [CatalogService::update_entry][crate::client::CatalogService::update_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2007,7 +2007,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::delete_entry][super::super::client::CatalogService::delete_entry] calls.
+    /// The request builder for [CatalogService::delete_entry][crate::client::CatalogService::delete_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2070,7 +2070,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_entries][super::super::client::CatalogService::list_entries] calls.
+    /// The request builder for [CatalogService::list_entries][crate::client::CatalogService::list_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2179,7 +2179,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_entry][super::super::client::CatalogService::get_entry] calls.
+    /// The request builder for [CatalogService::get_entry][crate::client::CatalogService::get_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2270,7 +2270,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::lookup_entry][super::super::client::CatalogService::lookup_entry] calls.
+    /// The request builder for [CatalogService::lookup_entry][crate::client::CatalogService::lookup_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2369,7 +2369,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::search_entries][super::super::client::CatalogService::search_entries] calls.
+    /// The request builder for [CatalogService::search_entries][crate::client::CatalogService::search_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2492,7 +2492,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::create_metadata_job][super::super::client::CatalogService::create_metadata_job] calls.
+    /// The request builder for [CatalogService::create_metadata_job][crate::client::CatalogService::create_metadata_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2540,7 +2540,7 @@ pub mod catalog_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_metadata_job][super::super::client::CatalogService::create_metadata_job].
+        /// on [create_metadata_job][crate::client::CatalogService::create_metadata_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_metadata_job(self.0.request, self.0.options)
@@ -2633,7 +2633,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_metadata_job][super::super::client::CatalogService::get_metadata_job] calls.
+    /// The request builder for [CatalogService::get_metadata_job][crate::client::CatalogService::get_metadata_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2696,7 +2696,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_metadata_jobs][super::super::client::CatalogService::list_metadata_jobs] calls.
+    /// The request builder for [CatalogService::list_metadata_jobs][crate::client::CatalogService::list_metadata_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2814,7 +2814,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::cancel_metadata_job][super::super::client::CatalogService::cancel_metadata_job] calls.
+    /// The request builder for [CatalogService::cancel_metadata_job][crate::client::CatalogService::cancel_metadata_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2880,7 +2880,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_locations][super::super::client::CatalogService::list_locations] calls.
+    /// The request builder for [CatalogService::list_locations][crate::client::CatalogService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2990,7 +2990,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_location][super::super::client::CatalogService::get_location] calls.
+    /// The request builder for [CatalogService::get_location][crate::client::CatalogService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3051,7 +3051,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::set_iam_policy][super::super::client::CatalogService::set_iam_policy] calls.
+    /// The request builder for [CatalogService::set_iam_policy][crate::client::CatalogService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3154,7 +3154,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_iam_policy][super::super::client::CatalogService::get_iam_policy] calls.
+    /// The request builder for [CatalogService::get_iam_policy][crate::client::CatalogService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3235,7 +3235,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::test_iam_permissions][super::super::client::CatalogService::test_iam_permissions] calls.
+    /// The request builder for [CatalogService::test_iam_permissions][crate::client::CatalogService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3314,7 +3314,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_operations][super::super::client::CatalogService::list_operations] calls.
+    /// The request builder for [CatalogService::list_operations][crate::client::CatalogService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3426,7 +3426,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_operation][super::super::client::CatalogService::get_operation] calls.
+    /// The request builder for [CatalogService::get_operation][crate::client::CatalogService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3490,7 +3490,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::delete_operation][super::super::client::CatalogService::delete_operation] calls.
+    /// The request builder for [CatalogService::delete_operation][crate::client::CatalogService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3554,7 +3554,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::cancel_operation][super::super::client::CatalogService::cancel_operation] calls.
+    /// The request builder for [CatalogService::cancel_operation][crate::client::CatalogService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3622,7 +3622,7 @@ pub mod catalog_service {
 pub mod cmek_service {
     use crate::Result;
 
-    /// A builder for [CmekService][super::super::client::CmekService].
+    /// A builder for [CmekService][crate::client::CmekService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3650,7 +3650,7 @@ pub mod cmek_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CmekService] request builders.
+    /// Common implementation for [crate::client::CmekService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CmekService>,
@@ -3673,7 +3673,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::create_encryption_config][super::super::client::CmekService::create_encryption_config] calls.
+    /// The request builder for [CmekService::create_encryption_config][crate::client::CmekService::create_encryption_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3721,7 +3721,7 @@ pub mod cmek_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_encryption_config][super::super::client::CmekService::create_encryption_config].
+        /// on [create_encryption_config][crate::client::CmekService::create_encryption_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_encryption_config(self.0.request, self.0.options)
@@ -3811,7 +3811,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::update_encryption_config][super::super::client::CmekService::update_encryption_config] calls.
+    /// The request builder for [CmekService::update_encryption_config][crate::client::CmekService::update_encryption_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3859,7 +3859,7 @@ pub mod cmek_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_encryption_config][super::super::client::CmekService::update_encryption_config].
+        /// on [update_encryption_config][crate::client::CmekService::update_encryption_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_encryption_config(self.0.request, self.0.options)
@@ -3951,7 +3951,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::delete_encryption_config][super::super::client::CmekService::delete_encryption_config] calls.
+    /// The request builder for [CmekService::delete_encryption_config][crate::client::CmekService::delete_encryption_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3999,7 +3999,7 @@ pub mod cmek_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_encryption_config][super::super::client::CmekService::delete_encryption_config].
+        /// on [delete_encryption_config][crate::client::CmekService::delete_encryption_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_encryption_config(self.0.request, self.0.options)
@@ -4064,7 +4064,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::list_encryption_configs][super::super::client::CmekService::list_encryption_configs] calls.
+    /// The request builder for [CmekService::list_encryption_configs][crate::client::CmekService::list_encryption_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4184,7 +4184,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::get_encryption_config][super::super::client::CmekService::get_encryption_config] calls.
+    /// The request builder for [CmekService::get_encryption_config][crate::client::CmekService::get_encryption_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4250,7 +4250,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::list_locations][super::super::client::CmekService::list_locations] calls.
+    /// The request builder for [CmekService::list_locations][crate::client::CmekService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4360,7 +4360,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::get_location][super::super::client::CmekService::get_location] calls.
+    /// The request builder for [CmekService::get_location][crate::client::CmekService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4421,7 +4421,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::set_iam_policy][super::super::client::CmekService::set_iam_policy] calls.
+    /// The request builder for [CmekService::set_iam_policy][crate::client::CmekService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4524,7 +4524,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::get_iam_policy][super::super::client::CmekService::get_iam_policy] calls.
+    /// The request builder for [CmekService::get_iam_policy][crate::client::CmekService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4605,7 +4605,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::test_iam_permissions][super::super::client::CmekService::test_iam_permissions] calls.
+    /// The request builder for [CmekService::test_iam_permissions][crate::client::CmekService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4684,7 +4684,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::list_operations][super::super::client::CmekService::list_operations] calls.
+    /// The request builder for [CmekService::list_operations][crate::client::CmekService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4796,7 +4796,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::get_operation][super::super::client::CmekService::get_operation] calls.
+    /// The request builder for [CmekService::get_operation][crate::client::CmekService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4860,7 +4860,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::delete_operation][super::super::client::CmekService::delete_operation] calls.
+    /// The request builder for [CmekService::delete_operation][crate::client::CmekService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4924,7 +4924,7 @@ pub mod cmek_service {
         }
     }
 
-    /// The request builder for [CmekService::cancel_operation][super::super::client::CmekService::cancel_operation] calls.
+    /// The request builder for [CmekService::cancel_operation][crate::client::CmekService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4992,7 +4992,7 @@ pub mod cmek_service {
 pub mod content_service {
     use crate::Result;
 
-    /// A builder for [ContentService][super::super::client::ContentService].
+    /// A builder for [ContentService][crate::client::ContentService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5020,7 +5020,7 @@ pub mod content_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ContentService] request builders.
+    /// Common implementation for [crate::client::ContentService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ContentService>,
@@ -5043,7 +5043,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::create_content][super::super::client::ContentService::create_content] calls.
+    /// The request builder for [ContentService::create_content][crate::client::ContentService::create_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5134,7 +5134,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::update_content][super::super::client::ContentService::update_content] calls.
+    /// The request builder for [ContentService::update_content][crate::client::ContentService::update_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5239,7 +5239,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::delete_content][super::super::client::ContentService::delete_content] calls.
+    /// The request builder for [ContentService::delete_content][crate::client::ContentService::delete_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5302,7 +5302,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::get_content][super::super::client::ContentService::get_content] calls.
+    /// The request builder for [ContentService::get_content][crate::client::ContentService::get_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5374,7 +5374,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::get_iam_policy][super::super::client::ContentService::get_iam_policy] calls.
+    /// The request builder for [ContentService::get_iam_policy][crate::client::ContentService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5455,7 +5455,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::set_iam_policy][super::super::client::ContentService::set_iam_policy] calls.
+    /// The request builder for [ContentService::set_iam_policy][crate::client::ContentService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5558,7 +5558,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::test_iam_permissions][super::super::client::ContentService::test_iam_permissions] calls.
+    /// The request builder for [ContentService::test_iam_permissions][crate::client::ContentService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5637,7 +5637,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::list_content][super::super::client::ContentService::list_content] calls.
+    /// The request builder for [ContentService::list_content][crate::client::ContentService::list_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5746,7 +5746,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::list_locations][super::super::client::ContentService::list_locations] calls.
+    /// The request builder for [ContentService::list_locations][crate::client::ContentService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5856,7 +5856,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::get_location][super::super::client::ContentService::get_location] calls.
+    /// The request builder for [ContentService::get_location][crate::client::ContentService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5917,7 +5917,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::list_operations][super::super::client::ContentService::list_operations] calls.
+    /// The request builder for [ContentService::list_operations][crate::client::ContentService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6029,7 +6029,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::get_operation][super::super::client::ContentService::get_operation] calls.
+    /// The request builder for [ContentService::get_operation][crate::client::ContentService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6093,7 +6093,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::delete_operation][super::super::client::ContentService::delete_operation] calls.
+    /// The request builder for [ContentService::delete_operation][crate::client::ContentService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6157,7 +6157,7 @@ pub mod content_service {
         }
     }
 
-    /// The request builder for [ContentService::cancel_operation][super::super::client::ContentService::cancel_operation] calls.
+    /// The request builder for [ContentService::cancel_operation][crate::client::ContentService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6225,7 +6225,7 @@ pub mod content_service {
 pub mod data_taxonomy_service {
     use crate::Result;
 
-    /// A builder for [DataTaxonomyService][super::super::client::DataTaxonomyService].
+    /// A builder for [DataTaxonomyService][crate::client::DataTaxonomyService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6253,7 +6253,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataTaxonomyService] request builders.
+    /// Common implementation for [crate::client::DataTaxonomyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataTaxonomyService>,
@@ -6276,7 +6276,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::create_data_taxonomy][super::super::client::DataTaxonomyService::create_data_taxonomy] calls.
+    /// The request builder for [DataTaxonomyService::create_data_taxonomy][crate::client::DataTaxonomyService::create_data_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6324,7 +6324,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_data_taxonomy][super::super::client::DataTaxonomyService::create_data_taxonomy].
+        /// on [create_data_taxonomy][crate::client::DataTaxonomyService::create_data_taxonomy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_data_taxonomy(self.0.request, self.0.options)
@@ -6419,7 +6419,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::update_data_taxonomy][super::super::client::DataTaxonomyService::update_data_taxonomy] calls.
+    /// The request builder for [DataTaxonomyService::update_data_taxonomy][crate::client::DataTaxonomyService::update_data_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6467,7 +6467,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_data_taxonomy][super::super::client::DataTaxonomyService::update_data_taxonomy].
+        /// on [update_data_taxonomy][crate::client::DataTaxonomyService::update_data_taxonomy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_data_taxonomy(self.0.request, self.0.options)
@@ -6568,7 +6568,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::delete_data_taxonomy][super::super::client::DataTaxonomyService::delete_data_taxonomy] calls.
+    /// The request builder for [DataTaxonomyService::delete_data_taxonomy][crate::client::DataTaxonomyService::delete_data_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6616,7 +6616,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_data_taxonomy][super::super::client::DataTaxonomyService::delete_data_taxonomy].
+        /// on [delete_data_taxonomy][crate::client::DataTaxonomyService::delete_data_taxonomy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_data_taxonomy(self.0.request, self.0.options)
@@ -6681,7 +6681,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::list_data_taxonomies][super::super::client::DataTaxonomyService::list_data_taxonomies] calls.
+    /// The request builder for [DataTaxonomyService::list_data_taxonomies][crate::client::DataTaxonomyService::list_data_taxonomies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6801,7 +6801,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::get_data_taxonomy][super::super::client::DataTaxonomyService::get_data_taxonomy] calls.
+    /// The request builder for [DataTaxonomyService::get_data_taxonomy][crate::client::DataTaxonomyService::get_data_taxonomy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6864,7 +6864,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::create_data_attribute_binding][super::super::client::DataTaxonomyService::create_data_attribute_binding] calls.
+    /// The request builder for [DataTaxonomyService::create_data_attribute_binding][crate::client::DataTaxonomyService::create_data_attribute_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6914,7 +6914,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_data_attribute_binding][super::super::client::DataTaxonomyService::create_data_attribute_binding].
+        /// on [create_data_attribute_binding][crate::client::DataTaxonomyService::create_data_attribute_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_data_attribute_binding(self.0.request, self.0.options)
@@ -7010,7 +7010,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::update_data_attribute_binding][super::super::client::DataTaxonomyService::update_data_attribute_binding] calls.
+    /// The request builder for [DataTaxonomyService::update_data_attribute_binding][crate::client::DataTaxonomyService::update_data_attribute_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7060,7 +7060,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_data_attribute_binding][super::super::client::DataTaxonomyService::update_data_attribute_binding].
+        /// on [update_data_attribute_binding][crate::client::DataTaxonomyService::update_data_attribute_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_data_attribute_binding(self.0.request, self.0.options)
@@ -7162,7 +7162,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::delete_data_attribute_binding][super::super::client::DataTaxonomyService::delete_data_attribute_binding] calls.
+    /// The request builder for [DataTaxonomyService::delete_data_attribute_binding][crate::client::DataTaxonomyService::delete_data_attribute_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7212,7 +7212,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_data_attribute_binding][super::super::client::DataTaxonomyService::delete_data_attribute_binding].
+        /// on [delete_data_attribute_binding][crate::client::DataTaxonomyService::delete_data_attribute_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_data_attribute_binding(self.0.request, self.0.options)
@@ -7279,7 +7279,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::list_data_attribute_bindings][super::super::client::DataTaxonomyService::list_data_attribute_bindings] calls.
+    /// The request builder for [DataTaxonomyService::list_data_attribute_bindings][crate::client::DataTaxonomyService::list_data_attribute_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7403,7 +7403,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::get_data_attribute_binding][super::super::client::DataTaxonomyService::get_data_attribute_binding] calls.
+    /// The request builder for [DataTaxonomyService::get_data_attribute_binding][crate::client::DataTaxonomyService::get_data_attribute_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7471,7 +7471,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::create_data_attribute][super::super::client::DataTaxonomyService::create_data_attribute] calls.
+    /// The request builder for [DataTaxonomyService::create_data_attribute][crate::client::DataTaxonomyService::create_data_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7519,7 +7519,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_data_attribute][super::super::client::DataTaxonomyService::create_data_attribute].
+        /// on [create_data_attribute][crate::client::DataTaxonomyService::create_data_attribute].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_data_attribute(self.0.request, self.0.options)
@@ -7615,7 +7615,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::update_data_attribute][super::super::client::DataTaxonomyService::update_data_attribute] calls.
+    /// The request builder for [DataTaxonomyService::update_data_attribute][crate::client::DataTaxonomyService::update_data_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7663,7 +7663,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_data_attribute][super::super::client::DataTaxonomyService::update_data_attribute].
+        /// on [update_data_attribute][crate::client::DataTaxonomyService::update_data_attribute].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_data_attribute(self.0.request, self.0.options)
@@ -7765,7 +7765,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::delete_data_attribute][super::super::client::DataTaxonomyService::delete_data_attribute] calls.
+    /// The request builder for [DataTaxonomyService::delete_data_attribute][crate::client::DataTaxonomyService::delete_data_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7813,7 +7813,7 @@ pub mod data_taxonomy_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_data_attribute][super::super::client::DataTaxonomyService::delete_data_attribute].
+        /// on [delete_data_attribute][crate::client::DataTaxonomyService::delete_data_attribute].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_data_attribute(self.0.request, self.0.options)
@@ -7878,7 +7878,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::list_data_attributes][super::super::client::DataTaxonomyService::list_data_attributes] calls.
+    /// The request builder for [DataTaxonomyService::list_data_attributes][crate::client::DataTaxonomyService::list_data_attributes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7998,7 +7998,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::get_data_attribute][super::super::client::DataTaxonomyService::get_data_attribute] calls.
+    /// The request builder for [DataTaxonomyService::get_data_attribute][crate::client::DataTaxonomyService::get_data_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8064,7 +8064,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::list_locations][super::super::client::DataTaxonomyService::list_locations] calls.
+    /// The request builder for [DataTaxonomyService::list_locations][crate::client::DataTaxonomyService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8174,7 +8174,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::get_location][super::super::client::DataTaxonomyService::get_location] calls.
+    /// The request builder for [DataTaxonomyService::get_location][crate::client::DataTaxonomyService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8235,7 +8235,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::set_iam_policy][super::super::client::DataTaxonomyService::set_iam_policy] calls.
+    /// The request builder for [DataTaxonomyService::set_iam_policy][crate::client::DataTaxonomyService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8338,7 +8338,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::get_iam_policy][super::super::client::DataTaxonomyService::get_iam_policy] calls.
+    /// The request builder for [DataTaxonomyService::get_iam_policy][crate::client::DataTaxonomyService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8419,7 +8419,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::test_iam_permissions][super::super::client::DataTaxonomyService::test_iam_permissions] calls.
+    /// The request builder for [DataTaxonomyService::test_iam_permissions][crate::client::DataTaxonomyService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8498,7 +8498,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::list_operations][super::super::client::DataTaxonomyService::list_operations] calls.
+    /// The request builder for [DataTaxonomyService::list_operations][crate::client::DataTaxonomyService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8610,7 +8610,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::get_operation][super::super::client::DataTaxonomyService::get_operation] calls.
+    /// The request builder for [DataTaxonomyService::get_operation][crate::client::DataTaxonomyService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8674,7 +8674,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::delete_operation][super::super::client::DataTaxonomyService::delete_operation] calls.
+    /// The request builder for [DataTaxonomyService::delete_operation][crate::client::DataTaxonomyService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8738,7 +8738,7 @@ pub mod data_taxonomy_service {
         }
     }
 
-    /// The request builder for [DataTaxonomyService::cancel_operation][super::super::client::DataTaxonomyService::cancel_operation] calls.
+    /// The request builder for [DataTaxonomyService::cancel_operation][crate::client::DataTaxonomyService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8806,7 +8806,7 @@ pub mod data_taxonomy_service {
 pub mod data_scan_service {
     use crate::Result;
 
-    /// A builder for [DataScanService][super::super::client::DataScanService].
+    /// A builder for [DataScanService][crate::client::DataScanService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -8834,7 +8834,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataScanService] request builders.
+    /// Common implementation for [crate::client::DataScanService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataScanService>,
@@ -8857,7 +8857,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::create_data_scan][super::super::client::DataScanService::create_data_scan] calls.
+    /// The request builder for [DataScanService::create_data_scan][crate::client::DataScanService::create_data_scan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8902,7 +8902,7 @@ pub mod data_scan_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_data_scan][super::super::client::DataScanService::create_data_scan].
+        /// on [create_data_scan][crate::client::DataScanService::create_data_scan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_data_scan(self.0.request, self.0.options)
@@ -8995,7 +8995,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::update_data_scan][super::super::client::DataScanService::update_data_scan] calls.
+    /// The request builder for [DataScanService::update_data_scan][crate::client::DataScanService::update_data_scan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9040,7 +9040,7 @@ pub mod data_scan_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_data_scan][super::super::client::DataScanService::update_data_scan].
+        /// on [update_data_scan][crate::client::DataScanService::update_data_scan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_data_scan(self.0.request, self.0.options)
@@ -9135,7 +9135,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::delete_data_scan][super::super::client::DataScanService::delete_data_scan] calls.
+    /// The request builder for [DataScanService::delete_data_scan][crate::client::DataScanService::delete_data_scan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9180,7 +9180,7 @@ pub mod data_scan_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_data_scan][super::super::client::DataScanService::delete_data_scan].
+        /// on [delete_data_scan][crate::client::DataScanService::delete_data_scan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_data_scan(self.0.request, self.0.options)
@@ -9245,7 +9245,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::get_data_scan][super::super::client::DataScanService::get_data_scan] calls.
+    /// The request builder for [DataScanService::get_data_scan][crate::client::DataScanService::get_data_scan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9317,7 +9317,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::list_data_scans][super::super::client::DataScanService::list_data_scans] calls.
+    /// The request builder for [DataScanService::list_data_scans][crate::client::DataScanService::list_data_scans] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9432,7 +9432,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::run_data_scan][super::super::client::DataScanService::run_data_scan] calls.
+    /// The request builder for [DataScanService::run_data_scan][crate::client::DataScanService::run_data_scan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9495,7 +9495,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::get_data_scan_job][super::super::client::DataScanService::get_data_scan_job] calls.
+    /// The request builder for [DataScanService::get_data_scan_job][crate::client::DataScanService::get_data_scan_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9567,7 +9567,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::list_data_scan_jobs][super::super::client::DataScanService::list_data_scan_jobs] calls.
+    /// The request builder for [DataScanService::list_data_scan_jobs][crate::client::DataScanService::list_data_scan_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9679,7 +9679,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::generate_data_quality_rules][super::super::client::DataScanService::generate_data_quality_rules] calls.
+    /// The request builder for [DataScanService::generate_data_quality_rules][crate::client::DataScanService::generate_data_quality_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9747,7 +9747,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::list_locations][super::super::client::DataScanService::list_locations] calls.
+    /// The request builder for [DataScanService::list_locations][crate::client::DataScanService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9857,7 +9857,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::get_location][super::super::client::DataScanService::get_location] calls.
+    /// The request builder for [DataScanService::get_location][crate::client::DataScanService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9918,7 +9918,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::set_iam_policy][super::super::client::DataScanService::set_iam_policy] calls.
+    /// The request builder for [DataScanService::set_iam_policy][crate::client::DataScanService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10021,7 +10021,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::get_iam_policy][super::super::client::DataScanService::get_iam_policy] calls.
+    /// The request builder for [DataScanService::get_iam_policy][crate::client::DataScanService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10102,7 +10102,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::test_iam_permissions][super::super::client::DataScanService::test_iam_permissions] calls.
+    /// The request builder for [DataScanService::test_iam_permissions][crate::client::DataScanService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10181,7 +10181,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::list_operations][super::super::client::DataScanService::list_operations] calls.
+    /// The request builder for [DataScanService::list_operations][crate::client::DataScanService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10293,7 +10293,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::get_operation][super::super::client::DataScanService::get_operation] calls.
+    /// The request builder for [DataScanService::get_operation][crate::client::DataScanService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10357,7 +10357,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::delete_operation][super::super::client::DataScanService::delete_operation] calls.
+    /// The request builder for [DataScanService::delete_operation][crate::client::DataScanService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10421,7 +10421,7 @@ pub mod data_scan_service {
         }
     }
 
-    /// The request builder for [DataScanService::cancel_operation][super::super::client::DataScanService::cancel_operation] calls.
+    /// The request builder for [DataScanService::cancel_operation][crate::client::DataScanService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10489,7 +10489,7 @@ pub mod data_scan_service {
 pub mod metadata_service {
     use crate::Result;
 
-    /// A builder for [MetadataService][super::super::client::MetadataService].
+    /// A builder for [MetadataService][crate::client::MetadataService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -10517,7 +10517,7 @@ pub mod metadata_service {
         }
     }
 
-    /// Common implementation for [super::super::client::MetadataService] request builders.
+    /// Common implementation for [crate::client::MetadataService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MetadataService>,
@@ -10540,7 +10540,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::create_entity][super::super::client::MetadataService::create_entity] calls.
+    /// The request builder for [MetadataService::create_entity][crate::client::MetadataService::create_entity] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10631,7 +10631,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::update_entity][super::super::client::MetadataService::update_entity] calls.
+    /// The request builder for [MetadataService::update_entity][crate::client::MetadataService::update_entity] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10714,7 +10714,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_entity][super::super::client::MetadataService::delete_entity] calls.
+    /// The request builder for [MetadataService::delete_entity][crate::client::MetadataService::delete_entity] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10785,7 +10785,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_entity][super::super::client::MetadataService::get_entity] calls.
+    /// The request builder for [MetadataService::get_entity][crate::client::MetadataService::get_entity] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10857,7 +10857,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_entities][super::super::client::MetadataService::list_entities] calls.
+    /// The request builder for [MetadataService::list_entities][crate::client::MetadataService::list_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10977,7 +10977,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::create_partition][super::super::client::MetadataService::create_partition] calls.
+    /// The request builder for [MetadataService::create_partition][crate::client::MetadataService::create_partition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11068,7 +11068,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_partition][super::super::client::MetadataService::delete_partition] calls.
+    /// The request builder for [MetadataService::delete_partition][crate::client::MetadataService::delete_partition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11138,7 +11138,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_partition][super::super::client::MetadataService::get_partition] calls.
+    /// The request builder for [MetadataService::get_partition][crate::client::MetadataService::get_partition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11201,7 +11201,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_partitions][super::super::client::MetadataService::list_partitions] calls.
+    /// The request builder for [MetadataService::list_partitions][crate::client::MetadataService::list_partitions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11310,7 +11310,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_locations][super::super::client::MetadataService::list_locations] calls.
+    /// The request builder for [MetadataService::list_locations][crate::client::MetadataService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11420,7 +11420,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_location][super::super::client::MetadataService::get_location] calls.
+    /// The request builder for [MetadataService::get_location][crate::client::MetadataService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11481,7 +11481,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::set_iam_policy][super::super::client::MetadataService::set_iam_policy] calls.
+    /// The request builder for [MetadataService::set_iam_policy][crate::client::MetadataService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11584,7 +11584,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_iam_policy][super::super::client::MetadataService::get_iam_policy] calls.
+    /// The request builder for [MetadataService::get_iam_policy][crate::client::MetadataService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11665,7 +11665,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::test_iam_permissions][super::super::client::MetadataService::test_iam_permissions] calls.
+    /// The request builder for [MetadataService::test_iam_permissions][crate::client::MetadataService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11744,7 +11744,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::list_operations][super::super::client::MetadataService::list_operations] calls.
+    /// The request builder for [MetadataService::list_operations][crate::client::MetadataService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11856,7 +11856,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::get_operation][super::super::client::MetadataService::get_operation] calls.
+    /// The request builder for [MetadataService::get_operation][crate::client::MetadataService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11920,7 +11920,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::delete_operation][super::super::client::MetadataService::delete_operation] calls.
+    /// The request builder for [MetadataService::delete_operation][crate::client::MetadataService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11984,7 +11984,7 @@ pub mod metadata_service {
         }
     }
 
-    /// The request builder for [MetadataService::cancel_operation][super::super::client::MetadataService::cancel_operation] calls.
+    /// The request builder for [MetadataService::cancel_operation][crate::client::MetadataService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12052,7 +12052,7 @@ pub mod metadata_service {
 pub mod dataplex_service {
     use crate::Result;
 
-    /// A builder for [DataplexService][super::super::client::DataplexService].
+    /// A builder for [DataplexService][crate::client::DataplexService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -12080,7 +12080,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataplexService] request builders.
+    /// Common implementation for [crate::client::DataplexService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataplexService>,
@@ -12103,7 +12103,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::create_lake][super::super::client::DataplexService::create_lake] calls.
+    /// The request builder for [DataplexService::create_lake][crate::client::DataplexService::create_lake] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12148,7 +12148,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_lake][super::super::client::DataplexService::create_lake].
+        /// on [create_lake][crate::client::DataplexService::create_lake].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_lake(self.0.request, self.0.options)
@@ -12241,7 +12241,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::update_lake][super::super::client::DataplexService::update_lake] calls.
+    /// The request builder for [DataplexService::update_lake][crate::client::DataplexService::update_lake] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12286,7 +12286,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_lake][super::super::client::DataplexService::update_lake].
+        /// on [update_lake][crate::client::DataplexService::update_lake].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_lake(self.0.request, self.0.options)
@@ -12385,7 +12385,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::delete_lake][super::super::client::DataplexService::delete_lake] calls.
+    /// The request builder for [DataplexService::delete_lake][crate::client::DataplexService::delete_lake] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12430,7 +12430,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_lake][super::super::client::DataplexService::delete_lake].
+        /// on [delete_lake][crate::client::DataplexService::delete_lake].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_lake(self.0.request, self.0.options)
@@ -12489,7 +12489,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_lakes][super::super::client::DataplexService::list_lakes] calls.
+    /// The request builder for [DataplexService::list_lakes][crate::client::DataplexService::list_lakes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12604,7 +12604,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_lake][super::super::client::DataplexService::get_lake] calls.
+    /// The request builder for [DataplexService::get_lake][crate::client::DataplexService::get_lake] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12667,7 +12667,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_lake_actions][super::super::client::DataplexService::list_lake_actions] calls.
+    /// The request builder for [DataplexService::list_lake_actions][crate::client::DataplexService::list_lake_actions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12770,7 +12770,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::create_zone][super::super::client::DataplexService::create_zone] calls.
+    /// The request builder for [DataplexService::create_zone][crate::client::DataplexService::create_zone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12815,7 +12815,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_zone][super::super::client::DataplexService::create_zone].
+        /// on [create_zone][crate::client::DataplexService::create_zone].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_zone(self.0.request, self.0.options)
@@ -12908,7 +12908,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::update_zone][super::super::client::DataplexService::update_zone] calls.
+    /// The request builder for [DataplexService::update_zone][crate::client::DataplexService::update_zone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12953,7 +12953,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_zone][super::super::client::DataplexService::update_zone].
+        /// on [update_zone][crate::client::DataplexService::update_zone].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_zone(self.0.request, self.0.options)
@@ -13052,7 +13052,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::delete_zone][super::super::client::DataplexService::delete_zone] calls.
+    /// The request builder for [DataplexService::delete_zone][crate::client::DataplexService::delete_zone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13097,7 +13097,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_zone][super::super::client::DataplexService::delete_zone].
+        /// on [delete_zone][crate::client::DataplexService::delete_zone].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_zone(self.0.request, self.0.options)
@@ -13156,7 +13156,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_zones][super::super::client::DataplexService::list_zones] calls.
+    /// The request builder for [DataplexService::list_zones][crate::client::DataplexService::list_zones] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13271,7 +13271,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_zone][super::super::client::DataplexService::get_zone] calls.
+    /// The request builder for [DataplexService::get_zone][crate::client::DataplexService::get_zone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13334,7 +13334,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_zone_actions][super::super::client::DataplexService::list_zone_actions] calls.
+    /// The request builder for [DataplexService::list_zone_actions][crate::client::DataplexService::list_zone_actions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13437,7 +13437,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::create_asset][super::super::client::DataplexService::create_asset] calls.
+    /// The request builder for [DataplexService::create_asset][crate::client::DataplexService::create_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13482,7 +13482,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_asset][super::super::client::DataplexService::create_asset].
+        /// on [create_asset][crate::client::DataplexService::create_asset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_asset(self.0.request, self.0.options)
@@ -13575,7 +13575,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::update_asset][super::super::client::DataplexService::update_asset] calls.
+    /// The request builder for [DataplexService::update_asset][crate::client::DataplexService::update_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13620,7 +13620,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_asset][super::super::client::DataplexService::update_asset].
+        /// on [update_asset][crate::client::DataplexService::update_asset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_asset(self.0.request, self.0.options)
@@ -13719,7 +13719,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::delete_asset][super::super::client::DataplexService::delete_asset] calls.
+    /// The request builder for [DataplexService::delete_asset][crate::client::DataplexService::delete_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13764,7 +13764,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_asset][super::super::client::DataplexService::delete_asset].
+        /// on [delete_asset][crate::client::DataplexService::delete_asset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_asset(self.0.request, self.0.options)
@@ -13823,7 +13823,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_assets][super::super::client::DataplexService::list_assets] calls.
+    /// The request builder for [DataplexService::list_assets][crate::client::DataplexService::list_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13938,7 +13938,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_asset][super::super::client::DataplexService::get_asset] calls.
+    /// The request builder for [DataplexService::get_asset][crate::client::DataplexService::get_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14001,7 +14001,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_asset_actions][super::super::client::DataplexService::list_asset_actions] calls.
+    /// The request builder for [DataplexService::list_asset_actions][crate::client::DataplexService::list_asset_actions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14107,7 +14107,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::create_task][super::super::client::DataplexService::create_task] calls.
+    /// The request builder for [DataplexService::create_task][crate::client::DataplexService::create_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14152,7 +14152,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_task][super::super::client::DataplexService::create_task].
+        /// on [create_task][crate::client::DataplexService::create_task].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_task(self.0.request, self.0.options)
@@ -14245,7 +14245,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::update_task][super::super::client::DataplexService::update_task] calls.
+    /// The request builder for [DataplexService::update_task][crate::client::DataplexService::update_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14290,7 +14290,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_task][super::super::client::DataplexService::update_task].
+        /// on [update_task][crate::client::DataplexService::update_task].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_task(self.0.request, self.0.options)
@@ -14389,7 +14389,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::delete_task][super::super::client::DataplexService::delete_task] calls.
+    /// The request builder for [DataplexService::delete_task][crate::client::DataplexService::delete_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14434,7 +14434,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_task][super::super::client::DataplexService::delete_task].
+        /// on [delete_task][crate::client::DataplexService::delete_task].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_task(self.0.request, self.0.options)
@@ -14493,7 +14493,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_tasks][super::super::client::DataplexService::list_tasks] calls.
+    /// The request builder for [DataplexService::list_tasks][crate::client::DataplexService::list_tasks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14608,7 +14608,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_task][super::super::client::DataplexService::get_task] calls.
+    /// The request builder for [DataplexService::get_task][crate::client::DataplexService::get_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14671,7 +14671,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_jobs][super::super::client::DataplexService::list_jobs] calls.
+    /// The request builder for [DataplexService::list_jobs][crate::client::DataplexService::list_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14774,7 +14774,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::run_task][super::super::client::DataplexService::run_task] calls.
+    /// The request builder for [DataplexService::run_task][crate::client::DataplexService::run_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14859,7 +14859,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_job][super::super::client::DataplexService::get_job] calls.
+    /// The request builder for [DataplexService::get_job][crate::client::DataplexService::get_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14922,7 +14922,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::cancel_job][super::super::client::DataplexService::cancel_job] calls.
+    /// The request builder for [DataplexService::cancel_job][crate::client::DataplexService::cancel_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14985,7 +14985,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::create_environment][super::super::client::DataplexService::create_environment] calls.
+    /// The request builder for [DataplexService::create_environment][crate::client::DataplexService::create_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15033,7 +15033,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_environment][super::super::client::DataplexService::create_environment].
+        /// on [create_environment][crate::client::DataplexService::create_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_environment(self.0.request, self.0.options)
@@ -15128,7 +15128,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::update_environment][super::super::client::DataplexService::update_environment] calls.
+    /// The request builder for [DataplexService::update_environment][crate::client::DataplexService::update_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15176,7 +15176,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_environment][super::super::client::DataplexService::update_environment].
+        /// on [update_environment][crate::client::DataplexService::update_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_environment(self.0.request, self.0.options)
@@ -15277,7 +15277,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::delete_environment][super::super::client::DataplexService::delete_environment] calls.
+    /// The request builder for [DataplexService::delete_environment][crate::client::DataplexService::delete_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15325,7 +15325,7 @@ pub mod dataplex_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_environment][super::super::client::DataplexService::delete_environment].
+        /// on [delete_environment][crate::client::DataplexService::delete_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_environment(self.0.request, self.0.options)
@@ -15384,7 +15384,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_environments][super::super::client::DataplexService::list_environments] calls.
+    /// The request builder for [DataplexService::list_environments][crate::client::DataplexService::list_environments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15502,7 +15502,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_environment][super::super::client::DataplexService::get_environment] calls.
+    /// The request builder for [DataplexService::get_environment][crate::client::DataplexService::get_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15565,7 +15565,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_sessions][super::super::client::DataplexService::list_sessions] calls.
+    /// The request builder for [DataplexService::list_sessions][crate::client::DataplexService::list_sessions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15674,7 +15674,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_locations][super::super::client::DataplexService::list_locations] calls.
+    /// The request builder for [DataplexService::list_locations][crate::client::DataplexService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15784,7 +15784,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_location][super::super::client::DataplexService::get_location] calls.
+    /// The request builder for [DataplexService::get_location][crate::client::DataplexService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15845,7 +15845,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::set_iam_policy][super::super::client::DataplexService::set_iam_policy] calls.
+    /// The request builder for [DataplexService::set_iam_policy][crate::client::DataplexService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15948,7 +15948,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_iam_policy][super::super::client::DataplexService::get_iam_policy] calls.
+    /// The request builder for [DataplexService::get_iam_policy][crate::client::DataplexService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16029,7 +16029,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::test_iam_permissions][super::super::client::DataplexService::test_iam_permissions] calls.
+    /// The request builder for [DataplexService::test_iam_permissions][crate::client::DataplexService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16108,7 +16108,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::list_operations][super::super::client::DataplexService::list_operations] calls.
+    /// The request builder for [DataplexService::list_operations][crate::client::DataplexService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16220,7 +16220,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::get_operation][super::super::client::DataplexService::get_operation] calls.
+    /// The request builder for [DataplexService::get_operation][crate::client::DataplexService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16284,7 +16284,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::delete_operation][super::super::client::DataplexService::delete_operation] calls.
+    /// The request builder for [DataplexService::delete_operation][crate::client::DataplexService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16348,7 +16348,7 @@ pub mod dataplex_service {
         }
     }
 
-    /// The request builder for [DataplexService::cancel_operation][super::super::client::DataplexService::cancel_operation] calls.
+    /// The request builder for [DataplexService::cancel_operation][crate::client::DataplexService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/dataproc/v1/src/builder.rs
+++ b/src/generated/cloud/dataproc/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod autoscaling_policy_service {
     use crate::Result;
 
-    /// A builder for [AutoscalingPolicyService][super::super::client::AutoscalingPolicyService].
+    /// A builder for [AutoscalingPolicyService][crate::client::AutoscalingPolicyService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AutoscalingPolicyService] request builders.
+    /// Common implementation for [crate::client::AutoscalingPolicyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AutoscalingPolicyService>,
@@ -68,7 +68,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::create_autoscaling_policy][super::super::client::AutoscalingPolicyService::create_autoscaling_policy] calls.
+    /// The request builder for [AutoscalingPolicyService::create_autoscaling_policy][crate::client::AutoscalingPolicyService::create_autoscaling_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -158,7 +158,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::update_autoscaling_policy][super::super::client::AutoscalingPolicyService::update_autoscaling_policy] calls.
+    /// The request builder for [AutoscalingPolicyService::update_autoscaling_policy][crate::client::AutoscalingPolicyService::update_autoscaling_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::get_autoscaling_policy][super::super::client::AutoscalingPolicyService::get_autoscaling_policy] calls.
+    /// The request builder for [AutoscalingPolicyService::get_autoscaling_policy][crate::client::AutoscalingPolicyService::get_autoscaling_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -306,7 +306,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::list_autoscaling_policies][super::super::client::AutoscalingPolicyService::list_autoscaling_policies] calls.
+    /// The request builder for [AutoscalingPolicyService::list_autoscaling_policies][crate::client::AutoscalingPolicyService::list_autoscaling_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -418,7 +418,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::delete_autoscaling_policy][super::super::client::AutoscalingPolicyService::delete_autoscaling_policy] calls.
+    /// The request builder for [AutoscalingPolicyService::delete_autoscaling_policy][crate::client::AutoscalingPolicyService::delete_autoscaling_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -486,7 +486,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::set_iam_policy][super::super::client::AutoscalingPolicyService::set_iam_policy] calls.
+    /// The request builder for [AutoscalingPolicyService::set_iam_policy][crate::client::AutoscalingPolicyService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -589,7 +589,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::get_iam_policy][super::super::client::AutoscalingPolicyService::get_iam_policy] calls.
+    /// The request builder for [AutoscalingPolicyService::get_iam_policy][crate::client::AutoscalingPolicyService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -670,7 +670,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::test_iam_permissions][super::super::client::AutoscalingPolicyService::test_iam_permissions] calls.
+    /// The request builder for [AutoscalingPolicyService::test_iam_permissions][crate::client::AutoscalingPolicyService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -749,7 +749,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::list_operations][super::super::client::AutoscalingPolicyService::list_operations] calls.
+    /// The request builder for [AutoscalingPolicyService::list_operations][crate::client::AutoscalingPolicyService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -861,7 +861,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::get_operation][super::super::client::AutoscalingPolicyService::get_operation] calls.
+    /// The request builder for [AutoscalingPolicyService::get_operation][crate::client::AutoscalingPolicyService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -925,7 +925,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::delete_operation][super::super::client::AutoscalingPolicyService::delete_operation] calls.
+    /// The request builder for [AutoscalingPolicyService::delete_operation][crate::client::AutoscalingPolicyService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -989,7 +989,7 @@ pub mod autoscaling_policy_service {
         }
     }
 
-    /// The request builder for [AutoscalingPolicyService::cancel_operation][super::super::client::AutoscalingPolicyService::cancel_operation] calls.
+    /// The request builder for [AutoscalingPolicyService::cancel_operation][crate::client::AutoscalingPolicyService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1057,7 +1057,7 @@ pub mod autoscaling_policy_service {
 pub mod batch_controller {
     use crate::Result;
 
-    /// A builder for [BatchController][super::super::client::BatchController].
+    /// A builder for [BatchController][crate::client::BatchController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1085,7 +1085,7 @@ pub mod batch_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::BatchController] request builders.
+    /// Common implementation for [crate::client::BatchController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::BatchController>,
@@ -1108,7 +1108,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::create_batch][super::super::client::BatchController::create_batch] calls.
+    /// The request builder for [BatchController::create_batch][crate::client::BatchController::create_batch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1153,7 +1153,7 @@ pub mod batch_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_batch][super::super::client::BatchController::create_batch].
+        /// on [create_batch][crate::client::BatchController::create_batch].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_batch(self.0.request, self.0.options)
@@ -1244,7 +1244,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::get_batch][super::super::client::BatchController::get_batch] calls.
+    /// The request builder for [BatchController::get_batch][crate::client::BatchController::get_batch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1307,7 +1307,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::list_batches][super::super::client::BatchController::list_batches] calls.
+    /// The request builder for [BatchController::list_batches][crate::client::BatchController::list_batches] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1422,7 +1422,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::delete_batch][super::super::client::BatchController::delete_batch] calls.
+    /// The request builder for [BatchController::delete_batch][crate::client::BatchController::delete_batch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1485,7 +1485,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::set_iam_policy][super::super::client::BatchController::set_iam_policy] calls.
+    /// The request builder for [BatchController::set_iam_policy][crate::client::BatchController::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1588,7 +1588,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::get_iam_policy][super::super::client::BatchController::get_iam_policy] calls.
+    /// The request builder for [BatchController::get_iam_policy][crate::client::BatchController::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1669,7 +1669,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::test_iam_permissions][super::super::client::BatchController::test_iam_permissions] calls.
+    /// The request builder for [BatchController::test_iam_permissions][crate::client::BatchController::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1748,7 +1748,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::list_operations][super::super::client::BatchController::list_operations] calls.
+    /// The request builder for [BatchController::list_operations][crate::client::BatchController::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1860,7 +1860,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::get_operation][super::super::client::BatchController::get_operation] calls.
+    /// The request builder for [BatchController::get_operation][crate::client::BatchController::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1924,7 +1924,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::delete_operation][super::super::client::BatchController::delete_operation] calls.
+    /// The request builder for [BatchController::delete_operation][crate::client::BatchController::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1988,7 +1988,7 @@ pub mod batch_controller {
         }
     }
 
-    /// The request builder for [BatchController::cancel_operation][super::super::client::BatchController::cancel_operation] calls.
+    /// The request builder for [BatchController::cancel_operation][crate::client::BatchController::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2056,7 +2056,7 @@ pub mod batch_controller {
 pub mod cluster_controller {
     use crate::Result;
 
-    /// A builder for [ClusterController][super::super::client::ClusterController].
+    /// A builder for [ClusterController][crate::client::ClusterController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2084,7 +2084,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::ClusterController] request builders.
+    /// Common implementation for [crate::client::ClusterController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ClusterController>,
@@ -2107,7 +2107,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::create_cluster][super::super::client::ClusterController::create_cluster] calls.
+    /// The request builder for [ClusterController::create_cluster][crate::client::ClusterController::create_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2152,7 +2152,7 @@ pub mod cluster_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cluster][super::super::client::ClusterController::create_cluster].
+        /// on [create_cluster][crate::client::ClusterController::create_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cluster(self.0.request, self.0.options)
@@ -2257,7 +2257,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::update_cluster][super::super::client::ClusterController::update_cluster] calls.
+    /// The request builder for [ClusterController::update_cluster][crate::client::ClusterController::update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2302,7 +2302,7 @@ pub mod cluster_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_cluster][super::super::client::ClusterController::update_cluster].
+        /// on [update_cluster][crate::client::ClusterController::update_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_cluster(self.0.request, self.0.options)
@@ -2449,7 +2449,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::stop_cluster][super::super::client::ClusterController::stop_cluster] calls.
+    /// The request builder for [ClusterController::stop_cluster][crate::client::ClusterController::stop_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2494,7 +2494,7 @@ pub mod cluster_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_cluster][super::super::client::ClusterController::stop_cluster].
+        /// on [stop_cluster][crate::client::ClusterController::stop_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_cluster(self.0.request, self.0.options)
@@ -2582,7 +2582,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::start_cluster][super::super::client::ClusterController::start_cluster] calls.
+    /// The request builder for [ClusterController::start_cluster][crate::client::ClusterController::start_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2627,7 +2627,7 @@ pub mod cluster_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_cluster][super::super::client::ClusterController::start_cluster].
+        /// on [start_cluster][crate::client::ClusterController::start_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_cluster(self.0.request, self.0.options)
@@ -2715,7 +2715,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::delete_cluster][super::super::client::ClusterController::delete_cluster] calls.
+    /// The request builder for [ClusterController::delete_cluster][crate::client::ClusterController::delete_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2760,7 +2760,7 @@ pub mod cluster_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cluster][super::super::client::ClusterController::delete_cluster].
+        /// on [delete_cluster][crate::client::ClusterController::delete_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cluster(self.0.request, self.0.options)
@@ -2848,7 +2848,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::get_cluster][super::super::client::ClusterController::get_cluster] calls.
+    /// The request builder for [ClusterController::get_cluster][crate::client::ClusterController::get_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2927,7 +2927,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::list_clusters][super::super::client::ClusterController::list_clusters] calls.
+    /// The request builder for [ClusterController::list_clusters][crate::client::ClusterController::list_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3044,7 +3044,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::diagnose_cluster][super::super::client::ClusterController::diagnose_cluster] calls.
+    /// The request builder for [ClusterController::diagnose_cluster][crate::client::ClusterController::diagnose_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3089,7 +3089,7 @@ pub mod cluster_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [diagnose_cluster][super::super::client::ClusterController::diagnose_cluster].
+        /// on [diagnose_cluster][crate::client::ClusterController::diagnose_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .diagnose_cluster(self.0.request, self.0.options)
@@ -3222,7 +3222,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::set_iam_policy][super::super::client::ClusterController::set_iam_policy] calls.
+    /// The request builder for [ClusterController::set_iam_policy][crate::client::ClusterController::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3325,7 +3325,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::get_iam_policy][super::super::client::ClusterController::get_iam_policy] calls.
+    /// The request builder for [ClusterController::get_iam_policy][crate::client::ClusterController::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3406,7 +3406,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::test_iam_permissions][super::super::client::ClusterController::test_iam_permissions] calls.
+    /// The request builder for [ClusterController::test_iam_permissions][crate::client::ClusterController::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3485,7 +3485,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::list_operations][super::super::client::ClusterController::list_operations] calls.
+    /// The request builder for [ClusterController::list_operations][crate::client::ClusterController::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3597,7 +3597,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::get_operation][super::super::client::ClusterController::get_operation] calls.
+    /// The request builder for [ClusterController::get_operation][crate::client::ClusterController::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3661,7 +3661,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::delete_operation][super::super::client::ClusterController::delete_operation] calls.
+    /// The request builder for [ClusterController::delete_operation][crate::client::ClusterController::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3725,7 +3725,7 @@ pub mod cluster_controller {
         }
     }
 
-    /// The request builder for [ClusterController::cancel_operation][super::super::client::ClusterController::cancel_operation] calls.
+    /// The request builder for [ClusterController::cancel_operation][crate::client::ClusterController::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3793,7 +3793,7 @@ pub mod cluster_controller {
 pub mod job_controller {
     use crate::Result;
 
-    /// A builder for [JobController][super::super::client::JobController].
+    /// A builder for [JobController][crate::client::JobController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3821,7 +3821,7 @@ pub mod job_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::JobController] request builders.
+    /// Common implementation for [crate::client::JobController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::JobController>,
@@ -3844,7 +3844,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::submit_job][super::super::client::JobController::submit_job] calls.
+    /// The request builder for [JobController::submit_job][crate::client::JobController::submit_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3943,7 +3943,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::submit_job_as_operation][super::super::client::JobController::submit_job_as_operation] calls.
+    /// The request builder for [JobController::submit_job_as_operation][crate::client::JobController::submit_job_as_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3988,7 +3988,7 @@ pub mod job_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [submit_job_as_operation][super::super::client::JobController::submit_job_as_operation].
+        /// on [submit_job_as_operation][crate::client::JobController::submit_job_as_operation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .submit_job_as_operation(self.0.request, self.0.options)
@@ -4078,7 +4078,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::get_job][super::super::client::JobController::get_job] calls.
+    /// The request builder for [JobController::get_job][crate::client::JobController::get_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4157,7 +4157,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::list_jobs][super::super::client::JobController::list_jobs] calls.
+    /// The request builder for [JobController::list_jobs][crate::client::JobController::list_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4289,7 +4289,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::update_job][super::super::client::JobController::update_job] calls.
+    /// The request builder for [JobController::update_job][crate::client::JobController::update_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4412,7 +4412,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::cancel_job][super::super::client::JobController::cancel_job] calls.
+    /// The request builder for [JobController::cancel_job][crate::client::JobController::cancel_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4491,7 +4491,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::delete_job][super::super::client::JobController::delete_job] calls.
+    /// The request builder for [JobController::delete_job][crate::client::JobController::delete_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4570,7 +4570,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::set_iam_policy][super::super::client::JobController::set_iam_policy] calls.
+    /// The request builder for [JobController::set_iam_policy][crate::client::JobController::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4673,7 +4673,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::get_iam_policy][super::super::client::JobController::get_iam_policy] calls.
+    /// The request builder for [JobController::get_iam_policy][crate::client::JobController::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4754,7 +4754,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::test_iam_permissions][super::super::client::JobController::test_iam_permissions] calls.
+    /// The request builder for [JobController::test_iam_permissions][crate::client::JobController::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4833,7 +4833,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::list_operations][super::super::client::JobController::list_operations] calls.
+    /// The request builder for [JobController::list_operations][crate::client::JobController::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4945,7 +4945,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::get_operation][super::super::client::JobController::get_operation] calls.
+    /// The request builder for [JobController::get_operation][crate::client::JobController::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5009,7 +5009,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::delete_operation][super::super::client::JobController::delete_operation] calls.
+    /// The request builder for [JobController::delete_operation][crate::client::JobController::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5073,7 +5073,7 @@ pub mod job_controller {
         }
     }
 
-    /// The request builder for [JobController::cancel_operation][super::super::client::JobController::cancel_operation] calls.
+    /// The request builder for [JobController::cancel_operation][crate::client::JobController::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5141,7 +5141,7 @@ pub mod job_controller {
 pub mod node_group_controller {
     use crate::Result;
 
-    /// A builder for [NodeGroupController][super::super::client::NodeGroupController].
+    /// A builder for [NodeGroupController][crate::client::NodeGroupController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5169,7 +5169,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::NodeGroupController] request builders.
+    /// Common implementation for [crate::client::NodeGroupController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::NodeGroupController>,
@@ -5192,7 +5192,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::create_node_group][super::super::client::NodeGroupController::create_node_group] calls.
+    /// The request builder for [NodeGroupController::create_node_group][crate::client::NodeGroupController::create_node_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5237,7 +5237,7 @@ pub mod node_group_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_node_group][super::super::client::NodeGroupController::create_node_group].
+        /// on [create_node_group][crate::client::NodeGroupController::create_node_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_node_group(self.0.request, self.0.options)
@@ -5331,7 +5331,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::resize_node_group][super::super::client::NodeGroupController::resize_node_group] calls.
+    /// The request builder for [NodeGroupController::resize_node_group][crate::client::NodeGroupController::resize_node_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5376,7 +5376,7 @@ pub mod node_group_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [resize_node_group][super::super::client::NodeGroupController::resize_node_group].
+        /// on [resize_node_group][crate::client::NodeGroupController::resize_node_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .resize_node_group(self.0.request, self.0.options)
@@ -5471,7 +5471,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::get_node_group][super::super::client::NodeGroupController::get_node_group] calls.
+    /// The request builder for [NodeGroupController::get_node_group][crate::client::NodeGroupController::get_node_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5534,7 +5534,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::set_iam_policy][super::super::client::NodeGroupController::set_iam_policy] calls.
+    /// The request builder for [NodeGroupController::set_iam_policy][crate::client::NodeGroupController::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5637,7 +5637,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::get_iam_policy][super::super::client::NodeGroupController::get_iam_policy] calls.
+    /// The request builder for [NodeGroupController::get_iam_policy][crate::client::NodeGroupController::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5718,7 +5718,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::test_iam_permissions][super::super::client::NodeGroupController::test_iam_permissions] calls.
+    /// The request builder for [NodeGroupController::test_iam_permissions][crate::client::NodeGroupController::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5797,7 +5797,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::list_operations][super::super::client::NodeGroupController::list_operations] calls.
+    /// The request builder for [NodeGroupController::list_operations][crate::client::NodeGroupController::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5909,7 +5909,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::get_operation][super::super::client::NodeGroupController::get_operation] calls.
+    /// The request builder for [NodeGroupController::get_operation][crate::client::NodeGroupController::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5973,7 +5973,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::delete_operation][super::super::client::NodeGroupController::delete_operation] calls.
+    /// The request builder for [NodeGroupController::delete_operation][crate::client::NodeGroupController::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6037,7 +6037,7 @@ pub mod node_group_controller {
         }
     }
 
-    /// The request builder for [NodeGroupController::cancel_operation][super::super::client::NodeGroupController::cancel_operation] calls.
+    /// The request builder for [NodeGroupController::cancel_operation][crate::client::NodeGroupController::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6105,7 +6105,7 @@ pub mod node_group_controller {
 pub mod session_template_controller {
     use crate::Result;
 
-    /// A builder for [SessionTemplateController][super::super::client::SessionTemplateController].
+    /// A builder for [SessionTemplateController][crate::client::SessionTemplateController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6133,7 +6133,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::SessionTemplateController] request builders.
+    /// Common implementation for [crate::client::SessionTemplateController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SessionTemplateController>,
@@ -6156,7 +6156,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::create_session_template][super::super::client::SessionTemplateController::create_session_template] calls.
+    /// The request builder for [SessionTemplateController::create_session_template][crate::client::SessionTemplateController::create_session_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6244,7 +6244,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::update_session_template][super::super::client::SessionTemplateController::update_session_template] calls.
+    /// The request builder for [SessionTemplateController::update_session_template][crate::client::SessionTemplateController::update_session_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6324,7 +6324,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::get_session_template][super::super::client::SessionTemplateController::get_session_template] calls.
+    /// The request builder for [SessionTemplateController::get_session_template][crate::client::SessionTemplateController::get_session_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6390,7 +6390,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::list_session_templates][super::super::client::SessionTemplateController::list_session_templates] calls.
+    /// The request builder for [SessionTemplateController::list_session_templates][crate::client::SessionTemplateController::list_session_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6504,7 +6504,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::delete_session_template][super::super::client::SessionTemplateController::delete_session_template] calls.
+    /// The request builder for [SessionTemplateController::delete_session_template][crate::client::SessionTemplateController::delete_session_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6570,7 +6570,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::set_iam_policy][super::super::client::SessionTemplateController::set_iam_policy] calls.
+    /// The request builder for [SessionTemplateController::set_iam_policy][crate::client::SessionTemplateController::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6673,7 +6673,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::get_iam_policy][super::super::client::SessionTemplateController::get_iam_policy] calls.
+    /// The request builder for [SessionTemplateController::get_iam_policy][crate::client::SessionTemplateController::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6754,7 +6754,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::test_iam_permissions][super::super::client::SessionTemplateController::test_iam_permissions] calls.
+    /// The request builder for [SessionTemplateController::test_iam_permissions][crate::client::SessionTemplateController::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6833,7 +6833,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::list_operations][super::super::client::SessionTemplateController::list_operations] calls.
+    /// The request builder for [SessionTemplateController::list_operations][crate::client::SessionTemplateController::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6945,7 +6945,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::get_operation][super::super::client::SessionTemplateController::get_operation] calls.
+    /// The request builder for [SessionTemplateController::get_operation][crate::client::SessionTemplateController::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7009,7 +7009,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::delete_operation][super::super::client::SessionTemplateController::delete_operation] calls.
+    /// The request builder for [SessionTemplateController::delete_operation][crate::client::SessionTemplateController::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7073,7 +7073,7 @@ pub mod session_template_controller {
         }
     }
 
-    /// The request builder for [SessionTemplateController::cancel_operation][super::super::client::SessionTemplateController::cancel_operation] calls.
+    /// The request builder for [SessionTemplateController::cancel_operation][crate::client::SessionTemplateController::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7141,7 +7141,7 @@ pub mod session_template_controller {
 pub mod session_controller {
     use crate::Result;
 
-    /// A builder for [SessionController][super::super::client::SessionController].
+    /// A builder for [SessionController][crate::client::SessionController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7169,7 +7169,7 @@ pub mod session_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::SessionController] request builders.
+    /// Common implementation for [crate::client::SessionController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SessionController>,
@@ -7192,7 +7192,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::create_session][super::super::client::SessionController::create_session] calls.
+    /// The request builder for [SessionController::create_session][crate::client::SessionController::create_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7237,7 +7237,7 @@ pub mod session_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_session][super::super::client::SessionController::create_session].
+        /// on [create_session][crate::client::SessionController::create_session].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_session(self.0.request, self.0.options)
@@ -7333,7 +7333,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::get_session][super::super::client::SessionController::get_session] calls.
+    /// The request builder for [SessionController::get_session][crate::client::SessionController::get_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7396,7 +7396,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::list_sessions][super::super::client::SessionController::list_sessions] calls.
+    /// The request builder for [SessionController::list_sessions][crate::client::SessionController::list_sessions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7505,7 +7505,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::terminate_session][super::super::client::SessionController::terminate_session] calls.
+    /// The request builder for [SessionController::terminate_session][crate::client::SessionController::terminate_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7553,7 +7553,7 @@ pub mod session_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [terminate_session][super::super::client::SessionController::terminate_session].
+        /// on [terminate_session][crate::client::SessionController::terminate_session].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .terminate_session(self.0.request, self.0.options)
@@ -7619,7 +7619,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::delete_session][super::super::client::SessionController::delete_session] calls.
+    /// The request builder for [SessionController::delete_session][crate::client::SessionController::delete_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7664,7 +7664,7 @@ pub mod session_controller {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_session][super::super::client::SessionController::delete_session].
+        /// on [delete_session][crate::client::SessionController::delete_session].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_session(self.0.request, self.0.options)
@@ -7730,7 +7730,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::set_iam_policy][super::super::client::SessionController::set_iam_policy] calls.
+    /// The request builder for [SessionController::set_iam_policy][crate::client::SessionController::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7833,7 +7833,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::get_iam_policy][super::super::client::SessionController::get_iam_policy] calls.
+    /// The request builder for [SessionController::get_iam_policy][crate::client::SessionController::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7914,7 +7914,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::test_iam_permissions][super::super::client::SessionController::test_iam_permissions] calls.
+    /// The request builder for [SessionController::test_iam_permissions][crate::client::SessionController::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7993,7 +7993,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::list_operations][super::super::client::SessionController::list_operations] calls.
+    /// The request builder for [SessionController::list_operations][crate::client::SessionController::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8105,7 +8105,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::get_operation][super::super::client::SessionController::get_operation] calls.
+    /// The request builder for [SessionController::get_operation][crate::client::SessionController::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8169,7 +8169,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::delete_operation][super::super::client::SessionController::delete_operation] calls.
+    /// The request builder for [SessionController::delete_operation][crate::client::SessionController::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8233,7 +8233,7 @@ pub mod session_controller {
         }
     }
 
-    /// The request builder for [SessionController::cancel_operation][super::super::client::SessionController::cancel_operation] calls.
+    /// The request builder for [SessionController::cancel_operation][crate::client::SessionController::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8301,7 +8301,7 @@ pub mod session_controller {
 pub mod workflow_template_service {
     use crate::Result;
 
-    /// A builder for [WorkflowTemplateService][super::super::client::WorkflowTemplateService].
+    /// A builder for [WorkflowTemplateService][crate::client::WorkflowTemplateService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -8329,7 +8329,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// Common implementation for [super::super::client::WorkflowTemplateService] request builders.
+    /// Common implementation for [crate::client::WorkflowTemplateService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::WorkflowTemplateService>,
@@ -8352,7 +8352,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::create_workflow_template][super::super::client::WorkflowTemplateService::create_workflow_template] calls.
+    /// The request builder for [WorkflowTemplateService::create_workflow_template][crate::client::WorkflowTemplateService::create_workflow_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8440,7 +8440,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::get_workflow_template][super::super::client::WorkflowTemplateService::get_workflow_template] calls.
+    /// The request builder for [WorkflowTemplateService::get_workflow_template][crate::client::WorkflowTemplateService::get_workflow_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8512,7 +8512,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::instantiate_workflow_template][super::super::client::WorkflowTemplateService::instantiate_workflow_template] calls.
+    /// The request builder for [WorkflowTemplateService::instantiate_workflow_template][crate::client::WorkflowTemplateService::instantiate_workflow_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8562,7 +8562,7 @@ pub mod workflow_template_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [instantiate_workflow_template][super::super::client::WorkflowTemplateService::instantiate_workflow_template].
+        /// on [instantiate_workflow_template][crate::client::WorkflowTemplateService::instantiate_workflow_template].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .instantiate_workflow_template(self.0.request, self.0.options)
@@ -8644,7 +8644,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::instantiate_inline_workflow_template][super::super::client::WorkflowTemplateService::instantiate_inline_workflow_template] calls.
+    /// The request builder for [WorkflowTemplateService::instantiate_inline_workflow_template][crate::client::WorkflowTemplateService::instantiate_inline_workflow_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8694,7 +8694,7 @@ pub mod workflow_template_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [instantiate_inline_workflow_template][super::super::client::WorkflowTemplateService::instantiate_inline_workflow_template].
+        /// on [instantiate_inline_workflow_template][crate::client::WorkflowTemplateService::instantiate_inline_workflow_template].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .instantiate_inline_workflow_template(self.0.request, self.0.options)
@@ -8781,7 +8781,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::update_workflow_template][super::super::client::WorkflowTemplateService::update_workflow_template] calls.
+    /// The request builder for [WorkflowTemplateService::update_workflow_template][crate::client::WorkflowTemplateService::update_workflow_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8861,7 +8861,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::list_workflow_templates][super::super::client::WorkflowTemplateService::list_workflow_templates] calls.
+    /// The request builder for [WorkflowTemplateService::list_workflow_templates][crate::client::WorkflowTemplateService::list_workflow_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8969,7 +8969,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::delete_workflow_template][super::super::client::WorkflowTemplateService::delete_workflow_template] calls.
+    /// The request builder for [WorkflowTemplateService::delete_workflow_template][crate::client::WorkflowTemplateService::delete_workflow_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9041,7 +9041,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::set_iam_policy][super::super::client::WorkflowTemplateService::set_iam_policy] calls.
+    /// The request builder for [WorkflowTemplateService::set_iam_policy][crate::client::WorkflowTemplateService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9144,7 +9144,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::get_iam_policy][super::super::client::WorkflowTemplateService::get_iam_policy] calls.
+    /// The request builder for [WorkflowTemplateService::get_iam_policy][crate::client::WorkflowTemplateService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9225,7 +9225,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::test_iam_permissions][super::super::client::WorkflowTemplateService::test_iam_permissions] calls.
+    /// The request builder for [WorkflowTemplateService::test_iam_permissions][crate::client::WorkflowTemplateService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9304,7 +9304,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::list_operations][super::super::client::WorkflowTemplateService::list_operations] calls.
+    /// The request builder for [WorkflowTemplateService::list_operations][crate::client::WorkflowTemplateService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9416,7 +9416,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::get_operation][super::super::client::WorkflowTemplateService::get_operation] calls.
+    /// The request builder for [WorkflowTemplateService::get_operation][crate::client::WorkflowTemplateService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9480,7 +9480,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::delete_operation][super::super::client::WorkflowTemplateService::delete_operation] calls.
+    /// The request builder for [WorkflowTemplateService::delete_operation][crate::client::WorkflowTemplateService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9544,7 +9544,7 @@ pub mod workflow_template_service {
         }
     }
 
-    /// The request builder for [WorkflowTemplateService::cancel_operation][super::super::client::WorkflowTemplateService::cancel_operation] calls.
+    /// The request builder for [WorkflowTemplateService::cancel_operation][crate::client::WorkflowTemplateService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/datastream/v1/src/builder.rs
+++ b/src/generated/cloud/datastream/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod datastream {
     use crate::Result;
 
-    /// A builder for [Datastream][super::super::client::Datastream].
+    /// A builder for [Datastream][crate::client::Datastream].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod datastream {
         }
     }
 
-    /// Common implementation for [super::super::client::Datastream] request builders.
+    /// Common implementation for [crate::client::Datastream] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Datastream>,
@@ -68,7 +68,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::list_connection_profiles][super::super::client::Datastream::list_connection_profiles] calls.
+    /// The request builder for [Datastream::list_connection_profiles][crate::client::Datastream::list_connection_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -190,7 +190,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::get_connection_profile][super::super::client::Datastream::get_connection_profile] calls.
+    /// The request builder for [Datastream::get_connection_profile][crate::client::Datastream::get_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -256,7 +256,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::create_connection_profile][super::super::client::Datastream::create_connection_profile] calls.
+    /// The request builder for [Datastream::create_connection_profile][crate::client::Datastream::create_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -306,7 +306,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_connection_profile][super::super::client::Datastream::create_connection_profile].
+        /// on [create_connection_profile][crate::client::Datastream::create_connection_profile].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_connection_profile(self.0.request, self.0.options)
@@ -414,7 +414,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::update_connection_profile][super::super::client::Datastream::update_connection_profile] calls.
+    /// The request builder for [Datastream::update_connection_profile][crate::client::Datastream::update_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -464,7 +464,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_connection_profile][super::super::client::Datastream::update_connection_profile].
+        /// on [update_connection_profile][crate::client::Datastream::update_connection_profile].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_connection_profile(self.0.request, self.0.options)
@@ -574,7 +574,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::delete_connection_profile][super::super::client::Datastream::delete_connection_profile] calls.
+    /// The request builder for [Datastream::delete_connection_profile][crate::client::Datastream::delete_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -624,7 +624,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_connection_profile][super::super::client::Datastream::delete_connection_profile].
+        /// on [delete_connection_profile][crate::client::Datastream::delete_connection_profile].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_connection_profile(self.0.request, self.0.options)
@@ -689,7 +689,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::discover_connection_profile][super::super::client::Datastream::discover_connection_profile] calls.
+    /// The request builder for [Datastream::discover_connection_profile][crate::client::Datastream::discover_connection_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -905,7 +905,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::list_streams][super::super::client::Datastream::list_streams] calls.
+    /// The request builder for [Datastream::list_streams][crate::client::Datastream::list_streams] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1020,7 +1020,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::get_stream][super::super::client::Datastream::get_stream] calls.
+    /// The request builder for [Datastream::get_stream][crate::client::Datastream::get_stream] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1083,7 +1083,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::create_stream][super::super::client::Datastream::create_stream] calls.
+    /// The request builder for [Datastream::create_stream][crate::client::Datastream::create_stream] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1128,7 +1128,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_stream][super::super::client::Datastream::create_stream].
+        /// on [create_stream][crate::client::Datastream::create_stream].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_stream(self.0.request, self.0.options)
@@ -1233,7 +1233,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::update_stream][super::super::client::Datastream::update_stream] calls.
+    /// The request builder for [Datastream::update_stream][crate::client::Datastream::update_stream] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1278,7 +1278,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_stream][super::super::client::Datastream::update_stream].
+        /// on [update_stream][crate::client::Datastream::update_stream].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_stream(self.0.request, self.0.options)
@@ -1385,7 +1385,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::delete_stream][super::super::client::Datastream::delete_stream] calls.
+    /// The request builder for [Datastream::delete_stream][crate::client::Datastream::delete_stream] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1430,7 +1430,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_stream][super::super::client::Datastream::delete_stream].
+        /// on [delete_stream][crate::client::Datastream::delete_stream].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_stream(self.0.request, self.0.options)
@@ -1495,7 +1495,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::run_stream][super::super::client::Datastream::run_stream] calls.
+    /// The request builder for [Datastream::run_stream][crate::client::Datastream::run_stream] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1540,7 +1540,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [run_stream][super::super::client::Datastream::run_stream].
+        /// on [run_stream][crate::client::Datastream::run_stream].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .run_stream(self.0.request, self.0.options)
@@ -1621,7 +1621,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::get_stream_object][super::super::client::Datastream::get_stream_object] calls.
+    /// The request builder for [Datastream::get_stream_object][crate::client::Datastream::get_stream_object] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1684,7 +1684,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::lookup_stream_object][super::super::client::Datastream::lookup_stream_object] calls.
+    /// The request builder for [Datastream::lookup_stream_object][crate::client::Datastream::lookup_stream_object] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1772,7 +1772,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::list_stream_objects][super::super::client::Datastream::list_stream_objects] calls.
+    /// The request builder for [Datastream::list_stream_objects][crate::client::Datastream::list_stream_objects] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1878,7 +1878,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::start_backfill_job][super::super::client::Datastream::start_backfill_job] calls.
+    /// The request builder for [Datastream::start_backfill_job][crate::client::Datastream::start_backfill_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1944,7 +1944,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::stop_backfill_job][super::super::client::Datastream::stop_backfill_job] calls.
+    /// The request builder for [Datastream::stop_backfill_job][crate::client::Datastream::stop_backfill_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2007,7 +2007,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::fetch_static_ips][super::super::client::Datastream::fetch_static_ips] calls.
+    /// The request builder for [Datastream::fetch_static_ips][crate::client::Datastream::fetch_static_ips] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2082,7 +2082,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::create_private_connection][super::super::client::Datastream::create_private_connection] calls.
+    /// The request builder for [Datastream::create_private_connection][crate::client::Datastream::create_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2132,7 +2132,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_private_connection][super::super::client::Datastream::create_private_connection].
+        /// on [create_private_connection][crate::client::Datastream::create_private_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_private_connection(self.0.request, self.0.options)
@@ -2234,7 +2234,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::get_private_connection][super::super::client::Datastream::get_private_connection] calls.
+    /// The request builder for [Datastream::get_private_connection][crate::client::Datastream::get_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2300,7 +2300,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::list_private_connections][super::super::client::Datastream::list_private_connections] calls.
+    /// The request builder for [Datastream::list_private_connections][crate::client::Datastream::list_private_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2422,7 +2422,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::delete_private_connection][super::super::client::Datastream::delete_private_connection] calls.
+    /// The request builder for [Datastream::delete_private_connection][crate::client::Datastream::delete_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2472,7 +2472,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_private_connection][super::super::client::Datastream::delete_private_connection].
+        /// on [delete_private_connection][crate::client::Datastream::delete_private_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_private_connection(self.0.request, self.0.options)
@@ -2543,7 +2543,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::create_route][super::super::client::Datastream::create_route] calls.
+    /// The request builder for [Datastream::create_route][crate::client::Datastream::create_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2588,7 +2588,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_route][super::super::client::Datastream::create_route].
+        /// on [create_route][crate::client::Datastream::create_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_route(self.0.request, self.0.options)
@@ -2681,7 +2681,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::get_route][super::super::client::Datastream::get_route] calls.
+    /// The request builder for [Datastream::get_route][crate::client::Datastream::get_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2744,7 +2744,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::list_routes][super::super::client::Datastream::list_routes] calls.
+    /// The request builder for [Datastream::list_routes][crate::client::Datastream::list_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2859,7 +2859,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::delete_route][super::super::client::Datastream::delete_route] calls.
+    /// The request builder for [Datastream::delete_route][crate::client::Datastream::delete_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2904,7 +2904,7 @@ pub mod datastream {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_route][super::super::client::Datastream::delete_route].
+        /// on [delete_route][crate::client::Datastream::delete_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_route(self.0.request, self.0.options)
@@ -2969,7 +2969,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::list_locations][super::super::client::Datastream::list_locations] calls.
+    /// The request builder for [Datastream::list_locations][crate::client::Datastream::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3079,7 +3079,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::get_location][super::super::client::Datastream::get_location] calls.
+    /// The request builder for [Datastream::get_location][crate::client::Datastream::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3140,7 +3140,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::list_operations][super::super::client::Datastream::list_operations] calls.
+    /// The request builder for [Datastream::list_operations][crate::client::Datastream::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3252,7 +3252,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::get_operation][super::super::client::Datastream::get_operation] calls.
+    /// The request builder for [Datastream::get_operation][crate::client::Datastream::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3316,7 +3316,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::delete_operation][super::super::client::Datastream::delete_operation] calls.
+    /// The request builder for [Datastream::delete_operation][crate::client::Datastream::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3380,7 +3380,7 @@ pub mod datastream {
         }
     }
 
-    /// The request builder for [Datastream::cancel_operation][super::super::client::Datastream::cancel_operation] calls.
+    /// The request builder for [Datastream::cancel_operation][crate::client::Datastream::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/deploy/v1/src/builder.rs
+++ b/src/generated/cloud/deploy/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_deploy {
     use crate::Result;
 
-    /// A builder for [CloudDeploy][super::super::client::CloudDeploy].
+    /// A builder for [CloudDeploy][crate::client::CloudDeploy].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudDeploy] request builders.
+    /// Common implementation for [crate::client::CloudDeploy] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudDeploy>,
@@ -68,7 +68,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_delivery_pipelines][super::super::client::CloudDeploy::list_delivery_pipelines] calls.
+    /// The request builder for [CloudDeploy::list_delivery_pipelines][crate::client::CloudDeploy::list_delivery_pipelines] calls.
     ///
     /// # Example
     /// ```no_run
@@ -188,7 +188,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_delivery_pipeline][super::super::client::CloudDeploy::get_delivery_pipeline] calls.
+    /// The request builder for [CloudDeploy::get_delivery_pipeline][crate::client::CloudDeploy::get_delivery_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::create_delivery_pipeline][super::super::client::CloudDeploy::create_delivery_pipeline] calls.
+    /// The request builder for [CloudDeploy::create_delivery_pipeline][crate::client::CloudDeploy::create_delivery_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -302,7 +302,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_delivery_pipeline][super::super::client::CloudDeploy::create_delivery_pipeline].
+        /// on [create_delivery_pipeline][crate::client::CloudDeploy::create_delivery_pipeline].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_delivery_pipeline(self.0.request, self.0.options)
@@ -404,7 +404,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::update_delivery_pipeline][super::super::client::CloudDeploy::update_delivery_pipeline] calls.
+    /// The request builder for [CloudDeploy::update_delivery_pipeline][crate::client::CloudDeploy::update_delivery_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -452,7 +452,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_delivery_pipeline][super::super::client::CloudDeploy::update_delivery_pipeline].
+        /// on [update_delivery_pipeline][crate::client::CloudDeploy::update_delivery_pipeline].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_delivery_pipeline(self.0.request, self.0.options)
@@ -566,7 +566,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::delete_delivery_pipeline][super::super::client::CloudDeploy::delete_delivery_pipeline] calls.
+    /// The request builder for [CloudDeploy::delete_delivery_pipeline][crate::client::CloudDeploy::delete_delivery_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -614,7 +614,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_delivery_pipeline][super::super::client::CloudDeploy::delete_delivery_pipeline].
+        /// on [delete_delivery_pipeline][crate::client::CloudDeploy::delete_delivery_pipeline].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_delivery_pipeline(self.0.request, self.0.options)
@@ -703,7 +703,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_targets][super::super::client::CloudDeploy::list_targets] calls.
+    /// The request builder for [CloudDeploy::list_targets][crate::client::CloudDeploy::list_targets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -818,7 +818,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::rollback_target][super::super::client::CloudDeploy::rollback_target] calls.
+    /// The request builder for [CloudDeploy::rollback_target][crate::client::CloudDeploy::rollback_target] calls.
     ///
     /// # Example
     /// ```no_run
@@ -944,7 +944,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_target][super::super::client::CloudDeploy::get_target] calls.
+    /// The request builder for [CloudDeploy::get_target][crate::client::CloudDeploy::get_target] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1007,7 +1007,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::create_target][super::super::client::CloudDeploy::create_target] calls.
+    /// The request builder for [CloudDeploy::create_target][crate::client::CloudDeploy::create_target] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1052,7 +1052,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_target][super::super::client::CloudDeploy::create_target].
+        /// on [create_target][crate::client::CloudDeploy::create_target].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_target(self.0.request, self.0.options)
@@ -1151,7 +1151,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::update_target][super::super::client::CloudDeploy::update_target] calls.
+    /// The request builder for [CloudDeploy::update_target][crate::client::CloudDeploy::update_target] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1196,7 +1196,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_target][super::super::client::CloudDeploy::update_target].
+        /// on [update_target][crate::client::CloudDeploy::update_target].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_target(self.0.request, self.0.options)
@@ -1307,7 +1307,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::delete_target][super::super::client::CloudDeploy::delete_target] calls.
+    /// The request builder for [CloudDeploy::delete_target][crate::client::CloudDeploy::delete_target] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1352,7 +1352,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_target][super::super::client::CloudDeploy::delete_target].
+        /// on [delete_target][crate::client::CloudDeploy::delete_target].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_target(self.0.request, self.0.options)
@@ -1435,7 +1435,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_custom_target_types][super::super::client::CloudDeploy::list_custom_target_types] calls.
+    /// The request builder for [CloudDeploy::list_custom_target_types][crate::client::CloudDeploy::list_custom_target_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1555,7 +1555,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_custom_target_type][super::super::client::CloudDeploy::get_custom_target_type] calls.
+    /// The request builder for [CloudDeploy::get_custom_target_type][crate::client::CloudDeploy::get_custom_target_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1621,7 +1621,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::create_custom_target_type][super::super::client::CloudDeploy::create_custom_target_type] calls.
+    /// The request builder for [CloudDeploy::create_custom_target_type][crate::client::CloudDeploy::create_custom_target_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1669,7 +1669,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_custom_target_type][super::super::client::CloudDeploy::create_custom_target_type].
+        /// on [create_custom_target_type][crate::client::CloudDeploy::create_custom_target_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_custom_target_type(self.0.request, self.0.options)
@@ -1771,7 +1771,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::update_custom_target_type][super::super::client::CloudDeploy::update_custom_target_type] calls.
+    /// The request builder for [CloudDeploy::update_custom_target_type][crate::client::CloudDeploy::update_custom_target_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1819,7 +1819,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_custom_target_type][super::super::client::CloudDeploy::update_custom_target_type].
+        /// on [update_custom_target_type][crate::client::CloudDeploy::update_custom_target_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_custom_target_type(self.0.request, self.0.options)
@@ -1933,7 +1933,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::delete_custom_target_type][super::super::client::CloudDeploy::delete_custom_target_type] calls.
+    /// The request builder for [CloudDeploy::delete_custom_target_type][crate::client::CloudDeploy::delete_custom_target_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1981,7 +1981,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_custom_target_type][super::super::client::CloudDeploy::delete_custom_target_type].
+        /// on [delete_custom_target_type][crate::client::CloudDeploy::delete_custom_target_type].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_custom_target_type(self.0.request, self.0.options)
@@ -2064,7 +2064,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_releases][super::super::client::CloudDeploy::list_releases] calls.
+    /// The request builder for [CloudDeploy::list_releases][crate::client::CloudDeploy::list_releases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2179,7 +2179,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_release][super::super::client::CloudDeploy::get_release] calls.
+    /// The request builder for [CloudDeploy::get_release][crate::client::CloudDeploy::get_release] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2242,7 +2242,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::create_release][super::super::client::CloudDeploy::create_release] calls.
+    /// The request builder for [CloudDeploy::create_release][crate::client::CloudDeploy::create_release] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2287,7 +2287,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_release][super::super::client::CloudDeploy::create_release].
+        /// on [create_release][crate::client::CloudDeploy::create_release].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_release(self.0.request, self.0.options)
@@ -2397,7 +2397,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::abandon_release][super::super::client::CloudDeploy::abandon_release] calls.
+    /// The request builder for [CloudDeploy::abandon_release][crate::client::CloudDeploy::abandon_release] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2460,7 +2460,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::create_deploy_policy][super::super::client::CloudDeploy::create_deploy_policy] calls.
+    /// The request builder for [CloudDeploy::create_deploy_policy][crate::client::CloudDeploy::create_deploy_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2508,7 +2508,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_deploy_policy][super::super::client::CloudDeploy::create_deploy_policy].
+        /// on [create_deploy_policy][crate::client::CloudDeploy::create_deploy_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_deploy_policy(self.0.request, self.0.options)
@@ -2609,7 +2609,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::update_deploy_policy][super::super::client::CloudDeploy::update_deploy_policy] calls.
+    /// The request builder for [CloudDeploy::update_deploy_policy][crate::client::CloudDeploy::update_deploy_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2657,7 +2657,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_deploy_policy][super::super::client::CloudDeploy::update_deploy_policy].
+        /// on [update_deploy_policy][crate::client::CloudDeploy::update_deploy_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_deploy_policy(self.0.request, self.0.options)
@@ -2770,7 +2770,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::delete_deploy_policy][super::super::client::CloudDeploy::delete_deploy_policy] calls.
+    /// The request builder for [CloudDeploy::delete_deploy_policy][crate::client::CloudDeploy::delete_deploy_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2818,7 +2818,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_deploy_policy][super::super::client::CloudDeploy::delete_deploy_policy].
+        /// on [delete_deploy_policy][crate::client::CloudDeploy::delete_deploy_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_deploy_policy(self.0.request, self.0.options)
@@ -2901,7 +2901,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_deploy_policies][super::super::client::CloudDeploy::list_deploy_policies] calls.
+    /// The request builder for [CloudDeploy::list_deploy_policies][crate::client::CloudDeploy::list_deploy_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3021,7 +3021,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_deploy_policy][super::super::client::CloudDeploy::get_deploy_policy] calls.
+    /// The request builder for [CloudDeploy::get_deploy_policy][crate::client::CloudDeploy::get_deploy_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3084,7 +3084,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::approve_rollout][super::super::client::CloudDeploy::approve_rollout] calls.
+    /// The request builder for [CloudDeploy::approve_rollout][crate::client::CloudDeploy::approve_rollout] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3166,7 +3166,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::advance_rollout][super::super::client::CloudDeploy::advance_rollout] calls.
+    /// The request builder for [CloudDeploy::advance_rollout][crate::client::CloudDeploy::advance_rollout] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3248,7 +3248,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::cancel_rollout][super::super::client::CloudDeploy::cancel_rollout] calls.
+    /// The request builder for [CloudDeploy::cancel_rollout][crate::client::CloudDeploy::cancel_rollout] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3322,7 +3322,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_rollouts][super::super::client::CloudDeploy::list_rollouts] calls.
+    /// The request builder for [CloudDeploy::list_rollouts][crate::client::CloudDeploy::list_rollouts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3437,7 +3437,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_rollout][super::super::client::CloudDeploy::get_rollout] calls.
+    /// The request builder for [CloudDeploy::get_rollout][crate::client::CloudDeploy::get_rollout] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3500,7 +3500,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::create_rollout][super::super::client::CloudDeploy::create_rollout] calls.
+    /// The request builder for [CloudDeploy::create_rollout][crate::client::CloudDeploy::create_rollout] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3545,7 +3545,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_rollout][super::super::client::CloudDeploy::create_rollout].
+        /// on [create_rollout][crate::client::CloudDeploy::create_rollout].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_rollout(self.0.request, self.0.options)
@@ -3661,7 +3661,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::ignore_job][super::super::client::CloudDeploy::ignore_job] calls.
+    /// The request builder for [CloudDeploy::ignore_job][crate::client::CloudDeploy::ignore_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3751,7 +3751,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::retry_job][super::super::client::CloudDeploy::retry_job] calls.
+    /// The request builder for [CloudDeploy::retry_job][crate::client::CloudDeploy::retry_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3841,7 +3841,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_job_runs][super::super::client::CloudDeploy::list_job_runs] calls.
+    /// The request builder for [CloudDeploy::list_job_runs][crate::client::CloudDeploy::list_job_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3956,7 +3956,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_job_run][super::super::client::CloudDeploy::get_job_run] calls.
+    /// The request builder for [CloudDeploy::get_job_run][crate::client::CloudDeploy::get_job_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4019,7 +4019,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::terminate_job_run][super::super::client::CloudDeploy::terminate_job_run] calls.
+    /// The request builder for [CloudDeploy::terminate_job_run][crate::client::CloudDeploy::terminate_job_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4093,7 +4093,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_config][super::super::client::CloudDeploy::get_config] calls.
+    /// The request builder for [CloudDeploy::get_config][crate::client::CloudDeploy::get_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4156,7 +4156,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::create_automation][super::super::client::CloudDeploy::create_automation] calls.
+    /// The request builder for [CloudDeploy::create_automation][crate::client::CloudDeploy::create_automation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4204,7 +4204,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_automation][super::super::client::CloudDeploy::create_automation].
+        /// on [create_automation][crate::client::CloudDeploy::create_automation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_automation(self.0.request, self.0.options)
@@ -4303,7 +4303,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::update_automation][super::super::client::CloudDeploy::update_automation] calls.
+    /// The request builder for [CloudDeploy::update_automation][crate::client::CloudDeploy::update_automation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4351,7 +4351,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_automation][super::super::client::CloudDeploy::update_automation].
+        /// on [update_automation][crate::client::CloudDeploy::update_automation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_automation(self.0.request, self.0.options)
@@ -4462,7 +4462,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::delete_automation][super::super::client::CloudDeploy::delete_automation] calls.
+    /// The request builder for [CloudDeploy::delete_automation][crate::client::CloudDeploy::delete_automation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4510,7 +4510,7 @@ pub mod cloud_deploy {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_automation][super::super::client::CloudDeploy::delete_automation].
+        /// on [delete_automation][crate::client::CloudDeploy::delete_automation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_automation(self.0.request, self.0.options)
@@ -4593,7 +4593,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_automation][super::super::client::CloudDeploy::get_automation] calls.
+    /// The request builder for [CloudDeploy::get_automation][crate::client::CloudDeploy::get_automation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4656,7 +4656,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_automations][super::super::client::CloudDeploy::list_automations] calls.
+    /// The request builder for [CloudDeploy::list_automations][crate::client::CloudDeploy::list_automations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4771,7 +4771,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_automation_run][super::super::client::CloudDeploy::get_automation_run] calls.
+    /// The request builder for [CloudDeploy::get_automation_run][crate::client::CloudDeploy::get_automation_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4837,7 +4837,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_automation_runs][super::super::client::CloudDeploy::list_automation_runs] calls.
+    /// The request builder for [CloudDeploy::list_automation_runs][crate::client::CloudDeploy::list_automation_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4957,7 +4957,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::cancel_automation_run][super::super::client::CloudDeploy::cancel_automation_run] calls.
+    /// The request builder for [CloudDeploy::cancel_automation_run][crate::client::CloudDeploy::cancel_automation_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5023,7 +5023,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_locations][super::super::client::CloudDeploy::list_locations] calls.
+    /// The request builder for [CloudDeploy::list_locations][crate::client::CloudDeploy::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5133,7 +5133,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_location][super::super::client::CloudDeploy::get_location] calls.
+    /// The request builder for [CloudDeploy::get_location][crate::client::CloudDeploy::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5194,7 +5194,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::set_iam_policy][super::super::client::CloudDeploy::set_iam_policy] calls.
+    /// The request builder for [CloudDeploy::set_iam_policy][crate::client::CloudDeploy::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5297,7 +5297,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_iam_policy][super::super::client::CloudDeploy::get_iam_policy] calls.
+    /// The request builder for [CloudDeploy::get_iam_policy][crate::client::CloudDeploy::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5378,7 +5378,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::test_iam_permissions][super::super::client::CloudDeploy::test_iam_permissions] calls.
+    /// The request builder for [CloudDeploy::test_iam_permissions][crate::client::CloudDeploy::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5457,7 +5457,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::list_operations][super::super::client::CloudDeploy::list_operations] calls.
+    /// The request builder for [CloudDeploy::list_operations][crate::client::CloudDeploy::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5569,7 +5569,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::get_operation][super::super::client::CloudDeploy::get_operation] calls.
+    /// The request builder for [CloudDeploy::get_operation][crate::client::CloudDeploy::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5633,7 +5633,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::delete_operation][super::super::client::CloudDeploy::delete_operation] calls.
+    /// The request builder for [CloudDeploy::delete_operation][crate::client::CloudDeploy::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5697,7 +5697,7 @@ pub mod cloud_deploy {
         }
     }
 
-    /// The request builder for [CloudDeploy::cancel_operation][super::super::client::CloudDeploy::cancel_operation] calls.
+    /// The request builder for [CloudDeploy::cancel_operation][crate::client::CloudDeploy::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/developerconnect/v1/src/builder.rs
+++ b/src/generated/cloud/developerconnect/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod developer_connect {
     use crate::Result;
 
-    /// A builder for [DeveloperConnect][super::super::client::DeveloperConnect].
+    /// A builder for [DeveloperConnect][crate::client::DeveloperConnect].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod developer_connect {
         }
     }
 
-    /// Common implementation for [super::super::client::DeveloperConnect] request builders.
+    /// Common implementation for [crate::client::DeveloperConnect] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DeveloperConnect>,
@@ -68,7 +68,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::list_connections][super::super::client::DeveloperConnect::list_connections] calls.
+    /// The request builder for [DeveloperConnect::list_connections][crate::client::DeveloperConnect::list_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::get_connection][super::super::client::DeveloperConnect::get_connection] calls.
+    /// The request builder for [DeveloperConnect::get_connection][crate::client::DeveloperConnect::get_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::create_connection][super::super::client::DeveloperConnect::create_connection] calls.
+    /// The request builder for [DeveloperConnect::create_connection][crate::client::DeveloperConnect::create_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -294,7 +294,7 @@ pub mod developer_connect {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_connection][super::super::client::DeveloperConnect::create_connection].
+        /// on [create_connection][crate::client::DeveloperConnect::create_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_connection(self.0.request, self.0.options)
@@ -393,7 +393,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::update_connection][super::super::client::DeveloperConnect::update_connection] calls.
+    /// The request builder for [DeveloperConnect::update_connection][crate::client::DeveloperConnect::update_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -441,7 +441,7 @@ pub mod developer_connect {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_connection][super::super::client::DeveloperConnect::update_connection].
+        /// on [update_connection][crate::client::DeveloperConnect::update_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_connection(self.0.request, self.0.options)
@@ -552,7 +552,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::delete_connection][super::super::client::DeveloperConnect::delete_connection] calls.
+    /// The request builder for [DeveloperConnect::delete_connection][crate::client::DeveloperConnect::delete_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -600,7 +600,7 @@ pub mod developer_connect {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_connection][super::super::client::DeveloperConnect::delete_connection].
+        /// on [delete_connection][crate::client::DeveloperConnect::delete_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_connection(self.0.request, self.0.options)
@@ -677,7 +677,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::create_git_repository_link][super::super::client::DeveloperConnect::create_git_repository_link] calls.
+    /// The request builder for [DeveloperConnect::create_git_repository_link][crate::client::DeveloperConnect::create_git_repository_link] calls.
     ///
     /// # Example
     /// ```no_run
@@ -727,7 +727,7 @@ pub mod developer_connect {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_git_repository_link][super::super::client::DeveloperConnect::create_git_repository_link].
+        /// on [create_git_repository_link][crate::client::DeveloperConnect::create_git_repository_link].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_git_repository_link(self.0.request, self.0.options)
@@ -829,7 +829,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::delete_git_repository_link][super::super::client::DeveloperConnect::delete_git_repository_link] calls.
+    /// The request builder for [DeveloperConnect::delete_git_repository_link][crate::client::DeveloperConnect::delete_git_repository_link] calls.
     ///
     /// # Example
     /// ```no_run
@@ -879,7 +879,7 @@ pub mod developer_connect {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_git_repository_link][super::super::client::DeveloperConnect::delete_git_repository_link].
+        /// on [delete_git_repository_link][crate::client::DeveloperConnect::delete_git_repository_link].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_git_repository_link(self.0.request, self.0.options)
@@ -956,7 +956,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::list_git_repository_links][super::super::client::DeveloperConnect::list_git_repository_links] calls.
+    /// The request builder for [DeveloperConnect::list_git_repository_links][crate::client::DeveloperConnect::list_git_repository_links] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1078,7 +1078,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::get_git_repository_link][super::super::client::DeveloperConnect::get_git_repository_link] calls.
+    /// The request builder for [DeveloperConnect::get_git_repository_link][crate::client::DeveloperConnect::get_git_repository_link] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1144,7 +1144,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::fetch_read_write_token][super::super::client::DeveloperConnect::fetch_read_write_token] calls.
+    /// The request builder for [DeveloperConnect::fetch_read_write_token][crate::client::DeveloperConnect::fetch_read_write_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1210,7 +1210,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::fetch_read_token][super::super::client::DeveloperConnect::fetch_read_token] calls.
+    /// The request builder for [DeveloperConnect::fetch_read_token][crate::client::DeveloperConnect::fetch_read_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1273,7 +1273,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::fetch_linkable_git_repositories][super::super::client::DeveloperConnect::fetch_linkable_git_repositories] calls.
+    /// The request builder for [DeveloperConnect::fetch_linkable_git_repositories][crate::client::DeveloperConnect::fetch_linkable_git_repositories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1385,7 +1385,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::fetch_git_hub_installations][super::super::client::DeveloperConnect::fetch_git_hub_installations] calls.
+    /// The request builder for [DeveloperConnect::fetch_git_hub_installations][crate::client::DeveloperConnect::fetch_git_hub_installations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1453,7 +1453,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::fetch_git_refs][super::super::client::DeveloperConnect::fetch_git_refs] calls.
+    /// The request builder for [DeveloperConnect::fetch_git_refs][crate::client::DeveloperConnect::fetch_git_refs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1539,7 +1539,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::list_locations][super::super::client::DeveloperConnect::list_locations] calls.
+    /// The request builder for [DeveloperConnect::list_locations][crate::client::DeveloperConnect::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1649,7 +1649,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::get_location][super::super::client::DeveloperConnect::get_location] calls.
+    /// The request builder for [DeveloperConnect::get_location][crate::client::DeveloperConnect::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1710,7 +1710,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::list_operations][super::super::client::DeveloperConnect::list_operations] calls.
+    /// The request builder for [DeveloperConnect::list_operations][crate::client::DeveloperConnect::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1822,7 +1822,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::get_operation][super::super::client::DeveloperConnect::get_operation] calls.
+    /// The request builder for [DeveloperConnect::get_operation][crate::client::DeveloperConnect::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1886,7 +1886,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::delete_operation][super::super::client::DeveloperConnect::delete_operation] calls.
+    /// The request builder for [DeveloperConnect::delete_operation][crate::client::DeveloperConnect::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1950,7 +1950,7 @@ pub mod developer_connect {
         }
     }
 
-    /// The request builder for [DeveloperConnect::cancel_operation][super::super::client::DeveloperConnect::cancel_operation] calls.
+    /// The request builder for [DeveloperConnect::cancel_operation][crate::client::DeveloperConnect::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
+++ b/src/generated/cloud/dialogflow/cx/v3/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod agents {
     use crate::Result;
 
-    /// A builder for [Agents][super::super::client::Agents].
+    /// A builder for [Agents][crate::client::Agents].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod agents {
         }
     }
 
-    /// Common implementation for [super::super::client::Agents] request builders.
+    /// Common implementation for [crate::client::Agents] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Agents>,
@@ -66,7 +66,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::list_agents][super::super::client::Agents::list_agents] calls.
+    /// The request builder for [Agents::list_agents][crate::client::Agents::list_agents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -167,7 +167,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_agent][super::super::client::Agents::get_agent] calls.
+    /// The request builder for [Agents::get_agent][crate::client::Agents::get_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -228,7 +228,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::create_agent][super::super::client::Agents::create_agent] calls.
+    /// The request builder for [Agents::create_agent][crate::client::Agents::create_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -311,7 +311,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::update_agent][super::super::client::Agents::update_agent] calls.
+    /// The request builder for [Agents::update_agent][crate::client::Agents::update_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -404,7 +404,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::delete_agent][super::super::client::Agents::delete_agent] calls.
+    /// The request builder for [Agents::delete_agent][crate::client::Agents::delete_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -465,7 +465,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::export_agent][super::super::client::Agents::export_agent] calls.
+    /// The request builder for [Agents::export_agent][crate::client::Agents::export_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -508,7 +508,7 @@ pub mod agents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_agent][super::super::client::Agents::export_agent].
+        /// on [export_agent][crate::client::Agents::export_agent].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_agent(self.0.request, self.0.options)
@@ -608,7 +608,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::restore_agent][super::super::client::Agents::restore_agent] calls.
+    /// The request builder for [Agents::restore_agent][crate::client::Agents::restore_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -651,7 +651,7 @@ pub mod agents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_agent][super::super::client::Agents::restore_agent].
+        /// on [restore_agent][crate::client::Agents::restore_agent].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_agent(self.0.request, self.0.options)
@@ -766,7 +766,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::validate_agent][super::super::client::Agents::validate_agent] calls.
+    /// The request builder for [Agents::validate_agent][crate::client::Agents::validate_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -833,7 +833,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_agent_validation_result][super::super::client::Agents::get_agent_validation_result] calls.
+    /// The request builder for [Agents::get_agent_validation_result][crate::client::Agents::get_agent_validation_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -905,7 +905,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_generative_settings][super::super::client::Agents::get_generative_settings] calls.
+    /// The request builder for [Agents::get_generative_settings][crate::client::Agents::get_generative_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -977,7 +977,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::update_generative_settings][super::super::client::Agents::update_generative_settings] calls.
+    /// The request builder for [Agents::update_generative_settings][crate::client::Agents::update_generative_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1075,7 +1075,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::list_locations][super::super::client::Agents::list_locations] calls.
+    /// The request builder for [Agents::list_locations][crate::client::Agents::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1183,7 +1183,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_location][super::super::client::Agents::get_location] calls.
+    /// The request builder for [Agents::get_location][crate::client::Agents::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1242,7 +1242,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::list_operations][super::super::client::Agents::list_operations] calls.
+    /// The request builder for [Agents::list_operations][crate::client::Agents::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1352,7 +1352,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_operation][super::super::client::Agents::get_operation] calls.
+    /// The request builder for [Agents::get_operation][crate::client::Agents::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1414,7 +1414,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::cancel_operation][super::super::client::Agents::cancel_operation] calls.
+    /// The request builder for [Agents::cancel_operation][crate::client::Agents::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1480,7 +1480,7 @@ pub mod agents {
 pub mod changelogs {
     use crate::Result;
 
-    /// A builder for [Changelogs][super::super::client::Changelogs].
+    /// A builder for [Changelogs][crate::client::Changelogs].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1508,7 +1508,7 @@ pub mod changelogs {
         }
     }
 
-    /// Common implementation for [super::super::client::Changelogs] request builders.
+    /// Common implementation for [crate::client::Changelogs] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Changelogs>,
@@ -1531,7 +1531,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for [Changelogs::list_changelogs][super::super::client::Changelogs::list_changelogs] calls.
+    /// The request builder for [Changelogs::list_changelogs][crate::client::Changelogs::list_changelogs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1640,7 +1640,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for [Changelogs::get_changelog][super::super::client::Changelogs::get_changelog] calls.
+    /// The request builder for [Changelogs::get_changelog][crate::client::Changelogs::get_changelog] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1703,7 +1703,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for [Changelogs::list_locations][super::super::client::Changelogs::list_locations] calls.
+    /// The request builder for [Changelogs::list_locations][crate::client::Changelogs::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1813,7 +1813,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for [Changelogs::get_location][super::super::client::Changelogs::get_location] calls.
+    /// The request builder for [Changelogs::get_location][crate::client::Changelogs::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1874,7 +1874,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for [Changelogs::list_operations][super::super::client::Changelogs::list_operations] calls.
+    /// The request builder for [Changelogs::list_operations][crate::client::Changelogs::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1986,7 +1986,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for [Changelogs::get_operation][super::super::client::Changelogs::get_operation] calls.
+    /// The request builder for [Changelogs::get_operation][crate::client::Changelogs::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2050,7 +2050,7 @@ pub mod changelogs {
         }
     }
 
-    /// The request builder for [Changelogs::cancel_operation][super::super::client::Changelogs::cancel_operation] calls.
+    /// The request builder for [Changelogs::cancel_operation][crate::client::Changelogs::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2118,7 +2118,7 @@ pub mod changelogs {
 pub mod deployments {
     use crate::Result;
 
-    /// A builder for [Deployments][super::super::client::Deployments].
+    /// A builder for [Deployments][crate::client::Deployments].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2146,7 +2146,7 @@ pub mod deployments {
         }
     }
 
-    /// Common implementation for [super::super::client::Deployments] request builders.
+    /// Common implementation for [crate::client::Deployments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Deployments>,
@@ -2169,7 +2169,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for [Deployments::list_deployments][super::super::client::Deployments::list_deployments] calls.
+    /// The request builder for [Deployments::list_deployments][crate::client::Deployments::list_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2272,7 +2272,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for [Deployments::get_deployment][super::super::client::Deployments::get_deployment] calls.
+    /// The request builder for [Deployments::get_deployment][crate::client::Deployments::get_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2335,7 +2335,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for [Deployments::list_locations][super::super::client::Deployments::list_locations] calls.
+    /// The request builder for [Deployments::list_locations][crate::client::Deployments::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2445,7 +2445,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for [Deployments::get_location][super::super::client::Deployments::get_location] calls.
+    /// The request builder for [Deployments::get_location][crate::client::Deployments::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2506,7 +2506,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for [Deployments::list_operations][super::super::client::Deployments::list_operations] calls.
+    /// The request builder for [Deployments::list_operations][crate::client::Deployments::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2618,7 +2618,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for [Deployments::get_operation][super::super::client::Deployments::get_operation] calls.
+    /// The request builder for [Deployments::get_operation][crate::client::Deployments::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2682,7 +2682,7 @@ pub mod deployments {
         }
     }
 
-    /// The request builder for [Deployments::cancel_operation][super::super::client::Deployments::cancel_operation] calls.
+    /// The request builder for [Deployments::cancel_operation][crate::client::Deployments::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2750,7 +2750,7 @@ pub mod deployments {
 pub mod entity_types {
     use crate::Result;
 
-    /// A builder for [EntityTypes][super::super::client::EntityTypes].
+    /// A builder for [EntityTypes][crate::client::EntityTypes].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2778,7 +2778,7 @@ pub mod entity_types {
         }
     }
 
-    /// Common implementation for [super::super::client::EntityTypes] request builders.
+    /// Common implementation for [crate::client::EntityTypes] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EntityTypes>,
@@ -2801,7 +2801,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::get_entity_type][super::super::client::EntityTypes::get_entity_type] calls.
+    /// The request builder for [EntityTypes::get_entity_type][crate::client::EntityTypes::get_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2870,7 +2870,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::create_entity_type][super::super::client::EntityTypes::create_entity_type] calls.
+    /// The request builder for [EntityTypes::create_entity_type][crate::client::EntityTypes::create_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2964,7 +2964,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::update_entity_type][super::super::client::EntityTypes::update_entity_type] calls.
+    /// The request builder for [EntityTypes::update_entity_type][crate::client::EntityTypes::update_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3068,7 +3068,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::delete_entity_type][super::super::client::EntityTypes::delete_entity_type] calls.
+    /// The request builder for [EntityTypes::delete_entity_type][crate::client::EntityTypes::delete_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3140,7 +3140,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::list_entity_types][super::super::client::EntityTypes::list_entity_types] calls.
+    /// The request builder for [EntityTypes::list_entity_types][crate::client::EntityTypes::list_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3249,7 +3249,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::export_entity_types][super::super::client::EntityTypes::export_entity_types] calls.
+    /// The request builder for [EntityTypes::export_entity_types][crate::client::EntityTypes::export_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3297,7 +3297,7 @@ pub mod entity_types {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_entity_types][super::super::client::EntityTypes::export_entity_types].
+        /// on [export_entity_types][crate::client::EntityTypes::export_entity_types].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_entity_types(self.0.request, self.0.options)
@@ -3427,7 +3427,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::import_entity_types][super::super::client::EntityTypes::import_entity_types] calls.
+    /// The request builder for [EntityTypes::import_entity_types][crate::client::EntityTypes::import_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3475,7 +3475,7 @@ pub mod entity_types {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_entity_types][super::super::client::EntityTypes::import_entity_types].
+        /// on [import_entity_types][crate::client::EntityTypes::import_entity_types].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_entity_types(self.0.request, self.0.options)
@@ -3596,7 +3596,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::list_locations][super::super::client::EntityTypes::list_locations] calls.
+    /// The request builder for [EntityTypes::list_locations][crate::client::EntityTypes::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3706,7 +3706,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::get_location][super::super::client::EntityTypes::get_location] calls.
+    /// The request builder for [EntityTypes::get_location][crate::client::EntityTypes::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3767,7 +3767,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::list_operations][super::super::client::EntityTypes::list_operations] calls.
+    /// The request builder for [EntityTypes::list_operations][crate::client::EntityTypes::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3879,7 +3879,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::get_operation][super::super::client::EntityTypes::get_operation] calls.
+    /// The request builder for [EntityTypes::get_operation][crate::client::EntityTypes::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3943,7 +3943,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::cancel_operation][super::super::client::EntityTypes::cancel_operation] calls.
+    /// The request builder for [EntityTypes::cancel_operation][crate::client::EntityTypes::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4011,7 +4011,7 @@ pub mod entity_types {
 pub mod environments {
     use crate::Result;
 
-    /// A builder for [Environments][super::super::client::Environments].
+    /// A builder for [Environments][crate::client::Environments].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4039,7 +4039,7 @@ pub mod environments {
         }
     }
 
-    /// Common implementation for [super::super::client::Environments] request builders.
+    /// Common implementation for [crate::client::Environments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Environments>,
@@ -4062,7 +4062,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
+    /// The request builder for [Environments::list_environments][crate::client::Environments::list_environments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4168,7 +4168,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
+    /// The request builder for [Environments::get_environment][crate::client::Environments::get_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4231,7 +4231,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
+    /// The request builder for [Environments::create_environment][crate::client::Environments::create_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4279,7 +4279,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_environment][super::super::client::Environments::create_environment].
+        /// on [create_environment][crate::client::Environments::create_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_environment(self.0.request, self.0.options)
@@ -4355,7 +4355,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
+    /// The request builder for [Environments::update_environment][crate::client::Environments::update_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4403,7 +4403,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_environment][super::super::client::Environments::update_environment].
+        /// on [update_environment][crate::client::Environments::update_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_environment(self.0.request, self.0.options)
@@ -4493,7 +4493,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
+    /// The request builder for [Environments::delete_environment][crate::client::Environments::delete_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4559,7 +4559,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::lookup_environment_history][super::super::client::Environments::lookup_environment_history] calls.
+    /// The request builder for [Environments::lookup_environment_history][crate::client::Environments::lookup_environment_history] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4671,7 +4671,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::run_continuous_test][super::super::client::Environments::run_continuous_test] calls.
+    /// The request builder for [Environments::run_continuous_test][crate::client::Environments::run_continuous_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4719,7 +4719,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [run_continuous_test][super::super::client::Environments::run_continuous_test].
+        /// on [run_continuous_test][crate::client::Environments::run_continuous_test].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .run_continuous_test(self.0.request, self.0.options)
@@ -4781,7 +4781,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_continuous_test_results][super::super::client::Environments::list_continuous_test_results] calls.
+    /// The request builder for [Environments::list_continuous_test_results][crate::client::Environments::list_continuous_test_results] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4893,7 +4893,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::deploy_flow][super::super::client::Environments::deploy_flow] calls.
+    /// The request builder for [Environments::deploy_flow][crate::client::Environments::deploy_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4938,7 +4938,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [deploy_flow][super::super::client::Environments::deploy_flow].
+        /// on [deploy_flow][crate::client::Environments::deploy_flow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .deploy_flow(self.0.request, self.0.options)
@@ -5006,7 +5006,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_locations][super::super::client::Environments::list_locations] calls.
+    /// The request builder for [Environments::list_locations][crate::client::Environments::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5116,7 +5116,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_location][super::super::client::Environments::get_location] calls.
+    /// The request builder for [Environments::get_location][crate::client::Environments::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5177,7 +5177,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
+    /// The request builder for [Environments::list_operations][crate::client::Environments::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5289,7 +5289,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
+    /// The request builder for [Environments::get_operation][crate::client::Environments::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5353,7 +5353,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::cancel_operation][super::super::client::Environments::cancel_operation] calls.
+    /// The request builder for [Environments::cancel_operation][crate::client::Environments::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5421,7 +5421,7 @@ pub mod environments {
 pub mod experiments {
     use crate::Result;
 
-    /// A builder for [Experiments][super::super::client::Experiments].
+    /// A builder for [Experiments][crate::client::Experiments].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5449,7 +5449,7 @@ pub mod experiments {
         }
     }
 
-    /// Common implementation for [super::super::client::Experiments] request builders.
+    /// Common implementation for [crate::client::Experiments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Experiments>,
@@ -5472,7 +5472,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::list_experiments][super::super::client::Experiments::list_experiments] calls.
+    /// The request builder for [Experiments::list_experiments][crate::client::Experiments::list_experiments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5575,7 +5575,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::get_experiment][super::super::client::Experiments::get_experiment] calls.
+    /// The request builder for [Experiments::get_experiment][crate::client::Experiments::get_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5638,7 +5638,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::create_experiment][super::super::client::Experiments::create_experiment] calls.
+    /// The request builder for [Experiments::create_experiment][crate::client::Experiments::create_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5726,7 +5726,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::update_experiment][super::super::client::Experiments::update_experiment] calls.
+    /// The request builder for [Experiments::update_experiment][crate::client::Experiments::update_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5828,7 +5828,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::delete_experiment][super::super::client::Experiments::delete_experiment] calls.
+    /// The request builder for [Experiments::delete_experiment][crate::client::Experiments::delete_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5894,7 +5894,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::start_experiment][super::super::client::Experiments::start_experiment] calls.
+    /// The request builder for [Experiments::start_experiment][crate::client::Experiments::start_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5957,7 +5957,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::stop_experiment][super::super::client::Experiments::stop_experiment] calls.
+    /// The request builder for [Experiments::stop_experiment][crate::client::Experiments::stop_experiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6020,7 +6020,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::list_locations][super::super::client::Experiments::list_locations] calls.
+    /// The request builder for [Experiments::list_locations][crate::client::Experiments::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6130,7 +6130,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::get_location][super::super::client::Experiments::get_location] calls.
+    /// The request builder for [Experiments::get_location][crate::client::Experiments::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6191,7 +6191,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::list_operations][super::super::client::Experiments::list_operations] calls.
+    /// The request builder for [Experiments::list_operations][crate::client::Experiments::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6303,7 +6303,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::get_operation][super::super::client::Experiments::get_operation] calls.
+    /// The request builder for [Experiments::get_operation][crate::client::Experiments::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6367,7 +6367,7 @@ pub mod experiments {
         }
     }
 
-    /// The request builder for [Experiments::cancel_operation][super::super::client::Experiments::cancel_operation] calls.
+    /// The request builder for [Experiments::cancel_operation][crate::client::Experiments::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6435,7 +6435,7 @@ pub mod experiments {
 pub mod flows {
     use crate::Result;
 
-    /// A builder for [Flows][super::super::client::Flows].
+    /// A builder for [Flows][crate::client::Flows].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6463,7 +6463,7 @@ pub mod flows {
         }
     }
 
-    /// Common implementation for [super::super::client::Flows] request builders.
+    /// Common implementation for [crate::client::Flows] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Flows>,
@@ -6484,7 +6484,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::create_flow][super::super::client::Flows::create_flow] calls.
+    /// The request builder for [Flows::create_flow][crate::client::Flows::create_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6573,7 +6573,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::delete_flow][super::super::client::Flows::delete_flow] calls.
+    /// The request builder for [Flows::delete_flow][crate::client::Flows::delete_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6640,7 +6640,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::list_flows][super::super::client::Flows::list_flows] calls.
+    /// The request builder for [Flows::list_flows][crate::client::Flows::list_flows] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6747,7 +6747,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::get_flow][super::super::client::Flows::get_flow] calls.
+    /// The request builder for [Flows::get_flow][crate::client::Flows::get_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6814,7 +6814,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::update_flow][super::super::client::Flows::update_flow] calls.
+    /// The request builder for [Flows::update_flow][crate::client::Flows::update_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6913,7 +6913,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::train_flow][super::super::client::Flows::train_flow] calls.
+    /// The request builder for [Flows::train_flow][crate::client::Flows::train_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6956,7 +6956,7 @@ pub mod flows {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [train_flow][super::super::client::Flows::train_flow].
+        /// on [train_flow][crate::client::Flows::train_flow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .train_flow(self.0.request, self.0.options)
@@ -7015,7 +7015,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::validate_flow][super::super::client::Flows::validate_flow] calls.
+    /// The request builder for [Flows::validate_flow][crate::client::Flows::validate_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7082,7 +7082,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::get_flow_validation_result][super::super::client::Flows::get_flow_validation_result] calls.
+    /// The request builder for [Flows::get_flow_validation_result][crate::client::Flows::get_flow_validation_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7154,7 +7154,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::import_flow][super::super::client::Flows::import_flow] calls.
+    /// The request builder for [Flows::import_flow][crate::client::Flows::import_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7197,7 +7197,7 @@ pub mod flows {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_flow][super::super::client::Flows::import_flow].
+        /// on [import_flow][crate::client::Flows::import_flow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_flow(self.0.request, self.0.options)
@@ -7311,7 +7311,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::export_flow][super::super::client::Flows::export_flow] calls.
+    /// The request builder for [Flows::export_flow][crate::client::Flows::export_flow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7354,7 +7354,7 @@ pub mod flows {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_flow][super::super::client::Flows::export_flow].
+        /// on [export_flow][crate::client::Flows::export_flow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_flow(self.0.request, self.0.options)
@@ -7421,7 +7421,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::list_locations][super::super::client::Flows::list_locations] calls.
+    /// The request builder for [Flows::list_locations][crate::client::Flows::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7529,7 +7529,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::get_location][super::super::client::Flows::get_location] calls.
+    /// The request builder for [Flows::get_location][crate::client::Flows::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7588,7 +7588,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::list_operations][super::super::client::Flows::list_operations] calls.
+    /// The request builder for [Flows::list_operations][crate::client::Flows::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7698,7 +7698,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::get_operation][super::super::client::Flows::get_operation] calls.
+    /// The request builder for [Flows::get_operation][crate::client::Flows::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7760,7 +7760,7 @@ pub mod flows {
         }
     }
 
-    /// The request builder for [Flows::cancel_operation][super::super::client::Flows::cancel_operation] calls.
+    /// The request builder for [Flows::cancel_operation][crate::client::Flows::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7826,7 +7826,7 @@ pub mod flows {
 pub mod generators {
     use crate::Result;
 
-    /// A builder for [Generators][super::super::client::Generators].
+    /// A builder for [Generators][crate::client::Generators].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7854,7 +7854,7 @@ pub mod generators {
         }
     }
 
-    /// Common implementation for [super::super::client::Generators] request builders.
+    /// Common implementation for [crate::client::Generators] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Generators>,
@@ -7877,7 +7877,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::list_generators][super::super::client::Generators::list_generators] calls.
+    /// The request builder for [Generators::list_generators][crate::client::Generators::list_generators] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7986,7 +7986,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::get_generator][super::super::client::Generators::get_generator] calls.
+    /// The request builder for [Generators::get_generator][crate::client::Generators::get_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8055,7 +8055,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::create_generator][super::super::client::Generators::create_generator] calls.
+    /// The request builder for [Generators::create_generator][crate::client::Generators::create_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8146,7 +8146,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::update_generator][super::super::client::Generators::update_generator] calls.
+    /// The request builder for [Generators::update_generator][crate::client::Generators::update_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8247,7 +8247,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::delete_generator][super::super::client::Generators::delete_generator] calls.
+    /// The request builder for [Generators::delete_generator][crate::client::Generators::delete_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8316,7 +8316,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::list_locations][super::super::client::Generators::list_locations] calls.
+    /// The request builder for [Generators::list_locations][crate::client::Generators::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8426,7 +8426,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::get_location][super::super::client::Generators::get_location] calls.
+    /// The request builder for [Generators::get_location][crate::client::Generators::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8487,7 +8487,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::list_operations][super::super::client::Generators::list_operations] calls.
+    /// The request builder for [Generators::list_operations][crate::client::Generators::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8599,7 +8599,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::get_operation][super::super::client::Generators::get_operation] calls.
+    /// The request builder for [Generators::get_operation][crate::client::Generators::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8663,7 +8663,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::cancel_operation][super::super::client::Generators::cancel_operation] calls.
+    /// The request builder for [Generators::cancel_operation][crate::client::Generators::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8731,7 +8731,7 @@ pub mod generators {
 pub mod intents {
     use crate::Result;
 
-    /// A builder for [Intents][super::super::client::Intents].
+    /// A builder for [Intents][crate::client::Intents].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -8759,7 +8759,7 @@ pub mod intents {
         }
     }
 
-    /// Common implementation for [super::super::client::Intents] request builders.
+    /// Common implementation for [crate::client::Intents] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Intents>,
@@ -8780,7 +8780,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::list_intents][super::super::client::Intents::list_intents] calls.
+    /// The request builder for [Intents::list_intents][crate::client::Intents::list_intents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8893,7 +8893,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::get_intent][super::super::client::Intents::get_intent] calls.
+    /// The request builder for [Intents::get_intent][crate::client::Intents::get_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8960,7 +8960,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::create_intent][super::super::client::Intents::create_intent] calls.
+    /// The request builder for [Intents::create_intent][crate::client::Intents::create_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9049,7 +9049,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::update_intent][super::super::client::Intents::update_intent] calls.
+    /// The request builder for [Intents::update_intent][crate::client::Intents::update_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9148,7 +9148,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::delete_intent][super::super::client::Intents::delete_intent] calls.
+    /// The request builder for [Intents::delete_intent][crate::client::Intents::delete_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9209,7 +9209,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::import_intents][super::super::client::Intents::import_intents] calls.
+    /// The request builder for [Intents::import_intents][crate::client::Intents::import_intents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9252,7 +9252,7 @@ pub mod intents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_intents][super::super::client::Intents::import_intents].
+        /// on [import_intents][crate::client::Intents::import_intents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_intents(self.0.request, self.0.options)
@@ -9358,7 +9358,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::export_intents][super::super::client::Intents::export_intents] calls.
+    /// The request builder for [Intents::export_intents][crate::client::Intents::export_intents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9401,7 +9401,7 @@ pub mod intents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_intents][super::super::client::Intents::export_intents].
+        /// on [export_intents][crate::client::Intents::export_intents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_intents(self.0.request, self.0.options)
@@ -9517,7 +9517,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::list_locations][super::super::client::Intents::list_locations] calls.
+    /// The request builder for [Intents::list_locations][crate::client::Intents::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9625,7 +9625,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::get_location][super::super::client::Intents::get_location] calls.
+    /// The request builder for [Intents::get_location][crate::client::Intents::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9684,7 +9684,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::list_operations][super::super::client::Intents::list_operations] calls.
+    /// The request builder for [Intents::list_operations][crate::client::Intents::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9794,7 +9794,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::get_operation][super::super::client::Intents::get_operation] calls.
+    /// The request builder for [Intents::get_operation][crate::client::Intents::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9856,7 +9856,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::cancel_operation][super::super::client::Intents::cancel_operation] calls.
+    /// The request builder for [Intents::cancel_operation][crate::client::Intents::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9922,7 +9922,7 @@ pub mod intents {
 pub mod pages {
     use crate::Result;
 
-    /// A builder for [Pages][super::super::client::Pages].
+    /// A builder for [Pages][crate::client::Pages].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -9950,7 +9950,7 @@ pub mod pages {
         }
     }
 
-    /// Common implementation for [super::super::client::Pages] request builders.
+    /// Common implementation for [crate::client::Pages] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Pages>,
@@ -9971,7 +9971,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::list_pages][super::super::client::Pages::list_pages] calls.
+    /// The request builder for [Pages::list_pages][crate::client::Pages::list_pages] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10078,7 +10078,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::get_page][super::super::client::Pages::get_page] calls.
+    /// The request builder for [Pages::get_page][crate::client::Pages::get_page] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10145,7 +10145,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::create_page][super::super::client::Pages::create_page] calls.
+    /// The request builder for [Pages::create_page][crate::client::Pages::create_page] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10234,7 +10234,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::update_page][super::super::client::Pages::update_page] calls.
+    /// The request builder for [Pages::update_page][crate::client::Pages::update_page] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10333,7 +10333,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::delete_page][super::super::client::Pages::delete_page] calls.
+    /// The request builder for [Pages::delete_page][crate::client::Pages::delete_page] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10400,7 +10400,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::list_locations][super::super::client::Pages::list_locations] calls.
+    /// The request builder for [Pages::list_locations][crate::client::Pages::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10508,7 +10508,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::get_location][super::super::client::Pages::get_location] calls.
+    /// The request builder for [Pages::get_location][crate::client::Pages::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10567,7 +10567,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::list_operations][super::super::client::Pages::list_operations] calls.
+    /// The request builder for [Pages::list_operations][crate::client::Pages::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10677,7 +10677,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::get_operation][super::super::client::Pages::get_operation] calls.
+    /// The request builder for [Pages::get_operation][crate::client::Pages::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10739,7 +10739,7 @@ pub mod pages {
         }
     }
 
-    /// The request builder for [Pages::cancel_operation][super::super::client::Pages::cancel_operation] calls.
+    /// The request builder for [Pages::cancel_operation][crate::client::Pages::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10805,7 +10805,7 @@ pub mod pages {
 pub mod security_settings_service {
     use crate::Result;
 
-    /// A builder for [SecuritySettingsService][super::super::client::SecuritySettingsService].
+    /// A builder for [SecuritySettingsService][crate::client::SecuritySettingsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -10833,7 +10833,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SecuritySettingsService] request builders.
+    /// Common implementation for [crate::client::SecuritySettingsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SecuritySettingsService>,
@@ -10856,7 +10856,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::create_security_settings][super::super::client::SecuritySettingsService::create_security_settings] calls.
+    /// The request builder for [SecuritySettingsService::create_security_settings][crate::client::SecuritySettingsService::create_security_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10944,7 +10944,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::get_security_settings][super::super::client::SecuritySettingsService::get_security_settings] calls.
+    /// The request builder for [SecuritySettingsService::get_security_settings][crate::client::SecuritySettingsService::get_security_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11010,7 +11010,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::update_security_settings][super::super::client::SecuritySettingsService::update_security_settings] calls.
+    /// The request builder for [SecuritySettingsService::update_security_settings][crate::client::SecuritySettingsService::update_security_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11112,7 +11112,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::list_security_settings][super::super::client::SecuritySettingsService::list_security_settings] calls.
+    /// The request builder for [SecuritySettingsService::list_security_settings][crate::client::SecuritySettingsService::list_security_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11220,7 +11220,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::delete_security_settings][super::super::client::SecuritySettingsService::delete_security_settings] calls.
+    /// The request builder for [SecuritySettingsService::delete_security_settings][crate::client::SecuritySettingsService::delete_security_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11286,7 +11286,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::list_locations][super::super::client::SecuritySettingsService::list_locations] calls.
+    /// The request builder for [SecuritySettingsService::list_locations][crate::client::SecuritySettingsService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11396,7 +11396,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::get_location][super::super::client::SecuritySettingsService::get_location] calls.
+    /// The request builder for [SecuritySettingsService::get_location][crate::client::SecuritySettingsService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11457,7 +11457,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::list_operations][super::super::client::SecuritySettingsService::list_operations] calls.
+    /// The request builder for [SecuritySettingsService::list_operations][crate::client::SecuritySettingsService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11569,7 +11569,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::get_operation][super::super::client::SecuritySettingsService::get_operation] calls.
+    /// The request builder for [SecuritySettingsService::get_operation][crate::client::SecuritySettingsService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11633,7 +11633,7 @@ pub mod security_settings_service {
         }
     }
 
-    /// The request builder for [SecuritySettingsService::cancel_operation][super::super::client::SecuritySettingsService::cancel_operation] calls.
+    /// The request builder for [SecuritySettingsService::cancel_operation][crate::client::SecuritySettingsService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11701,7 +11701,7 @@ pub mod security_settings_service {
 pub mod sessions {
     use crate::Result;
 
-    /// A builder for [Sessions][super::super::client::Sessions].
+    /// A builder for [Sessions][crate::client::Sessions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -11729,7 +11729,7 @@ pub mod sessions {
         }
     }
 
-    /// Common implementation for [super::super::client::Sessions] request builders.
+    /// Common implementation for [crate::client::Sessions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Sessions>,
@@ -11750,7 +11750,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::detect_intent][super::super::client::Sessions::detect_intent] calls.
+    /// The request builder for [Sessions::detect_intent][crate::client::Sessions::detect_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11869,7 +11869,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::match_intent][super::super::client::Sessions::match_intent] calls.
+    /// The request builder for [Sessions::match_intent][crate::client::Sessions::match_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11976,7 +11976,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::fulfill_intent][super::super::client::Sessions::fulfill_intent] calls.
+    /// The request builder for [Sessions::fulfill_intent][crate::client::Sessions::fulfill_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12083,7 +12083,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::submit_answer_feedback][super::super::client::Sessions::submit_answer_feedback] calls.
+    /// The request builder for [Sessions::submit_answer_feedback][crate::client::Sessions::submit_answer_feedback] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12195,7 +12195,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::list_locations][super::super::client::Sessions::list_locations] calls.
+    /// The request builder for [Sessions::list_locations][crate::client::Sessions::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12303,7 +12303,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::get_location][super::super::client::Sessions::get_location] calls.
+    /// The request builder for [Sessions::get_location][crate::client::Sessions::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12362,7 +12362,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::list_operations][super::super::client::Sessions::list_operations] calls.
+    /// The request builder for [Sessions::list_operations][crate::client::Sessions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12472,7 +12472,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::get_operation][super::super::client::Sessions::get_operation] calls.
+    /// The request builder for [Sessions::get_operation][crate::client::Sessions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12534,7 +12534,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::cancel_operation][super::super::client::Sessions::cancel_operation] calls.
+    /// The request builder for [Sessions::cancel_operation][crate::client::Sessions::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12600,7 +12600,7 @@ pub mod sessions {
 pub mod session_entity_types {
     use crate::Result;
 
-    /// A builder for [SessionEntityTypes][super::super::client::SessionEntityTypes].
+    /// A builder for [SessionEntityTypes][crate::client::SessionEntityTypes].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -12628,7 +12628,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// Common implementation for [super::super::client::SessionEntityTypes] request builders.
+    /// Common implementation for [crate::client::SessionEntityTypes] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SessionEntityTypes>,
@@ -12651,7 +12651,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::list_session_entity_types][super::super::client::SessionEntityTypes::list_session_entity_types] calls.
+    /// The request builder for [SessionEntityTypes::list_session_entity_types][crate::client::SessionEntityTypes::list_session_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12761,7 +12761,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::get_session_entity_type][super::super::client::SessionEntityTypes::get_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::get_session_entity_type][crate::client::SessionEntityTypes::get_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12827,7 +12827,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::create_session_entity_type][super::super::client::SessionEntityTypes::create_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::create_session_entity_type][crate::client::SessionEntityTypes::create_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12917,7 +12917,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::update_session_entity_type][super::super::client::SessionEntityTypes::update_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::update_session_entity_type][crate::client::SessionEntityTypes::update_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13017,7 +13017,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::delete_session_entity_type][super::super::client::SessionEntityTypes::delete_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::delete_session_entity_type][crate::client::SessionEntityTypes::delete_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13085,7 +13085,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::list_locations][super::super::client::SessionEntityTypes::list_locations] calls.
+    /// The request builder for [SessionEntityTypes::list_locations][crate::client::SessionEntityTypes::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13195,7 +13195,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::get_location][super::super::client::SessionEntityTypes::get_location] calls.
+    /// The request builder for [SessionEntityTypes::get_location][crate::client::SessionEntityTypes::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13256,7 +13256,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::list_operations][super::super::client::SessionEntityTypes::list_operations] calls.
+    /// The request builder for [SessionEntityTypes::list_operations][crate::client::SessionEntityTypes::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13368,7 +13368,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::get_operation][super::super::client::SessionEntityTypes::get_operation] calls.
+    /// The request builder for [SessionEntityTypes::get_operation][crate::client::SessionEntityTypes::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13432,7 +13432,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::cancel_operation][super::super::client::SessionEntityTypes::cancel_operation] calls.
+    /// The request builder for [SessionEntityTypes::cancel_operation][crate::client::SessionEntityTypes::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13500,7 +13500,7 @@ pub mod session_entity_types {
 pub mod test_cases {
     use crate::Result;
 
-    /// A builder for [TestCases][super::super::client::TestCases].
+    /// A builder for [TestCases][crate::client::TestCases].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -13528,7 +13528,7 @@ pub mod test_cases {
         }
     }
 
-    /// Common implementation for [super::super::client::TestCases] request builders.
+    /// Common implementation for [crate::client::TestCases] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TestCases>,
@@ -13551,7 +13551,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::list_test_cases][super::super::client::TestCases::list_test_cases] calls.
+    /// The request builder for [TestCases::list_test_cases][crate::client::TestCases::list_test_cases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13663,7 +13663,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::batch_delete_test_cases][super::super::client::TestCases::batch_delete_test_cases] calls.
+    /// The request builder for [TestCases::batch_delete_test_cases][crate::client::TestCases::batch_delete_test_cases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13742,7 +13742,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::get_test_case][super::super::client::TestCases::get_test_case] calls.
+    /// The request builder for [TestCases::get_test_case][crate::client::TestCases::get_test_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13805,7 +13805,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::create_test_case][super::super::client::TestCases::create_test_case] calls.
+    /// The request builder for [TestCases::create_test_case][crate::client::TestCases::create_test_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13890,7 +13890,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::update_test_case][super::super::client::TestCases::update_test_case] calls.
+    /// The request builder for [TestCases::update_test_case][crate::client::TestCases::update_test_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13989,7 +13989,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::run_test_case][super::super::client::TestCases::run_test_case] calls.
+    /// The request builder for [TestCases::run_test_case][crate::client::TestCases::run_test_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14034,7 +14034,7 @@ pub mod test_cases {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [run_test_case][super::super::client::TestCases::run_test_case].
+        /// on [run_test_case][crate::client::TestCases::run_test_case].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .run_test_case(self.0.request, self.0.options)
@@ -14100,7 +14100,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::batch_run_test_cases][super::super::client::TestCases::batch_run_test_cases] calls.
+    /// The request builder for [TestCases::batch_run_test_cases][crate::client::TestCases::batch_run_test_cases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14148,7 +14148,7 @@ pub mod test_cases {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_run_test_cases][super::super::client::TestCases::batch_run_test_cases].
+        /// on [batch_run_test_cases][crate::client::TestCases::batch_run_test_cases].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_run_test_cases(self.0.request, self.0.options)
@@ -14229,7 +14229,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::calculate_coverage][super::super::client::TestCases::calculate_coverage] calls.
+    /// The request builder for [TestCases::calculate_coverage][crate::client::TestCases::calculate_coverage] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14306,7 +14306,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::import_test_cases][super::super::client::TestCases::import_test_cases] calls.
+    /// The request builder for [TestCases::import_test_cases][crate::client::TestCases::import_test_cases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14351,7 +14351,7 @@ pub mod test_cases {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_test_cases][super::super::client::TestCases::import_test_cases].
+        /// on [import_test_cases][crate::client::TestCases::import_test_cases].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_test_cases(self.0.request, self.0.options)
@@ -14443,7 +14443,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::export_test_cases][super::super::client::TestCases::export_test_cases] calls.
+    /// The request builder for [TestCases::export_test_cases][crate::client::TestCases::export_test_cases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14488,7 +14488,7 @@ pub mod test_cases {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_test_cases][super::super::client::TestCases::export_test_cases].
+        /// on [export_test_cases][crate::client::TestCases::export_test_cases].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_test_cases(self.0.request, self.0.options)
@@ -14587,7 +14587,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::list_test_case_results][super::super::client::TestCases::list_test_case_results] calls.
+    /// The request builder for [TestCases::list_test_case_results][crate::client::TestCases::list_test_case_results] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14701,7 +14701,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::get_test_case_result][super::super::client::TestCases::get_test_case_result] calls.
+    /// The request builder for [TestCases::get_test_case_result][crate::client::TestCases::get_test_case_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14767,7 +14767,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::list_locations][super::super::client::TestCases::list_locations] calls.
+    /// The request builder for [TestCases::list_locations][crate::client::TestCases::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14877,7 +14877,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::get_location][super::super::client::TestCases::get_location] calls.
+    /// The request builder for [TestCases::get_location][crate::client::TestCases::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14938,7 +14938,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::list_operations][super::super::client::TestCases::list_operations] calls.
+    /// The request builder for [TestCases::list_operations][crate::client::TestCases::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15050,7 +15050,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::get_operation][super::super::client::TestCases::get_operation] calls.
+    /// The request builder for [TestCases::get_operation][crate::client::TestCases::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15114,7 +15114,7 @@ pub mod test_cases {
         }
     }
 
-    /// The request builder for [TestCases::cancel_operation][super::super::client::TestCases::cancel_operation] calls.
+    /// The request builder for [TestCases::cancel_operation][crate::client::TestCases::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15182,7 +15182,7 @@ pub mod test_cases {
 pub mod transition_route_groups {
     use crate::Result;
 
-    /// A builder for [TransitionRouteGroups][super::super::client::TransitionRouteGroups].
+    /// A builder for [TransitionRouteGroups][crate::client::TransitionRouteGroups].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -15210,7 +15210,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// Common implementation for [super::super::client::TransitionRouteGroups] request builders.
+    /// Common implementation for [crate::client::TransitionRouteGroups] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TransitionRouteGroups>,
@@ -15233,7 +15233,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::list_transition_route_groups][super::super::client::TransitionRouteGroups::list_transition_route_groups] calls.
+    /// The request builder for [TransitionRouteGroups::list_transition_route_groups][crate::client::TransitionRouteGroups::list_transition_route_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15351,7 +15351,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::get_transition_route_group][super::super::client::TransitionRouteGroups::get_transition_route_group] calls.
+    /// The request builder for [TransitionRouteGroups::get_transition_route_group][crate::client::TransitionRouteGroups::get_transition_route_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15425,7 +15425,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::create_transition_route_group][super::super::client::TransitionRouteGroups::create_transition_route_group] calls.
+    /// The request builder for [TransitionRouteGroups::create_transition_route_group][crate::client::TransitionRouteGroups::create_transition_route_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15521,7 +15521,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::update_transition_route_group][super::super::client::TransitionRouteGroups::update_transition_route_group] calls.
+    /// The request builder for [TransitionRouteGroups::update_transition_route_group][crate::client::TransitionRouteGroups::update_transition_route_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15627,7 +15627,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::delete_transition_route_group][super::super::client::TransitionRouteGroups::delete_transition_route_group] calls.
+    /// The request builder for [TransitionRouteGroups::delete_transition_route_group][crate::client::TransitionRouteGroups::delete_transition_route_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15701,7 +15701,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::list_locations][super::super::client::TransitionRouteGroups::list_locations] calls.
+    /// The request builder for [TransitionRouteGroups::list_locations][crate::client::TransitionRouteGroups::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15811,7 +15811,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::get_location][super::super::client::TransitionRouteGroups::get_location] calls.
+    /// The request builder for [TransitionRouteGroups::get_location][crate::client::TransitionRouteGroups::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15872,7 +15872,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::list_operations][super::super::client::TransitionRouteGroups::list_operations] calls.
+    /// The request builder for [TransitionRouteGroups::list_operations][crate::client::TransitionRouteGroups::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15984,7 +15984,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::get_operation][super::super::client::TransitionRouteGroups::get_operation] calls.
+    /// The request builder for [TransitionRouteGroups::get_operation][crate::client::TransitionRouteGroups::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16048,7 +16048,7 @@ pub mod transition_route_groups {
         }
     }
 
-    /// The request builder for [TransitionRouteGroups::cancel_operation][super::super::client::TransitionRouteGroups::cancel_operation] calls.
+    /// The request builder for [TransitionRouteGroups::cancel_operation][crate::client::TransitionRouteGroups::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16116,7 +16116,7 @@ pub mod transition_route_groups {
 pub mod versions {
     use crate::Result;
 
-    /// A builder for [Versions][super::super::client::Versions].
+    /// A builder for [Versions][crate::client::Versions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -16144,7 +16144,7 @@ pub mod versions {
         }
     }
 
-    /// Common implementation for [super::super::client::Versions] request builders.
+    /// Common implementation for [crate::client::Versions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Versions>,
@@ -16165,7 +16165,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
+    /// The request builder for [Versions::list_versions][crate::client::Versions::list_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16266,7 +16266,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
+    /// The request builder for [Versions::get_version][crate::client::Versions::get_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16327,7 +16327,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
+    /// The request builder for [Versions::create_version][crate::client::Versions::create_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16370,7 +16370,7 @@ pub mod versions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_version][super::super::client::Versions::create_version].
+        /// on [create_version][crate::client::Versions::create_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_version(self.0.request, self.0.options)
@@ -16452,7 +16452,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
+    /// The request builder for [Versions::update_version][crate::client::Versions::update_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16549,7 +16549,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
+    /// The request builder for [Versions::delete_version][crate::client::Versions::delete_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16610,7 +16610,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::load_version][super::super::client::Versions::load_version] calls.
+    /// The request builder for [Versions::load_version][crate::client::Versions::load_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16653,7 +16653,7 @@ pub mod versions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [load_version][super::super::client::Versions::load_version].
+        /// on [load_version][crate::client::Versions::load_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .load_version(self.0.request, self.0.options)
@@ -16718,7 +16718,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::compare_versions][super::super::client::Versions::compare_versions] calls.
+    /// The request builder for [Versions::compare_versions][crate::client::Versions::compare_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16793,7 +16793,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_locations][super::super::client::Versions::list_locations] calls.
+    /// The request builder for [Versions::list_locations][crate::client::Versions::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16901,7 +16901,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_location][super::super::client::Versions::get_location] calls.
+    /// The request builder for [Versions::get_location][crate::client::Versions::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16960,7 +16960,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
+    /// The request builder for [Versions::list_operations][crate::client::Versions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17070,7 +17070,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
+    /// The request builder for [Versions::get_operation][crate::client::Versions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17132,7 +17132,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::cancel_operation][super::super::client::Versions::cancel_operation] calls.
+    /// The request builder for [Versions::cancel_operation][crate::client::Versions::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17198,7 +17198,7 @@ pub mod versions {
 pub mod webhooks {
     use crate::Result;
 
-    /// A builder for [Webhooks][super::super::client::Webhooks].
+    /// A builder for [Webhooks][crate::client::Webhooks].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -17226,7 +17226,7 @@ pub mod webhooks {
         }
     }
 
-    /// Common implementation for [super::super::client::Webhooks] request builders.
+    /// Common implementation for [crate::client::Webhooks] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Webhooks>,
@@ -17247,7 +17247,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::list_webhooks][super::super::client::Webhooks::list_webhooks] calls.
+    /// The request builder for [Webhooks::list_webhooks][crate::client::Webhooks::list_webhooks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17348,7 +17348,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::get_webhook][super::super::client::Webhooks::get_webhook] calls.
+    /// The request builder for [Webhooks::get_webhook][crate::client::Webhooks::get_webhook] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17409,7 +17409,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::create_webhook][super::super::client::Webhooks::create_webhook] calls.
+    /// The request builder for [Webhooks::create_webhook][crate::client::Webhooks::create_webhook] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17492,7 +17492,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::update_webhook][super::super::client::Webhooks::update_webhook] calls.
+    /// The request builder for [Webhooks::update_webhook][crate::client::Webhooks::update_webhook] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17585,7 +17585,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::delete_webhook][super::super::client::Webhooks::delete_webhook] calls.
+    /// The request builder for [Webhooks::delete_webhook][crate::client::Webhooks::delete_webhook] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17652,7 +17652,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::list_locations][super::super::client::Webhooks::list_locations] calls.
+    /// The request builder for [Webhooks::list_locations][crate::client::Webhooks::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17760,7 +17760,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::get_location][super::super::client::Webhooks::get_location] calls.
+    /// The request builder for [Webhooks::get_location][crate::client::Webhooks::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17819,7 +17819,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::list_operations][super::super::client::Webhooks::list_operations] calls.
+    /// The request builder for [Webhooks::list_operations][crate::client::Webhooks::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17929,7 +17929,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::get_operation][super::super::client::Webhooks::get_operation] calls.
+    /// The request builder for [Webhooks::get_operation][crate::client::Webhooks::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17991,7 +17991,7 @@ pub mod webhooks {
         }
     }
 
-    /// The request builder for [Webhooks::cancel_operation][super::super::client::Webhooks::cancel_operation] calls.
+    /// The request builder for [Webhooks::cancel_operation][crate::client::Webhooks::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/dialogflow/v2/src/builder.rs
+++ b/src/generated/cloud/dialogflow/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod agents {
     use crate::Result;
 
-    /// A builder for [Agents][super::super::client::Agents].
+    /// A builder for [Agents][crate::client::Agents].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod agents {
         }
     }
 
-    /// Common implementation for [super::super::client::Agents] request builders.
+    /// Common implementation for [crate::client::Agents] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Agents>,
@@ -66,7 +66,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_agent][super::super::client::Agents::get_agent] calls.
+    /// The request builder for [Agents::get_agent][crate::client::Agents::get_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -127,7 +127,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::set_agent][super::super::client::Agents::set_agent] calls.
+    /// The request builder for [Agents::set_agent][crate::client::Agents::set_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -220,7 +220,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::delete_agent][super::super::client::Agents::delete_agent] calls.
+    /// The request builder for [Agents::delete_agent][crate::client::Agents::delete_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -281,7 +281,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::search_agents][super::super::client::Agents::search_agents] calls.
+    /// The request builder for [Agents::search_agents][crate::client::Agents::search_agents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -382,7 +382,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::train_agent][super::super::client::Agents::train_agent] calls.
+    /// The request builder for [Agents::train_agent][crate::client::Agents::train_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -425,7 +425,7 @@ pub mod agents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [train_agent][super::super::client::Agents::train_agent].
+        /// on [train_agent][crate::client::Agents::train_agent].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .train_agent(self.0.request, self.0.options)
@@ -484,7 +484,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::export_agent][super::super::client::Agents::export_agent] calls.
+    /// The request builder for [Agents::export_agent][crate::client::Agents::export_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -527,7 +527,7 @@ pub mod agents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_agent][super::super::client::Agents::export_agent].
+        /// on [export_agent][crate::client::Agents::export_agent].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_agent(self.0.request, self.0.options)
@@ -590,7 +590,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::import_agent][super::super::client::Agents::import_agent] calls.
+    /// The request builder for [Agents::import_agent][crate::client::Agents::import_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -633,7 +633,7 @@ pub mod agents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_agent][super::super::client::Agents::import_agent].
+        /// on [import_agent][crate::client::Agents::import_agent].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_agent(self.0.request, self.0.options)
@@ -724,7 +724,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::restore_agent][super::super::client::Agents::restore_agent] calls.
+    /// The request builder for [Agents::restore_agent][crate::client::Agents::restore_agent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -767,7 +767,7 @@ pub mod agents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_agent][super::super::client::Agents::restore_agent].
+        /// on [restore_agent][crate::client::Agents::restore_agent].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_agent(self.0.request, self.0.options)
@@ -858,7 +858,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_validation_result][super::super::client::Agents::get_validation_result] calls.
+    /// The request builder for [Agents::get_validation_result][crate::client::Agents::get_validation_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -928,7 +928,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::list_locations][super::super::client::Agents::list_locations] calls.
+    /// The request builder for [Agents::list_locations][crate::client::Agents::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1036,7 +1036,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_location][super::super::client::Agents::get_location] calls.
+    /// The request builder for [Agents::get_location][crate::client::Agents::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1095,7 +1095,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::list_operations][super::super::client::Agents::list_operations] calls.
+    /// The request builder for [Agents::list_operations][crate::client::Agents::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1205,7 +1205,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::get_operation][super::super::client::Agents::get_operation] calls.
+    /// The request builder for [Agents::get_operation][crate::client::Agents::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1267,7 +1267,7 @@ pub mod agents {
         }
     }
 
-    /// The request builder for [Agents::cancel_operation][super::super::client::Agents::cancel_operation] calls.
+    /// The request builder for [Agents::cancel_operation][crate::client::Agents::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1333,7 +1333,7 @@ pub mod agents {
 pub mod answer_records {
     use crate::Result;
 
-    /// A builder for [AnswerRecords][super::super::client::AnswerRecords].
+    /// A builder for [AnswerRecords][crate::client::AnswerRecords].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1361,7 +1361,7 @@ pub mod answer_records {
         }
     }
 
-    /// Common implementation for [super::super::client::AnswerRecords] request builders.
+    /// Common implementation for [crate::client::AnswerRecords] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AnswerRecords>,
@@ -1384,7 +1384,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for [AnswerRecords::list_answer_records][super::super::client::AnswerRecords::list_answer_records] calls.
+    /// The request builder for [AnswerRecords::list_answer_records][crate::client::AnswerRecords::list_answer_records] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1496,7 +1496,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for [AnswerRecords::update_answer_record][super::super::client::AnswerRecords::update_answer_record] calls.
+    /// The request builder for [AnswerRecords::update_answer_record][crate::client::AnswerRecords::update_answer_record] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1598,7 +1598,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for [AnswerRecords::list_locations][super::super::client::AnswerRecords::list_locations] calls.
+    /// The request builder for [AnswerRecords::list_locations][crate::client::AnswerRecords::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1708,7 +1708,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for [AnswerRecords::get_location][super::super::client::AnswerRecords::get_location] calls.
+    /// The request builder for [AnswerRecords::get_location][crate::client::AnswerRecords::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1769,7 +1769,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for [AnswerRecords::list_operations][super::super::client::AnswerRecords::list_operations] calls.
+    /// The request builder for [AnswerRecords::list_operations][crate::client::AnswerRecords::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1881,7 +1881,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for [AnswerRecords::get_operation][super::super::client::AnswerRecords::get_operation] calls.
+    /// The request builder for [AnswerRecords::get_operation][crate::client::AnswerRecords::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1945,7 +1945,7 @@ pub mod answer_records {
         }
     }
 
-    /// The request builder for [AnswerRecords::cancel_operation][super::super::client::AnswerRecords::cancel_operation] calls.
+    /// The request builder for [AnswerRecords::cancel_operation][crate::client::AnswerRecords::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2013,7 +2013,7 @@ pub mod answer_records {
 pub mod contexts {
     use crate::Result;
 
-    /// A builder for [Contexts][super::super::client::Contexts].
+    /// A builder for [Contexts][crate::client::Contexts].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2041,7 +2041,7 @@ pub mod contexts {
         }
     }
 
-    /// Common implementation for [super::super::client::Contexts] request builders.
+    /// Common implementation for [crate::client::Contexts] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Contexts>,
@@ -2062,7 +2062,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::list_contexts][super::super::client::Contexts::list_contexts] calls.
+    /// The request builder for [Contexts::list_contexts][crate::client::Contexts::list_contexts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2163,7 +2163,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::get_context][super::super::client::Contexts::get_context] calls.
+    /// The request builder for [Contexts::get_context][crate::client::Contexts::get_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2224,7 +2224,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::create_context][super::super::client::Contexts::create_context] calls.
+    /// The request builder for [Contexts::create_context][crate::client::Contexts::create_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2307,7 +2307,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::update_context][super::super::client::Contexts::update_context] calls.
+    /// The request builder for [Contexts::update_context][crate::client::Contexts::update_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2400,7 +2400,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::delete_context][super::super::client::Contexts::delete_context] calls.
+    /// The request builder for [Contexts::delete_context][crate::client::Contexts::delete_context] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2461,7 +2461,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::delete_all_contexts][super::super::client::Contexts::delete_all_contexts] calls.
+    /// The request builder for [Contexts::delete_all_contexts][crate::client::Contexts::delete_all_contexts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2525,7 +2525,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::list_locations][super::super::client::Contexts::list_locations] calls.
+    /// The request builder for [Contexts::list_locations][crate::client::Contexts::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2633,7 +2633,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::get_location][super::super::client::Contexts::get_location] calls.
+    /// The request builder for [Contexts::get_location][crate::client::Contexts::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2692,7 +2692,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::list_operations][super::super::client::Contexts::list_operations] calls.
+    /// The request builder for [Contexts::list_operations][crate::client::Contexts::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2802,7 +2802,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::get_operation][super::super::client::Contexts::get_operation] calls.
+    /// The request builder for [Contexts::get_operation][crate::client::Contexts::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2864,7 +2864,7 @@ pub mod contexts {
         }
     }
 
-    /// The request builder for [Contexts::cancel_operation][super::super::client::Contexts::cancel_operation] calls.
+    /// The request builder for [Contexts::cancel_operation][crate::client::Contexts::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2930,7 +2930,7 @@ pub mod contexts {
 pub mod conversations {
     use crate::Result;
 
-    /// A builder for [Conversations][super::super::client::Conversations].
+    /// A builder for [Conversations][crate::client::Conversations].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2958,7 +2958,7 @@ pub mod conversations {
         }
     }
 
-    /// Common implementation for [super::super::client::Conversations] request builders.
+    /// Common implementation for [crate::client::Conversations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Conversations>,
@@ -2981,7 +2981,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::create_conversation][super::super::client::Conversations::create_conversation] calls.
+    /// The request builder for [Conversations::create_conversation][crate::client::Conversations::create_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3075,7 +3075,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::list_conversations][super::super::client::Conversations::list_conversations] calls.
+    /// The request builder for [Conversations::list_conversations][crate::client::Conversations::list_conversations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3187,7 +3187,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::get_conversation][super::super::client::Conversations::get_conversation] calls.
+    /// The request builder for [Conversations::get_conversation][crate::client::Conversations::get_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3250,7 +3250,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::complete_conversation][super::super::client::Conversations::complete_conversation] calls.
+    /// The request builder for [Conversations::complete_conversation][crate::client::Conversations::complete_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3316,7 +3316,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::ingest_context_references][super::super::client::Conversations::ingest_context_references] calls.
+    /// The request builder for [Conversations::ingest_context_references][crate::client::Conversations::ingest_context_references] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3398,7 +3398,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::list_messages][super::super::client::Conversations::list_messages] calls.
+    /// The request builder for [Conversations::list_messages][crate::client::Conversations::list_messages] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3507,7 +3507,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::suggest_conversation_summary][super::super::client::Conversations::suggest_conversation_summary] calls.
+    /// The request builder for [Conversations::suggest_conversation_summary][crate::client::Conversations::suggest_conversation_summary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3605,7 +3605,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::generate_stateless_summary][super::super::client::Conversations::generate_stateless_summary] calls.
+    /// The request builder for [Conversations::generate_stateless_summary][crate::client::Conversations::generate_stateless_summary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3725,7 +3725,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::generate_stateless_suggestion][super::super::client::Conversations::generate_stateless_suggestion] calls.
+    /// The request builder for [Conversations::generate_stateless_suggestion][crate::client::Conversations::generate_stateless_suggestion] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3874,7 +3874,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::search_knowledge][super::super::client::Conversations::search_knowledge] calls.
+    /// The request builder for [Conversations::search_knowledge][crate::client::Conversations::search_knowledge] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4038,7 +4038,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::generate_suggestions][super::super::client::Conversations::generate_suggestions] calls.
+    /// The request builder for [Conversations::generate_suggestions][crate::client::Conversations::generate_suggestions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4121,7 +4121,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::list_locations][super::super::client::Conversations::list_locations] calls.
+    /// The request builder for [Conversations::list_locations][crate::client::Conversations::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4231,7 +4231,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::get_location][super::super::client::Conversations::get_location] calls.
+    /// The request builder for [Conversations::get_location][crate::client::Conversations::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4292,7 +4292,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::list_operations][super::super::client::Conversations::list_operations] calls.
+    /// The request builder for [Conversations::list_operations][crate::client::Conversations::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4404,7 +4404,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::get_operation][super::super::client::Conversations::get_operation] calls.
+    /// The request builder for [Conversations::get_operation][crate::client::Conversations::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4468,7 +4468,7 @@ pub mod conversations {
         }
     }
 
-    /// The request builder for [Conversations::cancel_operation][super::super::client::Conversations::cancel_operation] calls.
+    /// The request builder for [Conversations::cancel_operation][crate::client::Conversations::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4536,7 +4536,7 @@ pub mod conversations {
 pub mod conversation_datasets {
     use crate::Result;
 
-    /// A builder for [ConversationDatasets][super::super::client::ConversationDatasets].
+    /// A builder for [ConversationDatasets][crate::client::ConversationDatasets].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4564,7 +4564,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// Common implementation for [super::super::client::ConversationDatasets] request builders.
+    /// Common implementation for [crate::client::ConversationDatasets] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConversationDatasets>,
@@ -4587,7 +4587,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::create_conversation_dataset][super::super::client::ConversationDatasets::create_conversation_dataset] calls.
+    /// The request builder for [ConversationDatasets::create_conversation_dataset][crate::client::ConversationDatasets::create_conversation_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4637,7 +4637,7 @@ pub mod conversation_datasets {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_conversation_dataset][super::super::client::ConversationDatasets::create_conversation_dataset].
+        /// on [create_conversation_dataset][crate::client::ConversationDatasets::create_conversation_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_conversation_dataset(self.0.request, self.0.options)
@@ -4721,7 +4721,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::get_conversation_dataset][super::super::client::ConversationDatasets::get_conversation_dataset] calls.
+    /// The request builder for [ConversationDatasets::get_conversation_dataset][crate::client::ConversationDatasets::get_conversation_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4787,7 +4787,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::list_conversation_datasets][super::super::client::ConversationDatasets::list_conversation_datasets] calls.
+    /// The request builder for [ConversationDatasets::list_conversation_datasets][crate::client::ConversationDatasets::list_conversation_datasets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4899,7 +4899,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::delete_conversation_dataset][super::super::client::ConversationDatasets::delete_conversation_dataset] calls.
+    /// The request builder for [ConversationDatasets::delete_conversation_dataset][crate::client::ConversationDatasets::delete_conversation_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4949,7 +4949,7 @@ pub mod conversation_datasets {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_conversation_dataset][super::super::client::ConversationDatasets::delete_conversation_dataset].
+        /// on [delete_conversation_dataset][crate::client::ConversationDatasets::delete_conversation_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_conversation_dataset(self.0.request, self.0.options)
@@ -5014,7 +5014,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::import_conversation_data][super::super::client::ConversationDatasets::import_conversation_data] calls.
+    /// The request builder for [ConversationDatasets::import_conversation_data][crate::client::ConversationDatasets::import_conversation_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5062,7 +5062,7 @@ pub mod conversation_datasets {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_conversation_data][super::super::client::ConversationDatasets::import_conversation_data].
+        /// on [import_conversation_data][crate::client::ConversationDatasets::import_conversation_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_conversation_data(self.0.request, self.0.options)
@@ -5146,7 +5146,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::list_locations][super::super::client::ConversationDatasets::list_locations] calls.
+    /// The request builder for [ConversationDatasets::list_locations][crate::client::ConversationDatasets::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5256,7 +5256,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::get_location][super::super::client::ConversationDatasets::get_location] calls.
+    /// The request builder for [ConversationDatasets::get_location][crate::client::ConversationDatasets::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5317,7 +5317,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::list_operations][super::super::client::ConversationDatasets::list_operations] calls.
+    /// The request builder for [ConversationDatasets::list_operations][crate::client::ConversationDatasets::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5429,7 +5429,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::get_operation][super::super::client::ConversationDatasets::get_operation] calls.
+    /// The request builder for [ConversationDatasets::get_operation][crate::client::ConversationDatasets::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5493,7 +5493,7 @@ pub mod conversation_datasets {
         }
     }
 
-    /// The request builder for [ConversationDatasets::cancel_operation][super::super::client::ConversationDatasets::cancel_operation] calls.
+    /// The request builder for [ConversationDatasets::cancel_operation][crate::client::ConversationDatasets::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5561,7 +5561,7 @@ pub mod conversation_datasets {
 pub mod conversation_models {
     use crate::Result;
 
-    /// A builder for [ConversationModels][super::super::client::ConversationModels].
+    /// A builder for [ConversationModels][crate::client::ConversationModels].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5589,7 +5589,7 @@ pub mod conversation_models {
         }
     }
 
-    /// Common implementation for [super::super::client::ConversationModels] request builders.
+    /// Common implementation for [crate::client::ConversationModels] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConversationModels>,
@@ -5612,7 +5612,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::create_conversation_model][super::super::client::ConversationModels::create_conversation_model] calls.
+    /// The request builder for [ConversationModels::create_conversation_model][crate::client::ConversationModels::create_conversation_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5662,7 +5662,7 @@ pub mod conversation_models {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_conversation_model][super::super::client::ConversationModels::create_conversation_model].
+        /// on [create_conversation_model][crate::client::ConversationModels::create_conversation_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_conversation_model(self.0.request, self.0.options)
@@ -5744,7 +5744,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::get_conversation_model][super::super::client::ConversationModels::get_conversation_model] calls.
+    /// The request builder for [ConversationModels::get_conversation_model][crate::client::ConversationModels::get_conversation_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5810,7 +5810,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::list_conversation_models][super::super::client::ConversationModels::list_conversation_models] calls.
+    /// The request builder for [ConversationModels::list_conversation_models][crate::client::ConversationModels::list_conversation_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5920,7 +5920,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::delete_conversation_model][super::super::client::ConversationModels::delete_conversation_model] calls.
+    /// The request builder for [ConversationModels::delete_conversation_model][crate::client::ConversationModels::delete_conversation_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5970,7 +5970,7 @@ pub mod conversation_models {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_conversation_model][super::super::client::ConversationModels::delete_conversation_model].
+        /// on [delete_conversation_model][crate::client::ConversationModels::delete_conversation_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_conversation_model(self.0.request, self.0.options)
@@ -6034,7 +6034,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::deploy_conversation_model][super::super::client::ConversationModels::deploy_conversation_model] calls.
+    /// The request builder for [ConversationModels::deploy_conversation_model][crate::client::ConversationModels::deploy_conversation_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6084,7 +6084,7 @@ pub mod conversation_models {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [deploy_conversation_model][super::super::client::ConversationModels::deploy_conversation_model].
+        /// on [deploy_conversation_model][crate::client::ConversationModels::deploy_conversation_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .deploy_conversation_model(self.0.request, self.0.options)
@@ -6148,7 +6148,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::undeploy_conversation_model][super::super::client::ConversationModels::undeploy_conversation_model] calls.
+    /// The request builder for [ConversationModels::undeploy_conversation_model][crate::client::ConversationModels::undeploy_conversation_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6198,7 +6198,7 @@ pub mod conversation_models {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undeploy_conversation_model][super::super::client::ConversationModels::undeploy_conversation_model].
+        /// on [undeploy_conversation_model][crate::client::ConversationModels::undeploy_conversation_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undeploy_conversation_model(self.0.request, self.0.options)
@@ -6263,7 +6263,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::get_conversation_model_evaluation][super::super::client::ConversationModels::get_conversation_model_evaluation] calls.
+    /// The request builder for [ConversationModels::get_conversation_model_evaluation][crate::client::ConversationModels::get_conversation_model_evaluation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6331,7 +6331,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::list_conversation_model_evaluations][super::super::client::ConversationModels::list_conversation_model_evaluations] calls.
+    /// The request builder for [ConversationModels::list_conversation_model_evaluations][crate::client::ConversationModels::list_conversation_model_evaluations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6443,7 +6443,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::create_conversation_model_evaluation][super::super::client::ConversationModels::create_conversation_model_evaluation] calls.
+    /// The request builder for [ConversationModels::create_conversation_model_evaluation][crate::client::ConversationModels::create_conversation_model_evaluation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6493,7 +6493,7 @@ pub mod conversation_models {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_conversation_model_evaluation][super::super::client::ConversationModels::create_conversation_model_evaluation].
+        /// on [create_conversation_model_evaluation][crate::client::ConversationModels::create_conversation_model_evaluation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_conversation_model_evaluation(self.0.request, self.0.options)
@@ -6580,7 +6580,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::list_locations][super::super::client::ConversationModels::list_locations] calls.
+    /// The request builder for [ConversationModels::list_locations][crate::client::ConversationModels::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6690,7 +6690,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::get_location][super::super::client::ConversationModels::get_location] calls.
+    /// The request builder for [ConversationModels::get_location][crate::client::ConversationModels::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6751,7 +6751,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::list_operations][super::super::client::ConversationModels::list_operations] calls.
+    /// The request builder for [ConversationModels::list_operations][crate::client::ConversationModels::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6863,7 +6863,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::get_operation][super::super::client::ConversationModels::get_operation] calls.
+    /// The request builder for [ConversationModels::get_operation][crate::client::ConversationModels::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6927,7 +6927,7 @@ pub mod conversation_models {
         }
     }
 
-    /// The request builder for [ConversationModels::cancel_operation][super::super::client::ConversationModels::cancel_operation] calls.
+    /// The request builder for [ConversationModels::cancel_operation][crate::client::ConversationModels::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6995,7 +6995,7 @@ pub mod conversation_models {
 pub mod conversation_profiles {
     use crate::Result;
 
-    /// A builder for [ConversationProfiles][super::super::client::ConversationProfiles].
+    /// A builder for [ConversationProfiles][crate::client::ConversationProfiles].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7023,7 +7023,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// Common implementation for [super::super::client::ConversationProfiles] request builders.
+    /// Common implementation for [crate::client::ConversationProfiles] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConversationProfiles>,
@@ -7046,7 +7046,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::list_conversation_profiles][super::super::client::ConversationProfiles::list_conversation_profiles] calls.
+    /// The request builder for [ConversationProfiles::list_conversation_profiles][crate::client::ConversationProfiles::list_conversation_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7158,7 +7158,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::get_conversation_profile][super::super::client::ConversationProfiles::get_conversation_profile] calls.
+    /// The request builder for [ConversationProfiles::get_conversation_profile][crate::client::ConversationProfiles::get_conversation_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7224,7 +7224,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::create_conversation_profile][super::super::client::ConversationProfiles::create_conversation_profile] calls.
+    /// The request builder for [ConversationProfiles::create_conversation_profile][crate::client::ConversationProfiles::create_conversation_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7314,7 +7314,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::update_conversation_profile][super::super::client::ConversationProfiles::update_conversation_profile] calls.
+    /// The request builder for [ConversationProfiles::update_conversation_profile][crate::client::ConversationProfiles::update_conversation_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7418,7 +7418,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::delete_conversation_profile][super::super::client::ConversationProfiles::delete_conversation_profile] calls.
+    /// The request builder for [ConversationProfiles::delete_conversation_profile][crate::client::ConversationProfiles::delete_conversation_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7486,7 +7486,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::set_suggestion_feature_config][super::super::client::ConversationProfiles::set_suggestion_feature_config] calls.
+    /// The request builder for [ConversationProfiles::set_suggestion_feature_config][crate::client::ConversationProfiles::set_suggestion_feature_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7536,7 +7536,7 @@ pub mod conversation_profiles {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [set_suggestion_feature_config][super::super::client::ConversationProfiles::set_suggestion_feature_config].
+        /// on [set_suggestion_feature_config][crate::client::ConversationProfiles::set_suggestion_feature_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .set_suggestion_feature_config(self.0.request, self.0.options)
@@ -7638,7 +7638,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::clear_suggestion_feature_config][super::super::client::ConversationProfiles::clear_suggestion_feature_config] calls.
+    /// The request builder for [ConversationProfiles::clear_suggestion_feature_config][crate::client::ConversationProfiles::clear_suggestion_feature_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7688,7 +7688,7 @@ pub mod conversation_profiles {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [clear_suggestion_feature_config][super::super::client::ConversationProfiles::clear_suggestion_feature_config].
+        /// on [clear_suggestion_feature_config][crate::client::ConversationProfiles::clear_suggestion_feature_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .clear_suggestion_feature_config(self.0.request, self.0.options)
@@ -7772,7 +7772,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::list_locations][super::super::client::ConversationProfiles::list_locations] calls.
+    /// The request builder for [ConversationProfiles::list_locations][crate::client::ConversationProfiles::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7882,7 +7882,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::get_location][super::super::client::ConversationProfiles::get_location] calls.
+    /// The request builder for [ConversationProfiles::get_location][crate::client::ConversationProfiles::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7943,7 +7943,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::list_operations][super::super::client::ConversationProfiles::list_operations] calls.
+    /// The request builder for [ConversationProfiles::list_operations][crate::client::ConversationProfiles::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8055,7 +8055,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::get_operation][super::super::client::ConversationProfiles::get_operation] calls.
+    /// The request builder for [ConversationProfiles::get_operation][crate::client::ConversationProfiles::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8119,7 +8119,7 @@ pub mod conversation_profiles {
         }
     }
 
-    /// The request builder for [ConversationProfiles::cancel_operation][super::super::client::ConversationProfiles::cancel_operation] calls.
+    /// The request builder for [ConversationProfiles::cancel_operation][crate::client::ConversationProfiles::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8187,7 +8187,7 @@ pub mod conversation_profiles {
 pub mod documents {
     use crate::Result;
 
-    /// A builder for [Documents][super::super::client::Documents].
+    /// A builder for [Documents][crate::client::Documents].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -8215,7 +8215,7 @@ pub mod documents {
         }
     }
 
-    /// Common implementation for [super::super::client::Documents] request builders.
+    /// Common implementation for [crate::client::Documents] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Documents>,
@@ -8238,7 +8238,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::list_documents][super::super::client::Documents::list_documents] calls.
+    /// The request builder for [Documents::list_documents][crate::client::Documents::list_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8347,7 +8347,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::get_document][super::super::client::Documents::get_document] calls.
+    /// The request builder for [Documents::get_document][crate::client::Documents::get_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8410,7 +8410,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::create_document][super::super::client::Documents::create_document] calls.
+    /// The request builder for [Documents::create_document][crate::client::Documents::create_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8455,7 +8455,7 @@ pub mod documents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_document][super::super::client::Documents::create_document].
+        /// on [create_document][crate::client::Documents::create_document].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_document(self.0.request, self.0.options)
@@ -8537,7 +8537,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::import_documents][super::super::client::Documents::import_documents] calls.
+    /// The request builder for [Documents::import_documents][crate::client::Documents::import_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8582,7 +8582,7 @@ pub mod documents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_documents][super::super::client::Documents::import_documents].
+        /// on [import_documents][crate::client::Documents::import_documents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_documents(self.0.request, self.0.options)
@@ -8697,7 +8697,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::delete_document][super::super::client::Documents::delete_document] calls.
+    /// The request builder for [Documents::delete_document][crate::client::Documents::delete_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8742,7 +8742,7 @@ pub mod documents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_document][super::super::client::Documents::delete_document].
+        /// on [delete_document][crate::client::Documents::delete_document].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_document(self.0.request, self.0.options)
@@ -8802,7 +8802,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::update_document][super::super::client::Documents::update_document] calls.
+    /// The request builder for [Documents::update_document][crate::client::Documents::update_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8847,7 +8847,7 @@ pub mod documents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_document][super::super::client::Documents::update_document].
+        /// on [update_document][crate::client::Documents::update_document].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_document(self.0.request, self.0.options)
@@ -8939,7 +8939,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::reload_document][super::super::client::Documents::reload_document] calls.
+    /// The request builder for [Documents::reload_document][crate::client::Documents::reload_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8984,7 +8984,7 @@ pub mod documents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reload_document][super::super::client::Documents::reload_document].
+        /// on [reload_document][crate::client::Documents::reload_document].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reload_document(self.0.request, self.0.options)
@@ -9078,7 +9078,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::export_document][super::super::client::Documents::export_document] calls.
+    /// The request builder for [Documents::export_document][crate::client::Documents::export_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9123,7 +9123,7 @@ pub mod documents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_document][super::super::client::Documents::export_document].
+        /// on [export_document][crate::client::Documents::export_document].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_document(self.0.request, self.0.options)
@@ -9224,7 +9224,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::list_locations][super::super::client::Documents::list_locations] calls.
+    /// The request builder for [Documents::list_locations][crate::client::Documents::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9334,7 +9334,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::get_location][super::super::client::Documents::get_location] calls.
+    /// The request builder for [Documents::get_location][crate::client::Documents::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9395,7 +9395,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::list_operations][super::super::client::Documents::list_operations] calls.
+    /// The request builder for [Documents::list_operations][crate::client::Documents::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9507,7 +9507,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::get_operation][super::super::client::Documents::get_operation] calls.
+    /// The request builder for [Documents::get_operation][crate::client::Documents::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9571,7 +9571,7 @@ pub mod documents {
         }
     }
 
-    /// The request builder for [Documents::cancel_operation][super::super::client::Documents::cancel_operation] calls.
+    /// The request builder for [Documents::cancel_operation][crate::client::Documents::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9639,7 +9639,7 @@ pub mod documents {
 pub mod encryption_spec_service {
     use crate::Result;
 
-    /// A builder for [EncryptionSpecService][super::super::client::EncryptionSpecService].
+    /// A builder for [EncryptionSpecService][crate::client::EncryptionSpecService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -9667,7 +9667,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EncryptionSpecService] request builders.
+    /// Common implementation for [crate::client::EncryptionSpecService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EncryptionSpecService>,
@@ -9690,7 +9690,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for [EncryptionSpecService::get_encryption_spec][super::super::client::EncryptionSpecService::get_encryption_spec] calls.
+    /// The request builder for [EncryptionSpecService::get_encryption_spec][crate::client::EncryptionSpecService::get_encryption_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9756,7 +9756,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for [EncryptionSpecService::initialize_encryption_spec][super::super::client::EncryptionSpecService::initialize_encryption_spec] calls.
+    /// The request builder for [EncryptionSpecService::initialize_encryption_spec][crate::client::EncryptionSpecService::initialize_encryption_spec] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9806,7 +9806,7 @@ pub mod encryption_spec_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [initialize_encryption_spec][super::super::client::EncryptionSpecService::initialize_encryption_spec].
+        /// on [initialize_encryption_spec][crate::client::EncryptionSpecService::initialize_encryption_spec].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .initialize_encryption_spec(self.0.request, self.0.options)
@@ -9882,7 +9882,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for [EncryptionSpecService::list_locations][super::super::client::EncryptionSpecService::list_locations] calls.
+    /// The request builder for [EncryptionSpecService::list_locations][crate::client::EncryptionSpecService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9992,7 +9992,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for [EncryptionSpecService::get_location][super::super::client::EncryptionSpecService::get_location] calls.
+    /// The request builder for [EncryptionSpecService::get_location][crate::client::EncryptionSpecService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10053,7 +10053,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for [EncryptionSpecService::list_operations][super::super::client::EncryptionSpecService::list_operations] calls.
+    /// The request builder for [EncryptionSpecService::list_operations][crate::client::EncryptionSpecService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10165,7 +10165,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for [EncryptionSpecService::get_operation][super::super::client::EncryptionSpecService::get_operation] calls.
+    /// The request builder for [EncryptionSpecService::get_operation][crate::client::EncryptionSpecService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10229,7 +10229,7 @@ pub mod encryption_spec_service {
         }
     }
 
-    /// The request builder for [EncryptionSpecService::cancel_operation][super::super::client::EncryptionSpecService::cancel_operation] calls.
+    /// The request builder for [EncryptionSpecService::cancel_operation][crate::client::EncryptionSpecService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10297,7 +10297,7 @@ pub mod encryption_spec_service {
 pub mod entity_types {
     use crate::Result;
 
-    /// A builder for [EntityTypes][super::super::client::EntityTypes].
+    /// A builder for [EntityTypes][crate::client::EntityTypes].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -10325,7 +10325,7 @@ pub mod entity_types {
         }
     }
 
-    /// Common implementation for [super::super::client::EntityTypes] request builders.
+    /// Common implementation for [crate::client::EntityTypes] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EntityTypes>,
@@ -10348,7 +10348,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::list_entity_types][super::super::client::EntityTypes::list_entity_types] calls.
+    /// The request builder for [EntityTypes::list_entity_types][crate::client::EntityTypes::list_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10457,7 +10457,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::get_entity_type][super::super::client::EntityTypes::get_entity_type] calls.
+    /// The request builder for [EntityTypes::get_entity_type][crate::client::EntityTypes::get_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10526,7 +10526,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::create_entity_type][super::super::client::EntityTypes::create_entity_type] calls.
+    /// The request builder for [EntityTypes::create_entity_type][crate::client::EntityTypes::create_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10620,7 +10620,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::update_entity_type][super::super::client::EntityTypes::update_entity_type] calls.
+    /// The request builder for [EntityTypes::update_entity_type][crate::client::EntityTypes::update_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10724,7 +10724,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::delete_entity_type][super::super::client::EntityTypes::delete_entity_type] calls.
+    /// The request builder for [EntityTypes::delete_entity_type][crate::client::EntityTypes::delete_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10790,7 +10790,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::batch_update_entity_types][super::super::client::EntityTypes::batch_update_entity_types] calls.
+    /// The request builder for [EntityTypes::batch_update_entity_types][crate::client::EntityTypes::batch_update_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10838,7 +10838,7 @@ pub mod entity_types {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_update_entity_types][super::super::client::EntityTypes::batch_update_entity_types].
+        /// on [batch_update_entity_types][crate::client::EntityTypes::batch_update_entity_types].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_update_entity_types(self.0.request, self.0.options)
@@ -10961,7 +10961,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::batch_delete_entity_types][super::super::client::EntityTypes::batch_delete_entity_types] calls.
+    /// The request builder for [EntityTypes::batch_delete_entity_types][crate::client::EntityTypes::batch_delete_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11009,7 +11009,7 @@ pub mod entity_types {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_delete_entity_types][super::super::client::EntityTypes::batch_delete_entity_types].
+        /// on [batch_delete_entity_types][crate::client::EntityTypes::batch_delete_entity_types].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_delete_entity_types(self.0.request, self.0.options)
@@ -11081,7 +11081,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::batch_create_entities][super::super::client::EntityTypes::batch_create_entities] calls.
+    /// The request builder for [EntityTypes::batch_create_entities][crate::client::EntityTypes::batch_create_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11129,7 +11129,7 @@ pub mod entity_types {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_create_entities][super::super::client::EntityTypes::batch_create_entities].
+        /// on [batch_create_entities][crate::client::EntityTypes::batch_create_entities].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_create_entities(self.0.request, self.0.options)
@@ -11207,7 +11207,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::batch_update_entities][super::super::client::EntityTypes::batch_update_entities] calls.
+    /// The request builder for [EntityTypes::batch_update_entities][crate::client::EntityTypes::batch_update_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11255,7 +11255,7 @@ pub mod entity_types {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_update_entities][super::super::client::EntityTypes::batch_update_entities].
+        /// on [batch_update_entities][crate::client::EntityTypes::batch_update_entities].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_update_entities(self.0.request, self.0.options)
@@ -11351,7 +11351,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::batch_delete_entities][super::super::client::EntityTypes::batch_delete_entities] calls.
+    /// The request builder for [EntityTypes::batch_delete_entities][crate::client::EntityTypes::batch_delete_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11399,7 +11399,7 @@ pub mod entity_types {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_delete_entities][super::super::client::EntityTypes::batch_delete_entities].
+        /// on [batch_delete_entities][crate::client::EntityTypes::batch_delete_entities].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_delete_entities(self.0.request, self.0.options)
@@ -11477,7 +11477,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::list_locations][super::super::client::EntityTypes::list_locations] calls.
+    /// The request builder for [EntityTypes::list_locations][crate::client::EntityTypes::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11587,7 +11587,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::get_location][super::super::client::EntityTypes::get_location] calls.
+    /// The request builder for [EntityTypes::get_location][crate::client::EntityTypes::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11648,7 +11648,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::list_operations][super::super::client::EntityTypes::list_operations] calls.
+    /// The request builder for [EntityTypes::list_operations][crate::client::EntityTypes::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11760,7 +11760,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::get_operation][super::super::client::EntityTypes::get_operation] calls.
+    /// The request builder for [EntityTypes::get_operation][crate::client::EntityTypes::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11824,7 +11824,7 @@ pub mod entity_types {
         }
     }
 
-    /// The request builder for [EntityTypes::cancel_operation][super::super::client::EntityTypes::cancel_operation] calls.
+    /// The request builder for [EntityTypes::cancel_operation][crate::client::EntityTypes::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11892,7 +11892,7 @@ pub mod entity_types {
 pub mod environments {
     use crate::Result;
 
-    /// A builder for [Environments][super::super::client::Environments].
+    /// A builder for [Environments][crate::client::Environments].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -11920,7 +11920,7 @@ pub mod environments {
         }
     }
 
-    /// Common implementation for [super::super::client::Environments] request builders.
+    /// Common implementation for [crate::client::Environments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Environments>,
@@ -11943,7 +11943,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
+    /// The request builder for [Environments::list_environments][crate::client::Environments::list_environments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12049,7 +12049,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
+    /// The request builder for [Environments::get_environment][crate::client::Environments::get_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12112,7 +12112,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
+    /// The request builder for [Environments::create_environment][crate::client::Environments::create_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12208,7 +12208,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
+    /// The request builder for [Environments::update_environment][crate::client::Environments::update_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12316,7 +12316,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
+    /// The request builder for [Environments::delete_environment][crate::client::Environments::delete_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12382,7 +12382,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_environment_history][super::super::client::Environments::get_environment_history] calls.
+    /// The request builder for [Environments::get_environment_history][crate::client::Environments::get_environment_history] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12488,7 +12488,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_locations][super::super::client::Environments::list_locations] calls.
+    /// The request builder for [Environments::list_locations][crate::client::Environments::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12598,7 +12598,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_location][super::super::client::Environments::get_location] calls.
+    /// The request builder for [Environments::get_location][crate::client::Environments::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12659,7 +12659,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
+    /// The request builder for [Environments::list_operations][crate::client::Environments::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12771,7 +12771,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
+    /// The request builder for [Environments::get_operation][crate::client::Environments::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12835,7 +12835,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::cancel_operation][super::super::client::Environments::cancel_operation] calls.
+    /// The request builder for [Environments::cancel_operation][crate::client::Environments::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12903,7 +12903,7 @@ pub mod environments {
 pub mod fulfillments {
     use crate::Result;
 
-    /// A builder for [Fulfillments][super::super::client::Fulfillments].
+    /// A builder for [Fulfillments][crate::client::Fulfillments].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -12931,7 +12931,7 @@ pub mod fulfillments {
         }
     }
 
-    /// Common implementation for [super::super::client::Fulfillments] request builders.
+    /// Common implementation for [crate::client::Fulfillments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Fulfillments>,
@@ -12954,7 +12954,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for [Fulfillments::get_fulfillment][super::super::client::Fulfillments::get_fulfillment] calls.
+    /// The request builder for [Fulfillments::get_fulfillment][crate::client::Fulfillments::get_fulfillment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13017,7 +13017,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for [Fulfillments::update_fulfillment][super::super::client::Fulfillments::update_fulfillment] calls.
+    /// The request builder for [Fulfillments::update_fulfillment][crate::client::Fulfillments::update_fulfillment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13119,7 +13119,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for [Fulfillments::list_locations][super::super::client::Fulfillments::list_locations] calls.
+    /// The request builder for [Fulfillments::list_locations][crate::client::Fulfillments::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13229,7 +13229,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for [Fulfillments::get_location][super::super::client::Fulfillments::get_location] calls.
+    /// The request builder for [Fulfillments::get_location][crate::client::Fulfillments::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13290,7 +13290,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for [Fulfillments::list_operations][super::super::client::Fulfillments::list_operations] calls.
+    /// The request builder for [Fulfillments::list_operations][crate::client::Fulfillments::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13402,7 +13402,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for [Fulfillments::get_operation][super::super::client::Fulfillments::get_operation] calls.
+    /// The request builder for [Fulfillments::get_operation][crate::client::Fulfillments::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13466,7 +13466,7 @@ pub mod fulfillments {
         }
     }
 
-    /// The request builder for [Fulfillments::cancel_operation][super::super::client::Fulfillments::cancel_operation] calls.
+    /// The request builder for [Fulfillments::cancel_operation][crate::client::Fulfillments::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13534,7 +13534,7 @@ pub mod fulfillments {
 pub mod generators {
     use crate::Result;
 
-    /// A builder for [Generators][super::super::client::Generators].
+    /// A builder for [Generators][crate::client::Generators].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -13562,7 +13562,7 @@ pub mod generators {
         }
     }
 
-    /// Common implementation for [super::super::client::Generators] request builders.
+    /// Common implementation for [crate::client::Generators] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Generators>,
@@ -13585,7 +13585,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::create_generator][super::super::client::Generators::create_generator] calls.
+    /// The request builder for [Generators::create_generator][crate::client::Generators::create_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13676,7 +13676,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::get_generator][super::super::client::Generators::get_generator] calls.
+    /// The request builder for [Generators::get_generator][crate::client::Generators::get_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13739,7 +13739,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::list_generators][super::super::client::Generators::list_generators] calls.
+    /// The request builder for [Generators::list_generators][crate::client::Generators::list_generators] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13842,7 +13842,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::delete_generator][super::super::client::Generators::delete_generator] calls.
+    /// The request builder for [Generators::delete_generator][crate::client::Generators::delete_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13905,7 +13905,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::update_generator][super::super::client::Generators::update_generator] calls.
+    /// The request builder for [Generators::update_generator][crate::client::Generators::update_generator] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14000,7 +14000,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::list_locations][super::super::client::Generators::list_locations] calls.
+    /// The request builder for [Generators::list_locations][crate::client::Generators::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14110,7 +14110,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::get_location][super::super::client::Generators::get_location] calls.
+    /// The request builder for [Generators::get_location][crate::client::Generators::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14171,7 +14171,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::list_operations][super::super::client::Generators::list_operations] calls.
+    /// The request builder for [Generators::list_operations][crate::client::Generators::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14283,7 +14283,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::get_operation][super::super::client::Generators::get_operation] calls.
+    /// The request builder for [Generators::get_operation][crate::client::Generators::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14347,7 +14347,7 @@ pub mod generators {
         }
     }
 
-    /// The request builder for [Generators::cancel_operation][super::super::client::Generators::cancel_operation] calls.
+    /// The request builder for [Generators::cancel_operation][crate::client::Generators::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14415,7 +14415,7 @@ pub mod generators {
 pub mod intents {
     use crate::Result;
 
-    /// A builder for [Intents][super::super::client::Intents].
+    /// A builder for [Intents][crate::client::Intents].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -14443,7 +14443,7 @@ pub mod intents {
         }
     }
 
-    /// Common implementation for [super::super::client::Intents] request builders.
+    /// Common implementation for [crate::client::Intents] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Intents>,
@@ -14464,7 +14464,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::list_intents][super::super::client::Intents::list_intents] calls.
+    /// The request builder for [Intents::list_intents][crate::client::Intents::list_intents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14577,7 +14577,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::get_intent][super::super::client::Intents::get_intent] calls.
+    /// The request builder for [Intents::get_intent][crate::client::Intents::get_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14650,7 +14650,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::create_intent][super::super::client::Intents::create_intent] calls.
+    /// The request builder for [Intents::create_intent][crate::client::Intents::create_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14745,7 +14745,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::update_intent][super::super::client::Intents::update_intent] calls.
+    /// The request builder for [Intents::update_intent][crate::client::Intents::update_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14850,7 +14850,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::delete_intent][super::super::client::Intents::delete_intent] calls.
+    /// The request builder for [Intents::delete_intent][crate::client::Intents::delete_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14911,7 +14911,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::batch_update_intents][super::super::client::Intents::batch_update_intents] calls.
+    /// The request builder for [Intents::batch_update_intents][crate::client::Intents::batch_update_intents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -14957,7 +14957,7 @@ pub mod intents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_update_intents][super::super::client::Intents::batch_update_intents].
+        /// on [batch_update_intents][crate::client::Intents::batch_update_intents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_update_intents(self.0.request, self.0.options)
@@ -15086,7 +15086,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::batch_delete_intents][super::super::client::Intents::batch_delete_intents] calls.
+    /// The request builder for [Intents::batch_delete_intents][crate::client::Intents::batch_delete_intents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15132,7 +15132,7 @@ pub mod intents {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_delete_intents][super::super::client::Intents::batch_delete_intents].
+        /// on [batch_delete_intents][crate::client::Intents::batch_delete_intents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_delete_intents(self.0.request, self.0.options)
@@ -15204,7 +15204,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::list_locations][super::super::client::Intents::list_locations] calls.
+    /// The request builder for [Intents::list_locations][crate::client::Intents::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15312,7 +15312,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::get_location][super::super::client::Intents::get_location] calls.
+    /// The request builder for [Intents::get_location][crate::client::Intents::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15371,7 +15371,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::list_operations][super::super::client::Intents::list_operations] calls.
+    /// The request builder for [Intents::list_operations][crate::client::Intents::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15481,7 +15481,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::get_operation][super::super::client::Intents::get_operation] calls.
+    /// The request builder for [Intents::get_operation][crate::client::Intents::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15543,7 +15543,7 @@ pub mod intents {
         }
     }
 
-    /// The request builder for [Intents::cancel_operation][super::super::client::Intents::cancel_operation] calls.
+    /// The request builder for [Intents::cancel_operation][crate::client::Intents::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15609,7 +15609,7 @@ pub mod intents {
 pub mod knowledge_bases {
     use crate::Result;
 
-    /// A builder for [KnowledgeBases][super::super::client::KnowledgeBases].
+    /// A builder for [KnowledgeBases][crate::client::KnowledgeBases].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -15637,7 +15637,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// Common implementation for [super::super::client::KnowledgeBases] request builders.
+    /// Common implementation for [crate::client::KnowledgeBases] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::KnowledgeBases>,
@@ -15660,7 +15660,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::list_knowledge_bases][super::super::client::KnowledgeBases::list_knowledge_bases] calls.
+    /// The request builder for [KnowledgeBases::list_knowledge_bases][crate::client::KnowledgeBases::list_knowledge_bases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15774,7 +15774,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::get_knowledge_base][super::super::client::KnowledgeBases::get_knowledge_base] calls.
+    /// The request builder for [KnowledgeBases::get_knowledge_base][crate::client::KnowledgeBases::get_knowledge_base] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15840,7 +15840,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::create_knowledge_base][super::super::client::KnowledgeBases::create_knowledge_base] calls.
+    /// The request builder for [KnowledgeBases::create_knowledge_base][crate::client::KnowledgeBases::create_knowledge_base] calls.
     ///
     /// # Example
     /// ```no_run
@@ -15928,7 +15928,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::delete_knowledge_base][super::super::client::KnowledgeBases::delete_knowledge_base] calls.
+    /// The request builder for [KnowledgeBases::delete_knowledge_base][crate::client::KnowledgeBases::delete_knowledge_base] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16000,7 +16000,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::update_knowledge_base][super::super::client::KnowledgeBases::update_knowledge_base] calls.
+    /// The request builder for [KnowledgeBases::update_knowledge_base][crate::client::KnowledgeBases::update_knowledge_base] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16098,7 +16098,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::list_locations][super::super::client::KnowledgeBases::list_locations] calls.
+    /// The request builder for [KnowledgeBases::list_locations][crate::client::KnowledgeBases::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16208,7 +16208,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::get_location][super::super::client::KnowledgeBases::get_location] calls.
+    /// The request builder for [KnowledgeBases::get_location][crate::client::KnowledgeBases::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16269,7 +16269,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::list_operations][super::super::client::KnowledgeBases::list_operations] calls.
+    /// The request builder for [KnowledgeBases::list_operations][crate::client::KnowledgeBases::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16381,7 +16381,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::get_operation][super::super::client::KnowledgeBases::get_operation] calls.
+    /// The request builder for [KnowledgeBases::get_operation][crate::client::KnowledgeBases::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16445,7 +16445,7 @@ pub mod knowledge_bases {
         }
     }
 
-    /// The request builder for [KnowledgeBases::cancel_operation][super::super::client::KnowledgeBases::cancel_operation] calls.
+    /// The request builder for [KnowledgeBases::cancel_operation][crate::client::KnowledgeBases::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16513,7 +16513,7 @@ pub mod knowledge_bases {
 pub mod participants {
     use crate::Result;
 
-    /// A builder for [Participants][super::super::client::Participants].
+    /// A builder for [Participants][crate::client::Participants].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -16541,7 +16541,7 @@ pub mod participants {
         }
     }
 
-    /// Common implementation for [super::super::client::Participants] request builders.
+    /// Common implementation for [crate::client::Participants] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Participants>,
@@ -16564,7 +16564,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::create_participant][super::super::client::Participants::create_participant] calls.
+    /// The request builder for [Participants::create_participant][crate::client::Participants::create_participant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16652,7 +16652,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::get_participant][super::super::client::Participants::get_participant] calls.
+    /// The request builder for [Participants::get_participant][crate::client::Participants::get_participant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16715,7 +16715,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::list_participants][super::super::client::Participants::list_participants] calls.
+    /// The request builder for [Participants::list_participants][crate::client::Participants::list_participants] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16821,7 +16821,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::update_participant][super::super::client::Participants::update_participant] calls.
+    /// The request builder for [Participants::update_participant][crate::client::Participants::update_participant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -16923,7 +16923,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::analyze_content][super::super::client::Participants::analyze_content] calls.
+    /// The request builder for [Participants::analyze_content][crate::client::Participants::analyze_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17130,7 +17130,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::suggest_articles][super::super::client::Participants::suggest_articles] calls.
+    /// The request builder for [Participants::suggest_articles][crate::client::Participants::suggest_articles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17223,7 +17223,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::suggest_faq_answers][super::super::client::Participants::suggest_faq_answers] calls.
+    /// The request builder for [Participants::suggest_faq_answers][crate::client::Participants::suggest_faq_answers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17319,7 +17319,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::suggest_smart_replies][super::super::client::Participants::suggest_smart_replies] calls.
+    /// The request builder for [Participants::suggest_smart_replies][crate::client::Participants::suggest_smart_replies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17415,7 +17415,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::suggest_knowledge_assist][super::super::client::Participants::suggest_knowledge_assist] calls.
+    /// The request builder for [Participants::suggest_knowledge_assist][crate::client::Participants::suggest_knowledge_assist] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17499,7 +17499,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::list_locations][super::super::client::Participants::list_locations] calls.
+    /// The request builder for [Participants::list_locations][crate::client::Participants::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17609,7 +17609,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::get_location][super::super::client::Participants::get_location] calls.
+    /// The request builder for [Participants::get_location][crate::client::Participants::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17670,7 +17670,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::list_operations][super::super::client::Participants::list_operations] calls.
+    /// The request builder for [Participants::list_operations][crate::client::Participants::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17782,7 +17782,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::get_operation][super::super::client::Participants::get_operation] calls.
+    /// The request builder for [Participants::get_operation][crate::client::Participants::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17846,7 +17846,7 @@ pub mod participants {
         }
     }
 
-    /// The request builder for [Participants::cancel_operation][super::super::client::Participants::cancel_operation] calls.
+    /// The request builder for [Participants::cancel_operation][crate::client::Participants::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -17914,7 +17914,7 @@ pub mod participants {
 pub mod sessions {
     use crate::Result;
 
-    /// A builder for [Sessions][super::super::client::Sessions].
+    /// A builder for [Sessions][crate::client::Sessions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -17942,7 +17942,7 @@ pub mod sessions {
         }
     }
 
-    /// Common implementation for [super::super::client::Sessions] request builders.
+    /// Common implementation for [crate::client::Sessions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Sessions>,
@@ -17963,7 +17963,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::detect_intent][super::super::client::Sessions::detect_intent] calls.
+    /// The request builder for [Sessions::detect_intent][crate::client::Sessions::detect_intent] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18106,7 +18106,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::list_locations][super::super::client::Sessions::list_locations] calls.
+    /// The request builder for [Sessions::list_locations][crate::client::Sessions::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18214,7 +18214,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::get_location][super::super::client::Sessions::get_location] calls.
+    /// The request builder for [Sessions::get_location][crate::client::Sessions::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18273,7 +18273,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::list_operations][super::super::client::Sessions::list_operations] calls.
+    /// The request builder for [Sessions::list_operations][crate::client::Sessions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18383,7 +18383,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::get_operation][super::super::client::Sessions::get_operation] calls.
+    /// The request builder for [Sessions::get_operation][crate::client::Sessions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18445,7 +18445,7 @@ pub mod sessions {
         }
     }
 
-    /// The request builder for [Sessions::cancel_operation][super::super::client::Sessions::cancel_operation] calls.
+    /// The request builder for [Sessions::cancel_operation][crate::client::Sessions::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18511,7 +18511,7 @@ pub mod sessions {
 pub mod session_entity_types {
     use crate::Result;
 
-    /// A builder for [SessionEntityTypes][super::super::client::SessionEntityTypes].
+    /// A builder for [SessionEntityTypes][crate::client::SessionEntityTypes].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -18539,7 +18539,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// Common implementation for [super::super::client::SessionEntityTypes] request builders.
+    /// Common implementation for [crate::client::SessionEntityTypes] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SessionEntityTypes>,
@@ -18562,7 +18562,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::list_session_entity_types][super::super::client::SessionEntityTypes::list_session_entity_types] calls.
+    /// The request builder for [SessionEntityTypes::list_session_entity_types][crate::client::SessionEntityTypes::list_session_entity_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18672,7 +18672,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::get_session_entity_type][super::super::client::SessionEntityTypes::get_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::get_session_entity_type][crate::client::SessionEntityTypes::get_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18738,7 +18738,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::create_session_entity_type][super::super::client::SessionEntityTypes::create_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::create_session_entity_type][crate::client::SessionEntityTypes::create_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18828,7 +18828,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::update_session_entity_type][super::super::client::SessionEntityTypes::update_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::update_session_entity_type][crate::client::SessionEntityTypes::update_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18928,7 +18928,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::delete_session_entity_type][super::super::client::SessionEntityTypes::delete_session_entity_type] calls.
+    /// The request builder for [SessionEntityTypes::delete_session_entity_type][crate::client::SessionEntityTypes::delete_session_entity_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -18996,7 +18996,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::list_locations][super::super::client::SessionEntityTypes::list_locations] calls.
+    /// The request builder for [SessionEntityTypes::list_locations][crate::client::SessionEntityTypes::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19106,7 +19106,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::get_location][super::super::client::SessionEntityTypes::get_location] calls.
+    /// The request builder for [SessionEntityTypes::get_location][crate::client::SessionEntityTypes::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19167,7 +19167,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::list_operations][super::super::client::SessionEntityTypes::list_operations] calls.
+    /// The request builder for [SessionEntityTypes::list_operations][crate::client::SessionEntityTypes::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19279,7 +19279,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::get_operation][super::super::client::SessionEntityTypes::get_operation] calls.
+    /// The request builder for [SessionEntityTypes::get_operation][crate::client::SessionEntityTypes::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19343,7 +19343,7 @@ pub mod session_entity_types {
         }
     }
 
-    /// The request builder for [SessionEntityTypes::cancel_operation][super::super::client::SessionEntityTypes::cancel_operation] calls.
+    /// The request builder for [SessionEntityTypes::cancel_operation][crate::client::SessionEntityTypes::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19411,7 +19411,7 @@ pub mod session_entity_types {
 pub mod versions {
     use crate::Result;
 
-    /// A builder for [Versions][super::super::client::Versions].
+    /// A builder for [Versions][crate::client::Versions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -19439,7 +19439,7 @@ pub mod versions {
         }
     }
 
-    /// Common implementation for [super::super::client::Versions] request builders.
+    /// Common implementation for [crate::client::Versions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Versions>,
@@ -19460,7 +19460,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_versions][super::super::client::Versions::list_versions] calls.
+    /// The request builder for [Versions::list_versions][crate::client::Versions::list_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19561,7 +19561,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_version][super::super::client::Versions::get_version] calls.
+    /// The request builder for [Versions::get_version][crate::client::Versions::get_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19622,7 +19622,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::create_version][super::super::client::Versions::create_version] calls.
+    /// The request builder for [Versions::create_version][crate::client::Versions::create_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19705,7 +19705,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::update_version][super::super::client::Versions::update_version] calls.
+    /// The request builder for [Versions::update_version][crate::client::Versions::update_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19802,7 +19802,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::delete_version][super::super::client::Versions::delete_version] calls.
+    /// The request builder for [Versions::delete_version][crate::client::Versions::delete_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19863,7 +19863,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_locations][super::super::client::Versions::list_locations] calls.
+    /// The request builder for [Versions::list_locations][crate::client::Versions::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -19971,7 +19971,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_location][super::super::client::Versions::get_location] calls.
+    /// The request builder for [Versions::get_location][crate::client::Versions::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20030,7 +20030,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::list_operations][super::super::client::Versions::list_operations] calls.
+    /// The request builder for [Versions::list_operations][crate::client::Versions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20140,7 +20140,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::get_operation][super::super::client::Versions::get_operation] calls.
+    /// The request builder for [Versions::get_operation][crate::client::Versions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -20202,7 +20202,7 @@ pub mod versions {
         }
     }
 
-    /// The request builder for [Versions::cancel_operation][super::super::client::Versions::cancel_operation] calls.
+    /// The request builder for [Versions::cancel_operation][crate::client::Versions::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/discoveryengine/v1/src/builder.rs
+++ b/src/generated/cloud/discoveryengine/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod completion_service {
     use crate::Result;
 
-    /// A builder for [CompletionService][super::super::client::CompletionService].
+    /// A builder for [CompletionService][crate::client::CompletionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod completion_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CompletionService] request builders.
+    /// Common implementation for [crate::client::CompletionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CompletionService>,
@@ -68,7 +68,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::complete_query][super::super::client::CompletionService::complete_query] calls.
+    /// The request builder for [CompletionService::complete_query][crate::client::CompletionService::complete_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -157,7 +157,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::import_suggestion_deny_list_entries][super::super::client::CompletionService::import_suggestion_deny_list_entries] calls.
+    /// The request builder for [CompletionService::import_suggestion_deny_list_entries][crate::client::CompletionService::import_suggestion_deny_list_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -207,7 +207,7 @@ pub mod completion_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_suggestion_deny_list_entries][super::super::client::CompletionService::import_suggestion_deny_list_entries].
+        /// on [import_suggestion_deny_list_entries][crate::client::CompletionService::import_suggestion_deny_list_entries].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_suggestion_deny_list_entries(self.0.request, self.0.options)
@@ -315,7 +315,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::purge_suggestion_deny_list_entries][super::super::client::CompletionService::purge_suggestion_deny_list_entries] calls.
+    /// The request builder for [CompletionService::purge_suggestion_deny_list_entries][crate::client::CompletionService::purge_suggestion_deny_list_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -365,7 +365,7 @@ pub mod completion_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_suggestion_deny_list_entries][super::super::client::CompletionService::purge_suggestion_deny_list_entries].
+        /// on [purge_suggestion_deny_list_entries][crate::client::CompletionService::purge_suggestion_deny_list_entries].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_suggestion_deny_list_entries(self.0.request, self.0.options)
@@ -427,7 +427,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::import_completion_suggestions][super::super::client::CompletionService::import_completion_suggestions] calls.
+    /// The request builder for [CompletionService::import_completion_suggestions][crate::client::CompletionService::import_completion_suggestions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -477,7 +477,7 @@ pub mod completion_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_completion_suggestions][super::super::client::CompletionService::import_completion_suggestions].
+        /// on [import_completion_suggestions][crate::client::CompletionService::import_completion_suggestions].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_completion_suggestions(self.0.request, self.0.options)
@@ -618,7 +618,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::purge_completion_suggestions][super::super::client::CompletionService::purge_completion_suggestions] calls.
+    /// The request builder for [CompletionService::purge_completion_suggestions][crate::client::CompletionService::purge_completion_suggestions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -668,7 +668,7 @@ pub mod completion_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_completion_suggestions][super::super::client::CompletionService::purge_completion_suggestions].
+        /// on [purge_completion_suggestions][crate::client::CompletionService::purge_completion_suggestions].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_completion_suggestions(self.0.request, self.0.options)
@@ -730,7 +730,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::list_operations][super::super::client::CompletionService::list_operations] calls.
+    /// The request builder for [CompletionService::list_operations][crate::client::CompletionService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -842,7 +842,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::get_operation][super::super::client::CompletionService::get_operation] calls.
+    /// The request builder for [CompletionService::get_operation][crate::client::CompletionService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -906,7 +906,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::cancel_operation][super::super::client::CompletionService::cancel_operation] calls.
+    /// The request builder for [CompletionService::cancel_operation][crate::client::CompletionService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -974,7 +974,7 @@ pub mod completion_service {
 pub mod control_service {
     use crate::Result;
 
-    /// A builder for [ControlService][super::super::client::ControlService].
+    /// A builder for [ControlService][crate::client::ControlService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1002,7 +1002,7 @@ pub mod control_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ControlService] request builders.
+    /// Common implementation for [crate::client::ControlService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ControlService>,
@@ -1025,7 +1025,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::create_control][super::super::client::ControlService::create_control] calls.
+    /// The request builder for [ControlService::create_control][crate::client::ControlService::create_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1118,7 +1118,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::delete_control][super::super::client::ControlService::delete_control] calls.
+    /// The request builder for [ControlService::delete_control][crate::client::ControlService::delete_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1181,7 +1181,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::update_control][super::super::client::ControlService::update_control] calls.
+    /// The request builder for [ControlService::update_control][crate::client::ControlService::update_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1276,7 +1276,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::get_control][super::super::client::ControlService::get_control] calls.
+    /// The request builder for [ControlService::get_control][crate::client::ControlService::get_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1339,7 +1339,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::list_controls][super::super::client::ControlService::list_controls] calls.
+    /// The request builder for [ControlService::list_controls][crate::client::ControlService::list_controls] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1448,7 +1448,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::list_operations][super::super::client::ControlService::list_operations] calls.
+    /// The request builder for [ControlService::list_operations][crate::client::ControlService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1560,7 +1560,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::get_operation][super::super::client::ControlService::get_operation] calls.
+    /// The request builder for [ControlService::get_operation][crate::client::ControlService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1624,7 +1624,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::cancel_operation][super::super::client::ControlService::cancel_operation] calls.
+    /// The request builder for [ControlService::cancel_operation][crate::client::ControlService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1692,7 +1692,7 @@ pub mod control_service {
 pub mod conversational_search_service {
     use crate::Result;
 
-    /// A builder for [ConversationalSearchService][super::super::client::ConversationalSearchService].
+    /// A builder for [ConversationalSearchService][crate::client::ConversationalSearchService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1720,7 +1720,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ConversationalSearchService] request builders.
+    /// Common implementation for [crate::client::ConversationalSearchService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConversationalSearchService>,
@@ -1743,7 +1743,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::converse_conversation][super::super::client::ConversationalSearchService::converse_conversation] calls.
+    /// The request builder for [ConversationalSearchService::converse_conversation][crate::client::ConversationalSearchService::converse_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1914,7 +1914,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::create_conversation][super::super::client::ConversationalSearchService::create_conversation] calls.
+    /// The request builder for [ConversationalSearchService::create_conversation][crate::client::ConversationalSearchService::create_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2002,7 +2002,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::delete_conversation][super::super::client::ConversationalSearchService::delete_conversation] calls.
+    /// The request builder for [ConversationalSearchService::delete_conversation][crate::client::ConversationalSearchService::delete_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2068,7 +2068,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::update_conversation][super::super::client::ConversationalSearchService::update_conversation] calls.
+    /// The request builder for [ConversationalSearchService::update_conversation][crate::client::ConversationalSearchService::update_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2166,7 +2166,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::get_conversation][super::super::client::ConversationalSearchService::get_conversation] calls.
+    /// The request builder for [ConversationalSearchService::get_conversation][crate::client::ConversationalSearchService::get_conversation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2229,7 +2229,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::list_conversations][super::super::client::ConversationalSearchService::list_conversations] calls.
+    /// The request builder for [ConversationalSearchService::list_conversations][crate::client::ConversationalSearchService::list_conversations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2347,7 +2347,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::answer_query][super::super::client::ConversationalSearchService::answer_query] calls.
+    /// The request builder for [ConversationalSearchService::answer_query][crate::client::ConversationalSearchService::answer_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2588,7 +2588,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::get_answer][super::super::client::ConversationalSearchService::get_answer] calls.
+    /// The request builder for [ConversationalSearchService::get_answer][crate::client::ConversationalSearchService::get_answer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2651,7 +2651,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::create_session][super::super::client::ConversationalSearchService::create_session] calls.
+    /// The request builder for [ConversationalSearchService::create_session][crate::client::ConversationalSearchService::create_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2736,7 +2736,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::delete_session][super::super::client::ConversationalSearchService::delete_session] calls.
+    /// The request builder for [ConversationalSearchService::delete_session][crate::client::ConversationalSearchService::delete_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2799,7 +2799,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::update_session][super::super::client::ConversationalSearchService::update_session] calls.
+    /// The request builder for [ConversationalSearchService::update_session][crate::client::ConversationalSearchService::update_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2894,7 +2894,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::get_session][super::super::client::ConversationalSearchService::get_session] calls.
+    /// The request builder for [ConversationalSearchService::get_session][crate::client::ConversationalSearchService::get_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2963,7 +2963,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::list_sessions][super::super::client::ConversationalSearchService::list_sessions] calls.
+    /// The request builder for [ConversationalSearchService::list_sessions][crate::client::ConversationalSearchService::list_sessions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3078,7 +3078,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::list_operations][super::super::client::ConversationalSearchService::list_operations] calls.
+    /// The request builder for [ConversationalSearchService::list_operations][crate::client::ConversationalSearchService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3190,7 +3190,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::get_operation][super::super::client::ConversationalSearchService::get_operation] calls.
+    /// The request builder for [ConversationalSearchService::get_operation][crate::client::ConversationalSearchService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3254,7 +3254,7 @@ pub mod conversational_search_service {
         }
     }
 
-    /// The request builder for [ConversationalSearchService::cancel_operation][super::super::client::ConversationalSearchService::cancel_operation] calls.
+    /// The request builder for [ConversationalSearchService::cancel_operation][crate::client::ConversationalSearchService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3322,7 +3322,7 @@ pub mod conversational_search_service {
 pub mod data_store_service {
     use crate::Result;
 
-    /// A builder for [DataStoreService][super::super::client::DataStoreService].
+    /// A builder for [DataStoreService][crate::client::DataStoreService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3350,7 +3350,7 @@ pub mod data_store_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DataStoreService] request builders.
+    /// Common implementation for [crate::client::DataStoreService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataStoreService>,
@@ -3373,7 +3373,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::create_data_store][super::super::client::DataStoreService::create_data_store] calls.
+    /// The request builder for [DataStoreService::create_data_store][crate::client::DataStoreService::create_data_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3418,7 +3418,7 @@ pub mod data_store_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_data_store][super::super::client::DataStoreService::create_data_store].
+        /// on [create_data_store][crate::client::DataStoreService::create_data_store].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_data_store(self.0.request, self.0.options)
@@ -3520,7 +3520,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::get_data_store][super::super::client::DataStoreService::get_data_store] calls.
+    /// The request builder for [DataStoreService::get_data_store][crate::client::DataStoreService::get_data_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3583,7 +3583,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::list_data_stores][super::super::client::DataStoreService::list_data_stores] calls.
+    /// The request builder for [DataStoreService::list_data_stores][crate::client::DataStoreService::list_data_stores] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3692,7 +3692,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::delete_data_store][super::super::client::DataStoreService::delete_data_store] calls.
+    /// The request builder for [DataStoreService::delete_data_store][crate::client::DataStoreService::delete_data_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3737,7 +3737,7 @@ pub mod data_store_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_data_store][super::super::client::DataStoreService::delete_data_store].
+        /// on [delete_data_store][crate::client::DataStoreService::delete_data_store].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_data_store(self.0.request, self.0.options)
@@ -3797,7 +3797,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::update_data_store][super::super::client::DataStoreService::update_data_store] calls.
+    /// The request builder for [DataStoreService::update_data_store][crate::client::DataStoreService::update_data_store] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3892,7 +3892,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::list_operations][super::super::client::DataStoreService::list_operations] calls.
+    /// The request builder for [DataStoreService::list_operations][crate::client::DataStoreService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4004,7 +4004,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::get_operation][super::super::client::DataStoreService::get_operation] calls.
+    /// The request builder for [DataStoreService::get_operation][crate::client::DataStoreService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4068,7 +4068,7 @@ pub mod data_store_service {
         }
     }
 
-    /// The request builder for [DataStoreService::cancel_operation][super::super::client::DataStoreService::cancel_operation] calls.
+    /// The request builder for [DataStoreService::cancel_operation][crate::client::DataStoreService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4136,7 +4136,7 @@ pub mod data_store_service {
 pub mod document_service {
     use crate::Result;
 
-    /// A builder for [DocumentService][super::super::client::DocumentService].
+    /// A builder for [DocumentService][crate::client::DocumentService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4164,7 +4164,7 @@ pub mod document_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DocumentService] request builders.
+    /// Common implementation for [crate::client::DocumentService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DocumentService>,
@@ -4187,7 +4187,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::get_document][super::super::client::DocumentService::get_document] calls.
+    /// The request builder for [DocumentService::get_document][crate::client::DocumentService::get_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4250,7 +4250,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::list_documents][super::super::client::DocumentService::list_documents] calls.
+    /// The request builder for [DocumentService::list_documents][crate::client::DocumentService::list_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4353,7 +4353,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::create_document][super::super::client::DocumentService::create_document] calls.
+    /// The request builder for [DocumentService::create_document][crate::client::DocumentService::create_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4446,7 +4446,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::update_document][super::super::client::DocumentService::update_document] calls.
+    /// The request builder for [DocumentService::update_document][crate::client::DocumentService::update_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4547,7 +4547,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::delete_document][super::super::client::DocumentService::delete_document] calls.
+    /// The request builder for [DocumentService::delete_document][crate::client::DocumentService::delete_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4610,7 +4610,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::import_documents][super::super::client::DocumentService::import_documents] calls.
+    /// The request builder for [DocumentService::import_documents][crate::client::DocumentService::import_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4655,7 +4655,7 @@ pub mod document_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_documents][super::super::client::DocumentService::import_documents].
+        /// on [import_documents][crate::client::DocumentService::import_documents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_documents(self.0.request, self.0.options)
@@ -4927,7 +4927,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::purge_documents][super::super::client::DocumentService::purge_documents] calls.
+    /// The request builder for [DocumentService::purge_documents][crate::client::DocumentService::purge_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4972,7 +4972,7 @@ pub mod document_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_documents][super::super::client::DocumentService::purge_documents].
+        /// on [purge_documents][crate::client::DocumentService::purge_documents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_documents(self.0.request, self.0.options)
@@ -5106,7 +5106,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::batch_get_documents_metadata][super::super::client::DocumentService::batch_get_documents_metadata] calls.
+    /// The request builder for [DocumentService::batch_get_documents_metadata][crate::client::DocumentService::batch_get_documents_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5196,7 +5196,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::list_operations][super::super::client::DocumentService::list_operations] calls.
+    /// The request builder for [DocumentService::list_operations][crate::client::DocumentService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5308,7 +5308,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::get_operation][super::super::client::DocumentService::get_operation] calls.
+    /// The request builder for [DocumentService::get_operation][crate::client::DocumentService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5372,7 +5372,7 @@ pub mod document_service {
         }
     }
 
-    /// The request builder for [DocumentService::cancel_operation][super::super::client::DocumentService::cancel_operation] calls.
+    /// The request builder for [DocumentService::cancel_operation][crate::client::DocumentService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5440,7 +5440,7 @@ pub mod document_service {
 pub mod engine_service {
     use crate::Result;
 
-    /// A builder for [EngineService][super::super::client::EngineService].
+    /// A builder for [EngineService][crate::client::EngineService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5468,7 +5468,7 @@ pub mod engine_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EngineService] request builders.
+    /// Common implementation for [crate::client::EngineService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EngineService>,
@@ -5491,7 +5491,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::create_engine][super::super::client::EngineService::create_engine] calls.
+    /// The request builder for [EngineService::create_engine][crate::client::EngineService::create_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5536,7 +5536,7 @@ pub mod engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_engine][super::super::client::EngineService::create_engine].
+        /// on [create_engine][crate::client::EngineService::create_engine].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_engine(self.0.request, self.0.options)
@@ -5623,7 +5623,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::delete_engine][super::super::client::EngineService::delete_engine] calls.
+    /// The request builder for [EngineService::delete_engine][crate::client::EngineService::delete_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5668,7 +5668,7 @@ pub mod engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_engine][super::super::client::EngineService::delete_engine].
+        /// on [delete_engine][crate::client::EngineService::delete_engine].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_engine(self.0.request, self.0.options)
@@ -5728,7 +5728,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::update_engine][super::super::client::EngineService::update_engine] calls.
+    /// The request builder for [EngineService::update_engine][crate::client::EngineService::update_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5823,7 +5823,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::get_engine][super::super::client::EngineService::get_engine] calls.
+    /// The request builder for [EngineService::get_engine][crate::client::EngineService::get_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5886,7 +5886,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::list_engines][super::super::client::EngineService::list_engines] calls.
+    /// The request builder for [EngineService::list_engines][crate::client::EngineService::list_engines] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5995,7 +5995,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::list_operations][super::super::client::EngineService::list_operations] calls.
+    /// The request builder for [EngineService::list_operations][crate::client::EngineService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6107,7 +6107,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::get_operation][super::super::client::EngineService::get_operation] calls.
+    /// The request builder for [EngineService::get_operation][crate::client::EngineService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6171,7 +6171,7 @@ pub mod engine_service {
         }
     }
 
-    /// The request builder for [EngineService::cancel_operation][super::super::client::EngineService::cancel_operation] calls.
+    /// The request builder for [EngineService::cancel_operation][crate::client::EngineService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6239,7 +6239,7 @@ pub mod engine_service {
 pub mod grounded_generation_service {
     use crate::Result;
 
-    /// A builder for [GroundedGenerationService][super::super::client::GroundedGenerationService].
+    /// A builder for [GroundedGenerationService][crate::client::GroundedGenerationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6267,7 +6267,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// Common implementation for [super::super::client::GroundedGenerationService] request builders.
+    /// Common implementation for [crate::client::GroundedGenerationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GroundedGenerationService>,
@@ -6290,7 +6290,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for [GroundedGenerationService::generate_grounded_content][super::super::client::GroundedGenerationService::generate_grounded_content] calls.
+    /// The request builder for [GroundedGenerationService::generate_grounded_content][crate::client::GroundedGenerationService::generate_grounded_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6434,7 +6434,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for [GroundedGenerationService::check_grounding][super::super::client::GroundedGenerationService::check_grounding] calls.
+    /// The request builder for [GroundedGenerationService::check_grounding][crate::client::GroundedGenerationService::check_grounding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6543,7 +6543,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for [GroundedGenerationService::list_operations][super::super::client::GroundedGenerationService::list_operations] calls.
+    /// The request builder for [GroundedGenerationService::list_operations][crate::client::GroundedGenerationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6655,7 +6655,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for [GroundedGenerationService::get_operation][super::super::client::GroundedGenerationService::get_operation] calls.
+    /// The request builder for [GroundedGenerationService::get_operation][crate::client::GroundedGenerationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6719,7 +6719,7 @@ pub mod grounded_generation_service {
         }
     }
 
-    /// The request builder for [GroundedGenerationService::cancel_operation][super::super::client::GroundedGenerationService::cancel_operation] calls.
+    /// The request builder for [GroundedGenerationService::cancel_operation][crate::client::GroundedGenerationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6787,7 +6787,7 @@ pub mod grounded_generation_service {
 pub mod project_service {
     use crate::Result;
 
-    /// A builder for [ProjectService][super::super::client::ProjectService].
+    /// A builder for [ProjectService][crate::client::ProjectService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6815,7 +6815,7 @@ pub mod project_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ProjectService] request builders.
+    /// Common implementation for [crate::client::ProjectService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ProjectService>,
@@ -6838,7 +6838,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for [ProjectService::provision_project][super::super::client::ProjectService::provision_project] calls.
+    /// The request builder for [ProjectService::provision_project][crate::client::ProjectService::provision_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6886,7 +6886,7 @@ pub mod project_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [provision_project][super::super::client::ProjectService::provision_project].
+        /// on [provision_project][crate::client::ProjectService::provision_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .provision_project(self.0.request, self.0.options)
@@ -6962,7 +6962,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for [ProjectService::list_operations][super::super::client::ProjectService::list_operations] calls.
+    /// The request builder for [ProjectService::list_operations][crate::client::ProjectService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7074,7 +7074,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for [ProjectService::get_operation][super::super::client::ProjectService::get_operation] calls.
+    /// The request builder for [ProjectService::get_operation][crate::client::ProjectService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7138,7 +7138,7 @@ pub mod project_service {
         }
     }
 
-    /// The request builder for [ProjectService::cancel_operation][super::super::client::ProjectService::cancel_operation] calls.
+    /// The request builder for [ProjectService::cancel_operation][crate::client::ProjectService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7206,7 +7206,7 @@ pub mod project_service {
 pub mod rank_service {
     use crate::Result;
 
-    /// A builder for [RankService][super::super::client::RankService].
+    /// A builder for [RankService][crate::client::RankService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7234,7 +7234,7 @@ pub mod rank_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RankService] request builders.
+    /// Common implementation for [crate::client::RankService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RankService>,
@@ -7257,7 +7257,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for [RankService::rank][super::super::client::RankService::rank] calls.
+    /// The request builder for [RankService::rank][crate::client::RankService::rank] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7368,7 +7368,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for [RankService::list_operations][super::super::client::RankService::list_operations] calls.
+    /// The request builder for [RankService::list_operations][crate::client::RankService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7480,7 +7480,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for [RankService::get_operation][super::super::client::RankService::get_operation] calls.
+    /// The request builder for [RankService::get_operation][crate::client::RankService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7544,7 +7544,7 @@ pub mod rank_service {
         }
     }
 
-    /// The request builder for [RankService::cancel_operation][super::super::client::RankService::cancel_operation] calls.
+    /// The request builder for [RankService::cancel_operation][crate::client::RankService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7612,7 +7612,7 @@ pub mod rank_service {
 pub mod recommendation_service {
     use crate::Result;
 
-    /// A builder for [RecommendationService][super::super::client::RecommendationService].
+    /// A builder for [RecommendationService][crate::client::RecommendationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7640,7 +7640,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RecommendationService] request builders.
+    /// Common implementation for [crate::client::RecommendationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RecommendationService>,
@@ -7663,7 +7663,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for [RecommendationService::recommend][super::super::client::RecommendationService::recommend] calls.
+    /// The request builder for [RecommendationService::recommend][crate::client::RecommendationService::recommend] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7788,7 +7788,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for [RecommendationService::list_operations][super::super::client::RecommendationService::list_operations] calls.
+    /// The request builder for [RecommendationService::list_operations][crate::client::RecommendationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7900,7 +7900,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for [RecommendationService::get_operation][super::super::client::RecommendationService::get_operation] calls.
+    /// The request builder for [RecommendationService::get_operation][crate::client::RecommendationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7964,7 +7964,7 @@ pub mod recommendation_service {
         }
     }
 
-    /// The request builder for [RecommendationService::cancel_operation][super::super::client::RecommendationService::cancel_operation] calls.
+    /// The request builder for [RecommendationService::cancel_operation][crate::client::RecommendationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8032,7 +8032,7 @@ pub mod recommendation_service {
 pub mod schema_service {
     use crate::Result;
 
-    /// A builder for [SchemaService][super::super::client::SchemaService].
+    /// A builder for [SchemaService][crate::client::SchemaService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -8060,7 +8060,7 @@ pub mod schema_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SchemaService] request builders.
+    /// Common implementation for [crate::client::SchemaService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SchemaService>,
@@ -8083,7 +8083,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::get_schema][super::super::client::SchemaService::get_schema] calls.
+    /// The request builder for [SchemaService::get_schema][crate::client::SchemaService::get_schema] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8146,7 +8146,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::list_schemas][super::super::client::SchemaService::list_schemas] calls.
+    /// The request builder for [SchemaService::list_schemas][crate::client::SchemaService::list_schemas] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8249,7 +8249,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::create_schema][super::super::client::SchemaService::create_schema] calls.
+    /// The request builder for [SchemaService::create_schema][crate::client::SchemaService::create_schema] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8294,7 +8294,7 @@ pub mod schema_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_schema][super::super::client::SchemaService::create_schema].
+        /// on [create_schema][crate::client::SchemaService::create_schema].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_schema(self.0.request, self.0.options)
@@ -8381,7 +8381,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::update_schema][super::super::client::SchemaService::update_schema] calls.
+    /// The request builder for [SchemaService::update_schema][crate::client::SchemaService::update_schema] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8426,7 +8426,7 @@ pub mod schema_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_schema][super::super::client::SchemaService::update_schema].
+        /// on [update_schema][crate::client::SchemaService::update_schema].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_schema(self.0.request, self.0.options)
@@ -8503,7 +8503,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::delete_schema][super::super::client::SchemaService::delete_schema] calls.
+    /// The request builder for [SchemaService::delete_schema][crate::client::SchemaService::delete_schema] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8548,7 +8548,7 @@ pub mod schema_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_schema][super::super::client::SchemaService::delete_schema].
+        /// on [delete_schema][crate::client::SchemaService::delete_schema].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_schema(self.0.request, self.0.options)
@@ -8608,7 +8608,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::list_operations][super::super::client::SchemaService::list_operations] calls.
+    /// The request builder for [SchemaService::list_operations][crate::client::SchemaService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8720,7 +8720,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::get_operation][super::super::client::SchemaService::get_operation] calls.
+    /// The request builder for [SchemaService::get_operation][crate::client::SchemaService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8784,7 +8784,7 @@ pub mod schema_service {
         }
     }
 
-    /// The request builder for [SchemaService::cancel_operation][super::super::client::SchemaService::cancel_operation] calls.
+    /// The request builder for [SchemaService::cancel_operation][crate::client::SchemaService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8852,7 +8852,7 @@ pub mod schema_service {
 pub mod search_service {
     use crate::Result;
 
-    /// A builder for [SearchService][super::super::client::SearchService].
+    /// A builder for [SearchService][crate::client::SearchService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -8880,7 +8880,7 @@ pub mod search_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SearchService] request builders.
+    /// Common implementation for [crate::client::SearchService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SearchService>,
@@ -8903,7 +8903,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::search][super::super::client::SearchService::search] calls.
+    /// The request builder for [SearchService::search][crate::client::SearchService::search] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9307,7 +9307,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::search_lite][super::super::client::SearchService::search_lite] calls.
+    /// The request builder for [SearchService::search_lite][crate::client::SearchService::search_lite] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9711,7 +9711,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::list_operations][super::super::client::SearchService::list_operations] calls.
+    /// The request builder for [SearchService::list_operations][crate::client::SearchService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9823,7 +9823,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::get_operation][super::super::client::SearchService::get_operation] calls.
+    /// The request builder for [SearchService::get_operation][crate::client::SearchService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9887,7 +9887,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::cancel_operation][super::super::client::SearchService::cancel_operation] calls.
+    /// The request builder for [SearchService::cancel_operation][crate::client::SearchService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9955,7 +9955,7 @@ pub mod search_service {
 pub mod search_tuning_service {
     use crate::Result;
 
-    /// A builder for [SearchTuningService][super::super::client::SearchTuningService].
+    /// A builder for [SearchTuningService][crate::client::SearchTuningService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -9983,7 +9983,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SearchTuningService] request builders.
+    /// Common implementation for [crate::client::SearchTuningService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SearchTuningService>,
@@ -10006,7 +10006,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for [SearchTuningService::train_custom_model][super::super::client::SearchTuningService::train_custom_model] calls.
+    /// The request builder for [SearchTuningService::train_custom_model][crate::client::SearchTuningService::train_custom_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10054,7 +10054,7 @@ pub mod search_tuning_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [train_custom_model][super::super::client::SearchTuningService::train_custom_model].
+        /// on [train_custom_model][crate::client::SearchTuningService::train_custom_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .train_custom_model(self.0.request, self.0.options)
@@ -10177,7 +10177,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for [SearchTuningService::list_custom_models][super::super::client::SearchTuningService::list_custom_models] calls.
+    /// The request builder for [SearchTuningService::list_custom_models][crate::client::SearchTuningService::list_custom_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10243,7 +10243,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for [SearchTuningService::list_operations][super::super::client::SearchTuningService::list_operations] calls.
+    /// The request builder for [SearchTuningService::list_operations][crate::client::SearchTuningService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10355,7 +10355,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for [SearchTuningService::get_operation][super::super::client::SearchTuningService::get_operation] calls.
+    /// The request builder for [SearchTuningService::get_operation][crate::client::SearchTuningService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10419,7 +10419,7 @@ pub mod search_tuning_service {
         }
     }
 
-    /// The request builder for [SearchTuningService::cancel_operation][super::super::client::SearchTuningService::cancel_operation] calls.
+    /// The request builder for [SearchTuningService::cancel_operation][crate::client::SearchTuningService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10487,7 +10487,7 @@ pub mod search_tuning_service {
 pub mod serving_config_service {
     use crate::Result;
 
-    /// A builder for [ServingConfigService][super::super::client::ServingConfigService].
+    /// A builder for [ServingConfigService][crate::client::ServingConfigService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -10515,7 +10515,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ServingConfigService] request builders.
+    /// Common implementation for [crate::client::ServingConfigService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServingConfigService>,
@@ -10538,7 +10538,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::update_serving_config][super::super::client::ServingConfigService::update_serving_config] calls.
+    /// The request builder for [ServingConfigService::update_serving_config][crate::client::ServingConfigService::update_serving_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10636,7 +10636,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::list_operations][super::super::client::ServingConfigService::list_operations] calls.
+    /// The request builder for [ServingConfigService::list_operations][crate::client::ServingConfigService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10748,7 +10748,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::get_operation][super::super::client::ServingConfigService::get_operation] calls.
+    /// The request builder for [ServingConfigService::get_operation][crate::client::ServingConfigService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10812,7 +10812,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::cancel_operation][super::super::client::ServingConfigService::cancel_operation] calls.
+    /// The request builder for [ServingConfigService::cancel_operation][crate::client::ServingConfigService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10880,7 +10880,7 @@ pub mod serving_config_service {
 pub mod site_search_engine_service {
     use crate::Result;
 
-    /// A builder for [SiteSearchEngineService][super::super::client::SiteSearchEngineService].
+    /// A builder for [SiteSearchEngineService][crate::client::SiteSearchEngineService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -10908,7 +10908,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SiteSearchEngineService] request builders.
+    /// Common implementation for [crate::client::SiteSearchEngineService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SiteSearchEngineService>,
@@ -10931,7 +10931,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::get_site_search_engine][super::super::client::SiteSearchEngineService::get_site_search_engine] calls.
+    /// The request builder for [SiteSearchEngineService::get_site_search_engine][crate::client::SiteSearchEngineService::get_site_search_engine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -10997,7 +10997,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::create_target_site][super::super::client::SiteSearchEngineService::create_target_site] calls.
+    /// The request builder for [SiteSearchEngineService::create_target_site][crate::client::SiteSearchEngineService::create_target_site] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11045,7 +11045,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_target_site][super::super::client::SiteSearchEngineService::create_target_site].
+        /// on [create_target_site][crate::client::SiteSearchEngineService::create_target_site].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_target_site(self.0.request, self.0.options)
@@ -11127,7 +11127,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::batch_create_target_sites][super::super::client::SiteSearchEngineService::batch_create_target_sites] calls.
+    /// The request builder for [SiteSearchEngineService::batch_create_target_sites][crate::client::SiteSearchEngineService::batch_create_target_sites] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11175,7 +11175,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_create_target_sites][super::super::client::SiteSearchEngineService::batch_create_target_sites].
+        /// on [batch_create_target_sites][crate::client::SiteSearchEngineService::batch_create_target_sites].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_create_target_sites(self.0.request, self.0.options)
@@ -11250,7 +11250,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::get_target_site][super::super::client::SiteSearchEngineService::get_target_site] calls.
+    /// The request builder for [SiteSearchEngineService::get_target_site][crate::client::SiteSearchEngineService::get_target_site] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11313,7 +11313,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::update_target_site][super::super::client::SiteSearchEngineService::update_target_site] calls.
+    /// The request builder for [SiteSearchEngineService::update_target_site][crate::client::SiteSearchEngineService::update_target_site] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11361,7 +11361,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_target_site][super::super::client::SiteSearchEngineService::update_target_site].
+        /// on [update_target_site][crate::client::SiteSearchEngineService::update_target_site].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_target_site(self.0.request, self.0.options)
@@ -11435,7 +11435,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::delete_target_site][super::super::client::SiteSearchEngineService::delete_target_site] calls.
+    /// The request builder for [SiteSearchEngineService::delete_target_site][crate::client::SiteSearchEngineService::delete_target_site] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11483,7 +11483,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_target_site][super::super::client::SiteSearchEngineService::delete_target_site].
+        /// on [delete_target_site][crate::client::SiteSearchEngineService::delete_target_site].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_target_site(self.0.request, self.0.options)
@@ -11543,7 +11543,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::list_target_sites][super::super::client::SiteSearchEngineService::list_target_sites] calls.
+    /// The request builder for [SiteSearchEngineService::list_target_sites][crate::client::SiteSearchEngineService::list_target_sites] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11646,7 +11646,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::create_sitemap][super::super::client::SiteSearchEngineService::create_sitemap] calls.
+    /// The request builder for [SiteSearchEngineService::create_sitemap][crate::client::SiteSearchEngineService::create_sitemap] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11691,7 +11691,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_sitemap][super::super::client::SiteSearchEngineService::create_sitemap].
+        /// on [create_sitemap][crate::client::SiteSearchEngineService::create_sitemap].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_sitemap(self.0.request, self.0.options)
@@ -11772,7 +11772,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::delete_sitemap][super::super::client::SiteSearchEngineService::delete_sitemap] calls.
+    /// The request builder for [SiteSearchEngineService::delete_sitemap][crate::client::SiteSearchEngineService::delete_sitemap] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11817,7 +11817,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_sitemap][super::super::client::SiteSearchEngineService::delete_sitemap].
+        /// on [delete_sitemap][crate::client::SiteSearchEngineService::delete_sitemap].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_sitemap(self.0.request, self.0.options)
@@ -11877,7 +11877,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::fetch_sitemaps][super::super::client::SiteSearchEngineService::fetch_sitemaps] calls.
+    /// The request builder for [SiteSearchEngineService::fetch_sitemaps][crate::client::SiteSearchEngineService::fetch_sitemaps] calls.
     ///
     /// # Example
     /// ```no_run
@@ -11958,7 +11958,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::enable_advanced_site_search][super::super::client::SiteSearchEngineService::enable_advanced_site_search] calls.
+    /// The request builder for [SiteSearchEngineService::enable_advanced_site_search][crate::client::SiteSearchEngineService::enable_advanced_site_search] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12008,7 +12008,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [enable_advanced_site_search][super::super::client::SiteSearchEngineService::enable_advanced_site_search].
+        /// on [enable_advanced_site_search][crate::client::SiteSearchEngineService::enable_advanced_site_search].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .enable_advanced_site_search(self.0.request, self.0.options)
@@ -12070,7 +12070,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::disable_advanced_site_search][super::super::client::SiteSearchEngineService::disable_advanced_site_search] calls.
+    /// The request builder for [SiteSearchEngineService::disable_advanced_site_search][crate::client::SiteSearchEngineService::disable_advanced_site_search] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12120,7 +12120,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [disable_advanced_site_search][super::super::client::SiteSearchEngineService::disable_advanced_site_search].
+        /// on [disable_advanced_site_search][crate::client::SiteSearchEngineService::disable_advanced_site_search].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .disable_advanced_site_search(self.0.request, self.0.options)
@@ -12182,7 +12182,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::recrawl_uris][super::super::client::SiteSearchEngineService::recrawl_uris] calls.
+    /// The request builder for [SiteSearchEngineService::recrawl_uris][crate::client::SiteSearchEngineService::recrawl_uris] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12227,7 +12227,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [recrawl_uris][super::super::client::SiteSearchEngineService::recrawl_uris].
+        /// on [recrawl_uris][crate::client::SiteSearchEngineService::recrawl_uris].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .recrawl_uris(self.0.request, self.0.options)
@@ -12306,7 +12306,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::batch_verify_target_sites][super::super::client::SiteSearchEngineService::batch_verify_target_sites] calls.
+    /// The request builder for [SiteSearchEngineService::batch_verify_target_sites][crate::client::SiteSearchEngineService::batch_verify_target_sites] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12354,7 +12354,7 @@ pub mod site_search_engine_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_verify_target_sites][super::super::client::SiteSearchEngineService::batch_verify_target_sites].
+        /// on [batch_verify_target_sites][crate::client::SiteSearchEngineService::batch_verify_target_sites].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_verify_target_sites(self.0.request, self.0.options)
@@ -12416,7 +12416,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::fetch_domain_verification_status][super::super::client::SiteSearchEngineService::fetch_domain_verification_status] calls.
+    /// The request builder for [SiteSearchEngineService::fetch_domain_verification_status][crate::client::SiteSearchEngineService::fetch_domain_verification_status] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12528,7 +12528,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::list_operations][super::super::client::SiteSearchEngineService::list_operations] calls.
+    /// The request builder for [SiteSearchEngineService::list_operations][crate::client::SiteSearchEngineService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12640,7 +12640,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::get_operation][super::super::client::SiteSearchEngineService::get_operation] calls.
+    /// The request builder for [SiteSearchEngineService::get_operation][crate::client::SiteSearchEngineService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12704,7 +12704,7 @@ pub mod site_search_engine_service {
         }
     }
 
-    /// The request builder for [SiteSearchEngineService::cancel_operation][super::super::client::SiteSearchEngineService::cancel_operation] calls.
+    /// The request builder for [SiteSearchEngineService::cancel_operation][crate::client::SiteSearchEngineService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12772,7 +12772,7 @@ pub mod site_search_engine_service {
 pub mod user_event_service {
     use crate::Result;
 
-    /// A builder for [UserEventService][super::super::client::UserEventService].
+    /// A builder for [UserEventService][crate::client::UserEventService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -12800,7 +12800,7 @@ pub mod user_event_service {
         }
     }
 
-    /// Common implementation for [super::super::client::UserEventService] request builders.
+    /// Common implementation for [crate::client::UserEventService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::UserEventService>,
@@ -12823,7 +12823,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::write_user_event][super::super::client::UserEventService::write_user_event] calls.
+    /// The request builder for [UserEventService::write_user_event][crate::client::UserEventService::write_user_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -12914,7 +12914,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::collect_user_event][super::super::client::UserEventService::collect_user_event] calls.
+    /// The request builder for [UserEventService::collect_user_event][crate::client::UserEventService::collect_user_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13024,7 +13024,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::purge_user_events][super::super::client::UserEventService::purge_user_events] calls.
+    /// The request builder for [UserEventService::purge_user_events][crate::client::UserEventService::purge_user_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13069,7 +13069,7 @@ pub mod user_event_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_user_events][super::super::client::UserEventService::purge_user_events].
+        /// on [purge_user_events][crate::client::UserEventService::purge_user_events].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_user_events(self.0.request, self.0.options)
@@ -13143,7 +13143,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::import_user_events][super::super::client::UserEventService::import_user_events] calls.
+    /// The request builder for [UserEventService::import_user_events][crate::client::UserEventService::import_user_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13191,7 +13191,7 @@ pub mod user_event_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_user_events][super::super::client::UserEventService::import_user_events].
+        /// on [import_user_events][crate::client::UserEventService::import_user_events].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_user_events(self.0.request, self.0.options)
@@ -13328,7 +13328,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::list_operations][super::super::client::UserEventService::list_operations] calls.
+    /// The request builder for [UserEventService::list_operations][crate::client::UserEventService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13440,7 +13440,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::get_operation][super::super::client::UserEventService::get_operation] calls.
+    /// The request builder for [UserEventService::get_operation][crate::client::UserEventService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -13504,7 +13504,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::cancel_operation][super::super::client::UserEventService::cancel_operation] calls.
+    /// The request builder for [UserEventService::cancel_operation][crate::client::UserEventService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/documentai/v1/src/builder.rs
+++ b/src/generated/cloud/documentai/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod document_processor_service {
     use crate::Result;
 
-    /// A builder for [DocumentProcessorService][super::super::client::DocumentProcessorService].
+    /// A builder for [DocumentProcessorService][crate::client::DocumentProcessorService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DocumentProcessorService] request builders.
+    /// Common implementation for [crate::client::DocumentProcessorService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DocumentProcessorService>,
@@ -68,7 +68,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::process_document][super::super::client::DocumentProcessorService::process_document] calls.
+    /// The request builder for [DocumentProcessorService::process_document][crate::client::DocumentProcessorService::process_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -247,7 +247,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::batch_process_documents][super::super::client::DocumentProcessorService::batch_process_documents] calls.
+    /// The request builder for [DocumentProcessorService::batch_process_documents][crate::client::DocumentProcessorService::batch_process_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -292,7 +292,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_process_documents][super::super::client::DocumentProcessorService::batch_process_documents].
+        /// on [batch_process_documents][crate::client::DocumentProcessorService::batch_process_documents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_process_documents(self.0.request, self.0.options)
@@ -423,7 +423,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::fetch_processor_types][super::super::client::DocumentProcessorService::fetch_processor_types] calls.
+    /// The request builder for [DocumentProcessorService::fetch_processor_types][crate::client::DocumentProcessorService::fetch_processor_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -489,7 +489,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::list_processor_types][super::super::client::DocumentProcessorService::list_processor_types] calls.
+    /// The request builder for [DocumentProcessorService::list_processor_types][crate::client::DocumentProcessorService::list_processor_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -597,7 +597,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::get_processor_type][super::super::client::DocumentProcessorService::get_processor_type] calls.
+    /// The request builder for [DocumentProcessorService::get_processor_type][crate::client::DocumentProcessorService::get_processor_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -663,7 +663,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::list_processors][super::super::client::DocumentProcessorService::list_processors] calls.
+    /// The request builder for [DocumentProcessorService::list_processors][crate::client::DocumentProcessorService::list_processors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -766,7 +766,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::get_processor][super::super::client::DocumentProcessorService::get_processor] calls.
+    /// The request builder for [DocumentProcessorService::get_processor][crate::client::DocumentProcessorService::get_processor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -829,7 +829,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::train_processor_version][super::super::client::DocumentProcessorService::train_processor_version] calls.
+    /// The request builder for [DocumentProcessorService::train_processor_version][crate::client::DocumentProcessorService::train_processor_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -877,7 +877,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [train_processor_version][super::super::client::DocumentProcessorService::train_processor_version].
+        /// on [train_processor_version][crate::client::DocumentProcessorService::train_processor_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .train_processor_version(self.0.request, self.0.options)
@@ -1046,7 +1046,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::get_processor_version][super::super::client::DocumentProcessorService::get_processor_version] calls.
+    /// The request builder for [DocumentProcessorService::get_processor_version][crate::client::DocumentProcessorService::get_processor_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1112,7 +1112,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::list_processor_versions][super::super::client::DocumentProcessorService::list_processor_versions] calls.
+    /// The request builder for [DocumentProcessorService::list_processor_versions][crate::client::DocumentProcessorService::list_processor_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1220,7 +1220,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::delete_processor_version][super::super::client::DocumentProcessorService::delete_processor_version] calls.
+    /// The request builder for [DocumentProcessorService::delete_processor_version][crate::client::DocumentProcessorService::delete_processor_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1268,7 +1268,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_processor_version][super::super::client::DocumentProcessorService::delete_processor_version].
+        /// on [delete_processor_version][crate::client::DocumentProcessorService::delete_processor_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_processor_version(self.0.request, self.0.options)
@@ -1328,7 +1328,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::deploy_processor_version][super::super::client::DocumentProcessorService::deploy_processor_version] calls.
+    /// The request builder for [DocumentProcessorService::deploy_processor_version][crate::client::DocumentProcessorService::deploy_processor_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1376,7 +1376,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [deploy_processor_version][super::super::client::DocumentProcessorService::deploy_processor_version].
+        /// on [deploy_processor_version][crate::client::DocumentProcessorService::deploy_processor_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .deploy_processor_version(self.0.request, self.0.options)
@@ -1438,7 +1438,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::undeploy_processor_version][super::super::client::DocumentProcessorService::undeploy_processor_version] calls.
+    /// The request builder for [DocumentProcessorService::undeploy_processor_version][crate::client::DocumentProcessorService::undeploy_processor_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1488,7 +1488,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undeploy_processor_version][super::super::client::DocumentProcessorService::undeploy_processor_version].
+        /// on [undeploy_processor_version][crate::client::DocumentProcessorService::undeploy_processor_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undeploy_processor_version(self.0.request, self.0.options)
@@ -1550,7 +1550,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::create_processor][super::super::client::DocumentProcessorService::create_processor] calls.
+    /// The request builder for [DocumentProcessorService::create_processor][crate::client::DocumentProcessorService::create_processor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1635,7 +1635,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::delete_processor][super::super::client::DocumentProcessorService::delete_processor] calls.
+    /// The request builder for [DocumentProcessorService::delete_processor][crate::client::DocumentProcessorService::delete_processor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1680,7 +1680,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_processor][super::super::client::DocumentProcessorService::delete_processor].
+        /// on [delete_processor][crate::client::DocumentProcessorService::delete_processor].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_processor(self.0.request, self.0.options)
@@ -1740,7 +1740,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::enable_processor][super::super::client::DocumentProcessorService::enable_processor] calls.
+    /// The request builder for [DocumentProcessorService::enable_processor][crate::client::DocumentProcessorService::enable_processor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1785,7 +1785,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [enable_processor][super::super::client::DocumentProcessorService::enable_processor].
+        /// on [enable_processor][crate::client::DocumentProcessorService::enable_processor].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .enable_processor(self.0.request, self.0.options)
@@ -1845,7 +1845,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::disable_processor][super::super::client::DocumentProcessorService::disable_processor] calls.
+    /// The request builder for [DocumentProcessorService::disable_processor][crate::client::DocumentProcessorService::disable_processor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1893,7 +1893,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [disable_processor][super::super::client::DocumentProcessorService::disable_processor].
+        /// on [disable_processor][crate::client::DocumentProcessorService::disable_processor].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .disable_processor(self.0.request, self.0.options)
@@ -1955,7 +1955,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::set_default_processor_version][super::super::client::DocumentProcessorService::set_default_processor_version] calls.
+    /// The request builder for [DocumentProcessorService::set_default_processor_version][crate::client::DocumentProcessorService::set_default_processor_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2005,7 +2005,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [set_default_processor_version][super::super::client::DocumentProcessorService::set_default_processor_version].
+        /// on [set_default_processor_version][crate::client::DocumentProcessorService::set_default_processor_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .set_default_processor_version(self.0.request, self.0.options)
@@ -2075,7 +2075,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::review_document][super::super::client::DocumentProcessorService::review_document] calls.
+    /// The request builder for [DocumentProcessorService::review_document][crate::client::DocumentProcessorService::review_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2120,7 +2120,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [review_document][super::super::client::DocumentProcessorService::review_document].
+        /// on [review_document][crate::client::DocumentProcessorService::review_document].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .review_document(self.0.request, self.0.options)
@@ -2242,7 +2242,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::evaluate_processor_version][super::super::client::DocumentProcessorService::evaluate_processor_version] calls.
+    /// The request builder for [DocumentProcessorService::evaluate_processor_version][crate::client::DocumentProcessorService::evaluate_processor_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2292,7 +2292,7 @@ pub mod document_processor_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [evaluate_processor_version][super::super::client::DocumentProcessorService::evaluate_processor_version].
+        /// on [evaluate_processor_version][crate::client::DocumentProcessorService::evaluate_processor_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .evaluate_processor_version(self.0.request, self.0.options)
@@ -2372,7 +2372,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::get_evaluation][super::super::client::DocumentProcessorService::get_evaluation] calls.
+    /// The request builder for [DocumentProcessorService::get_evaluation][crate::client::DocumentProcessorService::get_evaluation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2435,7 +2435,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::list_evaluations][super::super::client::DocumentProcessorService::list_evaluations] calls.
+    /// The request builder for [DocumentProcessorService::list_evaluations][crate::client::DocumentProcessorService::list_evaluations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2538,7 +2538,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::list_locations][super::super::client::DocumentProcessorService::list_locations] calls.
+    /// The request builder for [DocumentProcessorService::list_locations][crate::client::DocumentProcessorService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2648,7 +2648,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::get_location][super::super::client::DocumentProcessorService::get_location] calls.
+    /// The request builder for [DocumentProcessorService::get_location][crate::client::DocumentProcessorService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2709,7 +2709,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::list_operations][super::super::client::DocumentProcessorService::list_operations] calls.
+    /// The request builder for [DocumentProcessorService::list_operations][crate::client::DocumentProcessorService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2821,7 +2821,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::get_operation][super::super::client::DocumentProcessorService::get_operation] calls.
+    /// The request builder for [DocumentProcessorService::get_operation][crate::client::DocumentProcessorService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2885,7 +2885,7 @@ pub mod document_processor_service {
         }
     }
 
-    /// The request builder for [DocumentProcessorService::cancel_operation][super::super::client::DocumentProcessorService::cancel_operation] calls.
+    /// The request builder for [DocumentProcessorService::cancel_operation][crate::client::DocumentProcessorService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/domains/v1/src/builder.rs
+++ b/src/generated/cloud/domains/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod domains {
     use crate::Result;
 
-    /// A builder for [Domains][super::super::client::Domains].
+    /// A builder for [Domains][crate::client::Domains].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod domains {
         }
     }
 
-    /// Common implementation for [super::super::client::Domains] request builders.
+    /// Common implementation for [crate::client::Domains] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Domains>,
@@ -66,7 +66,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::search_domains][super::super::client::Domains::search_domains] calls.
+    /// The request builder for [Domains::search_domains][crate::client::Domains::search_domains] calls.
     ///
     /// # Example
     /// ```no_run
@@ -135,7 +135,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::retrieve_register_parameters][super::super::client::Domains::retrieve_register_parameters] calls.
+    /// The request builder for [Domains::retrieve_register_parameters][crate::client::Domains::retrieve_register_parameters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -209,7 +209,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::register_domain][super::super::client::Domains::register_domain] calls.
+    /// The request builder for [Domains::register_domain][crate::client::Domains::register_domain] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [register_domain][super::super::client::Domains::register_domain].
+        /// on [register_domain][crate::client::Domains::register_domain].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .register_domain(self.0.request, self.0.options)
@@ -383,7 +383,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::retrieve_transfer_parameters][super::super::client::Domains::retrieve_transfer_parameters] calls.
+    /// The request builder for [Domains::retrieve_transfer_parameters][crate::client::Domains::retrieve_transfer_parameters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -457,7 +457,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::transfer_domain][super::super::client::Domains::transfer_domain] calls.
+    /// The request builder for [Domains::transfer_domain][crate::client::Domains::transfer_domain] calls.
     ///
     /// # Example
     /// ```no_run
@@ -500,7 +500,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [transfer_domain][super::super::client::Domains::transfer_domain].
+        /// on [transfer_domain][crate::client::Domains::transfer_domain].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .transfer_domain(self.0.request, self.0.options)
@@ -638,7 +638,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::list_registrations][super::super::client::Domains::list_registrations] calls.
+    /// The request builder for [Domains::list_registrations][crate::client::Domains::list_registrations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -748,7 +748,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::get_registration][super::super::client::Domains::get_registration] calls.
+    /// The request builder for [Domains::get_registration][crate::client::Domains::get_registration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -809,7 +809,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::update_registration][super::super::client::Domains::update_registration] calls.
+    /// The request builder for [Domains::update_registration][crate::client::Domains::update_registration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -855,7 +855,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_registration][super::super::client::Domains::update_registration].
+        /// on [update_registration][crate::client::Domains::update_registration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_registration(self.0.request, self.0.options)
@@ -946,7 +946,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::configure_management_settings][super::super::client::Domains::configure_management_settings] calls.
+    /// The request builder for [Domains::configure_management_settings][crate::client::Domains::configure_management_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -994,7 +994,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [configure_management_settings][super::super::client::Domains::configure_management_settings].
+        /// on [configure_management_settings][crate::client::Domains::configure_management_settings].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .configure_management_settings(self.0.request, self.0.options)
@@ -1093,7 +1093,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::configure_dns_settings][super::super::client::Domains::configure_dns_settings] calls.
+    /// The request builder for [Domains::configure_dns_settings][crate::client::Domains::configure_dns_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1139,7 +1139,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [configure_dns_settings][super::super::client::Domains::configure_dns_settings].
+        /// on [configure_dns_settings][crate::client::Domains::configure_dns_settings].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .configure_dns_settings(self.0.request, self.0.options)
@@ -1244,7 +1244,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::configure_contact_settings][super::super::client::Domains::configure_contact_settings] calls.
+    /// The request builder for [Domains::configure_contact_settings][crate::client::Domains::configure_contact_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1292,7 +1292,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [configure_contact_settings][super::super::client::Domains::configure_contact_settings].
+        /// on [configure_contact_settings][crate::client::Domains::configure_contact_settings].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .configure_contact_settings(self.0.request, self.0.options)
@@ -1408,7 +1408,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::export_registration][super::super::client::Domains::export_registration] calls.
+    /// The request builder for [Domains::export_registration][crate::client::Domains::export_registration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1454,7 +1454,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_registration][super::super::client::Domains::export_registration].
+        /// on [export_registration][crate::client::Domains::export_registration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_registration(self.0.request, self.0.options)
@@ -1513,7 +1513,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::delete_registration][super::super::client::Domains::delete_registration] calls.
+    /// The request builder for [Domains::delete_registration][crate::client::Domains::delete_registration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1559,7 +1559,7 @@ pub mod domains {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_registration][super::super::client::Domains::delete_registration].
+        /// on [delete_registration][crate::client::Domains::delete_registration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_registration(self.0.request, self.0.options)
@@ -1618,7 +1618,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::retrieve_authorization_code][super::super::client::Domains::retrieve_authorization_code] calls.
+    /// The request builder for [Domains::retrieve_authorization_code][crate::client::Domains::retrieve_authorization_code] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1684,7 +1684,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::reset_authorization_code][super::super::client::Domains::reset_authorization_code] calls.
+    /// The request builder for [Domains::reset_authorization_code][crate::client::Domains::reset_authorization_code] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1748,7 +1748,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::list_operations][super::super::client::Domains::list_operations] calls.
+    /// The request builder for [Domains::list_operations][crate::client::Domains::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1858,7 +1858,7 @@ pub mod domains {
         }
     }
 
-    /// The request builder for [Domains::get_operation][super::super::client::Domains::get_operation] calls.
+    /// The request builder for [Domains::get_operation][crate::client::Domains::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/edgecontainer/v1/src/builder.rs
+++ b/src/generated/cloud/edgecontainer/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod edge_container {
     use crate::Result;
 
-    /// A builder for [EdgeContainer][super::super::client::EdgeContainer].
+    /// A builder for [EdgeContainer][crate::client::EdgeContainer].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod edge_container {
         }
     }
 
-    /// Common implementation for [super::super::client::EdgeContainer] request builders.
+    /// Common implementation for [crate::client::EdgeContainer] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EdgeContainer>,
@@ -68,7 +68,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::list_clusters][super::super::client::EdgeContainer::list_clusters] calls.
+    /// The request builder for [EdgeContainer::list_clusters][crate::client::EdgeContainer::list_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::get_cluster][super::super::client::EdgeContainer::get_cluster] calls.
+    /// The request builder for [EdgeContainer::get_cluster][crate::client::EdgeContainer::get_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::create_cluster][super::super::client::EdgeContainer::create_cluster] calls.
+    /// The request builder for [EdgeContainer::create_cluster][crate::client::EdgeContainer::create_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cluster][super::super::client::EdgeContainer::create_cluster].
+        /// on [create_cluster][crate::client::EdgeContainer::create_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cluster(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::update_cluster][super::super::client::EdgeContainer::update_cluster] calls.
+    /// The request builder for [EdgeContainer::update_cluster][crate::client::EdgeContainer::update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_cluster][super::super::client::EdgeContainer::update_cluster].
+        /// on [update_cluster][crate::client::EdgeContainer::update_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_cluster(self.0.request, self.0.options)
@@ -520,7 +520,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::upgrade_cluster][super::super::client::EdgeContainer::upgrade_cluster] calls.
+    /// The request builder for [EdgeContainer::upgrade_cluster][crate::client::EdgeContainer::upgrade_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -565,7 +565,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upgrade_cluster][super::super::client::EdgeContainer::upgrade_cluster].
+        /// on [upgrade_cluster][crate::client::EdgeContainer::upgrade_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upgrade_cluster(self.0.request, self.0.options)
@@ -645,7 +645,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::delete_cluster][super::super::client::EdgeContainer::delete_cluster] calls.
+    /// The request builder for [EdgeContainer::delete_cluster][crate::client::EdgeContainer::delete_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -690,7 +690,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cluster][super::super::client::EdgeContainer::delete_cluster].
+        /// on [delete_cluster][crate::client::EdgeContainer::delete_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cluster(self.0.request, self.0.options)
@@ -755,7 +755,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::generate_access_token][super::super::client::EdgeContainer::generate_access_token] calls.
+    /// The request builder for [EdgeContainer::generate_access_token][crate::client::EdgeContainer::generate_access_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -821,7 +821,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::generate_offline_credential][super::super::client::EdgeContainer::generate_offline_credential] calls.
+    /// The request builder for [EdgeContainer::generate_offline_credential][crate::client::EdgeContainer::generate_offline_credential] calls.
     ///
     /// # Example
     /// ```no_run
@@ -889,7 +889,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::list_node_pools][super::super::client::EdgeContainer::list_node_pools] calls.
+    /// The request builder for [EdgeContainer::list_node_pools][crate::client::EdgeContainer::list_node_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1004,7 +1004,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::get_node_pool][super::super::client::EdgeContainer::get_node_pool] calls.
+    /// The request builder for [EdgeContainer::get_node_pool][crate::client::EdgeContainer::get_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1067,7 +1067,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::create_node_pool][super::super::client::EdgeContainer::create_node_pool] calls.
+    /// The request builder for [EdgeContainer::create_node_pool][crate::client::EdgeContainer::create_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1112,7 +1112,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_node_pool][super::super::client::EdgeContainer::create_node_pool].
+        /// on [create_node_pool][crate::client::EdgeContainer::create_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_node_pool(self.0.request, self.0.options)
@@ -1205,7 +1205,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::update_node_pool][super::super::client::EdgeContainer::update_node_pool] calls.
+    /// The request builder for [EdgeContainer::update_node_pool][crate::client::EdgeContainer::update_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1250,7 +1250,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_node_pool][super::super::client::EdgeContainer::update_node_pool].
+        /// on [update_node_pool][crate::client::EdgeContainer::update_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_node_pool(self.0.request, self.0.options)
@@ -1341,7 +1341,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::delete_node_pool][super::super::client::EdgeContainer::delete_node_pool] calls.
+    /// The request builder for [EdgeContainer::delete_node_pool][crate::client::EdgeContainer::delete_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1386,7 +1386,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_node_pool][super::super::client::EdgeContainer::delete_node_pool].
+        /// on [delete_node_pool][crate::client::EdgeContainer::delete_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_node_pool(self.0.request, self.0.options)
@@ -1451,7 +1451,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::list_machines][super::super::client::EdgeContainer::list_machines] calls.
+    /// The request builder for [EdgeContainer::list_machines][crate::client::EdgeContainer::list_machines] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1566,7 +1566,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::get_machine][super::super::client::EdgeContainer::get_machine] calls.
+    /// The request builder for [EdgeContainer::get_machine][crate::client::EdgeContainer::get_machine] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1629,7 +1629,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::list_vpn_connections][super::super::client::EdgeContainer::list_vpn_connections] calls.
+    /// The request builder for [EdgeContainer::list_vpn_connections][crate::client::EdgeContainer::list_vpn_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1749,7 +1749,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::get_vpn_connection][super::super::client::EdgeContainer::get_vpn_connection] calls.
+    /// The request builder for [EdgeContainer::get_vpn_connection][crate::client::EdgeContainer::get_vpn_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1815,7 +1815,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::create_vpn_connection][super::super::client::EdgeContainer::create_vpn_connection] calls.
+    /// The request builder for [EdgeContainer::create_vpn_connection][crate::client::EdgeContainer::create_vpn_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1863,7 +1863,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_vpn_connection][super::super::client::EdgeContainer::create_vpn_connection].
+        /// on [create_vpn_connection][crate::client::EdgeContainer::create_vpn_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_vpn_connection(self.0.request, self.0.options)
@@ -1959,7 +1959,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::delete_vpn_connection][super::super::client::EdgeContainer::delete_vpn_connection] calls.
+    /// The request builder for [EdgeContainer::delete_vpn_connection][crate::client::EdgeContainer::delete_vpn_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2007,7 +2007,7 @@ pub mod edge_container {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_vpn_connection][super::super::client::EdgeContainer::delete_vpn_connection].
+        /// on [delete_vpn_connection][crate::client::EdgeContainer::delete_vpn_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_vpn_connection(self.0.request, self.0.options)
@@ -2072,7 +2072,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::get_server_config][super::super::client::EdgeContainer::get_server_config] calls.
+    /// The request builder for [EdgeContainer::get_server_config][crate::client::EdgeContainer::get_server_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2135,7 +2135,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::list_locations][super::super::client::EdgeContainer::list_locations] calls.
+    /// The request builder for [EdgeContainer::list_locations][crate::client::EdgeContainer::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2245,7 +2245,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::get_location][super::super::client::EdgeContainer::get_location] calls.
+    /// The request builder for [EdgeContainer::get_location][crate::client::EdgeContainer::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2306,7 +2306,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::list_operations][super::super::client::EdgeContainer::list_operations] calls.
+    /// The request builder for [EdgeContainer::list_operations][crate::client::EdgeContainer::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2418,7 +2418,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::get_operation][super::super::client::EdgeContainer::get_operation] calls.
+    /// The request builder for [EdgeContainer::get_operation][crate::client::EdgeContainer::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2482,7 +2482,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::delete_operation][super::super::client::EdgeContainer::delete_operation] calls.
+    /// The request builder for [EdgeContainer::delete_operation][crate::client::EdgeContainer::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2546,7 +2546,7 @@ pub mod edge_container {
         }
     }
 
-    /// The request builder for [EdgeContainer::cancel_operation][super::super::client::EdgeContainer::cancel_operation] calls.
+    /// The request builder for [EdgeContainer::cancel_operation][crate::client::EdgeContainer::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/edgenetwork/v1/src/builder.rs
+++ b/src/generated/cloud/edgenetwork/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod edge_network {
     use crate::Result;
 
-    /// A builder for [EdgeNetwork][super::super::client::EdgeNetwork].
+    /// A builder for [EdgeNetwork][crate::client::EdgeNetwork].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod edge_network {
         }
     }
 
-    /// Common implementation for [super::super::client::EdgeNetwork] request builders.
+    /// Common implementation for [crate::client::EdgeNetwork] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EdgeNetwork>,
@@ -68,7 +68,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::initialize_zone][super::super::client::EdgeNetwork::initialize_zone] calls.
+    /// The request builder for [EdgeNetwork::initialize_zone][crate::client::EdgeNetwork::initialize_zone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_zones][super::super::client::EdgeNetwork::list_zones] calls.
+    /// The request builder for [EdgeNetwork::list_zones][crate::client::EdgeNetwork::list_zones] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_zone][super::super::client::EdgeNetwork::get_zone] calls.
+    /// The request builder for [EdgeNetwork::get_zone][crate::client::EdgeNetwork::get_zone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -309,7 +309,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_networks][super::super::client::EdgeNetwork::list_networks] calls.
+    /// The request builder for [EdgeNetwork::list_networks][crate::client::EdgeNetwork::list_networks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -424,7 +424,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_network][super::super::client::EdgeNetwork::get_network] calls.
+    /// The request builder for [EdgeNetwork::get_network][crate::client::EdgeNetwork::get_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -487,7 +487,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::diagnose_network][super::super::client::EdgeNetwork::diagnose_network] calls.
+    /// The request builder for [EdgeNetwork::diagnose_network][crate::client::EdgeNetwork::diagnose_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -550,7 +550,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::create_network][super::super::client::EdgeNetwork::create_network] calls.
+    /// The request builder for [EdgeNetwork::create_network][crate::client::EdgeNetwork::create_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -595,7 +595,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_network][super::super::client::EdgeNetwork::create_network].
+        /// on [create_network][crate::client::EdgeNetwork::create_network].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_network(self.0.request, self.0.options)
@@ -688,7 +688,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::delete_network][super::super::client::EdgeNetwork::delete_network] calls.
+    /// The request builder for [EdgeNetwork::delete_network][crate::client::EdgeNetwork::delete_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -733,7 +733,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_network][super::super::client::EdgeNetwork::delete_network].
+        /// on [delete_network][crate::client::EdgeNetwork::delete_network].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_network(self.0.request, self.0.options)
@@ -798,7 +798,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_subnets][super::super::client::EdgeNetwork::list_subnets] calls.
+    /// The request builder for [EdgeNetwork::list_subnets][crate::client::EdgeNetwork::list_subnets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -913,7 +913,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_subnet][super::super::client::EdgeNetwork::get_subnet] calls.
+    /// The request builder for [EdgeNetwork::get_subnet][crate::client::EdgeNetwork::get_subnet] calls.
     ///
     /// # Example
     /// ```no_run
@@ -976,7 +976,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::create_subnet][super::super::client::EdgeNetwork::create_subnet] calls.
+    /// The request builder for [EdgeNetwork::create_subnet][crate::client::EdgeNetwork::create_subnet] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1021,7 +1021,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_subnet][super::super::client::EdgeNetwork::create_subnet].
+        /// on [create_subnet][crate::client::EdgeNetwork::create_subnet].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_subnet(self.0.request, self.0.options)
@@ -1114,7 +1114,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::update_subnet][super::super::client::EdgeNetwork::update_subnet] calls.
+    /// The request builder for [EdgeNetwork::update_subnet][crate::client::EdgeNetwork::update_subnet] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1159,7 +1159,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_subnet][super::super::client::EdgeNetwork::update_subnet].
+        /// on [update_subnet][crate::client::EdgeNetwork::update_subnet].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_subnet(self.0.request, self.0.options)
@@ -1258,7 +1258,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::delete_subnet][super::super::client::EdgeNetwork::delete_subnet] calls.
+    /// The request builder for [EdgeNetwork::delete_subnet][crate::client::EdgeNetwork::delete_subnet] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1303,7 +1303,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_subnet][super::super::client::EdgeNetwork::delete_subnet].
+        /// on [delete_subnet][crate::client::EdgeNetwork::delete_subnet].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_subnet(self.0.request, self.0.options)
@@ -1368,7 +1368,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_interconnects][super::super::client::EdgeNetwork::list_interconnects] calls.
+    /// The request builder for [EdgeNetwork::list_interconnects][crate::client::EdgeNetwork::list_interconnects] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1486,7 +1486,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_interconnect][super::super::client::EdgeNetwork::get_interconnect] calls.
+    /// The request builder for [EdgeNetwork::get_interconnect][crate::client::EdgeNetwork::get_interconnect] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1549,7 +1549,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::diagnose_interconnect][super::super::client::EdgeNetwork::diagnose_interconnect] calls.
+    /// The request builder for [EdgeNetwork::diagnose_interconnect][crate::client::EdgeNetwork::diagnose_interconnect] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1615,7 +1615,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_interconnect_attachments][super::super::client::EdgeNetwork::list_interconnect_attachments] calls.
+    /// The request builder for [EdgeNetwork::list_interconnect_attachments][crate::client::EdgeNetwork::list_interconnect_attachments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1739,7 +1739,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_interconnect_attachment][super::super::client::EdgeNetwork::get_interconnect_attachment] calls.
+    /// The request builder for [EdgeNetwork::get_interconnect_attachment][crate::client::EdgeNetwork::get_interconnect_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1807,7 +1807,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::create_interconnect_attachment][super::super::client::EdgeNetwork::create_interconnect_attachment] calls.
+    /// The request builder for [EdgeNetwork::create_interconnect_attachment][crate::client::EdgeNetwork::create_interconnect_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1857,7 +1857,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_interconnect_attachment][super::super::client::EdgeNetwork::create_interconnect_attachment].
+        /// on [create_interconnect_attachment][crate::client::EdgeNetwork::create_interconnect_attachment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_interconnect_attachment(self.0.request, self.0.options)
@@ -1956,7 +1956,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::delete_interconnect_attachment][super::super::client::EdgeNetwork::delete_interconnect_attachment] calls.
+    /// The request builder for [EdgeNetwork::delete_interconnect_attachment][crate::client::EdgeNetwork::delete_interconnect_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2006,7 +2006,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_interconnect_attachment][super::super::client::EdgeNetwork::delete_interconnect_attachment].
+        /// on [delete_interconnect_attachment][crate::client::EdgeNetwork::delete_interconnect_attachment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_interconnect_attachment(self.0.request, self.0.options)
@@ -2071,7 +2071,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_routers][super::super::client::EdgeNetwork::list_routers] calls.
+    /// The request builder for [EdgeNetwork::list_routers][crate::client::EdgeNetwork::list_routers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2186,7 +2186,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_router][super::super::client::EdgeNetwork::get_router] calls.
+    /// The request builder for [EdgeNetwork::get_router][crate::client::EdgeNetwork::get_router] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2249,7 +2249,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::diagnose_router][super::super::client::EdgeNetwork::diagnose_router] calls.
+    /// The request builder for [EdgeNetwork::diagnose_router][crate::client::EdgeNetwork::diagnose_router] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2312,7 +2312,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::create_router][super::super::client::EdgeNetwork::create_router] calls.
+    /// The request builder for [EdgeNetwork::create_router][crate::client::EdgeNetwork::create_router] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2357,7 +2357,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_router][super::super::client::EdgeNetwork::create_router].
+        /// on [create_router][crate::client::EdgeNetwork::create_router].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_router(self.0.request, self.0.options)
@@ -2450,7 +2450,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::update_router][super::super::client::EdgeNetwork::update_router] calls.
+    /// The request builder for [EdgeNetwork::update_router][crate::client::EdgeNetwork::update_router] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2495,7 +2495,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_router][super::super::client::EdgeNetwork::update_router].
+        /// on [update_router][crate::client::EdgeNetwork::update_router].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_router(self.0.request, self.0.options)
@@ -2594,7 +2594,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::delete_router][super::super::client::EdgeNetwork::delete_router] calls.
+    /// The request builder for [EdgeNetwork::delete_router][crate::client::EdgeNetwork::delete_router] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2639,7 +2639,7 @@ pub mod edge_network {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_router][super::super::client::EdgeNetwork::delete_router].
+        /// on [delete_router][crate::client::EdgeNetwork::delete_router].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_router(self.0.request, self.0.options)
@@ -2704,7 +2704,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_locations][super::super::client::EdgeNetwork::list_locations] calls.
+    /// The request builder for [EdgeNetwork::list_locations][crate::client::EdgeNetwork::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2814,7 +2814,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_location][super::super::client::EdgeNetwork::get_location] calls.
+    /// The request builder for [EdgeNetwork::get_location][crate::client::EdgeNetwork::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2875,7 +2875,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::list_operations][super::super::client::EdgeNetwork::list_operations] calls.
+    /// The request builder for [EdgeNetwork::list_operations][crate::client::EdgeNetwork::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2987,7 +2987,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::get_operation][super::super::client::EdgeNetwork::get_operation] calls.
+    /// The request builder for [EdgeNetwork::get_operation][crate::client::EdgeNetwork::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3051,7 +3051,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::delete_operation][super::super::client::EdgeNetwork::delete_operation] calls.
+    /// The request builder for [EdgeNetwork::delete_operation][crate::client::EdgeNetwork::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3115,7 +3115,7 @@ pub mod edge_network {
         }
     }
 
-    /// The request builder for [EdgeNetwork::cancel_operation][super::super::client::EdgeNetwork::cancel_operation] calls.
+    /// The request builder for [EdgeNetwork::cancel_operation][crate::client::EdgeNetwork::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/essentialcontacts/v1/src/builder.rs
+++ b/src/generated/cloud/essentialcontacts/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod essential_contacts_service {
     use crate::Result;
 
-    /// A builder for [EssentialContactsService][super::super::client::EssentialContactsService].
+    /// A builder for [EssentialContactsService][crate::client::EssentialContactsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EssentialContactsService] request builders.
+    /// Common implementation for [crate::client::EssentialContactsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EssentialContactsService>,
@@ -68,7 +68,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for [EssentialContactsService::create_contact][super::super::client::EssentialContactsService::create_contact] calls.
+    /// The request builder for [EssentialContactsService::create_contact][crate::client::EssentialContactsService::create_contact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -153,7 +153,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for [EssentialContactsService::update_contact][super::super::client::EssentialContactsService::update_contact] calls.
+    /// The request builder for [EssentialContactsService::update_contact][crate::client::EssentialContactsService::update_contact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -248,7 +248,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for [EssentialContactsService::list_contacts][super::super::client::EssentialContactsService::list_contacts] calls.
+    /// The request builder for [EssentialContactsService::list_contacts][crate::client::EssentialContactsService::list_contacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -351,7 +351,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for [EssentialContactsService::get_contact][super::super::client::EssentialContactsService::get_contact] calls.
+    /// The request builder for [EssentialContactsService::get_contact][crate::client::EssentialContactsService::get_contact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -414,7 +414,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for [EssentialContactsService::delete_contact][super::super::client::EssentialContactsService::delete_contact] calls.
+    /// The request builder for [EssentialContactsService::delete_contact][crate::client::EssentialContactsService::delete_contact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -477,7 +477,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for [EssentialContactsService::compute_contacts][super::super::client::EssentialContactsService::compute_contacts] calls.
+    /// The request builder for [EssentialContactsService::compute_contacts][crate::client::EssentialContactsService::compute_contacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -591,7 +591,7 @@ pub mod essential_contacts_service {
         }
     }
 
-    /// The request builder for [EssentialContactsService::send_test_message][super::super::client::EssentialContactsService::send_test_message] calls.
+    /// The request builder for [EssentialContactsService::send_test_message][crate::client::EssentialContactsService::send_test_message] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/eventarc/v1/src/builder.rs
+++ b/src/generated/cloud/eventarc/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod eventarc {
     use crate::Result;
 
-    /// A builder for [Eventarc][super::super::client::Eventarc].
+    /// A builder for [Eventarc][crate::client::Eventarc].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod eventarc {
         }
     }
 
-    /// Common implementation for [super::super::client::Eventarc] request builders.
+    /// Common implementation for [crate::client::Eventarc] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Eventarc>,
@@ -66,7 +66,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_trigger][super::super::client::Eventarc::get_trigger] calls.
+    /// The request builder for [Eventarc::get_trigger][crate::client::Eventarc::get_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -127,7 +127,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_triggers][super::super::client::Eventarc::list_triggers] calls.
+    /// The request builder for [Eventarc::list_triggers][crate::client::Eventarc::list_triggers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::create_trigger][super::super::client::Eventarc::create_trigger] calls.
+    /// The request builder for [Eventarc::create_trigger][crate::client::Eventarc::create_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -283,7 +283,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_trigger][super::super::client::Eventarc::create_trigger].
+        /// on [create_trigger][crate::client::Eventarc::create_trigger].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_trigger(self.0.request, self.0.options)
@@ -376,7 +376,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::update_trigger][super::super::client::Eventarc::update_trigger] calls.
+    /// The request builder for [Eventarc::update_trigger][crate::client::Eventarc::update_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -419,7 +419,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_trigger][super::super::client::Eventarc::update_trigger].
+        /// on [update_trigger][crate::client::Eventarc::update_trigger].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_trigger(self.0.request, self.0.options)
@@ -516,7 +516,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_trigger][super::super::client::Eventarc::delete_trigger] calls.
+    /// The request builder for [Eventarc::delete_trigger][crate::client::Eventarc::delete_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -559,7 +559,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_trigger][super::super::client::Eventarc::delete_trigger].
+        /// on [delete_trigger][crate::client::Eventarc::delete_trigger].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_trigger(self.0.request, self.0.options)
@@ -634,7 +634,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_channel][super::super::client::Eventarc::get_channel] calls.
+    /// The request builder for [Eventarc::get_channel][crate::client::Eventarc::get_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -695,7 +695,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_channels][super::super::client::Eventarc::list_channels] calls.
+    /// The request builder for [Eventarc::list_channels][crate::client::Eventarc::list_channels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -802,7 +802,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::create_channel][super::super::client::Eventarc::create_channel] calls.
+    /// The request builder for [Eventarc::create_channel][crate::client::Eventarc::create_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -845,7 +845,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_channel][super::super::client::Eventarc::create_channel].
+        /// on [create_channel][crate::client::Eventarc::create_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_channel(self.0.request, self.0.options)
@@ -938,7 +938,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::update_channel][super::super::client::Eventarc::update_channel] calls.
+    /// The request builder for [Eventarc::update_channel][crate::client::Eventarc::update_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -981,7 +981,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_channel][super::super::client::Eventarc::update_channel].
+        /// on [update_channel][crate::client::Eventarc::update_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_channel(self.0.request, self.0.options)
@@ -1072,7 +1072,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_channel][super::super::client::Eventarc::delete_channel] calls.
+    /// The request builder for [Eventarc::delete_channel][crate::client::Eventarc::delete_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1115,7 +1115,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_channel][super::super::client::Eventarc::delete_channel].
+        /// on [delete_channel][crate::client::Eventarc::delete_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_channel(self.0.request, self.0.options)
@@ -1178,7 +1178,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_provider][super::super::client::Eventarc::get_provider] calls.
+    /// The request builder for [Eventarc::get_provider][crate::client::Eventarc::get_provider] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1239,7 +1239,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_providers][super::super::client::Eventarc::list_providers] calls.
+    /// The request builder for [Eventarc::list_providers][crate::client::Eventarc::list_providers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1352,7 +1352,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_channel_connection][super::super::client::Eventarc::get_channel_connection] calls.
+    /// The request builder for [Eventarc::get_channel_connection][crate::client::Eventarc::get_channel_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1416,7 +1416,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_channel_connections][super::super::client::Eventarc::list_channel_connections] calls.
+    /// The request builder for [Eventarc::list_channel_connections][crate::client::Eventarc::list_channel_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1524,7 +1524,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::create_channel_connection][super::super::client::Eventarc::create_channel_connection] calls.
+    /// The request builder for [Eventarc::create_channel_connection][crate::client::Eventarc::create_channel_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1572,7 +1572,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_channel_connection][super::super::client::Eventarc::create_channel_connection].
+        /// on [create_channel_connection][crate::client::Eventarc::create_channel_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_channel_connection(self.0.request, self.0.options)
@@ -1662,7 +1662,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_channel_connection][super::super::client::Eventarc::delete_channel_connection] calls.
+    /// The request builder for [Eventarc::delete_channel_connection][crate::client::Eventarc::delete_channel_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1710,7 +1710,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_channel_connection][super::super::client::Eventarc::delete_channel_connection].
+        /// on [delete_channel_connection][crate::client::Eventarc::delete_channel_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_channel_connection(self.0.request, self.0.options)
@@ -1770,7 +1770,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_google_channel_config][super::super::client::Eventarc::get_google_channel_config] calls.
+    /// The request builder for [Eventarc::get_google_channel_config][crate::client::Eventarc::get_google_channel_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1834,7 +1834,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::update_google_channel_config][super::super::client::Eventarc::update_google_channel_config] calls.
+    /// The request builder for [Eventarc::update_google_channel_config][crate::client::Eventarc::update_google_channel_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1932,7 +1932,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_message_bus][super::super::client::Eventarc::get_message_bus] calls.
+    /// The request builder for [Eventarc::get_message_bus][crate::client::Eventarc::get_message_bus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1993,7 +1993,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_message_buses][super::super::client::Eventarc::list_message_buses] calls.
+    /// The request builder for [Eventarc::list_message_buses][crate::client::Eventarc::list_message_buses] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2109,7 +2109,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_message_bus_enrollments][super::super::client::Eventarc::list_message_bus_enrollments] calls.
+    /// The request builder for [Eventarc::list_message_bus_enrollments][crate::client::Eventarc::list_message_bus_enrollments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2187,7 +2187,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::create_message_bus][super::super::client::Eventarc::create_message_bus] calls.
+    /// The request builder for [Eventarc::create_message_bus][crate::client::Eventarc::create_message_bus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2233,7 +2233,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_message_bus][super::super::client::Eventarc::create_message_bus].
+        /// on [create_message_bus][crate::client::Eventarc::create_message_bus].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_message_bus(self.0.request, self.0.options)
@@ -2326,7 +2326,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::update_message_bus][super::super::client::Eventarc::update_message_bus] calls.
+    /// The request builder for [Eventarc::update_message_bus][crate::client::Eventarc::update_message_bus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2372,7 +2372,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_message_bus][super::super::client::Eventarc::update_message_bus].
+        /// on [update_message_bus][crate::client::Eventarc::update_message_bus].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_message_bus(self.0.request, self.0.options)
@@ -2473,7 +2473,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_message_bus][super::super::client::Eventarc::delete_message_bus] calls.
+    /// The request builder for [Eventarc::delete_message_bus][crate::client::Eventarc::delete_message_bus] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2519,7 +2519,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_message_bus][super::super::client::Eventarc::delete_message_bus].
+        /// on [delete_message_bus][crate::client::Eventarc::delete_message_bus].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_message_bus(self.0.request, self.0.options)
@@ -2594,7 +2594,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_enrollment][super::super::client::Eventarc::get_enrollment] calls.
+    /// The request builder for [Eventarc::get_enrollment][crate::client::Eventarc::get_enrollment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2655,7 +2655,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_enrollments][super::super::client::Eventarc::list_enrollments] calls.
+    /// The request builder for [Eventarc::list_enrollments][crate::client::Eventarc::list_enrollments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2768,7 +2768,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::create_enrollment][super::super::client::Eventarc::create_enrollment] calls.
+    /// The request builder for [Eventarc::create_enrollment][crate::client::Eventarc::create_enrollment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2814,7 +2814,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_enrollment][super::super::client::Eventarc::create_enrollment].
+        /// on [create_enrollment][crate::client::Eventarc::create_enrollment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_enrollment(self.0.request, self.0.options)
@@ -2907,7 +2907,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::update_enrollment][super::super::client::Eventarc::update_enrollment] calls.
+    /// The request builder for [Eventarc::update_enrollment][crate::client::Eventarc::update_enrollment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2953,7 +2953,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_enrollment][super::super::client::Eventarc::update_enrollment].
+        /// on [update_enrollment][crate::client::Eventarc::update_enrollment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_enrollment(self.0.request, self.0.options)
@@ -3054,7 +3054,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_enrollment][super::super::client::Eventarc::delete_enrollment] calls.
+    /// The request builder for [Eventarc::delete_enrollment][crate::client::Eventarc::delete_enrollment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3100,7 +3100,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_enrollment][super::super::client::Eventarc::delete_enrollment].
+        /// on [delete_enrollment][crate::client::Eventarc::delete_enrollment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_enrollment(self.0.request, self.0.options)
@@ -3175,7 +3175,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_pipeline][super::super::client::Eventarc::get_pipeline] calls.
+    /// The request builder for [Eventarc::get_pipeline][crate::client::Eventarc::get_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3236,7 +3236,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_pipelines][super::super::client::Eventarc::list_pipelines] calls.
+    /// The request builder for [Eventarc::list_pipelines][crate::client::Eventarc::list_pipelines] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3349,7 +3349,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::create_pipeline][super::super::client::Eventarc::create_pipeline] calls.
+    /// The request builder for [Eventarc::create_pipeline][crate::client::Eventarc::create_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3392,7 +3392,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_pipeline][super::super::client::Eventarc::create_pipeline].
+        /// on [create_pipeline][crate::client::Eventarc::create_pipeline].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_pipeline(self.0.request, self.0.options)
@@ -3485,7 +3485,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::update_pipeline][super::super::client::Eventarc::update_pipeline] calls.
+    /// The request builder for [Eventarc::update_pipeline][crate::client::Eventarc::update_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3528,7 +3528,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_pipeline][super::super::client::Eventarc::update_pipeline].
+        /// on [update_pipeline][crate::client::Eventarc::update_pipeline].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_pipeline(self.0.request, self.0.options)
@@ -3629,7 +3629,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_pipeline][super::super::client::Eventarc::delete_pipeline] calls.
+    /// The request builder for [Eventarc::delete_pipeline][crate::client::Eventarc::delete_pipeline] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3672,7 +3672,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_pipeline][super::super::client::Eventarc::delete_pipeline].
+        /// on [delete_pipeline][crate::client::Eventarc::delete_pipeline].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_pipeline(self.0.request, self.0.options)
@@ -3747,7 +3747,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_google_api_source][super::super::client::Eventarc::get_google_api_source] calls.
+    /// The request builder for [Eventarc::get_google_api_source][crate::client::Eventarc::get_google_api_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3811,7 +3811,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_google_api_sources][super::super::client::Eventarc::list_google_api_sources] calls.
+    /// The request builder for [Eventarc::list_google_api_sources][crate::client::Eventarc::list_google_api_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3929,7 +3929,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::create_google_api_source][super::super::client::Eventarc::create_google_api_source] calls.
+    /// The request builder for [Eventarc::create_google_api_source][crate::client::Eventarc::create_google_api_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3975,7 +3975,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_google_api_source][super::super::client::Eventarc::create_google_api_source].
+        /// on [create_google_api_source][crate::client::Eventarc::create_google_api_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_google_api_source(self.0.request, self.0.options)
@@ -4071,7 +4071,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::update_google_api_source][super::super::client::Eventarc::update_google_api_source] calls.
+    /// The request builder for [Eventarc::update_google_api_source][crate::client::Eventarc::update_google_api_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4117,7 +4117,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_google_api_source][super::super::client::Eventarc::update_google_api_source].
+        /// on [update_google_api_source][crate::client::Eventarc::update_google_api_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_google_api_source(self.0.request, self.0.options)
@@ -4221,7 +4221,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_google_api_source][super::super::client::Eventarc::delete_google_api_source] calls.
+    /// The request builder for [Eventarc::delete_google_api_source][crate::client::Eventarc::delete_google_api_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4267,7 +4267,7 @@ pub mod eventarc {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_google_api_source][super::super::client::Eventarc::delete_google_api_source].
+        /// on [delete_google_api_source][crate::client::Eventarc::delete_google_api_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_google_api_source(self.0.request, self.0.options)
@@ -4345,7 +4345,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_locations][super::super::client::Eventarc::list_locations] calls.
+    /// The request builder for [Eventarc::list_locations][crate::client::Eventarc::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4453,7 +4453,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_location][super::super::client::Eventarc::get_location] calls.
+    /// The request builder for [Eventarc::get_location][crate::client::Eventarc::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4512,7 +4512,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::set_iam_policy][super::super::client::Eventarc::set_iam_policy] calls.
+    /// The request builder for [Eventarc::set_iam_policy][crate::client::Eventarc::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4613,7 +4613,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_iam_policy][super::super::client::Eventarc::get_iam_policy] calls.
+    /// The request builder for [Eventarc::get_iam_policy][crate::client::Eventarc::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4692,7 +4692,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::test_iam_permissions][super::super::client::Eventarc::test_iam_permissions] calls.
+    /// The request builder for [Eventarc::test_iam_permissions][crate::client::Eventarc::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4769,7 +4769,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::list_operations][super::super::client::Eventarc::list_operations] calls.
+    /// The request builder for [Eventarc::list_operations][crate::client::Eventarc::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4879,7 +4879,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::get_operation][super::super::client::Eventarc::get_operation] calls.
+    /// The request builder for [Eventarc::get_operation][crate::client::Eventarc::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4941,7 +4941,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::delete_operation][super::super::client::Eventarc::delete_operation] calls.
+    /// The request builder for [Eventarc::delete_operation][crate::client::Eventarc::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5003,7 +5003,7 @@ pub mod eventarc {
         }
     }
 
-    /// The request builder for [Eventarc::cancel_operation][super::super::client::Eventarc::cancel_operation] calls.
+    /// The request builder for [Eventarc::cancel_operation][crate::client::Eventarc::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/filestore/v1/src/builder.rs
+++ b/src/generated/cloud/filestore/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_filestore_manager {
     use crate::Result;
 
-    /// A builder for [CloudFilestoreManager][super::super::client::CloudFilestoreManager].
+    /// A builder for [CloudFilestoreManager][crate::client::CloudFilestoreManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudFilestoreManager] request builders.
+    /// Common implementation for [crate::client::CloudFilestoreManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudFilestoreManager>,
@@ -68,7 +68,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::list_instances][super::super::client::CloudFilestoreManager::list_instances] calls.
+    /// The request builder for [CloudFilestoreManager::list_instances][crate::client::CloudFilestoreManager::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::get_instance][super::super::client::CloudFilestoreManager::get_instance] calls.
+    /// The request builder for [CloudFilestoreManager::get_instance][crate::client::CloudFilestoreManager::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::create_instance][super::super::client::CloudFilestoreManager::create_instance] calls.
+    /// The request builder for [CloudFilestoreManager::create_instance][crate::client::CloudFilestoreManager::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::CloudFilestoreManager::create_instance].
+        /// on [create_instance][crate::client::CloudFilestoreManager::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -381,7 +381,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::update_instance][super::super::client::CloudFilestoreManager::update_instance] calls.
+    /// The request builder for [CloudFilestoreManager::update_instance][crate::client::CloudFilestoreManager::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -426,7 +426,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::CloudFilestoreManager::update_instance].
+        /// on [update_instance][crate::client::CloudFilestoreManager::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -514,7 +514,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::restore_instance][super::super::client::CloudFilestoreManager::restore_instance] calls.
+    /// The request builder for [CloudFilestoreManager::restore_instance][crate::client::CloudFilestoreManager::restore_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -559,7 +559,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_instance][super::super::client::CloudFilestoreManager::restore_instance].
+        /// on [restore_instance][crate::client::CloudFilestoreManager::restore_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_instance(self.0.request, self.0.options)
@@ -652,7 +652,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::revert_instance][super::super::client::CloudFilestoreManager::revert_instance] calls.
+    /// The request builder for [CloudFilestoreManager::revert_instance][crate::client::CloudFilestoreManager::revert_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -697,7 +697,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [revert_instance][super::super::client::CloudFilestoreManager::revert_instance].
+        /// on [revert_instance][crate::client::CloudFilestoreManager::revert_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .revert_instance(self.0.request, self.0.options)
@@ -765,7 +765,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::delete_instance][super::super::client::CloudFilestoreManager::delete_instance] calls.
+    /// The request builder for [CloudFilestoreManager::delete_instance][crate::client::CloudFilestoreManager::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -810,7 +810,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::CloudFilestoreManager::delete_instance].
+        /// on [delete_instance][crate::client::CloudFilestoreManager::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -876,7 +876,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::list_snapshots][super::super::client::CloudFilestoreManager::list_snapshots] calls.
+    /// The request builder for [CloudFilestoreManager::list_snapshots][crate::client::CloudFilestoreManager::list_snapshots] calls.
     ///
     /// # Example
     /// ```no_run
@@ -997,7 +997,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::get_snapshot][super::super::client::CloudFilestoreManager::get_snapshot] calls.
+    /// The request builder for [CloudFilestoreManager::get_snapshot][crate::client::CloudFilestoreManager::get_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1060,7 +1060,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::create_snapshot][super::super::client::CloudFilestoreManager::create_snapshot] calls.
+    /// The request builder for [CloudFilestoreManager::create_snapshot][crate::client::CloudFilestoreManager::create_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1105,7 +1105,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_snapshot][super::super::client::CloudFilestoreManager::create_snapshot].
+        /// on [create_snapshot][crate::client::CloudFilestoreManager::create_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_snapshot(self.0.request, self.0.options)
@@ -1195,7 +1195,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::delete_snapshot][super::super::client::CloudFilestoreManager::delete_snapshot] calls.
+    /// The request builder for [CloudFilestoreManager::delete_snapshot][crate::client::CloudFilestoreManager::delete_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1240,7 +1240,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_snapshot][super::super::client::CloudFilestoreManager::delete_snapshot].
+        /// on [delete_snapshot][crate::client::CloudFilestoreManager::delete_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_snapshot(self.0.request, self.0.options)
@@ -1300,7 +1300,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::update_snapshot][super::super::client::CloudFilestoreManager::update_snapshot] calls.
+    /// The request builder for [CloudFilestoreManager::update_snapshot][crate::client::CloudFilestoreManager::update_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1345,7 +1345,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_snapshot][super::super::client::CloudFilestoreManager::update_snapshot].
+        /// on [update_snapshot][crate::client::CloudFilestoreManager::update_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_snapshot(self.0.request, self.0.options)
@@ -1441,7 +1441,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::list_backups][super::super::client::CloudFilestoreManager::list_backups] calls.
+    /// The request builder for [CloudFilestoreManager::list_backups][crate::client::CloudFilestoreManager::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1556,7 +1556,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::get_backup][super::super::client::CloudFilestoreManager::get_backup] calls.
+    /// The request builder for [CloudFilestoreManager::get_backup][crate::client::CloudFilestoreManager::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1619,7 +1619,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::create_backup][super::super::client::CloudFilestoreManager::create_backup] calls.
+    /// The request builder for [CloudFilestoreManager::create_backup][crate::client::CloudFilestoreManager::create_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1664,7 +1664,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup][super::super::client::CloudFilestoreManager::create_backup].
+        /// on [create_backup][crate::client::CloudFilestoreManager::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
@@ -1754,7 +1754,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::delete_backup][super::super::client::CloudFilestoreManager::delete_backup] calls.
+    /// The request builder for [CloudFilestoreManager::delete_backup][crate::client::CloudFilestoreManager::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1799,7 +1799,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::CloudFilestoreManager::delete_backup].
+        /// on [delete_backup][crate::client::CloudFilestoreManager::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -1859,7 +1859,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::update_backup][super::super::client::CloudFilestoreManager::update_backup] calls.
+    /// The request builder for [CloudFilestoreManager::update_backup][crate::client::CloudFilestoreManager::update_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1904,7 +1904,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup][super::super::client::CloudFilestoreManager::update_backup].
+        /// on [update_backup][crate::client::CloudFilestoreManager::update_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup(self.0.request, self.0.options)
@@ -2000,7 +2000,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::promote_replica][super::super::client::CloudFilestoreManager::promote_replica] calls.
+    /// The request builder for [CloudFilestoreManager::promote_replica][crate::client::CloudFilestoreManager::promote_replica] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2045,7 +2045,7 @@ pub mod cloud_filestore_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [promote_replica][super::super::client::CloudFilestoreManager::promote_replica].
+        /// on [promote_replica][crate::client::CloudFilestoreManager::promote_replica].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .promote_replica(self.0.request, self.0.options)
@@ -2111,7 +2111,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::list_locations][super::super::client::CloudFilestoreManager::list_locations] calls.
+    /// The request builder for [CloudFilestoreManager::list_locations][crate::client::CloudFilestoreManager::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2221,7 +2221,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::get_location][super::super::client::CloudFilestoreManager::get_location] calls.
+    /// The request builder for [CloudFilestoreManager::get_location][crate::client::CloudFilestoreManager::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2282,7 +2282,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::list_operations][super::super::client::CloudFilestoreManager::list_operations] calls.
+    /// The request builder for [CloudFilestoreManager::list_operations][crate::client::CloudFilestoreManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2394,7 +2394,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::get_operation][super::super::client::CloudFilestoreManager::get_operation] calls.
+    /// The request builder for [CloudFilestoreManager::get_operation][crate::client::CloudFilestoreManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2458,7 +2458,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::delete_operation][super::super::client::CloudFilestoreManager::delete_operation] calls.
+    /// The request builder for [CloudFilestoreManager::delete_operation][crate::client::CloudFilestoreManager::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2522,7 +2522,7 @@ pub mod cloud_filestore_manager {
         }
     }
 
-    /// The request builder for [CloudFilestoreManager::cancel_operation][super::super::client::CloudFilestoreManager::cancel_operation] calls.
+    /// The request builder for [CloudFilestoreManager::cancel_operation][crate::client::CloudFilestoreManager::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/financialservices/v1/src/builder.rs
+++ b/src/generated/cloud/financialservices/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod aml {
     use crate::Result;
 
-    /// A builder for [Aml][super::super::client::Aml].
+    /// A builder for [Aml][crate::client::Aml].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod aml {
         }
     }
 
-    /// Common implementation for [super::super::client::Aml] request builders.
+    /// Common implementation for [crate::client::Aml] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Aml>,
@@ -66,7 +66,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_instances][super::super::client::Aml::list_instances] calls.
+    /// The request builder for [Aml::list_instances][crate::client::Aml::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -179,7 +179,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_instance][super::super::client::Aml::get_instance] calls.
+    /// The request builder for [Aml::get_instance][crate::client::Aml::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::create_instance][super::super::client::Aml::create_instance] calls.
+    /// The request builder for [Aml::create_instance][crate::client::Aml::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -283,7 +283,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::Aml::create_instance].
+        /// on [create_instance][crate::client::Aml::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -376,7 +376,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::update_instance][super::super::client::Aml::update_instance] calls.
+    /// The request builder for [Aml::update_instance][crate::client::Aml::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -419,7 +419,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::Aml::update_instance].
+        /// on [update_instance][crate::client::Aml::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -514,7 +514,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::delete_instance][super::super::client::Aml::delete_instance] calls.
+    /// The request builder for [Aml::delete_instance][crate::client::Aml::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -557,7 +557,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::Aml::delete_instance].
+        /// on [delete_instance][crate::client::Aml::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -622,7 +622,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::import_registered_parties][super::super::client::Aml::import_registered_parties] calls.
+    /// The request builder for [Aml::import_registered_parties][crate::client::Aml::import_registered_parties] calls.
     ///
     /// # Example
     /// ```no_run
@@ -670,7 +670,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_registered_parties][super::super::client::Aml::import_registered_parties].
+        /// on [import_registered_parties][crate::client::Aml::import_registered_parties].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_registered_parties(self.0.request, self.0.options)
@@ -768,7 +768,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::export_registered_parties][super::super::client::Aml::export_registered_parties] calls.
+    /// The request builder for [Aml::export_registered_parties][crate::client::Aml::export_registered_parties] calls.
     ///
     /// # Example
     /// ```no_run
@@ -816,7 +816,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_registered_parties][super::super::client::Aml::export_registered_parties].
+        /// on [export_registered_parties][crate::client::Aml::export_registered_parties].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_registered_parties(self.0.request, self.0.options)
@@ -908,7 +908,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_datasets][super::super::client::Aml::list_datasets] calls.
+    /// The request builder for [Aml::list_datasets][crate::client::Aml::list_datasets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1021,7 +1021,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_dataset][super::super::client::Aml::get_dataset] calls.
+    /// The request builder for [Aml::get_dataset][crate::client::Aml::get_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1082,7 +1082,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::create_dataset][super::super::client::Aml::create_dataset] calls.
+    /// The request builder for [Aml::create_dataset][crate::client::Aml::create_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1125,7 +1125,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_dataset][super::super::client::Aml::create_dataset].
+        /// on [create_dataset][crate::client::Aml::create_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_dataset(self.0.request, self.0.options)
@@ -1218,7 +1218,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::update_dataset][super::super::client::Aml::update_dataset] calls.
+    /// The request builder for [Aml::update_dataset][crate::client::Aml::update_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1261,7 +1261,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_dataset][super::super::client::Aml::update_dataset].
+        /// on [update_dataset][crate::client::Aml::update_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_dataset(self.0.request, self.0.options)
@@ -1356,7 +1356,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::delete_dataset][super::super::client::Aml::delete_dataset] calls.
+    /// The request builder for [Aml::delete_dataset][crate::client::Aml::delete_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1399,7 +1399,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_dataset][super::super::client::Aml::delete_dataset].
+        /// on [delete_dataset][crate::client::Aml::delete_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_dataset(self.0.request, self.0.options)
@@ -1464,7 +1464,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_models][super::super::client::Aml::list_models] calls.
+    /// The request builder for [Aml::list_models][crate::client::Aml::list_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1577,7 +1577,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_model][super::super::client::Aml::get_model] calls.
+    /// The request builder for [Aml::get_model][crate::client::Aml::get_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1638,7 +1638,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::create_model][super::super::client::Aml::create_model] calls.
+    /// The request builder for [Aml::create_model][crate::client::Aml::create_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1681,7 +1681,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_model][super::super::client::Aml::create_model].
+        /// on [create_model][crate::client::Aml::create_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_model(self.0.request, self.0.options)
@@ -1774,7 +1774,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::update_model][super::super::client::Aml::update_model] calls.
+    /// The request builder for [Aml::update_model][crate::client::Aml::update_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1817,7 +1817,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_model][super::super::client::Aml::update_model].
+        /// on [update_model][crate::client::Aml::update_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_model(self.0.request, self.0.options)
@@ -1912,7 +1912,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::export_model_metadata][super::super::client::Aml::export_model_metadata] calls.
+    /// The request builder for [Aml::export_model_metadata][crate::client::Aml::export_model_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1958,7 +1958,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_model_metadata][super::super::client::Aml::export_model_metadata].
+        /// on [export_model_metadata][crate::client::Aml::export_model_metadata].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_model_metadata(self.0.request, self.0.options)
@@ -2043,7 +2043,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::delete_model][super::super::client::Aml::delete_model] calls.
+    /// The request builder for [Aml::delete_model][crate::client::Aml::delete_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2086,7 +2086,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_model][super::super::client::Aml::delete_model].
+        /// on [delete_model][crate::client::Aml::delete_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_model(self.0.request, self.0.options)
@@ -2151,7 +2151,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_engine_configs][super::super::client::Aml::list_engine_configs] calls.
+    /// The request builder for [Aml::list_engine_configs][crate::client::Aml::list_engine_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2267,7 +2267,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_engine_config][super::super::client::Aml::get_engine_config] calls.
+    /// The request builder for [Aml::get_engine_config][crate::client::Aml::get_engine_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2328,7 +2328,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::create_engine_config][super::super::client::Aml::create_engine_config] calls.
+    /// The request builder for [Aml::create_engine_config][crate::client::Aml::create_engine_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2374,7 +2374,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_engine_config][super::super::client::Aml::create_engine_config].
+        /// on [create_engine_config][crate::client::Aml::create_engine_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_engine_config(self.0.request, self.0.options)
@@ -2469,7 +2469,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::update_engine_config][super::super::client::Aml::update_engine_config] calls.
+    /// The request builder for [Aml::update_engine_config][crate::client::Aml::update_engine_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2515,7 +2515,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_engine_config][super::super::client::Aml::update_engine_config].
+        /// on [update_engine_config][crate::client::Aml::update_engine_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_engine_config(self.0.request, self.0.options)
@@ -2612,7 +2612,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::export_engine_config_metadata][super::super::client::Aml::export_engine_config_metadata] calls.
+    /// The request builder for [Aml::export_engine_config_metadata][crate::client::Aml::export_engine_config_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2660,7 +2660,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_engine_config_metadata][super::super::client::Aml::export_engine_config_metadata].
+        /// on [export_engine_config_metadata][crate::client::Aml::export_engine_config_metadata].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_engine_config_metadata(self.0.request, self.0.options)
@@ -2747,7 +2747,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::delete_engine_config][super::super::client::Aml::delete_engine_config] calls.
+    /// The request builder for [Aml::delete_engine_config][crate::client::Aml::delete_engine_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2793,7 +2793,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_engine_config][super::super::client::Aml::delete_engine_config].
+        /// on [delete_engine_config][crate::client::Aml::delete_engine_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_engine_config(self.0.request, self.0.options)
@@ -2858,7 +2858,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_engine_version][super::super::client::Aml::get_engine_version] calls.
+    /// The request builder for [Aml::get_engine_version][crate::client::Aml::get_engine_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2922,7 +2922,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_engine_versions][super::super::client::Aml::list_engine_versions] calls.
+    /// The request builder for [Aml::list_engine_versions][crate::client::Aml::list_engine_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3040,7 +3040,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_prediction_results][super::super::client::Aml::list_prediction_results] calls.
+    /// The request builder for [Aml::list_prediction_results][crate::client::Aml::list_prediction_results] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3158,7 +3158,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_prediction_result][super::super::client::Aml::get_prediction_result] calls.
+    /// The request builder for [Aml::get_prediction_result][crate::client::Aml::get_prediction_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3222,7 +3222,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::create_prediction_result][super::super::client::Aml::create_prediction_result] calls.
+    /// The request builder for [Aml::create_prediction_result][crate::client::Aml::create_prediction_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3268,7 +3268,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_prediction_result][super::super::client::Aml::create_prediction_result].
+        /// on [create_prediction_result][crate::client::Aml::create_prediction_result].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_prediction_result(self.0.request, self.0.options)
@@ -3364,7 +3364,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::update_prediction_result][super::super::client::Aml::update_prediction_result] calls.
+    /// The request builder for [Aml::update_prediction_result][crate::client::Aml::update_prediction_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3410,7 +3410,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_prediction_result][super::super::client::Aml::update_prediction_result].
+        /// on [update_prediction_result][crate::client::Aml::update_prediction_result].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_prediction_result(self.0.request, self.0.options)
@@ -3508,7 +3508,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::export_prediction_result_metadata][super::super::client::Aml::export_prediction_result_metadata] calls.
+    /// The request builder for [Aml::export_prediction_result_metadata][crate::client::Aml::export_prediction_result_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3556,7 +3556,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_prediction_result_metadata][super::super::client::Aml::export_prediction_result_metadata].
+        /// on [export_prediction_result_metadata][crate::client::Aml::export_prediction_result_metadata].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_prediction_result_metadata(self.0.request, self.0.options)
@@ -3643,7 +3643,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::delete_prediction_result][super::super::client::Aml::delete_prediction_result] calls.
+    /// The request builder for [Aml::delete_prediction_result][crate::client::Aml::delete_prediction_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3689,7 +3689,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_prediction_result][super::super::client::Aml::delete_prediction_result].
+        /// on [delete_prediction_result][crate::client::Aml::delete_prediction_result].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_prediction_result(self.0.request, self.0.options)
@@ -3754,7 +3754,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_backtest_results][super::super::client::Aml::list_backtest_results] calls.
+    /// The request builder for [Aml::list_backtest_results][crate::client::Aml::list_backtest_results] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3872,7 +3872,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_backtest_result][super::super::client::Aml::get_backtest_result] calls.
+    /// The request builder for [Aml::get_backtest_result][crate::client::Aml::get_backtest_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3936,7 +3936,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::create_backtest_result][super::super::client::Aml::create_backtest_result] calls.
+    /// The request builder for [Aml::create_backtest_result][crate::client::Aml::create_backtest_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3982,7 +3982,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backtest_result][super::super::client::Aml::create_backtest_result].
+        /// on [create_backtest_result][crate::client::Aml::create_backtest_result].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backtest_result(self.0.request, self.0.options)
@@ -4078,7 +4078,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::update_backtest_result][super::super::client::Aml::update_backtest_result] calls.
+    /// The request builder for [Aml::update_backtest_result][crate::client::Aml::update_backtest_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4124,7 +4124,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backtest_result][super::super::client::Aml::update_backtest_result].
+        /// on [update_backtest_result][crate::client::Aml::update_backtest_result].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backtest_result(self.0.request, self.0.options)
@@ -4222,7 +4222,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::export_backtest_result_metadata][super::super::client::Aml::export_backtest_result_metadata] calls.
+    /// The request builder for [Aml::export_backtest_result_metadata][crate::client::Aml::export_backtest_result_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4270,7 +4270,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_backtest_result_metadata][super::super::client::Aml::export_backtest_result_metadata].
+        /// on [export_backtest_result_metadata][crate::client::Aml::export_backtest_result_metadata].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_backtest_result_metadata(self.0.request, self.0.options)
@@ -4357,7 +4357,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::delete_backtest_result][super::super::client::Aml::delete_backtest_result] calls.
+    /// The request builder for [Aml::delete_backtest_result][crate::client::Aml::delete_backtest_result] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4403,7 +4403,7 @@ pub mod aml {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backtest_result][super::super::client::Aml::delete_backtest_result].
+        /// on [delete_backtest_result][crate::client::Aml::delete_backtest_result].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backtest_result(self.0.request, self.0.options)
@@ -4468,7 +4468,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_locations][super::super::client::Aml::list_locations] calls.
+    /// The request builder for [Aml::list_locations][crate::client::Aml::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4576,7 +4576,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_location][super::super::client::Aml::get_location] calls.
+    /// The request builder for [Aml::get_location][crate::client::Aml::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4635,7 +4635,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::list_operations][super::super::client::Aml::list_operations] calls.
+    /// The request builder for [Aml::list_operations][crate::client::Aml::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4745,7 +4745,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::get_operation][super::super::client::Aml::get_operation] calls.
+    /// The request builder for [Aml::get_operation][crate::client::Aml::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4807,7 +4807,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::delete_operation][super::super::client::Aml::delete_operation] calls.
+    /// The request builder for [Aml::delete_operation][crate::client::Aml::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4869,7 +4869,7 @@ pub mod aml {
         }
     }
 
-    /// The request builder for [Aml::cancel_operation][super::super::client::Aml::cancel_operation] calls.
+    /// The request builder for [Aml::cancel_operation][crate::client::Aml::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/functions/v2/src/builder.rs
+++ b/src/generated/cloud/functions/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod function_service {
     use crate::Result;
 
-    /// A builder for [FunctionService][super::super::client::FunctionService].
+    /// A builder for [FunctionService][crate::client::FunctionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod function_service {
         }
     }
 
-    /// Common implementation for [super::super::client::FunctionService] request builders.
+    /// Common implementation for [crate::client::FunctionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FunctionService>,
@@ -68,7 +68,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::get_function][super::super::client::FunctionService::get_function] calls.
+    /// The request builder for [FunctionService::get_function][crate::client::FunctionService::get_function] calls.
     ///
     /// # Example
     /// ```no_run
@@ -137,7 +137,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::list_functions][super::super::client::FunctionService::list_functions] calls.
+    /// The request builder for [FunctionService::list_functions][crate::client::FunctionService::list_functions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::create_function][super::super::client::FunctionService::create_function] calls.
+    /// The request builder for [FunctionService::create_function][crate::client::FunctionService::create_function] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod function_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_function][super::super::client::FunctionService::create_function].
+        /// on [create_function][crate::client::FunctionService::create_function].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_function(self.0.request, self.0.options)
@@ -382,7 +382,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::update_function][super::super::client::FunctionService::update_function] calls.
+    /// The request builder for [FunctionService::update_function][crate::client::FunctionService::update_function] calls.
     ///
     /// # Example
     /// ```no_run
@@ -427,7 +427,7 @@ pub mod function_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_function][super::super::client::FunctionService::update_function].
+        /// on [update_function][crate::client::FunctionService::update_function].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_function(self.0.request, self.0.options)
@@ -516,7 +516,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::delete_function][super::super::client::FunctionService::delete_function] calls.
+    /// The request builder for [FunctionService::delete_function][crate::client::FunctionService::delete_function] calls.
     ///
     /// # Example
     /// ```no_run
@@ -561,7 +561,7 @@ pub mod function_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_function][super::super::client::FunctionService::delete_function].
+        /// on [delete_function][crate::client::FunctionService::delete_function].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_function(self.0.request, self.0.options)
@@ -620,7 +620,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::generate_upload_url][super::super::client::FunctionService::generate_upload_url] calls.
+    /// The request builder for [FunctionService::generate_upload_url][crate::client::FunctionService::generate_upload_url] calls.
     ///
     /// # Example
     /// ```no_run
@@ -698,7 +698,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::generate_download_url][super::super::client::FunctionService::generate_download_url] calls.
+    /// The request builder for [FunctionService::generate_download_url][crate::client::FunctionService::generate_download_url] calls.
     ///
     /// # Example
     /// ```no_run
@@ -764,7 +764,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::list_runtimes][super::super::client::FunctionService::list_runtimes] calls.
+    /// The request builder for [FunctionService::list_runtimes][crate::client::FunctionService::list_runtimes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -833,7 +833,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::list_locations][super::super::client::FunctionService::list_locations] calls.
+    /// The request builder for [FunctionService::list_locations][crate::client::FunctionService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -943,7 +943,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::set_iam_policy][super::super::client::FunctionService::set_iam_policy] calls.
+    /// The request builder for [FunctionService::set_iam_policy][crate::client::FunctionService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1046,7 +1046,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::get_iam_policy][super::super::client::FunctionService::get_iam_policy] calls.
+    /// The request builder for [FunctionService::get_iam_policy][crate::client::FunctionService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1127,7 +1127,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::test_iam_permissions][super::super::client::FunctionService::test_iam_permissions] calls.
+    /// The request builder for [FunctionService::test_iam_permissions][crate::client::FunctionService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1206,7 +1206,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::list_operations][super::super::client::FunctionService::list_operations] calls.
+    /// The request builder for [FunctionService::list_operations][crate::client::FunctionService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1318,7 +1318,7 @@ pub mod function_service {
         }
     }
 
-    /// The request builder for [FunctionService::get_operation][super::super::client::FunctionService::get_operation] calls.
+    /// The request builder for [FunctionService::get_operation][crate::client::FunctionService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/gkebackup/v1/src/builder.rs
+++ b/src/generated/cloud/gkebackup/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod backup_for_gke {
     use crate::Result;
 
-    /// A builder for [BackupForGKE][super::super::client::BackupForGKE].
+    /// A builder for [BackupForGKE][crate::client::BackupForGKE].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// Common implementation for [super::super::client::BackupForGKE] request builders.
+    /// Common implementation for [crate::client::BackupForGKE] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::BackupForGKE>,
@@ -68,7 +68,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::create_backup_plan][super::super::client::BackupForGKE::create_backup_plan] calls.
+    /// The request builder for [BackupForGKE::create_backup_plan][crate::client::BackupForGKE::create_backup_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -116,7 +116,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup_plan][super::super::client::BackupForGKE::create_backup_plan].
+        /// on [create_backup_plan][crate::client::BackupForGKE::create_backup_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup_plan(self.0.request, self.0.options)
@@ -203,7 +203,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_backup_plans][super::super::client::BackupForGKE::list_backup_plans] calls.
+    /// The request builder for [BackupForGKE::list_backup_plans][crate::client::BackupForGKE::list_backup_plans] calls.
     ///
     /// # Example
     /// ```no_run
@@ -318,7 +318,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_backup_plan][super::super::client::BackupForGKE::get_backup_plan] calls.
+    /// The request builder for [BackupForGKE::get_backup_plan][crate::client::BackupForGKE::get_backup_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -381,7 +381,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::update_backup_plan][super::super::client::BackupForGKE::update_backup_plan] calls.
+    /// The request builder for [BackupForGKE::update_backup_plan][crate::client::BackupForGKE::update_backup_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup_plan][super::super::client::BackupForGKE::update_backup_plan].
+        /// on [update_backup_plan][crate::client::BackupForGKE::update_backup_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup_plan(self.0.request, self.0.options)
@@ -518,7 +518,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::delete_backup_plan][super::super::client::BackupForGKE::delete_backup_plan] calls.
+    /// The request builder for [BackupForGKE::delete_backup_plan][crate::client::BackupForGKE::delete_backup_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -566,7 +566,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup_plan][super::super::client::BackupForGKE::delete_backup_plan].
+        /// on [delete_backup_plan][crate::client::BackupForGKE::delete_backup_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup_plan(self.0.request, self.0.options)
@@ -631,7 +631,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::create_backup_channel][super::super::client::BackupForGKE::create_backup_channel] calls.
+    /// The request builder for [BackupForGKE::create_backup_channel][crate::client::BackupForGKE::create_backup_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -679,7 +679,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup_channel][super::super::client::BackupForGKE::create_backup_channel].
+        /// on [create_backup_channel][crate::client::BackupForGKE::create_backup_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup_channel(self.0.request, self.0.options)
@@ -767,7 +767,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_backup_channels][super::super::client::BackupForGKE::list_backup_channels] calls.
+    /// The request builder for [BackupForGKE::list_backup_channels][crate::client::BackupForGKE::list_backup_channels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -887,7 +887,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_backup_channel][super::super::client::BackupForGKE::get_backup_channel] calls.
+    /// The request builder for [BackupForGKE::get_backup_channel][crate::client::BackupForGKE::get_backup_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -953,7 +953,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::update_backup_channel][super::super::client::BackupForGKE::update_backup_channel] calls.
+    /// The request builder for [BackupForGKE::update_backup_channel][crate::client::BackupForGKE::update_backup_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1001,7 +1001,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup_channel][super::super::client::BackupForGKE::update_backup_channel].
+        /// on [update_backup_channel][crate::client::BackupForGKE::update_backup_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup_channel(self.0.request, self.0.options)
@@ -1093,7 +1093,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::delete_backup_channel][super::super::client::BackupForGKE::delete_backup_channel] calls.
+    /// The request builder for [BackupForGKE::delete_backup_channel][crate::client::BackupForGKE::delete_backup_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1141,7 +1141,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup_channel][super::super::client::BackupForGKE::delete_backup_channel].
+        /// on [delete_backup_channel][crate::client::BackupForGKE::delete_backup_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup_channel(self.0.request, self.0.options)
@@ -1212,7 +1212,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_backup_plan_bindings][super::super::client::BackupForGKE::list_backup_plan_bindings] calls.
+    /// The request builder for [BackupForGKE::list_backup_plan_bindings][crate::client::BackupForGKE::list_backup_plan_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1334,7 +1334,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_backup_plan_binding][super::super::client::BackupForGKE::get_backup_plan_binding] calls.
+    /// The request builder for [BackupForGKE::get_backup_plan_binding][crate::client::BackupForGKE::get_backup_plan_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1400,7 +1400,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::create_backup][super::super::client::BackupForGKE::create_backup] calls.
+    /// The request builder for [BackupForGKE::create_backup][crate::client::BackupForGKE::create_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1445,7 +1445,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup][super::super::client::BackupForGKE::create_backup].
+        /// on [create_backup][crate::client::BackupForGKE::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
@@ -1526,7 +1526,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_backups][super::super::client::BackupForGKE::list_backups] calls.
+    /// The request builder for [BackupForGKE::list_backups][crate::client::BackupForGKE::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1647,7 +1647,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_backup][super::super::client::BackupForGKE::get_backup] calls.
+    /// The request builder for [BackupForGKE::get_backup][crate::client::BackupForGKE::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1710,7 +1710,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::update_backup][super::super::client::BackupForGKE::update_backup] calls.
+    /// The request builder for [BackupForGKE::update_backup][crate::client::BackupForGKE::update_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1755,7 +1755,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup][super::super::client::BackupForGKE::update_backup].
+        /// on [update_backup][crate::client::BackupForGKE::update_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup(self.0.request, self.0.options)
@@ -1844,7 +1844,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::delete_backup][super::super::client::BackupForGKE::delete_backup] calls.
+    /// The request builder for [BackupForGKE::delete_backup][crate::client::BackupForGKE::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1889,7 +1889,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::BackupForGKE::delete_backup].
+        /// on [delete_backup][crate::client::BackupForGKE::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -1960,7 +1960,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_volume_backups][super::super::client::BackupForGKE::list_volume_backups] calls.
+    /// The request builder for [BackupForGKE::list_volume_backups][crate::client::BackupForGKE::list_volume_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2078,7 +2078,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_volume_backup][super::super::client::BackupForGKE::get_volume_backup] calls.
+    /// The request builder for [BackupForGKE::get_volume_backup][crate::client::BackupForGKE::get_volume_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2141,7 +2141,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::create_restore_plan][super::super::client::BackupForGKE::create_restore_plan] calls.
+    /// The request builder for [BackupForGKE::create_restore_plan][crate::client::BackupForGKE::create_restore_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2189,7 +2189,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_restore_plan][super::super::client::BackupForGKE::create_restore_plan].
+        /// on [create_restore_plan][crate::client::BackupForGKE::create_restore_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_restore_plan(self.0.request, self.0.options)
@@ -2278,7 +2278,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_restore_plans][super::super::client::BackupForGKE::list_restore_plans] calls.
+    /// The request builder for [BackupForGKE::list_restore_plans][crate::client::BackupForGKE::list_restore_plans] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2396,7 +2396,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_restore_plan][super::super::client::BackupForGKE::get_restore_plan] calls.
+    /// The request builder for [BackupForGKE::get_restore_plan][crate::client::BackupForGKE::get_restore_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2459,7 +2459,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::update_restore_plan][super::super::client::BackupForGKE::update_restore_plan] calls.
+    /// The request builder for [BackupForGKE::update_restore_plan][crate::client::BackupForGKE::update_restore_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2507,7 +2507,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_restore_plan][super::super::client::BackupForGKE::update_restore_plan].
+        /// on [update_restore_plan][crate::client::BackupForGKE::update_restore_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_restore_plan(self.0.request, self.0.options)
@@ -2598,7 +2598,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::delete_restore_plan][super::super::client::BackupForGKE::delete_restore_plan] calls.
+    /// The request builder for [BackupForGKE::delete_restore_plan][crate::client::BackupForGKE::delete_restore_plan] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2646,7 +2646,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_restore_plan][super::super::client::BackupForGKE::delete_restore_plan].
+        /// on [delete_restore_plan][crate::client::BackupForGKE::delete_restore_plan].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_restore_plan(self.0.request, self.0.options)
@@ -2717,7 +2717,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::create_restore_channel][super::super::client::BackupForGKE::create_restore_channel] calls.
+    /// The request builder for [BackupForGKE::create_restore_channel][crate::client::BackupForGKE::create_restore_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2765,7 +2765,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_restore_channel][super::super::client::BackupForGKE::create_restore_channel].
+        /// on [create_restore_channel][crate::client::BackupForGKE::create_restore_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_restore_channel(self.0.request, self.0.options)
@@ -2853,7 +2853,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_restore_channels][super::super::client::BackupForGKE::list_restore_channels] calls.
+    /// The request builder for [BackupForGKE::list_restore_channels][crate::client::BackupForGKE::list_restore_channels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2973,7 +2973,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_restore_channel][super::super::client::BackupForGKE::get_restore_channel] calls.
+    /// The request builder for [BackupForGKE::get_restore_channel][crate::client::BackupForGKE::get_restore_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3039,7 +3039,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::update_restore_channel][super::super::client::BackupForGKE::update_restore_channel] calls.
+    /// The request builder for [BackupForGKE::update_restore_channel][crate::client::BackupForGKE::update_restore_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3087,7 +3087,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_restore_channel][super::super::client::BackupForGKE::update_restore_channel].
+        /// on [update_restore_channel][crate::client::BackupForGKE::update_restore_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_restore_channel(self.0.request, self.0.options)
@@ -3179,7 +3179,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::delete_restore_channel][super::super::client::BackupForGKE::delete_restore_channel] calls.
+    /// The request builder for [BackupForGKE::delete_restore_channel][crate::client::BackupForGKE::delete_restore_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3227,7 +3227,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_restore_channel][super::super::client::BackupForGKE::delete_restore_channel].
+        /// on [delete_restore_channel][crate::client::BackupForGKE::delete_restore_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_restore_channel(self.0.request, self.0.options)
@@ -3292,7 +3292,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_restore_plan_bindings][super::super::client::BackupForGKE::list_restore_plan_bindings] calls.
+    /// The request builder for [BackupForGKE::list_restore_plan_bindings][crate::client::BackupForGKE::list_restore_plan_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3416,7 +3416,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_restore_plan_binding][super::super::client::BackupForGKE::get_restore_plan_binding] calls.
+    /// The request builder for [BackupForGKE::get_restore_plan_binding][crate::client::BackupForGKE::get_restore_plan_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3482,7 +3482,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::create_restore][super::super::client::BackupForGKE::create_restore] calls.
+    /// The request builder for [BackupForGKE::create_restore][crate::client::BackupForGKE::create_restore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3527,7 +3527,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_restore][super::super::client::BackupForGKE::create_restore].
+        /// on [create_restore][crate::client::BackupForGKE::create_restore].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_restore(self.0.request, self.0.options)
@@ -3614,7 +3614,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_restores][super::super::client::BackupForGKE::list_restores] calls.
+    /// The request builder for [BackupForGKE::list_restores][crate::client::BackupForGKE::list_restores] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3729,7 +3729,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_restore][super::super::client::BackupForGKE::get_restore] calls.
+    /// The request builder for [BackupForGKE::get_restore][crate::client::BackupForGKE::get_restore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3792,7 +3792,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::update_restore][super::super::client::BackupForGKE::update_restore] calls.
+    /// The request builder for [BackupForGKE::update_restore][crate::client::BackupForGKE::update_restore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3837,7 +3837,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_restore][super::super::client::BackupForGKE::update_restore].
+        /// on [update_restore][crate::client::BackupForGKE::update_restore].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_restore(self.0.request, self.0.options)
@@ -3926,7 +3926,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::delete_restore][super::super::client::BackupForGKE::delete_restore] calls.
+    /// The request builder for [BackupForGKE::delete_restore][crate::client::BackupForGKE::delete_restore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3971,7 +3971,7 @@ pub mod backup_for_gke {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_restore][super::super::client::BackupForGKE::delete_restore].
+        /// on [delete_restore][crate::client::BackupForGKE::delete_restore].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_restore(self.0.request, self.0.options)
@@ -4042,7 +4042,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_volume_restores][super::super::client::BackupForGKE::list_volume_restores] calls.
+    /// The request builder for [BackupForGKE::list_volume_restores][crate::client::BackupForGKE::list_volume_restores] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4162,7 +4162,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_volume_restore][super::super::client::BackupForGKE::get_volume_restore] calls.
+    /// The request builder for [BackupForGKE::get_volume_restore][crate::client::BackupForGKE::get_volume_restore] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4228,7 +4228,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_backup_index_download_url][super::super::client::BackupForGKE::get_backup_index_download_url] calls.
+    /// The request builder for [BackupForGKE::get_backup_index_download_url][crate::client::BackupForGKE::get_backup_index_download_url] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4296,7 +4296,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_locations][super::super::client::BackupForGKE::list_locations] calls.
+    /// The request builder for [BackupForGKE::list_locations][crate::client::BackupForGKE::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4406,7 +4406,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_location][super::super::client::BackupForGKE::get_location] calls.
+    /// The request builder for [BackupForGKE::get_location][crate::client::BackupForGKE::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4467,7 +4467,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::set_iam_policy][super::super::client::BackupForGKE::set_iam_policy] calls.
+    /// The request builder for [BackupForGKE::set_iam_policy][crate::client::BackupForGKE::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4570,7 +4570,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_iam_policy][super::super::client::BackupForGKE::get_iam_policy] calls.
+    /// The request builder for [BackupForGKE::get_iam_policy][crate::client::BackupForGKE::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4651,7 +4651,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::test_iam_permissions][super::super::client::BackupForGKE::test_iam_permissions] calls.
+    /// The request builder for [BackupForGKE::test_iam_permissions][crate::client::BackupForGKE::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4730,7 +4730,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::list_operations][super::super::client::BackupForGKE::list_operations] calls.
+    /// The request builder for [BackupForGKE::list_operations][crate::client::BackupForGKE::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4842,7 +4842,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::get_operation][super::super::client::BackupForGKE::get_operation] calls.
+    /// The request builder for [BackupForGKE::get_operation][crate::client::BackupForGKE::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4906,7 +4906,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::delete_operation][super::super::client::BackupForGKE::delete_operation] calls.
+    /// The request builder for [BackupForGKE::delete_operation][crate::client::BackupForGKE::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4970,7 +4970,7 @@ pub mod backup_for_gke {
         }
     }
 
-    /// The request builder for [BackupForGKE::cancel_operation][super::super::client::BackupForGKE::cancel_operation] calls.
+    /// The request builder for [BackupForGKE::cancel_operation][crate::client::BackupForGKE::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
+++ b/src/generated/cloud/gkeconnect/gateway/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod gateway_control {
     use crate::Result;
 
-    /// A builder for [GatewayControl][super::super::client::GatewayControl].
+    /// A builder for [GatewayControl][crate::client::GatewayControl].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod gateway_control {
         }
     }
 
-    /// Common implementation for [super::super::client::GatewayControl] request builders.
+    /// Common implementation for [crate::client::GatewayControl] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GatewayControl>,
@@ -68,7 +68,7 @@ pub mod gateway_control {
         }
     }
 
-    /// The request builder for [GatewayControl::generate_credentials][super::super::client::GatewayControl::generate_credentials] calls.
+    /// The request builder for [GatewayControl::generate_credentials][crate::client::GatewayControl::generate_credentials] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/gkehub/v1/src/builder.rs
+++ b/src/generated/cloud/gkehub/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod gke_hub {
     use crate::Result;
 
-    /// A builder for [GkeHub][super::super::client::GkeHub].
+    /// A builder for [GkeHub][crate::client::GkeHub].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod gke_hub {
         }
     }
 
-    /// Common implementation for [super::super::client::GkeHub] request builders.
+    /// Common implementation for [crate::client::GkeHub] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GkeHub>,
@@ -66,7 +66,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::list_memberships][super::super::client::GkeHub::list_memberships] calls.
+    /// The request builder for [GkeHub::list_memberships][crate::client::GkeHub::list_memberships] calls.
     ///
     /// # Example
     /// ```no_run
@@ -179,7 +179,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::list_features][super::super::client::GkeHub::list_features] calls.
+    /// The request builder for [GkeHub::list_features][crate::client::GkeHub::list_features] calls.
     ///
     /// # Example
     /// ```no_run
@@ -290,7 +290,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::get_membership][super::super::client::GkeHub::get_membership] calls.
+    /// The request builder for [GkeHub::get_membership][crate::client::GkeHub::get_membership] calls.
     ///
     /// # Example
     /// ```no_run
@@ -351,7 +351,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::get_feature][super::super::client::GkeHub::get_feature] calls.
+    /// The request builder for [GkeHub::get_feature][crate::client::GkeHub::get_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -410,7 +410,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::create_membership][super::super::client::GkeHub::create_membership] calls.
+    /// The request builder for [GkeHub::create_membership][crate::client::GkeHub::create_membership] calls.
     ///
     /// # Example
     /// ```no_run
@@ -456,7 +456,7 @@ pub mod gke_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_membership][super::super::client::GkeHub::create_membership].
+        /// on [create_membership][crate::client::GkeHub::create_membership].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_membership(self.0.request, self.0.options)
@@ -549,7 +549,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::create_feature][super::super::client::GkeHub::create_feature] calls.
+    /// The request builder for [GkeHub::create_feature][crate::client::GkeHub::create_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -592,7 +592,7 @@ pub mod gke_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_feature][super::super::client::GkeHub::create_feature].
+        /// on [create_feature][crate::client::GkeHub::create_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_feature(self.0.request, self.0.options)
@@ -677,7 +677,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::delete_membership][super::super::client::GkeHub::delete_membership] calls.
+    /// The request builder for [GkeHub::delete_membership][crate::client::GkeHub::delete_membership] calls.
     ///
     /// # Example
     /// ```no_run
@@ -723,7 +723,7 @@ pub mod gke_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_membership][super::super::client::GkeHub::delete_membership].
+        /// on [delete_membership][crate::client::GkeHub::delete_membership].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_membership(self.0.request, self.0.options)
@@ -794,7 +794,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::delete_feature][super::super::client::GkeHub::delete_feature] calls.
+    /// The request builder for [GkeHub::delete_feature][crate::client::GkeHub::delete_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -837,7 +837,7 @@ pub mod gke_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_feature][super::super::client::GkeHub::delete_feature].
+        /// on [delete_feature][crate::client::GkeHub::delete_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_feature(self.0.request, self.0.options)
@@ -906,7 +906,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::update_membership][super::super::client::GkeHub::update_membership] calls.
+    /// The request builder for [GkeHub::update_membership][crate::client::GkeHub::update_membership] calls.
     ///
     /// # Example
     /// ```no_run
@@ -952,7 +952,7 @@ pub mod gke_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_membership][super::super::client::GkeHub::update_membership].
+        /// on [update_membership][crate::client::GkeHub::update_membership].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_membership(self.0.request, self.0.options)
@@ -1059,7 +1059,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::update_feature][super::super::client::GkeHub::update_feature] calls.
+    /// The request builder for [GkeHub::update_feature][crate::client::GkeHub::update_feature] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1102,7 +1102,7 @@ pub mod gke_hub {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_feature][super::super::client::GkeHub::update_feature].
+        /// on [update_feature][crate::client::GkeHub::update_feature].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_feature(self.0.request, self.0.options)
@@ -1199,7 +1199,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::generate_connect_manifest][super::super::client::GkeHub::generate_connect_manifest] calls.
+    /// The request builder for [GkeHub::generate_connect_manifest][crate::client::GkeHub::generate_connect_manifest] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1301,7 +1301,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::list_operations][super::super::client::GkeHub::list_operations] calls.
+    /// The request builder for [GkeHub::list_operations][crate::client::GkeHub::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1411,7 +1411,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::get_operation][super::super::client::GkeHub::get_operation] calls.
+    /// The request builder for [GkeHub::get_operation][crate::client::GkeHub::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1473,7 +1473,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::delete_operation][super::super::client::GkeHub::delete_operation] calls.
+    /// The request builder for [GkeHub::delete_operation][crate::client::GkeHub::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1535,7 +1535,7 @@ pub mod gke_hub {
         }
     }
 
-    /// The request builder for [GkeHub::cancel_operation][super::super::client::GkeHub::cancel_operation] calls.
+    /// The request builder for [GkeHub::cancel_operation][crate::client::GkeHub::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/gkemulticloud/v1/src/builder.rs
+++ b/src/generated/cloud/gkemulticloud/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod attached_clusters {
     use crate::Result;
 
-    /// A builder for [AttachedClusters][super::super::client::AttachedClusters].
+    /// A builder for [AttachedClusters][crate::client::AttachedClusters].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// Common implementation for [super::super::client::AttachedClusters] request builders.
+    /// Common implementation for [crate::client::AttachedClusters] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AttachedClusters>,
@@ -68,7 +68,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::create_attached_cluster][super::super::client::AttachedClusters::create_attached_cluster] calls.
+    /// The request builder for [AttachedClusters::create_attached_cluster][crate::client::AttachedClusters::create_attached_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -116,7 +116,7 @@ pub mod attached_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_attached_cluster][super::super::client::AttachedClusters::create_attached_cluster].
+        /// on [create_attached_cluster][crate::client::AttachedClusters::create_attached_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_attached_cluster(self.0.request, self.0.options)
@@ -212,7 +212,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::update_attached_cluster][super::super::client::AttachedClusters::update_attached_cluster] calls.
+    /// The request builder for [AttachedClusters::update_attached_cluster][crate::client::AttachedClusters::update_attached_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -260,7 +260,7 @@ pub mod attached_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_attached_cluster][super::super::client::AttachedClusters::update_attached_cluster].
+        /// on [update_attached_cluster][crate::client::AttachedClusters::update_attached_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_attached_cluster(self.0.request, self.0.options)
@@ -362,7 +362,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::import_attached_cluster][super::super::client::AttachedClusters::import_attached_cluster] calls.
+    /// The request builder for [AttachedClusters::import_attached_cluster][crate::client::AttachedClusters::import_attached_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -410,7 +410,7 @@ pub mod attached_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_attached_cluster][super::super::client::AttachedClusters::import_attached_cluster].
+        /// on [import_attached_cluster][crate::client::AttachedClusters::import_attached_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_attached_cluster(self.0.request, self.0.options)
@@ -518,7 +518,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::get_attached_cluster][super::super::client::AttachedClusters::get_attached_cluster] calls.
+    /// The request builder for [AttachedClusters::get_attached_cluster][crate::client::AttachedClusters::get_attached_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -584,7 +584,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::list_attached_clusters][super::super::client::AttachedClusters::list_attached_clusters] calls.
+    /// The request builder for [AttachedClusters::list_attached_clusters][crate::client::AttachedClusters::list_attached_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -692,7 +692,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::delete_attached_cluster][super::super::client::AttachedClusters::delete_attached_cluster] calls.
+    /// The request builder for [AttachedClusters::delete_attached_cluster][crate::client::AttachedClusters::delete_attached_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -740,7 +740,7 @@ pub mod attached_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_attached_cluster][super::super::client::AttachedClusters::delete_attached_cluster].
+        /// on [delete_attached_cluster][crate::client::AttachedClusters::delete_attached_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_attached_cluster(self.0.request, self.0.options)
@@ -823,7 +823,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::get_attached_server_config][super::super::client::AttachedClusters::get_attached_server_config] calls.
+    /// The request builder for [AttachedClusters::get_attached_server_config][crate::client::AttachedClusters::get_attached_server_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -891,7 +891,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::generate_attached_cluster_install_manifest][super::super::client::AttachedClusters::generate_attached_cluster_install_manifest] calls.
+    /// The request builder for [AttachedClusters::generate_attached_cluster_install_manifest][crate::client::AttachedClusters::generate_attached_cluster_install_manifest] calls.
     ///
     /// # Example
     /// ```no_run
@@ -997,7 +997,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::generate_attached_cluster_agent_token][super::super::client::AttachedClusters::generate_attached_cluster_agent_token] calls.
+    /// The request builder for [AttachedClusters::generate_attached_cluster_agent_token][crate::client::AttachedClusters::generate_attached_cluster_agent_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1119,7 +1119,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::list_operations][super::super::client::AttachedClusters::list_operations] calls.
+    /// The request builder for [AttachedClusters::list_operations][crate::client::AttachedClusters::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1231,7 +1231,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::get_operation][super::super::client::AttachedClusters::get_operation] calls.
+    /// The request builder for [AttachedClusters::get_operation][crate::client::AttachedClusters::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1295,7 +1295,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::delete_operation][super::super::client::AttachedClusters::delete_operation] calls.
+    /// The request builder for [AttachedClusters::delete_operation][crate::client::AttachedClusters::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1359,7 +1359,7 @@ pub mod attached_clusters {
         }
     }
 
-    /// The request builder for [AttachedClusters::cancel_operation][super::super::client::AttachedClusters::cancel_operation] calls.
+    /// The request builder for [AttachedClusters::cancel_operation][crate::client::AttachedClusters::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1427,7 +1427,7 @@ pub mod attached_clusters {
 pub mod aws_clusters {
     use crate::Result;
 
-    /// A builder for [AwsClusters][super::super::client::AwsClusters].
+    /// A builder for [AwsClusters][crate::client::AwsClusters].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1455,7 +1455,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// Common implementation for [super::super::client::AwsClusters] request builders.
+    /// Common implementation for [crate::client::AwsClusters] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AwsClusters>,
@@ -1478,7 +1478,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::create_aws_cluster][super::super::client::AwsClusters::create_aws_cluster] calls.
+    /// The request builder for [AwsClusters::create_aws_cluster][crate::client::AwsClusters::create_aws_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1526,7 +1526,7 @@ pub mod aws_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_aws_cluster][super::super::client::AwsClusters::create_aws_cluster].
+        /// on [create_aws_cluster][crate::client::AwsClusters::create_aws_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_aws_cluster(self.0.request, self.0.options)
@@ -1619,7 +1619,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::update_aws_cluster][super::super::client::AwsClusters::update_aws_cluster] calls.
+    /// The request builder for [AwsClusters::update_aws_cluster][crate::client::AwsClusters::update_aws_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1667,7 +1667,7 @@ pub mod aws_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_aws_cluster][super::super::client::AwsClusters::update_aws_cluster].
+        /// on [update_aws_cluster][crate::client::AwsClusters::update_aws_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_aws_cluster(self.0.request, self.0.options)
@@ -1766,7 +1766,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::get_aws_cluster][super::super::client::AwsClusters::get_aws_cluster] calls.
+    /// The request builder for [AwsClusters::get_aws_cluster][crate::client::AwsClusters::get_aws_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1829,7 +1829,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::list_aws_clusters][super::super::client::AwsClusters::list_aws_clusters] calls.
+    /// The request builder for [AwsClusters::list_aws_clusters][crate::client::AwsClusters::list_aws_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1932,7 +1932,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::delete_aws_cluster][super::super::client::AwsClusters::delete_aws_cluster] calls.
+    /// The request builder for [AwsClusters::delete_aws_cluster][crate::client::AwsClusters::delete_aws_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1980,7 +1980,7 @@ pub mod aws_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_aws_cluster][super::super::client::AwsClusters::delete_aws_cluster].
+        /// on [delete_aws_cluster][crate::client::AwsClusters::delete_aws_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_aws_cluster(self.0.request, self.0.options)
@@ -2063,7 +2063,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::generate_aws_cluster_agent_token][super::super::client::AwsClusters::generate_aws_cluster_agent_token] calls.
+    /// The request builder for [AwsClusters::generate_aws_cluster_agent_token][crate::client::AwsClusters::generate_aws_cluster_agent_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2191,7 +2191,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::generate_aws_access_token][super::super::client::AwsClusters::generate_aws_access_token] calls.
+    /// The request builder for [AwsClusters::generate_aws_access_token][crate::client::AwsClusters::generate_aws_access_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2257,7 +2257,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::create_aws_node_pool][super::super::client::AwsClusters::create_aws_node_pool] calls.
+    /// The request builder for [AwsClusters::create_aws_node_pool][crate::client::AwsClusters::create_aws_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2305,7 +2305,7 @@ pub mod aws_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_aws_node_pool][super::super::client::AwsClusters::create_aws_node_pool].
+        /// on [create_aws_node_pool][crate::client::AwsClusters::create_aws_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_aws_node_pool(self.0.request, self.0.options)
@@ -2400,7 +2400,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::update_aws_node_pool][super::super::client::AwsClusters::update_aws_node_pool] calls.
+    /// The request builder for [AwsClusters::update_aws_node_pool][crate::client::AwsClusters::update_aws_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2448,7 +2448,7 @@ pub mod aws_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_aws_node_pool][super::super::client::AwsClusters::update_aws_node_pool].
+        /// on [update_aws_node_pool][crate::client::AwsClusters::update_aws_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_aws_node_pool(self.0.request, self.0.options)
@@ -2549,7 +2549,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::rollback_aws_node_pool_update][super::super::client::AwsClusters::rollback_aws_node_pool_update] calls.
+    /// The request builder for [AwsClusters::rollback_aws_node_pool_update][crate::client::AwsClusters::rollback_aws_node_pool_update] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2599,7 +2599,7 @@ pub mod aws_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [rollback_aws_node_pool_update][super::super::client::AwsClusters::rollback_aws_node_pool_update].
+        /// on [rollback_aws_node_pool_update][crate::client::AwsClusters::rollback_aws_node_pool_update].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .rollback_aws_node_pool_update(self.0.request, self.0.options)
@@ -2664,7 +2664,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::get_aws_node_pool][super::super::client::AwsClusters::get_aws_node_pool] calls.
+    /// The request builder for [AwsClusters::get_aws_node_pool][crate::client::AwsClusters::get_aws_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2727,7 +2727,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::list_aws_node_pools][super::super::client::AwsClusters::list_aws_node_pools] calls.
+    /// The request builder for [AwsClusters::list_aws_node_pools][crate::client::AwsClusters::list_aws_node_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2833,7 +2833,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::delete_aws_node_pool][super::super::client::AwsClusters::delete_aws_node_pool] calls.
+    /// The request builder for [AwsClusters::delete_aws_node_pool][crate::client::AwsClusters::delete_aws_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2881,7 +2881,7 @@ pub mod aws_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_aws_node_pool][super::super::client::AwsClusters::delete_aws_node_pool].
+        /// on [delete_aws_node_pool][crate::client::AwsClusters::delete_aws_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_aws_node_pool(self.0.request, self.0.options)
@@ -2964,7 +2964,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::get_aws_open_id_config][super::super::client::AwsClusters::get_aws_open_id_config] calls.
+    /// The request builder for [AwsClusters::get_aws_open_id_config][crate::client::AwsClusters::get_aws_open_id_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3030,7 +3030,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::get_aws_json_web_keys][super::super::client::AwsClusters::get_aws_json_web_keys] calls.
+    /// The request builder for [AwsClusters::get_aws_json_web_keys][crate::client::AwsClusters::get_aws_json_web_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3096,7 +3096,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::get_aws_server_config][super::super::client::AwsClusters::get_aws_server_config] calls.
+    /// The request builder for [AwsClusters::get_aws_server_config][crate::client::AwsClusters::get_aws_server_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3162,7 +3162,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::list_operations][super::super::client::AwsClusters::list_operations] calls.
+    /// The request builder for [AwsClusters::list_operations][crate::client::AwsClusters::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3274,7 +3274,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::get_operation][super::super::client::AwsClusters::get_operation] calls.
+    /// The request builder for [AwsClusters::get_operation][crate::client::AwsClusters::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3338,7 +3338,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::delete_operation][super::super::client::AwsClusters::delete_operation] calls.
+    /// The request builder for [AwsClusters::delete_operation][crate::client::AwsClusters::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3402,7 +3402,7 @@ pub mod aws_clusters {
         }
     }
 
-    /// The request builder for [AwsClusters::cancel_operation][super::super::client::AwsClusters::cancel_operation] calls.
+    /// The request builder for [AwsClusters::cancel_operation][crate::client::AwsClusters::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3470,7 +3470,7 @@ pub mod aws_clusters {
 pub mod azure_clusters {
     use crate::Result;
 
-    /// A builder for [AzureClusters][super::super::client::AzureClusters].
+    /// A builder for [AzureClusters][crate::client::AzureClusters].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3498,7 +3498,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// Common implementation for [super::super::client::AzureClusters] request builders.
+    /// Common implementation for [crate::client::AzureClusters] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AzureClusters>,
@@ -3521,7 +3521,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::create_azure_client][super::super::client::AzureClusters::create_azure_client] calls.
+    /// The request builder for [AzureClusters::create_azure_client][crate::client::AzureClusters::create_azure_client] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3569,7 +3569,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_azure_client][super::super::client::AzureClusters::create_azure_client].
+        /// on [create_azure_client][crate::client::AzureClusters::create_azure_client].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_azure_client(self.0.request, self.0.options)
@@ -3664,7 +3664,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::get_azure_client][super::super::client::AzureClusters::get_azure_client] calls.
+    /// The request builder for [AzureClusters::get_azure_client][crate::client::AzureClusters::get_azure_client] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3727,7 +3727,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::list_azure_clients][super::super::client::AzureClusters::list_azure_clients] calls.
+    /// The request builder for [AzureClusters::list_azure_clients][crate::client::AzureClusters::list_azure_clients] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3833,7 +3833,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::delete_azure_client][super::super::client::AzureClusters::delete_azure_client] calls.
+    /// The request builder for [AzureClusters::delete_azure_client][crate::client::AzureClusters::delete_azure_client] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3881,7 +3881,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_azure_client][super::super::client::AzureClusters::delete_azure_client].
+        /// on [delete_azure_client][crate::client::AzureClusters::delete_azure_client].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_azure_client(self.0.request, self.0.options)
@@ -3952,7 +3952,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::create_azure_cluster][super::super::client::AzureClusters::create_azure_cluster] calls.
+    /// The request builder for [AzureClusters::create_azure_cluster][crate::client::AzureClusters::create_azure_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4000,7 +4000,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_azure_cluster][super::super::client::AzureClusters::create_azure_cluster].
+        /// on [create_azure_cluster][crate::client::AzureClusters::create_azure_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_azure_cluster(self.0.request, self.0.options)
@@ -4095,7 +4095,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::update_azure_cluster][super::super::client::AzureClusters::update_azure_cluster] calls.
+    /// The request builder for [AzureClusters::update_azure_cluster][crate::client::AzureClusters::update_azure_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4143,7 +4143,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_azure_cluster][super::super::client::AzureClusters::update_azure_cluster].
+        /// on [update_azure_cluster][crate::client::AzureClusters::update_azure_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_azure_cluster(self.0.request, self.0.options)
@@ -4244,7 +4244,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::get_azure_cluster][super::super::client::AzureClusters::get_azure_cluster] calls.
+    /// The request builder for [AzureClusters::get_azure_cluster][crate::client::AzureClusters::get_azure_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4307,7 +4307,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::list_azure_clusters][super::super::client::AzureClusters::list_azure_clusters] calls.
+    /// The request builder for [AzureClusters::list_azure_clusters][crate::client::AzureClusters::list_azure_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4413,7 +4413,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::delete_azure_cluster][super::super::client::AzureClusters::delete_azure_cluster] calls.
+    /// The request builder for [AzureClusters::delete_azure_cluster][crate::client::AzureClusters::delete_azure_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4461,7 +4461,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_azure_cluster][super::super::client::AzureClusters::delete_azure_cluster].
+        /// on [delete_azure_cluster][crate::client::AzureClusters::delete_azure_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_azure_cluster(self.0.request, self.0.options)
@@ -4544,7 +4544,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::generate_azure_cluster_agent_token][super::super::client::AzureClusters::generate_azure_cluster_agent_token] calls.
+    /// The request builder for [AzureClusters::generate_azure_cluster_agent_token][crate::client::AzureClusters::generate_azure_cluster_agent_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4672,7 +4672,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::generate_azure_access_token][super::super::client::AzureClusters::generate_azure_access_token] calls.
+    /// The request builder for [AzureClusters::generate_azure_access_token][crate::client::AzureClusters::generate_azure_access_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4740,7 +4740,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::create_azure_node_pool][super::super::client::AzureClusters::create_azure_node_pool] calls.
+    /// The request builder for [AzureClusters::create_azure_node_pool][crate::client::AzureClusters::create_azure_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4788,7 +4788,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_azure_node_pool][super::super::client::AzureClusters::create_azure_node_pool].
+        /// on [create_azure_node_pool][crate::client::AzureClusters::create_azure_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_azure_node_pool(self.0.request, self.0.options)
@@ -4884,7 +4884,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::update_azure_node_pool][super::super::client::AzureClusters::update_azure_node_pool] calls.
+    /// The request builder for [AzureClusters::update_azure_node_pool][crate::client::AzureClusters::update_azure_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4932,7 +4932,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_azure_node_pool][super::super::client::AzureClusters::update_azure_node_pool].
+        /// on [update_azure_node_pool][crate::client::AzureClusters::update_azure_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_azure_node_pool(self.0.request, self.0.options)
@@ -5034,7 +5034,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::get_azure_node_pool][super::super::client::AzureClusters::get_azure_node_pool] calls.
+    /// The request builder for [AzureClusters::get_azure_node_pool][crate::client::AzureClusters::get_azure_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5100,7 +5100,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::list_azure_node_pools][super::super::client::AzureClusters::list_azure_node_pools] calls.
+    /// The request builder for [AzureClusters::list_azure_node_pools][crate::client::AzureClusters::list_azure_node_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5208,7 +5208,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::delete_azure_node_pool][super::super::client::AzureClusters::delete_azure_node_pool] calls.
+    /// The request builder for [AzureClusters::delete_azure_node_pool][crate::client::AzureClusters::delete_azure_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5256,7 +5256,7 @@ pub mod azure_clusters {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_azure_node_pool][super::super::client::AzureClusters::delete_azure_node_pool].
+        /// on [delete_azure_node_pool][crate::client::AzureClusters::delete_azure_node_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_azure_node_pool(self.0.request, self.0.options)
@@ -5339,7 +5339,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::get_azure_open_id_config][super::super::client::AzureClusters::get_azure_open_id_config] calls.
+    /// The request builder for [AzureClusters::get_azure_open_id_config][crate::client::AzureClusters::get_azure_open_id_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5405,7 +5405,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::get_azure_json_web_keys][super::super::client::AzureClusters::get_azure_json_web_keys] calls.
+    /// The request builder for [AzureClusters::get_azure_json_web_keys][crate::client::AzureClusters::get_azure_json_web_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5471,7 +5471,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::get_azure_server_config][super::super::client::AzureClusters::get_azure_server_config] calls.
+    /// The request builder for [AzureClusters::get_azure_server_config][crate::client::AzureClusters::get_azure_server_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5537,7 +5537,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::list_operations][super::super::client::AzureClusters::list_operations] calls.
+    /// The request builder for [AzureClusters::list_operations][crate::client::AzureClusters::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5649,7 +5649,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::get_operation][super::super::client::AzureClusters::get_operation] calls.
+    /// The request builder for [AzureClusters::get_operation][crate::client::AzureClusters::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5713,7 +5713,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::delete_operation][super::super::client::AzureClusters::delete_operation] calls.
+    /// The request builder for [AzureClusters::delete_operation][crate::client::AzureClusters::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5777,7 +5777,7 @@ pub mod azure_clusters {
         }
     }
 
-    /// The request builder for [AzureClusters::cancel_operation][super::super::client::AzureClusters::cancel_operation] calls.
+    /// The request builder for [AzureClusters::cancel_operation][crate::client::AzureClusters::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
+++ b/src/generated/cloud/gsuiteaddons/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod g_suite_add_ons {
     use crate::Result;
 
-    /// A builder for [GSuiteAddOns][super::super::client::GSuiteAddOns].
+    /// A builder for [GSuiteAddOns][crate::client::GSuiteAddOns].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// Common implementation for [super::super::client::GSuiteAddOns] request builders.
+    /// Common implementation for [crate::client::GSuiteAddOns] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GSuiteAddOns>,
@@ -68,7 +68,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::get_authorization][super::super::client::GSuiteAddOns::get_authorization] calls.
+    /// The request builder for [GSuiteAddOns::get_authorization][crate::client::GSuiteAddOns::get_authorization] calls.
     ///
     /// # Example
     /// ```no_run
@@ -134,7 +134,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::create_deployment][super::super::client::GSuiteAddOns::create_deployment] calls.
+    /// The request builder for [GSuiteAddOns::create_deployment][crate::client::GSuiteAddOns::create_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -230,7 +230,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::replace_deployment][super::super::client::GSuiteAddOns::replace_deployment] calls.
+    /// The request builder for [GSuiteAddOns::replace_deployment][crate::client::GSuiteAddOns::replace_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -310,7 +310,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::get_deployment][super::super::client::GSuiteAddOns::get_deployment] calls.
+    /// The request builder for [GSuiteAddOns::get_deployment][crate::client::GSuiteAddOns::get_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -373,7 +373,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::list_deployments][super::super::client::GSuiteAddOns::list_deployments] calls.
+    /// The request builder for [GSuiteAddOns::list_deployments][crate::client::GSuiteAddOns::list_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -476,7 +476,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::delete_deployment][super::super::client::GSuiteAddOns::delete_deployment] calls.
+    /// The request builder for [GSuiteAddOns::delete_deployment][crate::client::GSuiteAddOns::delete_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -548,7 +548,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::install_deployment][super::super::client::GSuiteAddOns::install_deployment] calls.
+    /// The request builder for [GSuiteAddOns::install_deployment][crate::client::GSuiteAddOns::install_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -614,7 +614,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::uninstall_deployment][super::super::client::GSuiteAddOns::uninstall_deployment] calls.
+    /// The request builder for [GSuiteAddOns::uninstall_deployment][crate::client::GSuiteAddOns::uninstall_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -680,7 +680,7 @@ pub mod g_suite_add_ons {
         }
     }
 
-    /// The request builder for [GSuiteAddOns::get_install_status][super::super::client::GSuiteAddOns::get_install_status] calls.
+    /// The request builder for [GSuiteAddOns::get_install_status][crate::client::GSuiteAddOns::get_install_status] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/iap/v1/src/builder.rs
+++ b/src/generated/cloud/iap/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod identity_aware_proxy_admin_service {
     use crate::Result;
 
-    /// A builder for [IdentityAwareProxyAdminService][super::super::client::IdentityAwareProxyAdminService].
+    /// A builder for [IdentityAwareProxyAdminService][crate::client::IdentityAwareProxyAdminService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// Common implementation for [super::super::client::IdentityAwareProxyAdminService] request builders.
+    /// Common implementation for [crate::client::IdentityAwareProxyAdminService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::IdentityAwareProxyAdminService>,
@@ -68,7 +68,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::set_iam_policy][super::super::client::IdentityAwareProxyAdminService::set_iam_policy] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::set_iam_policy][crate::client::IdentityAwareProxyAdminService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::get_iam_policy][super::super::client::IdentityAwareProxyAdminService::get_iam_policy] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::get_iam_policy][crate::client::IdentityAwareProxyAdminService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::test_iam_permissions][super::super::client::IdentityAwareProxyAdminService::test_iam_permissions] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::test_iam_permissions][crate::client::IdentityAwareProxyAdminService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -331,7 +331,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::get_iap_settings][super::super::client::IdentityAwareProxyAdminService::get_iap_settings] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::get_iap_settings][crate::client::IdentityAwareProxyAdminService::get_iap_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -394,7 +394,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::update_iap_settings][super::super::client::IdentityAwareProxyAdminService::update_iap_settings] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::update_iap_settings][crate::client::IdentityAwareProxyAdminService::update_iap_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -492,7 +492,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::validate_iap_attribute_expression][super::super::client::IdentityAwareProxyAdminService::validate_iap_attribute_expression] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::validate_iap_attribute_expression][crate::client::IdentityAwareProxyAdminService::validate_iap_attribute_expression] calls.
     ///
     /// # Example
     /// ```no_run
@@ -568,7 +568,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::list_tunnel_dest_groups][super::super::client::IdentityAwareProxyAdminService::list_tunnel_dest_groups] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::list_tunnel_dest_groups][crate::client::IdentityAwareProxyAdminService::list_tunnel_dest_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -676,7 +676,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::create_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::create_tunnel_dest_group] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::create_tunnel_dest_group][crate::client::IdentityAwareProxyAdminService::create_tunnel_dest_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -772,7 +772,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::get_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::get_tunnel_dest_group] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::get_tunnel_dest_group][crate::client::IdentityAwareProxyAdminService::get_tunnel_dest_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -838,7 +838,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::delete_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::delete_tunnel_dest_group] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::delete_tunnel_dest_group][crate::client::IdentityAwareProxyAdminService::delete_tunnel_dest_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -904,7 +904,7 @@ pub mod identity_aware_proxy_admin_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyAdminService::update_tunnel_dest_group][super::super::client::IdentityAwareProxyAdminService::update_tunnel_dest_group] calls.
+    /// The request builder for [IdentityAwareProxyAdminService::update_tunnel_dest_group][crate::client::IdentityAwareProxyAdminService::update_tunnel_dest_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1006,7 +1006,7 @@ pub mod identity_aware_proxy_admin_service {
 pub mod identity_aware_proxy_o_auth_service {
     use crate::Result;
 
-    /// A builder for [IdentityAwareProxyOAuthService][super::super::client::IdentityAwareProxyOAuthService].
+    /// A builder for [IdentityAwareProxyOAuthService][crate::client::IdentityAwareProxyOAuthService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1034,7 +1034,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// Common implementation for [super::super::client::IdentityAwareProxyOAuthService] request builders.
+    /// Common implementation for [crate::client::IdentityAwareProxyOAuthService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::IdentityAwareProxyOAuthService>,
@@ -1057,7 +1057,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::list_brands][super::super::client::IdentityAwareProxyOAuthService::list_brands] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::list_brands][crate::client::IdentityAwareProxyOAuthService::list_brands] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1120,7 +1120,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::create_brand][super::super::client::IdentityAwareProxyOAuthService::create_brand] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::create_brand][crate::client::IdentityAwareProxyOAuthService::create_brand] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1205,7 +1205,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::get_brand][super::super::client::IdentityAwareProxyOAuthService::get_brand] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::get_brand][crate::client::IdentityAwareProxyOAuthService::get_brand] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1268,7 +1268,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::create_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::create_identity_aware_proxy_client] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::create_identity_aware_proxy_client][crate::client::IdentityAwareProxyOAuthService::create_identity_aware_proxy_client] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1361,7 +1361,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients][super::super::client::IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients][crate::client::IdentityAwareProxyOAuthService::list_identity_aware_proxy_clients] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1473,7 +1473,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::get_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::get_identity_aware_proxy_client] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::get_identity_aware_proxy_client][crate::client::IdentityAwareProxyOAuthService::get_identity_aware_proxy_client] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1541,7 +1541,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret][super::super::client::IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret][crate::client::IdentityAwareProxyOAuthService::reset_identity_aware_proxy_client_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1609,7 +1609,7 @@ pub mod identity_aware_proxy_o_auth_service {
         }
     }
 
-    /// The request builder for [IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client][super::super::client::IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client] calls.
+    /// The request builder for [IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client][crate::client::IdentityAwareProxyOAuthService::delete_identity_aware_proxy_client] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/ids/v1/src/builder.rs
+++ b/src/generated/cloud/ids/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod ids {
     use crate::Result;
 
-    /// A builder for [Ids][super::super::client::Ids].
+    /// A builder for [Ids][crate::client::Ids].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod ids {
         }
     }
 
-    /// Common implementation for [super::super::client::Ids] request builders.
+    /// Common implementation for [crate::client::Ids] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Ids>,
@@ -66,7 +66,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::list_endpoints][super::super::client::Ids::list_endpoints] calls.
+    /// The request builder for [Ids::list_endpoints][crate::client::Ids::list_endpoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -179,7 +179,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::get_endpoint][super::super::client::Ids::get_endpoint] calls.
+    /// The request builder for [Ids::get_endpoint][crate::client::Ids::get_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::create_endpoint][super::super::client::Ids::create_endpoint] calls.
+    /// The request builder for [Ids::create_endpoint][crate::client::Ids::create_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -283,7 +283,7 @@ pub mod ids {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_endpoint][super::super::client::Ids::create_endpoint].
+        /// on [create_endpoint][crate::client::Ids::create_endpoint].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_endpoint(self.0.request, self.0.options)
@@ -376,7 +376,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::delete_endpoint][super::super::client::Ids::delete_endpoint] calls.
+    /// The request builder for [Ids::delete_endpoint][crate::client::Ids::delete_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -419,7 +419,7 @@ pub mod ids {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_endpoint][super::super::client::Ids::delete_endpoint].
+        /// on [delete_endpoint][crate::client::Ids::delete_endpoint].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_endpoint(self.0.request, self.0.options)
@@ -484,7 +484,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::list_operations][super::super::client::Ids::list_operations] calls.
+    /// The request builder for [Ids::list_operations][crate::client::Ids::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -594,7 +594,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::get_operation][super::super::client::Ids::get_operation] calls.
+    /// The request builder for [Ids::get_operation][crate::client::Ids::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -656,7 +656,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::delete_operation][super::super::client::Ids::delete_operation] calls.
+    /// The request builder for [Ids::delete_operation][crate::client::Ids::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -718,7 +718,7 @@ pub mod ids {
         }
     }
 
-    /// The request builder for [Ids::cancel_operation][super::super::client::Ids::cancel_operation] calls.
+    /// The request builder for [Ids::cancel_operation][crate::client::Ids::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/kms/inventory/v1/src/builder.rs
+++ b/src/generated/cloud/kms/inventory/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod key_dashboard_service {
     use crate::Result;
 
-    /// A builder for [KeyDashboardService][super::super::client::KeyDashboardService].
+    /// A builder for [KeyDashboardService][crate::client::KeyDashboardService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod key_dashboard_service {
         }
     }
 
-    /// Common implementation for [super::super::client::KeyDashboardService] request builders.
+    /// Common implementation for [crate::client::KeyDashboardService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::KeyDashboardService>,
@@ -68,7 +68,7 @@ pub mod key_dashboard_service {
         }
     }
 
-    /// The request builder for [KeyDashboardService::list_crypto_keys][super::super::client::KeyDashboardService::list_crypto_keys] calls.
+    /// The request builder for [KeyDashboardService::list_crypto_keys][crate::client::KeyDashboardService::list_crypto_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -175,7 +175,7 @@ pub mod key_dashboard_service {
 pub mod key_tracking_service {
     use crate::Result;
 
-    /// A builder for [KeyTrackingService][super::super::client::KeyTrackingService].
+    /// A builder for [KeyTrackingService][crate::client::KeyTrackingService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -203,7 +203,7 @@ pub mod key_tracking_service {
         }
     }
 
-    /// Common implementation for [super::super::client::KeyTrackingService] request builders.
+    /// Common implementation for [crate::client::KeyTrackingService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::KeyTrackingService>,
@@ -226,7 +226,7 @@ pub mod key_tracking_service {
         }
     }
 
-    /// The request builder for [KeyTrackingService::get_protected_resources_summary][super::super::client::KeyTrackingService::get_protected_resources_summary] calls.
+    /// The request builder for [KeyTrackingService::get_protected_resources_summary][crate::client::KeyTrackingService::get_protected_resources_summary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -294,7 +294,7 @@ pub mod key_tracking_service {
         }
     }
 
-    /// The request builder for [KeyTrackingService::search_protected_resources][super::super::client::KeyTrackingService::search_protected_resources] calls.
+    /// The request builder for [KeyTrackingService::search_protected_resources][crate::client::KeyTrackingService::search_protected_resources] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/kms/v1/src/builder.rs
+++ b/src/generated/cloud/kms/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod autokey {
     use crate::Result;
 
-    /// A builder for [Autokey][super::super::client::Autokey].
+    /// A builder for [Autokey][crate::client::Autokey].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod autokey {
         }
     }
 
-    /// Common implementation for [super::super::client::Autokey] request builders.
+    /// Common implementation for [crate::client::Autokey] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Autokey>,
@@ -66,7 +66,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::create_key_handle][super::super::client::Autokey::create_key_handle] calls.
+    /// The request builder for [Autokey::create_key_handle][crate::client::Autokey::create_key_handle] calls.
     ///
     /// # Example
     /// ```no_run
@@ -109,7 +109,7 @@ pub mod autokey {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_key_handle][super::super::client::Autokey::create_key_handle].
+        /// on [create_key_handle][crate::client::Autokey::create_key_handle].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_key_handle(self.0.request, self.0.options)
@@ -197,7 +197,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::get_key_handle][super::super::client::Autokey::get_key_handle] calls.
+    /// The request builder for [Autokey::get_key_handle][crate::client::Autokey::get_key_handle] calls.
     ///
     /// # Example
     /// ```no_run
@@ -258,7 +258,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::list_key_handles][super::super::client::Autokey::list_key_handles] calls.
+    /// The request builder for [Autokey::list_key_handles][crate::client::Autokey::list_key_handles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -365,7 +365,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::list_locations][super::super::client::Autokey::list_locations] calls.
+    /// The request builder for [Autokey::list_locations][crate::client::Autokey::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -473,7 +473,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::get_location][super::super::client::Autokey::get_location] calls.
+    /// The request builder for [Autokey::get_location][crate::client::Autokey::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -532,7 +532,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::set_iam_policy][super::super::client::Autokey::set_iam_policy] calls.
+    /// The request builder for [Autokey::set_iam_policy][crate::client::Autokey::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -633,7 +633,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::get_iam_policy][super::super::client::Autokey::get_iam_policy] calls.
+    /// The request builder for [Autokey::get_iam_policy][crate::client::Autokey::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -712,7 +712,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::test_iam_permissions][super::super::client::Autokey::test_iam_permissions] calls.
+    /// The request builder for [Autokey::test_iam_permissions][crate::client::Autokey::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -789,7 +789,7 @@ pub mod autokey {
         }
     }
 
-    /// The request builder for [Autokey::get_operation][super::super::client::Autokey::get_operation] calls.
+    /// The request builder for [Autokey::get_operation][crate::client::Autokey::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -855,7 +855,7 @@ pub mod autokey {
 pub mod autokey_admin {
     use crate::Result;
 
-    /// A builder for [AutokeyAdmin][super::super::client::AutokeyAdmin].
+    /// A builder for [AutokeyAdmin][crate::client::AutokeyAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -883,7 +883,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::AutokeyAdmin] request builders.
+    /// Common implementation for [crate::client::AutokeyAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AutokeyAdmin>,
@@ -906,7 +906,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::update_autokey_config][super::super::client::AutokeyAdmin::update_autokey_config] calls.
+    /// The request builder for [AutokeyAdmin::update_autokey_config][crate::client::AutokeyAdmin::update_autokey_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1008,7 +1008,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::get_autokey_config][super::super::client::AutokeyAdmin::get_autokey_config] calls.
+    /// The request builder for [AutokeyAdmin::get_autokey_config][crate::client::AutokeyAdmin::get_autokey_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1074,7 +1074,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::show_effective_autokey_config][super::super::client::AutokeyAdmin::show_effective_autokey_config] calls.
+    /// The request builder for [AutokeyAdmin::show_effective_autokey_config][crate::client::AutokeyAdmin::show_effective_autokey_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1142,7 +1142,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::list_locations][super::super::client::AutokeyAdmin::list_locations] calls.
+    /// The request builder for [AutokeyAdmin::list_locations][crate::client::AutokeyAdmin::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1252,7 +1252,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::get_location][super::super::client::AutokeyAdmin::get_location] calls.
+    /// The request builder for [AutokeyAdmin::get_location][crate::client::AutokeyAdmin::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1313,7 +1313,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::set_iam_policy][super::super::client::AutokeyAdmin::set_iam_policy] calls.
+    /// The request builder for [AutokeyAdmin::set_iam_policy][crate::client::AutokeyAdmin::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1416,7 +1416,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::get_iam_policy][super::super::client::AutokeyAdmin::get_iam_policy] calls.
+    /// The request builder for [AutokeyAdmin::get_iam_policy][crate::client::AutokeyAdmin::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1497,7 +1497,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::test_iam_permissions][super::super::client::AutokeyAdmin::test_iam_permissions] calls.
+    /// The request builder for [AutokeyAdmin::test_iam_permissions][crate::client::AutokeyAdmin::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1576,7 +1576,7 @@ pub mod autokey_admin {
         }
     }
 
-    /// The request builder for [AutokeyAdmin::get_operation][super::super::client::AutokeyAdmin::get_operation] calls.
+    /// The request builder for [AutokeyAdmin::get_operation][crate::client::AutokeyAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1644,7 +1644,7 @@ pub mod autokey_admin {
 pub mod ekm_service {
     use crate::Result;
 
-    /// A builder for [EkmService][super::super::client::EkmService].
+    /// A builder for [EkmService][crate::client::EkmService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1672,7 +1672,7 @@ pub mod ekm_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EkmService] request builders.
+    /// Common implementation for [crate::client::EkmService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EkmService>,
@@ -1695,7 +1695,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::list_ekm_connections][super::super::client::EkmService::list_ekm_connections] calls.
+    /// The request builder for [EkmService::list_ekm_connections][crate::client::EkmService::list_ekm_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1815,7 +1815,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::get_ekm_connection][super::super::client::EkmService::get_ekm_connection] calls.
+    /// The request builder for [EkmService::get_ekm_connection][crate::client::EkmService::get_ekm_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1881,7 +1881,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::create_ekm_connection][super::super::client::EkmService::create_ekm_connection] calls.
+    /// The request builder for [EkmService::create_ekm_connection][crate::client::EkmService::create_ekm_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1977,7 +1977,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::update_ekm_connection][super::super::client::EkmService::update_ekm_connection] calls.
+    /// The request builder for [EkmService::update_ekm_connection][crate::client::EkmService::update_ekm_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2079,7 +2079,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::get_ekm_config][super::super::client::EkmService::get_ekm_config] calls.
+    /// The request builder for [EkmService::get_ekm_config][crate::client::EkmService::get_ekm_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2142,7 +2142,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::update_ekm_config][super::super::client::EkmService::update_ekm_config] calls.
+    /// The request builder for [EkmService::update_ekm_config][crate::client::EkmService::update_ekm_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2241,7 +2241,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::verify_connectivity][super::super::client::EkmService::verify_connectivity] calls.
+    /// The request builder for [EkmService::verify_connectivity][crate::client::EkmService::verify_connectivity] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2307,7 +2307,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::list_locations][super::super::client::EkmService::list_locations] calls.
+    /// The request builder for [EkmService::list_locations][crate::client::EkmService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2417,7 +2417,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::get_location][super::super::client::EkmService::get_location] calls.
+    /// The request builder for [EkmService::get_location][crate::client::EkmService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2478,7 +2478,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::set_iam_policy][super::super::client::EkmService::set_iam_policy] calls.
+    /// The request builder for [EkmService::set_iam_policy][crate::client::EkmService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2581,7 +2581,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::get_iam_policy][super::super::client::EkmService::get_iam_policy] calls.
+    /// The request builder for [EkmService::get_iam_policy][crate::client::EkmService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2662,7 +2662,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::test_iam_permissions][super::super::client::EkmService::test_iam_permissions] calls.
+    /// The request builder for [EkmService::test_iam_permissions][crate::client::EkmService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2741,7 +2741,7 @@ pub mod ekm_service {
         }
     }
 
-    /// The request builder for [EkmService::get_operation][super::super::client::EkmService::get_operation] calls.
+    /// The request builder for [EkmService::get_operation][crate::client::EkmService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2809,7 +2809,7 @@ pub mod ekm_service {
 pub mod key_management_service {
     use crate::Result;
 
-    /// A builder for [KeyManagementService][super::super::client::KeyManagementService].
+    /// A builder for [KeyManagementService][crate::client::KeyManagementService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2837,7 +2837,7 @@ pub mod key_management_service {
         }
     }
 
-    /// Common implementation for [super::super::client::KeyManagementService] request builders.
+    /// Common implementation for [crate::client::KeyManagementService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::KeyManagementService>,
@@ -2860,7 +2860,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::list_key_rings][super::super::client::KeyManagementService::list_key_rings] calls.
+    /// The request builder for [KeyManagementService::list_key_rings][crate::client::KeyManagementService::list_key_rings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2975,7 +2975,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::list_crypto_keys][super::super::client::KeyManagementService::list_crypto_keys] calls.
+    /// The request builder for [KeyManagementService::list_crypto_keys][crate::client::KeyManagementService::list_crypto_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3099,7 +3099,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::list_crypto_key_versions][super::super::client::KeyManagementService::list_crypto_key_versions] calls.
+    /// The request builder for [KeyManagementService::list_crypto_key_versions][crate::client::KeyManagementService::list_crypto_key_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3228,7 +3228,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::list_import_jobs][super::super::client::KeyManagementService::list_import_jobs] calls.
+    /// The request builder for [KeyManagementService::list_import_jobs][crate::client::KeyManagementService::list_import_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3343,7 +3343,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_key_ring][super::super::client::KeyManagementService::get_key_ring] calls.
+    /// The request builder for [KeyManagementService::get_key_ring][crate::client::KeyManagementService::get_key_ring] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3406,7 +3406,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_crypto_key][super::super::client::KeyManagementService::get_crypto_key] calls.
+    /// The request builder for [KeyManagementService::get_crypto_key][crate::client::KeyManagementService::get_crypto_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3469,7 +3469,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_crypto_key_version][super::super::client::KeyManagementService::get_crypto_key_version] calls.
+    /// The request builder for [KeyManagementService::get_crypto_key_version][crate::client::KeyManagementService::get_crypto_key_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3535,7 +3535,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_public_key][super::super::client::KeyManagementService::get_public_key] calls.
+    /// The request builder for [KeyManagementService::get_public_key][crate::client::KeyManagementService::get_public_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3607,7 +3607,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_import_job][super::super::client::KeyManagementService::get_import_job] calls.
+    /// The request builder for [KeyManagementService::get_import_job][crate::client::KeyManagementService::get_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3670,7 +3670,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::create_key_ring][super::super::client::KeyManagementService::create_key_ring] calls.
+    /// The request builder for [KeyManagementService::create_key_ring][crate::client::KeyManagementService::create_key_ring] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3763,7 +3763,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::create_crypto_key][super::super::client::KeyManagementService::create_crypto_key] calls.
+    /// The request builder for [KeyManagementService::create_crypto_key][crate::client::KeyManagementService::create_crypto_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3862,7 +3862,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::create_crypto_key_version][super::super::client::KeyManagementService::create_crypto_key_version] calls.
+    /// The request builder for [KeyManagementService::create_crypto_key_version][crate::client::KeyManagementService::create_crypto_key_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3950,7 +3950,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::import_crypto_key_version][super::super::client::KeyManagementService::import_crypto_key_version] calls.
+    /// The request builder for [KeyManagementService::import_crypto_key_version][crate::client::KeyManagementService::import_crypto_key_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4076,7 +4076,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::create_import_job][super::super::client::KeyManagementService::create_import_job] calls.
+    /// The request builder for [KeyManagementService::create_import_job][crate::client::KeyManagementService::create_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4169,7 +4169,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::update_crypto_key][super::super::client::KeyManagementService::update_crypto_key] calls.
+    /// The request builder for [KeyManagementService::update_crypto_key][crate::client::KeyManagementService::update_crypto_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4268,7 +4268,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::update_crypto_key_version][super::super::client::KeyManagementService::update_crypto_key_version] calls.
+    /// The request builder for [KeyManagementService::update_crypto_key_version][crate::client::KeyManagementService::update_crypto_key_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4370,7 +4370,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::update_crypto_key_primary_version][super::super::client::KeyManagementService::update_crypto_key_primary_version] calls.
+    /// The request builder for [KeyManagementService::update_crypto_key_primary_version][crate::client::KeyManagementService::update_crypto_key_primary_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4446,7 +4446,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::destroy_crypto_key_version][super::super::client::KeyManagementService::destroy_crypto_key_version] calls.
+    /// The request builder for [KeyManagementService::destroy_crypto_key_version][crate::client::KeyManagementService::destroy_crypto_key_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4514,7 +4514,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::restore_crypto_key_version][super::super::client::KeyManagementService::restore_crypto_key_version] calls.
+    /// The request builder for [KeyManagementService::restore_crypto_key_version][crate::client::KeyManagementService::restore_crypto_key_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4582,7 +4582,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::encrypt][super::super::client::KeyManagementService::encrypt] calls.
+    /// The request builder for [KeyManagementService::encrypt][crate::client::KeyManagementService::encrypt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4699,7 +4699,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::decrypt][super::super::client::KeyManagementService::decrypt] calls.
+    /// The request builder for [KeyManagementService::decrypt][crate::client::KeyManagementService::decrypt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4816,7 +4816,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::raw_encrypt][super::super::client::KeyManagementService::raw_encrypt] calls.
+    /// The request builder for [KeyManagementService::raw_encrypt][crate::client::KeyManagementService::raw_encrypt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4960,7 +4960,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::raw_decrypt][super::super::client::KeyManagementService::raw_decrypt] calls.
+    /// The request builder for [KeyManagementService::raw_decrypt][crate::client::KeyManagementService::raw_decrypt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5112,7 +5112,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::asymmetric_sign][super::super::client::KeyManagementService::asymmetric_sign] calls.
+    /// The request builder for [KeyManagementService::asymmetric_sign][crate::client::KeyManagementService::asymmetric_sign] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5235,7 +5235,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::asymmetric_decrypt][super::super::client::KeyManagementService::asymmetric_decrypt] calls.
+    /// The request builder for [KeyManagementService::asymmetric_decrypt][crate::client::KeyManagementService::asymmetric_decrypt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5327,7 +5327,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::mac_sign][super::super::client::KeyManagementService::mac_sign] calls.
+    /// The request builder for [KeyManagementService::mac_sign][crate::client::KeyManagementService::mac_sign] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5416,7 +5416,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::mac_verify][super::super::client::KeyManagementService::mac_verify] calls.
+    /// The request builder for [KeyManagementService::mac_verify][crate::client::KeyManagementService::mac_verify] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5531,7 +5531,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::generate_random_bytes][super::super::client::KeyManagementService::generate_random_bytes] calls.
+    /// The request builder for [KeyManagementService::generate_random_bytes][crate::client::KeyManagementService::generate_random_bytes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5610,7 +5610,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::list_locations][super::super::client::KeyManagementService::list_locations] calls.
+    /// The request builder for [KeyManagementService::list_locations][crate::client::KeyManagementService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5720,7 +5720,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_location][super::super::client::KeyManagementService::get_location] calls.
+    /// The request builder for [KeyManagementService::get_location][crate::client::KeyManagementService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5781,7 +5781,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::set_iam_policy][super::super::client::KeyManagementService::set_iam_policy] calls.
+    /// The request builder for [KeyManagementService::set_iam_policy][crate::client::KeyManagementService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5884,7 +5884,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_iam_policy][super::super::client::KeyManagementService::get_iam_policy] calls.
+    /// The request builder for [KeyManagementService::get_iam_policy][crate::client::KeyManagementService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5965,7 +5965,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::test_iam_permissions][super::super::client::KeyManagementService::test_iam_permissions] calls.
+    /// The request builder for [KeyManagementService::test_iam_permissions][crate::client::KeyManagementService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6044,7 +6044,7 @@ pub mod key_management_service {
         }
     }
 
-    /// The request builder for [KeyManagementService::get_operation][super::super::client::KeyManagementService::get_operation] calls.
+    /// The request builder for [KeyManagementService::get_operation][crate::client::KeyManagementService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/language/v2/src/builder.rs
+++ b/src/generated/cloud/language/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod language_service {
     use crate::Result;
 
-    /// A builder for [LanguageService][super::super::client::LanguageService].
+    /// A builder for [LanguageService][crate::client::LanguageService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod language_service {
         }
     }
 
-    /// Common implementation for [super::super::client::LanguageService] request builders.
+    /// Common implementation for [crate::client::LanguageService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LanguageService>,
@@ -68,7 +68,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for [LanguageService::analyze_sentiment][super::super::client::LanguageService::analyze_sentiment] calls.
+    /// The request builder for [LanguageService::analyze_sentiment][crate::client::LanguageService::analyze_sentiment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -154,7 +154,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for [LanguageService::analyze_entities][super::super::client::LanguageService::analyze_entities] calls.
+    /// The request builder for [LanguageService::analyze_entities][crate::client::LanguageService::analyze_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -237,7 +237,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for [LanguageService::classify_text][super::super::client::LanguageService::classify_text] calls.
+    /// The request builder for [LanguageService::classify_text][crate::client::LanguageService::classify_text] calls.
     ///
     /// # Example
     /// ```no_run
@@ -314,7 +314,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for [LanguageService::moderate_text][super::super::client::LanguageService::moderate_text] calls.
+    /// The request builder for [LanguageService::moderate_text][crate::client::LanguageService::moderate_text] calls.
     ///
     /// # Example
     /// ```no_run
@@ -400,7 +400,7 @@ pub mod language_service {
         }
     }
 
-    /// The request builder for [LanguageService::annotate_text][super::super::client::LanguageService::annotate_text] calls.
+    /// The request builder for [LanguageService::annotate_text][crate::client::LanguageService::annotate_text] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/licensemanager/v1/src/builder.rs
+++ b/src/generated/cloud/licensemanager/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod license_manager {
     use crate::Result;
 
-    /// A builder for [LicenseManager][super::super::client::LicenseManager].
+    /// A builder for [LicenseManager][crate::client::LicenseManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod license_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::LicenseManager] request builders.
+    /// Common implementation for [crate::client::LicenseManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LicenseManager>,
@@ -68,7 +68,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::list_configurations][super::super::client::LicenseManager::list_configurations] calls.
+    /// The request builder for [LicenseManager::list_configurations][crate::client::LicenseManager::list_configurations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -188,7 +188,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::get_configuration][super::super::client::LicenseManager::get_configuration] calls.
+    /// The request builder for [LicenseManager::get_configuration][crate::client::LicenseManager::get_configuration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::create_configuration][super::super::client::LicenseManager::create_configuration] calls.
+    /// The request builder for [LicenseManager::create_configuration][crate::client::LicenseManager::create_configuration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -302,7 +302,7 @@ pub mod license_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_configuration][super::super::client::LicenseManager::create_configuration].
+        /// on [create_configuration][crate::client::LicenseManager::create_configuration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_configuration(self.0.request, self.0.options)
@@ -398,7 +398,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::update_configuration][super::super::client::LicenseManager::update_configuration] calls.
+    /// The request builder for [LicenseManager::update_configuration][crate::client::LicenseManager::update_configuration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -446,7 +446,7 @@ pub mod license_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_configuration][super::super::client::LicenseManager::update_configuration].
+        /// on [update_configuration][crate::client::LicenseManager::update_configuration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_configuration(self.0.request, self.0.options)
@@ -544,7 +544,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::delete_configuration][super::super::client::LicenseManager::delete_configuration] calls.
+    /// The request builder for [LicenseManager::delete_configuration][crate::client::LicenseManager::delete_configuration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -592,7 +592,7 @@ pub mod license_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_configuration][super::super::client::LicenseManager::delete_configuration].
+        /// on [delete_configuration][crate::client::LicenseManager::delete_configuration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_configuration(self.0.request, self.0.options)
@@ -657,7 +657,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::list_instances][super::super::client::LicenseManager::list_instances] calls.
+    /// The request builder for [LicenseManager::list_instances][crate::client::LicenseManager::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -772,7 +772,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::get_instance][super::super::client::LicenseManager::get_instance] calls.
+    /// The request builder for [LicenseManager::get_instance][crate::client::LicenseManager::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -835,7 +835,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::deactivate_configuration][super::super::client::LicenseManager::deactivate_configuration] calls.
+    /// The request builder for [LicenseManager::deactivate_configuration][crate::client::LicenseManager::deactivate_configuration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -885,7 +885,7 @@ pub mod license_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [deactivate_configuration][super::super::client::LicenseManager::deactivate_configuration].
+        /// on [deactivate_configuration][crate::client::LicenseManager::deactivate_configuration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .deactivate_configuration(self.0.request, self.0.options)
@@ -951,7 +951,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::reactivate_configuration][super::super::client::LicenseManager::reactivate_configuration] calls.
+    /// The request builder for [LicenseManager::reactivate_configuration][crate::client::LicenseManager::reactivate_configuration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1001,7 +1001,7 @@ pub mod license_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reactivate_configuration][super::super::client::LicenseManager::reactivate_configuration].
+        /// on [reactivate_configuration][crate::client::LicenseManager::reactivate_configuration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reactivate_configuration(self.0.request, self.0.options)
@@ -1067,7 +1067,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::query_configuration_license_usage][super::super::client::LicenseManager::query_configuration_license_usage] calls.
+    /// The request builder for [LicenseManager::query_configuration_license_usage][crate::client::LicenseManager::query_configuration_license_usage] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1179,7 +1179,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::aggregate_usage][super::super::client::LicenseManager::aggregate_usage] calls.
+    /// The request builder for [LicenseManager::aggregate_usage][crate::client::LicenseManager::aggregate_usage] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1338,7 +1338,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::list_products][super::super::client::LicenseManager::list_products] calls.
+    /// The request builder for [LicenseManager::list_products][crate::client::LicenseManager::list_products] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1453,7 +1453,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::get_product][super::super::client::LicenseManager::get_product] calls.
+    /// The request builder for [LicenseManager::get_product][crate::client::LicenseManager::get_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1516,7 +1516,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::list_locations][super::super::client::LicenseManager::list_locations] calls.
+    /// The request builder for [LicenseManager::list_locations][crate::client::LicenseManager::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1626,7 +1626,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::get_location][super::super::client::LicenseManager::get_location] calls.
+    /// The request builder for [LicenseManager::get_location][crate::client::LicenseManager::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1687,7 +1687,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::list_operations][super::super::client::LicenseManager::list_operations] calls.
+    /// The request builder for [LicenseManager::list_operations][crate::client::LicenseManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1799,7 +1799,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::get_operation][super::super::client::LicenseManager::get_operation] calls.
+    /// The request builder for [LicenseManager::get_operation][crate::client::LicenseManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1863,7 +1863,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::delete_operation][super::super::client::LicenseManager::delete_operation] calls.
+    /// The request builder for [LicenseManager::delete_operation][crate::client::LicenseManager::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1927,7 +1927,7 @@ pub mod license_manager {
         }
     }
 
-    /// The request builder for [LicenseManager::cancel_operation][super::super::client::LicenseManager::cancel_operation] calls.
+    /// The request builder for [LicenseManager::cancel_operation][crate::client::LicenseManager::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/location/src/builder.rs
+++ b/src/generated/cloud/location/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod locations {
     use crate::Result;
 
-    /// A builder for [Locations][super::super::client::Locations].
+    /// A builder for [Locations][crate::client::Locations].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod locations {
         }
     }
 
-    /// Common implementation for [super::super::client::Locations] request builders.
+    /// Common implementation for [crate::client::Locations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Locations>,
@@ -68,7 +68,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for [Locations::list_locations][super::super::client::Locations::list_locations] calls.
+    /// The request builder for [Locations::list_locations][crate::client::Locations::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -175,7 +175,7 @@ pub mod locations {
         }
     }
 
-    /// The request builder for [Locations::get_location][super::super::client::Locations::get_location] calls.
+    /// The request builder for [Locations::get_location][crate::client::Locations::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/lustre/v1/src/builder.rs
+++ b/src/generated/cloud/lustre/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod lustre {
     use crate::Result;
 
-    /// A builder for [Lustre][super::super::client::Lustre].
+    /// A builder for [Lustre][crate::client::Lustre].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod lustre {
         }
     }
 
-    /// Common implementation for [super::super::client::Lustre] request builders.
+    /// Common implementation for [crate::client::Lustre] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Lustre>,
@@ -66,7 +66,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::list_instances][super::super::client::Lustre::list_instances] calls.
+    /// The request builder for [Lustre::list_instances][crate::client::Lustre::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -179,7 +179,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::get_instance][super::super::client::Lustre::get_instance] calls.
+    /// The request builder for [Lustre::get_instance][crate::client::Lustre::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::create_instance][super::super::client::Lustre::create_instance] calls.
+    /// The request builder for [Lustre::create_instance][crate::client::Lustre::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -283,7 +283,7 @@ pub mod lustre {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::Lustre::create_instance].
+        /// on [create_instance][crate::client::Lustre::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -376,7 +376,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::update_instance][super::super::client::Lustre::update_instance] calls.
+    /// The request builder for [Lustre::update_instance][crate::client::Lustre::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -419,7 +419,7 @@ pub mod lustre {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::Lustre::update_instance].
+        /// on [update_instance][crate::client::Lustre::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -514,7 +514,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::delete_instance][super::super::client::Lustre::delete_instance] calls.
+    /// The request builder for [Lustre::delete_instance][crate::client::Lustre::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -557,7 +557,7 @@ pub mod lustre {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::Lustre::delete_instance].
+        /// on [delete_instance][crate::client::Lustre::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -622,7 +622,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::import_data][super::super::client::Lustre::import_data] calls.
+    /// The request builder for [Lustre::import_data][crate::client::Lustre::import_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -665,7 +665,7 @@ pub mod lustre {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_data][super::super::client::Lustre::import_data].
+        /// on [import_data][crate::client::Lustre::import_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_data(self.0.request, self.0.options)
@@ -787,7 +787,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::export_data][super::super::client::Lustre::export_data] calls.
+    /// The request builder for [Lustre::export_data][crate::client::Lustre::export_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -830,7 +830,7 @@ pub mod lustre {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_data][super::super::client::Lustre::export_data].
+        /// on [export_data][crate::client::Lustre::export_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_data(self.0.request, self.0.options)
@@ -952,7 +952,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::list_locations][super::super::client::Lustre::list_locations] calls.
+    /// The request builder for [Lustre::list_locations][crate::client::Lustre::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1060,7 +1060,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::get_location][super::super::client::Lustre::get_location] calls.
+    /// The request builder for [Lustre::get_location][crate::client::Lustre::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1119,7 +1119,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::list_operations][super::super::client::Lustre::list_operations] calls.
+    /// The request builder for [Lustre::list_operations][crate::client::Lustre::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1229,7 +1229,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::get_operation][super::super::client::Lustre::get_operation] calls.
+    /// The request builder for [Lustre::get_operation][crate::client::Lustre::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1291,7 +1291,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::delete_operation][super::super::client::Lustre::delete_operation] calls.
+    /// The request builder for [Lustre::delete_operation][crate::client::Lustre::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1353,7 +1353,7 @@ pub mod lustre {
         }
     }
 
-    /// The request builder for [Lustre::cancel_operation][super::super::client::Lustre::cancel_operation] calls.
+    /// The request builder for [Lustre::cancel_operation][crate::client::Lustre::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/managedidentities/v1/src/builder.rs
+++ b/src/generated/cloud/managedidentities/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod managed_identities_service {
     use crate::Result;
 
-    /// A builder for [ManagedIdentitiesService][super::super::client::ManagedIdentitiesService].
+    /// A builder for [ManagedIdentitiesService][crate::client::ManagedIdentitiesService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ManagedIdentitiesService] request builders.
+    /// Common implementation for [crate::client::ManagedIdentitiesService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ManagedIdentitiesService>,
@@ -68,7 +68,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::create_microsoft_ad_domain][super::super::client::ManagedIdentitiesService::create_microsoft_ad_domain] calls.
+    /// The request builder for [ManagedIdentitiesService::create_microsoft_ad_domain][crate::client::ManagedIdentitiesService::create_microsoft_ad_domain] calls.
     ///
     /// # Example
     /// ```no_run
@@ -118,7 +118,7 @@ pub mod managed_identities_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_microsoft_ad_domain][super::super::client::ManagedIdentitiesService::create_microsoft_ad_domain].
+        /// on [create_microsoft_ad_domain][crate::client::ManagedIdentitiesService::create_microsoft_ad_domain].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_microsoft_ad_domain(self.0.request, self.0.options)
@@ -203,7 +203,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::reset_admin_password][super::super::client::ManagedIdentitiesService::reset_admin_password] calls.
+    /// The request builder for [ManagedIdentitiesService::reset_admin_password][crate::client::ManagedIdentitiesService::reset_admin_password] calls.
     ///
     /// # Example
     /// ```no_run
@@ -269,7 +269,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::list_domains][super::super::client::ManagedIdentitiesService::list_domains] calls.
+    /// The request builder for [ManagedIdentitiesService::list_domains][crate::client::ManagedIdentitiesService::list_domains] calls.
     ///
     /// # Example
     /// ```no_run
@@ -384,7 +384,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::get_domain][super::super::client::ManagedIdentitiesService::get_domain] calls.
+    /// The request builder for [ManagedIdentitiesService::get_domain][crate::client::ManagedIdentitiesService::get_domain] calls.
     ///
     /// # Example
     /// ```no_run
@@ -447,7 +447,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::update_domain][super::super::client::ManagedIdentitiesService::update_domain] calls.
+    /// The request builder for [ManagedIdentitiesService::update_domain][crate::client::ManagedIdentitiesService::update_domain] calls.
     ///
     /// # Example
     /// ```no_run
@@ -492,7 +492,7 @@ pub mod managed_identities_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_domain][super::super::client::ManagedIdentitiesService::update_domain].
+        /// on [update_domain][crate::client::ManagedIdentitiesService::update_domain].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_domain(self.0.request, self.0.options)
@@ -583,7 +583,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::delete_domain][super::super::client::ManagedIdentitiesService::delete_domain] calls.
+    /// The request builder for [ManagedIdentitiesService::delete_domain][crate::client::ManagedIdentitiesService::delete_domain] calls.
     ///
     /// # Example
     /// ```no_run
@@ -628,7 +628,7 @@ pub mod managed_identities_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_domain][super::super::client::ManagedIdentitiesService::delete_domain].
+        /// on [delete_domain][crate::client::ManagedIdentitiesService::delete_domain].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_domain(self.0.request, self.0.options)
@@ -687,7 +687,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::attach_trust][super::super::client::ManagedIdentitiesService::attach_trust] calls.
+    /// The request builder for [ManagedIdentitiesService::attach_trust][crate::client::ManagedIdentitiesService::attach_trust] calls.
     ///
     /// # Example
     /// ```no_run
@@ -732,7 +732,7 @@ pub mod managed_identities_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [attach_trust][super::super::client::ManagedIdentitiesService::attach_trust].
+        /// on [attach_trust][crate::client::ManagedIdentitiesService::attach_trust].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .attach_trust(self.0.request, self.0.options)
@@ -809,7 +809,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::reconfigure_trust][super::super::client::ManagedIdentitiesService::reconfigure_trust] calls.
+    /// The request builder for [ManagedIdentitiesService::reconfigure_trust][crate::client::ManagedIdentitiesService::reconfigure_trust] calls.
     ///
     /// # Example
     /// ```no_run
@@ -857,7 +857,7 @@ pub mod managed_identities_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reconfigure_trust][super::super::client::ManagedIdentitiesService::reconfigure_trust].
+        /// on [reconfigure_trust][crate::client::ManagedIdentitiesService::reconfigure_trust].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reconfigure_trust(self.0.request, self.0.options)
@@ -933,7 +933,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::detach_trust][super::super::client::ManagedIdentitiesService::detach_trust] calls.
+    /// The request builder for [ManagedIdentitiesService::detach_trust][crate::client::ManagedIdentitiesService::detach_trust] calls.
     ///
     /// # Example
     /// ```no_run
@@ -978,7 +978,7 @@ pub mod managed_identities_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [detach_trust][super::super::client::ManagedIdentitiesService::detach_trust].
+        /// on [detach_trust][crate::client::ManagedIdentitiesService::detach_trust].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .detach_trust(self.0.request, self.0.options)
@@ -1055,7 +1055,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::validate_trust][super::super::client::ManagedIdentitiesService::validate_trust] calls.
+    /// The request builder for [ManagedIdentitiesService::validate_trust][crate::client::ManagedIdentitiesService::validate_trust] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1100,7 +1100,7 @@ pub mod managed_identities_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [validate_trust][super::super::client::ManagedIdentitiesService::validate_trust].
+        /// on [validate_trust][crate::client::ManagedIdentitiesService::validate_trust].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .validate_trust(self.0.request, self.0.options)
@@ -1177,7 +1177,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::list_operations][super::super::client::ManagedIdentitiesService::list_operations] calls.
+    /// The request builder for [ManagedIdentitiesService::list_operations][crate::client::ManagedIdentitiesService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1289,7 +1289,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::get_operation][super::super::client::ManagedIdentitiesService::get_operation] calls.
+    /// The request builder for [ManagedIdentitiesService::get_operation][crate::client::ManagedIdentitiesService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1353,7 +1353,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::delete_operation][super::super::client::ManagedIdentitiesService::delete_operation] calls.
+    /// The request builder for [ManagedIdentitiesService::delete_operation][crate::client::ManagedIdentitiesService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1417,7 +1417,7 @@ pub mod managed_identities_service {
         }
     }
 
-    /// The request builder for [ManagedIdentitiesService::cancel_operation][super::super::client::ManagedIdentitiesService::cancel_operation] calls.
+    /// The request builder for [ManagedIdentitiesService::cancel_operation][crate::client::ManagedIdentitiesService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/memcache/v1/src/builder.rs
+++ b/src/generated/cloud/memcache/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_memcache {
     use crate::Result;
 
-    /// A builder for [CloudMemcache][super::super::client::CloudMemcache].
+    /// A builder for [CloudMemcache][crate::client::CloudMemcache].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudMemcache] request builders.
+    /// Common implementation for [crate::client::CloudMemcache] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudMemcache>,
@@ -68,7 +68,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::list_instances][super::super::client::CloudMemcache::list_instances] calls.
+    /// The request builder for [CloudMemcache::list_instances][crate::client::CloudMemcache::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::get_instance][super::super::client::CloudMemcache::get_instance] calls.
+    /// The request builder for [CloudMemcache::get_instance][crate::client::CloudMemcache::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::create_instance][super::super::client::CloudMemcache::create_instance] calls.
+    /// The request builder for [CloudMemcache::create_instance][crate::client::CloudMemcache::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod cloud_memcache {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::CloudMemcache::create_instance].
+        /// on [create_instance][crate::client::CloudMemcache::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -378,7 +378,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::update_instance][super::super::client::CloudMemcache::update_instance] calls.
+    /// The request builder for [CloudMemcache::update_instance][crate::client::CloudMemcache::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -423,7 +423,7 @@ pub mod cloud_memcache {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::CloudMemcache::update_instance].
+        /// on [update_instance][crate::client::CloudMemcache::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -516,7 +516,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::update_parameters][super::super::client::CloudMemcache::update_parameters] calls.
+    /// The request builder for [CloudMemcache::update_parameters][crate::client::CloudMemcache::update_parameters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -564,7 +564,7 @@ pub mod cloud_memcache {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_parameters][super::super::client::CloudMemcache::update_parameters].
+        /// on [update_parameters][crate::client::CloudMemcache::update_parameters].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_parameters(self.0.request, self.0.options)
@@ -661,7 +661,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::delete_instance][super::super::client::CloudMemcache::delete_instance] calls.
+    /// The request builder for [CloudMemcache::delete_instance][crate::client::CloudMemcache::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -706,7 +706,7 @@ pub mod cloud_memcache {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::CloudMemcache::delete_instance].
+        /// on [delete_instance][crate::client::CloudMemcache::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -765,7 +765,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::apply_parameters][super::super::client::CloudMemcache::apply_parameters] calls.
+    /// The request builder for [CloudMemcache::apply_parameters][crate::client::CloudMemcache::apply_parameters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -810,7 +810,7 @@ pub mod cloud_memcache {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [apply_parameters][super::super::client::CloudMemcache::apply_parameters].
+        /// on [apply_parameters][crate::client::CloudMemcache::apply_parameters].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .apply_parameters(self.0.request, self.0.options)
@@ -884,7 +884,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::reschedule_maintenance][super::super::client::CloudMemcache::reschedule_maintenance] calls.
+    /// The request builder for [CloudMemcache::reschedule_maintenance][crate::client::CloudMemcache::reschedule_maintenance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -932,7 +932,7 @@ pub mod cloud_memcache {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reschedule_maintenance][super::super::client::CloudMemcache::reschedule_maintenance].
+        /// on [reschedule_maintenance][crate::client::CloudMemcache::reschedule_maintenance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reschedule_maintenance(self.0.request, self.0.options)
@@ -1020,7 +1020,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::list_locations][super::super::client::CloudMemcache::list_locations] calls.
+    /// The request builder for [CloudMemcache::list_locations][crate::client::CloudMemcache::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1130,7 +1130,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::get_location][super::super::client::CloudMemcache::get_location] calls.
+    /// The request builder for [CloudMemcache::get_location][crate::client::CloudMemcache::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1191,7 +1191,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::list_operations][super::super::client::CloudMemcache::list_operations] calls.
+    /// The request builder for [CloudMemcache::list_operations][crate::client::CloudMemcache::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1303,7 +1303,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::get_operation][super::super::client::CloudMemcache::get_operation] calls.
+    /// The request builder for [CloudMemcache::get_operation][crate::client::CloudMemcache::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1367,7 +1367,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::delete_operation][super::super::client::CloudMemcache::delete_operation] calls.
+    /// The request builder for [CloudMemcache::delete_operation][crate::client::CloudMemcache::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1431,7 +1431,7 @@ pub mod cloud_memcache {
         }
     }
 
-    /// The request builder for [CloudMemcache::cancel_operation][super::super::client::CloudMemcache::cancel_operation] calls.
+    /// The request builder for [CloudMemcache::cancel_operation][crate::client::CloudMemcache::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/memorystore/v1/src/builder.rs
+++ b/src/generated/cloud/memorystore/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod memorystore {
     use crate::Result;
 
-    /// A builder for [Memorystore][super::super::client::Memorystore].
+    /// A builder for [Memorystore][crate::client::Memorystore].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod memorystore {
         }
     }
 
-    /// Common implementation for [super::super::client::Memorystore] request builders.
+    /// Common implementation for [crate::client::Memorystore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Memorystore>,
@@ -68,7 +68,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::list_instances][super::super::client::Memorystore::list_instances] calls.
+    /// The request builder for [Memorystore::list_instances][crate::client::Memorystore::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::get_instance][super::super::client::Memorystore::get_instance] calls.
+    /// The request builder for [Memorystore::get_instance][crate::client::Memorystore::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::create_instance][super::super::client::Memorystore::create_instance] calls.
+    /// The request builder for [Memorystore::create_instance][crate::client::Memorystore::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod memorystore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::Memorystore::create_instance].
+        /// on [create_instance][crate::client::Memorystore::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::update_instance][super::super::client::Memorystore::update_instance] calls.
+    /// The request builder for [Memorystore::update_instance][crate::client::Memorystore::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod memorystore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::Memorystore::update_instance].
+        /// on [update_instance][crate::client::Memorystore::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -524,7 +524,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::delete_instance][super::super::client::Memorystore::delete_instance] calls.
+    /// The request builder for [Memorystore::delete_instance][crate::client::Memorystore::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -569,7 +569,7 @@ pub mod memorystore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::Memorystore::delete_instance].
+        /// on [delete_instance][crate::client::Memorystore::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -634,7 +634,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::get_certificate_authority][super::super::client::Memorystore::get_certificate_authority] calls.
+    /// The request builder for [Memorystore::get_certificate_authority][crate::client::Memorystore::get_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -702,7 +702,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::reschedule_maintenance][super::super::client::Memorystore::reschedule_maintenance] calls.
+    /// The request builder for [Memorystore::reschedule_maintenance][crate::client::Memorystore::reschedule_maintenance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -750,7 +750,7 @@ pub mod memorystore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reschedule_maintenance][super::super::client::Memorystore::reschedule_maintenance].
+        /// on [reschedule_maintenance][crate::client::Memorystore::reschedule_maintenance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reschedule_maintenance(self.0.request, self.0.options)
@@ -838,7 +838,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::list_backup_collections][super::super::client::Memorystore::list_backup_collections] calls.
+    /// The request builder for [Memorystore::list_backup_collections][crate::client::Memorystore::list_backup_collections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -946,7 +946,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::get_backup_collection][super::super::client::Memorystore::get_backup_collection] calls.
+    /// The request builder for [Memorystore::get_backup_collection][crate::client::Memorystore::get_backup_collection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1012,7 +1012,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::list_backups][super::super::client::Memorystore::list_backups] calls.
+    /// The request builder for [Memorystore::list_backups][crate::client::Memorystore::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1115,7 +1115,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::get_backup][super::super::client::Memorystore::get_backup] calls.
+    /// The request builder for [Memorystore::get_backup][crate::client::Memorystore::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1178,7 +1178,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::delete_backup][super::super::client::Memorystore::delete_backup] calls.
+    /// The request builder for [Memorystore::delete_backup][crate::client::Memorystore::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1223,7 +1223,7 @@ pub mod memorystore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::Memorystore::delete_backup].
+        /// on [delete_backup][crate::client::Memorystore::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -1288,7 +1288,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::export_backup][super::super::client::Memorystore::export_backup] calls.
+    /// The request builder for [Memorystore::export_backup][crate::client::Memorystore::export_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1333,7 +1333,7 @@ pub mod memorystore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_backup][super::super::client::Memorystore::export_backup].
+        /// on [export_backup][crate::client::Memorystore::export_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_backup(self.0.request, self.0.options)
@@ -1414,7 +1414,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::backup_instance][super::super::client::Memorystore::backup_instance] calls.
+    /// The request builder for [Memorystore::backup_instance][crate::client::Memorystore::backup_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1459,7 +1459,7 @@ pub mod memorystore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [backup_instance][super::super::client::Memorystore::backup_instance].
+        /// on [backup_instance][crate::client::Memorystore::backup_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .backup_instance(self.0.request, self.0.options)
@@ -1552,7 +1552,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::list_locations][super::super::client::Memorystore::list_locations] calls.
+    /// The request builder for [Memorystore::list_locations][crate::client::Memorystore::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1662,7 +1662,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::get_location][super::super::client::Memorystore::get_location] calls.
+    /// The request builder for [Memorystore::get_location][crate::client::Memorystore::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1723,7 +1723,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::list_operations][super::super::client::Memorystore::list_operations] calls.
+    /// The request builder for [Memorystore::list_operations][crate::client::Memorystore::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1835,7 +1835,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::get_operation][super::super::client::Memorystore::get_operation] calls.
+    /// The request builder for [Memorystore::get_operation][crate::client::Memorystore::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1899,7 +1899,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::delete_operation][super::super::client::Memorystore::delete_operation] calls.
+    /// The request builder for [Memorystore::delete_operation][crate::client::Memorystore::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1963,7 +1963,7 @@ pub mod memorystore {
         }
     }
 
-    /// The request builder for [Memorystore::cancel_operation][super::super::client::Memorystore::cancel_operation] calls.
+    /// The request builder for [Memorystore::cancel_operation][crate::client::Memorystore::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/metastore/v1/src/builder.rs
+++ b/src/generated/cloud/metastore/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod dataproc_metastore {
     use crate::Result;
 
-    /// A builder for [DataprocMetastore][super::super::client::DataprocMetastore].
+    /// A builder for [DataprocMetastore][crate::client::DataprocMetastore].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// Common implementation for [super::super::client::DataprocMetastore] request builders.
+    /// Common implementation for [crate::client::DataprocMetastore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataprocMetastore>,
@@ -68,7 +68,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::list_services][super::super::client::DataprocMetastore::list_services] calls.
+    /// The request builder for [DataprocMetastore::list_services][crate::client::DataprocMetastore::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::get_service][super::super::client::DataprocMetastore::get_service] calls.
+    /// The request builder for [DataprocMetastore::get_service][crate::client::DataprocMetastore::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::create_service][super::super::client::DataprocMetastore::create_service] calls.
+    /// The request builder for [DataprocMetastore::create_service][crate::client::DataprocMetastore::create_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service][super::super::client::DataprocMetastore::create_service].
+        /// on [create_service][crate::client::DataprocMetastore::create_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::update_service][super::super::client::DataprocMetastore::update_service] calls.
+    /// The request builder for [DataprocMetastore::update_service][crate::client::DataprocMetastore::update_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service][super::super::client::DataprocMetastore::update_service].
+        /// on [update_service][crate::client::DataprocMetastore::update_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service(self.0.request, self.0.options)
@@ -528,7 +528,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::delete_service][super::super::client::DataprocMetastore::delete_service] calls.
+    /// The request builder for [DataprocMetastore::delete_service][crate::client::DataprocMetastore::delete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -573,7 +573,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service][super::super::client::DataprocMetastore::delete_service].
+        /// on [delete_service][crate::client::DataprocMetastore::delete_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service(self.0.request, self.0.options)
@@ -638,7 +638,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::list_metadata_imports][super::super::client::DataprocMetastore::list_metadata_imports] calls.
+    /// The request builder for [DataprocMetastore::list_metadata_imports][crate::client::DataprocMetastore::list_metadata_imports] calls.
     ///
     /// # Example
     /// ```no_run
@@ -758,7 +758,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::get_metadata_import][super::super::client::DataprocMetastore::get_metadata_import] calls.
+    /// The request builder for [DataprocMetastore::get_metadata_import][crate::client::DataprocMetastore::get_metadata_import] calls.
     ///
     /// # Example
     /// ```no_run
@@ -824,7 +824,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::create_metadata_import][super::super::client::DataprocMetastore::create_metadata_import] calls.
+    /// The request builder for [DataprocMetastore::create_metadata_import][crate::client::DataprocMetastore::create_metadata_import] calls.
     ///
     /// # Example
     /// ```no_run
@@ -872,7 +872,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_metadata_import][super::super::client::DataprocMetastore::create_metadata_import].
+        /// on [create_metadata_import][crate::client::DataprocMetastore::create_metadata_import].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_metadata_import(self.0.request, self.0.options)
@@ -968,7 +968,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::update_metadata_import][super::super::client::DataprocMetastore::update_metadata_import] calls.
+    /// The request builder for [DataprocMetastore::update_metadata_import][crate::client::DataprocMetastore::update_metadata_import] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1016,7 +1016,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_metadata_import][super::super::client::DataprocMetastore::update_metadata_import].
+        /// on [update_metadata_import][crate::client::DataprocMetastore::update_metadata_import].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_metadata_import(self.0.request, self.0.options)
@@ -1118,7 +1118,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::export_metadata][super::super::client::DataprocMetastore::export_metadata] calls.
+    /// The request builder for [DataprocMetastore::export_metadata][crate::client::DataprocMetastore::export_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1163,7 +1163,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_metadata][super::super::client::DataprocMetastore::export_metadata].
+        /// on [export_metadata][crate::client::DataprocMetastore::export_metadata].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_metadata(self.0.request, self.0.options)
@@ -1265,7 +1265,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::restore_service][super::super::client::DataprocMetastore::restore_service] calls.
+    /// The request builder for [DataprocMetastore::restore_service][crate::client::DataprocMetastore::restore_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1310,7 +1310,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_service][super::super::client::DataprocMetastore::restore_service].
+        /// on [restore_service][crate::client::DataprocMetastore::restore_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_service(self.0.request, self.0.options)
@@ -1390,7 +1390,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::list_backups][super::super::client::DataprocMetastore::list_backups] calls.
+    /// The request builder for [DataprocMetastore::list_backups][crate::client::DataprocMetastore::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1505,7 +1505,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::get_backup][super::super::client::DataprocMetastore::get_backup] calls.
+    /// The request builder for [DataprocMetastore::get_backup][crate::client::DataprocMetastore::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1568,7 +1568,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::create_backup][super::super::client::DataprocMetastore::create_backup] calls.
+    /// The request builder for [DataprocMetastore::create_backup][crate::client::DataprocMetastore::create_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1613,7 +1613,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup][super::super::client::DataprocMetastore::create_backup].
+        /// on [create_backup][crate::client::DataprocMetastore::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
@@ -1706,7 +1706,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::delete_backup][super::super::client::DataprocMetastore::delete_backup] calls.
+    /// The request builder for [DataprocMetastore::delete_backup][crate::client::DataprocMetastore::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1751,7 +1751,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::DataprocMetastore::delete_backup].
+        /// on [delete_backup][crate::client::DataprocMetastore::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -1816,7 +1816,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::query_metadata][super::super::client::DataprocMetastore::query_metadata] calls.
+    /// The request builder for [DataprocMetastore::query_metadata][crate::client::DataprocMetastore::query_metadata] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1861,7 +1861,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [query_metadata][super::super::client::DataprocMetastore::query_metadata].
+        /// on [query_metadata][crate::client::DataprocMetastore::query_metadata].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .query_metadata(self.0.request, self.0.options)
@@ -1929,7 +1929,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::move_table_to_database][super::super::client::DataprocMetastore::move_table_to_database] calls.
+    /// The request builder for [DataprocMetastore::move_table_to_database][crate::client::DataprocMetastore::move_table_to_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1977,7 +1977,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [move_table_to_database][super::super::client::DataprocMetastore::move_table_to_database].
+        /// on [move_table_to_database][crate::client::DataprocMetastore::move_table_to_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .move_table_to_database(self.0.request, self.0.options)
@@ -2061,7 +2061,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::alter_metadata_resource_location][super::super::client::DataprocMetastore::alter_metadata_resource_location] calls.
+    /// The request builder for [DataprocMetastore::alter_metadata_resource_location][crate::client::DataprocMetastore::alter_metadata_resource_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2111,7 +2111,7 @@ pub mod dataproc_metastore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [alter_metadata_resource_location][super::super::client::DataprocMetastore::alter_metadata_resource_location].
+        /// on [alter_metadata_resource_location][crate::client::DataprocMetastore::alter_metadata_resource_location].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .alter_metadata_resource_location(self.0.request, self.0.options)
@@ -2189,7 +2189,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::list_locations][super::super::client::DataprocMetastore::list_locations] calls.
+    /// The request builder for [DataprocMetastore::list_locations][crate::client::DataprocMetastore::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2299,7 +2299,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::get_location][super::super::client::DataprocMetastore::get_location] calls.
+    /// The request builder for [DataprocMetastore::get_location][crate::client::DataprocMetastore::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2360,7 +2360,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::set_iam_policy][super::super::client::DataprocMetastore::set_iam_policy] calls.
+    /// The request builder for [DataprocMetastore::set_iam_policy][crate::client::DataprocMetastore::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2463,7 +2463,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::get_iam_policy][super::super::client::DataprocMetastore::get_iam_policy] calls.
+    /// The request builder for [DataprocMetastore::get_iam_policy][crate::client::DataprocMetastore::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2544,7 +2544,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::test_iam_permissions][super::super::client::DataprocMetastore::test_iam_permissions] calls.
+    /// The request builder for [DataprocMetastore::test_iam_permissions][crate::client::DataprocMetastore::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2623,7 +2623,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::list_operations][super::super::client::DataprocMetastore::list_operations] calls.
+    /// The request builder for [DataprocMetastore::list_operations][crate::client::DataprocMetastore::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2735,7 +2735,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::get_operation][super::super::client::DataprocMetastore::get_operation] calls.
+    /// The request builder for [DataprocMetastore::get_operation][crate::client::DataprocMetastore::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2799,7 +2799,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::delete_operation][super::super::client::DataprocMetastore::delete_operation] calls.
+    /// The request builder for [DataprocMetastore::delete_operation][crate::client::DataprocMetastore::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2863,7 +2863,7 @@ pub mod dataproc_metastore {
         }
     }
 
-    /// The request builder for [DataprocMetastore::cancel_operation][super::super::client::DataprocMetastore::cancel_operation] calls.
+    /// The request builder for [DataprocMetastore::cancel_operation][crate::client::DataprocMetastore::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2931,7 +2931,7 @@ pub mod dataproc_metastore {
 pub mod dataproc_metastore_federation {
     use crate::Result;
 
-    /// A builder for [DataprocMetastoreFederation][super::super::client::DataprocMetastoreFederation].
+    /// A builder for [DataprocMetastoreFederation][crate::client::DataprocMetastoreFederation].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2959,7 +2959,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// Common implementation for [super::super::client::DataprocMetastoreFederation] request builders.
+    /// Common implementation for [crate::client::DataprocMetastoreFederation] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DataprocMetastoreFederation>,
@@ -2982,7 +2982,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::list_federations][super::super::client::DataprocMetastoreFederation::list_federations] calls.
+    /// The request builder for [DataprocMetastoreFederation::list_federations][crate::client::DataprocMetastoreFederation::list_federations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3097,7 +3097,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::get_federation][super::super::client::DataprocMetastoreFederation::get_federation] calls.
+    /// The request builder for [DataprocMetastoreFederation::get_federation][crate::client::DataprocMetastoreFederation::get_federation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3160,7 +3160,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::create_federation][super::super::client::DataprocMetastoreFederation::create_federation] calls.
+    /// The request builder for [DataprocMetastoreFederation::create_federation][crate::client::DataprocMetastoreFederation::create_federation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3208,7 +3208,7 @@ pub mod dataproc_metastore_federation {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_federation][super::super::client::DataprocMetastoreFederation::create_federation].
+        /// on [create_federation][crate::client::DataprocMetastoreFederation::create_federation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_federation(self.0.request, self.0.options)
@@ -3301,7 +3301,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::update_federation][super::super::client::DataprocMetastoreFederation::update_federation] calls.
+    /// The request builder for [DataprocMetastoreFederation::update_federation][crate::client::DataprocMetastoreFederation::update_federation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3349,7 +3349,7 @@ pub mod dataproc_metastore_federation {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_federation][super::super::client::DataprocMetastoreFederation::update_federation].
+        /// on [update_federation][crate::client::DataprocMetastoreFederation::update_federation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_federation(self.0.request, self.0.options)
@@ -3448,7 +3448,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::delete_federation][super::super::client::DataprocMetastoreFederation::delete_federation] calls.
+    /// The request builder for [DataprocMetastoreFederation::delete_federation][crate::client::DataprocMetastoreFederation::delete_federation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3496,7 +3496,7 @@ pub mod dataproc_metastore_federation {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_federation][super::super::client::DataprocMetastoreFederation::delete_federation].
+        /// on [delete_federation][crate::client::DataprocMetastoreFederation::delete_federation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_federation(self.0.request, self.0.options)
@@ -3561,7 +3561,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::list_locations][super::super::client::DataprocMetastoreFederation::list_locations] calls.
+    /// The request builder for [DataprocMetastoreFederation::list_locations][crate::client::DataprocMetastoreFederation::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3671,7 +3671,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::get_location][super::super::client::DataprocMetastoreFederation::get_location] calls.
+    /// The request builder for [DataprocMetastoreFederation::get_location][crate::client::DataprocMetastoreFederation::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3732,7 +3732,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::set_iam_policy][super::super::client::DataprocMetastoreFederation::set_iam_policy] calls.
+    /// The request builder for [DataprocMetastoreFederation::set_iam_policy][crate::client::DataprocMetastoreFederation::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3835,7 +3835,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::get_iam_policy][super::super::client::DataprocMetastoreFederation::get_iam_policy] calls.
+    /// The request builder for [DataprocMetastoreFederation::get_iam_policy][crate::client::DataprocMetastoreFederation::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3916,7 +3916,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::test_iam_permissions][super::super::client::DataprocMetastoreFederation::test_iam_permissions] calls.
+    /// The request builder for [DataprocMetastoreFederation::test_iam_permissions][crate::client::DataprocMetastoreFederation::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3995,7 +3995,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::list_operations][super::super::client::DataprocMetastoreFederation::list_operations] calls.
+    /// The request builder for [DataprocMetastoreFederation::list_operations][crate::client::DataprocMetastoreFederation::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4107,7 +4107,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::get_operation][super::super::client::DataprocMetastoreFederation::get_operation] calls.
+    /// The request builder for [DataprocMetastoreFederation::get_operation][crate::client::DataprocMetastoreFederation::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4171,7 +4171,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::delete_operation][super::super::client::DataprocMetastoreFederation::delete_operation] calls.
+    /// The request builder for [DataprocMetastoreFederation::delete_operation][crate::client::DataprocMetastoreFederation::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4235,7 +4235,7 @@ pub mod dataproc_metastore_federation {
         }
     }
 
-    /// The request builder for [DataprocMetastoreFederation::cancel_operation][super::super::client::DataprocMetastoreFederation::cancel_operation] calls.
+    /// The request builder for [DataprocMetastoreFederation::cancel_operation][crate::client::DataprocMetastoreFederation::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/migrationcenter/v1/src/builder.rs
+++ b/src/generated/cloud/migrationcenter/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod migration_center {
     use crate::Result;
 
-    /// A builder for [MigrationCenter][super::super::client::MigrationCenter].
+    /// A builder for [MigrationCenter][crate::client::MigrationCenter].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod migration_center {
         }
     }
 
-    /// Common implementation for [super::super::client::MigrationCenter] request builders.
+    /// Common implementation for [crate::client::MigrationCenter] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MigrationCenter>,
@@ -68,7 +68,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_assets][super::super::client::MigrationCenter::list_assets] calls.
+    /// The request builder for [MigrationCenter::list_assets][crate::client::MigrationCenter::list_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -189,7 +189,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_asset][super::super::client::MigrationCenter::get_asset] calls.
+    /// The request builder for [MigrationCenter::get_asset][crate::client::MigrationCenter::get_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -258,7 +258,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::update_asset][super::super::client::MigrationCenter::update_asset] calls.
+    /// The request builder for [MigrationCenter::update_asset][crate::client::MigrationCenter::update_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -363,7 +363,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::batch_update_assets][super::super::client::MigrationCenter::batch_update_assets] calls.
+    /// The request builder for [MigrationCenter::batch_update_assets][crate::client::MigrationCenter::batch_update_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -442,7 +442,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_asset][super::super::client::MigrationCenter::delete_asset] calls.
+    /// The request builder for [MigrationCenter::delete_asset][crate::client::MigrationCenter::delete_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -511,7 +511,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::batch_delete_assets][super::super::client::MigrationCenter::batch_delete_assets] calls.
+    /// The request builder for [MigrationCenter::batch_delete_assets][crate::client::MigrationCenter::batch_delete_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -596,7 +596,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::report_asset_frames][super::super::client::MigrationCenter::report_asset_frames] calls.
+    /// The request builder for [MigrationCenter::report_asset_frames][crate::client::MigrationCenter::report_asset_frames] calls.
     ///
     /// # Example
     /// ```no_run
@@ -688,7 +688,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::aggregate_assets_values][super::super::client::MigrationCenter::aggregate_assets_values] calls.
+    /// The request builder for [MigrationCenter::aggregate_assets_values][crate::client::MigrationCenter::aggregate_assets_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -771,7 +771,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::create_import_job][super::super::client::MigrationCenter::create_import_job] calls.
+    /// The request builder for [MigrationCenter::create_import_job][crate::client::MigrationCenter::create_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -816,7 +816,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_import_job][super::super::client::MigrationCenter::create_import_job].
+        /// on [create_import_job][crate::client::MigrationCenter::create_import_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_import_job(self.0.request, self.0.options)
@@ -909,7 +909,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_import_jobs][super::super::client::MigrationCenter::list_import_jobs] calls.
+    /// The request builder for [MigrationCenter::list_import_jobs][crate::client::MigrationCenter::list_import_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1030,7 +1030,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_import_job][super::super::client::MigrationCenter::get_import_job] calls.
+    /// The request builder for [MigrationCenter::get_import_job][crate::client::MigrationCenter::get_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1099,7 +1099,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_import_job][super::super::client::MigrationCenter::delete_import_job] calls.
+    /// The request builder for [MigrationCenter::delete_import_job][crate::client::MigrationCenter::delete_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1144,7 +1144,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_import_job][super::super::client::MigrationCenter::delete_import_job].
+        /// on [delete_import_job][crate::client::MigrationCenter::delete_import_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_import_job(self.0.request, self.0.options)
@@ -1215,7 +1215,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::update_import_job][super::super::client::MigrationCenter::update_import_job] calls.
+    /// The request builder for [MigrationCenter::update_import_job][crate::client::MigrationCenter::update_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1260,7 +1260,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_import_job][super::super::client::MigrationCenter::update_import_job].
+        /// on [update_import_job][crate::client::MigrationCenter::update_import_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_import_job(self.0.request, self.0.options)
@@ -1359,7 +1359,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::validate_import_job][super::super::client::MigrationCenter::validate_import_job] calls.
+    /// The request builder for [MigrationCenter::validate_import_job][crate::client::MigrationCenter::validate_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1407,7 +1407,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [validate_import_job][super::super::client::MigrationCenter::validate_import_job].
+        /// on [validate_import_job][crate::client::MigrationCenter::validate_import_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .validate_import_job(self.0.request, self.0.options)
@@ -1472,7 +1472,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::run_import_job][super::super::client::MigrationCenter::run_import_job] calls.
+    /// The request builder for [MigrationCenter::run_import_job][crate::client::MigrationCenter::run_import_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1517,7 +1517,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [run_import_job][super::super::client::MigrationCenter::run_import_job].
+        /// on [run_import_job][crate::client::MigrationCenter::run_import_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .run_import_job(self.0.request, self.0.options)
@@ -1582,7 +1582,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_import_data_file][super::super::client::MigrationCenter::get_import_data_file] calls.
+    /// The request builder for [MigrationCenter::get_import_data_file][crate::client::MigrationCenter::get_import_data_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1648,7 +1648,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_import_data_files][super::super::client::MigrationCenter::list_import_data_files] calls.
+    /// The request builder for [MigrationCenter::list_import_data_files][crate::client::MigrationCenter::list_import_data_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1768,7 +1768,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::create_import_data_file][super::super::client::MigrationCenter::create_import_data_file] calls.
+    /// The request builder for [MigrationCenter::create_import_data_file][crate::client::MigrationCenter::create_import_data_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1816,7 +1816,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_import_data_file][super::super::client::MigrationCenter::create_import_data_file].
+        /// on [create_import_data_file][crate::client::MigrationCenter::create_import_data_file].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_import_data_file(self.0.request, self.0.options)
@@ -1912,7 +1912,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_import_data_file][super::super::client::MigrationCenter::delete_import_data_file] calls.
+    /// The request builder for [MigrationCenter::delete_import_data_file][crate::client::MigrationCenter::delete_import_data_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1960,7 +1960,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_import_data_file][super::super::client::MigrationCenter::delete_import_data_file].
+        /// on [delete_import_data_file][crate::client::MigrationCenter::delete_import_data_file].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_import_data_file(self.0.request, self.0.options)
@@ -2025,7 +2025,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_groups][super::super::client::MigrationCenter::list_groups] calls.
+    /// The request builder for [MigrationCenter::list_groups][crate::client::MigrationCenter::list_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2140,7 +2140,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_group][super::super::client::MigrationCenter::get_group] calls.
+    /// The request builder for [MigrationCenter::get_group][crate::client::MigrationCenter::get_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2203,7 +2203,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::create_group][super::super::client::MigrationCenter::create_group] calls.
+    /// The request builder for [MigrationCenter::create_group][crate::client::MigrationCenter::create_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2248,7 +2248,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_group][super::super::client::MigrationCenter::create_group].
+        /// on [create_group][crate::client::MigrationCenter::create_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_group(self.0.request, self.0.options)
@@ -2341,7 +2341,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::update_group][super::super::client::MigrationCenter::update_group] calls.
+    /// The request builder for [MigrationCenter::update_group][crate::client::MigrationCenter::update_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2386,7 +2386,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_group][super::super::client::MigrationCenter::update_group].
+        /// on [update_group][crate::client::MigrationCenter::update_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_group(self.0.request, self.0.options)
@@ -2485,7 +2485,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_group][super::super::client::MigrationCenter::delete_group] calls.
+    /// The request builder for [MigrationCenter::delete_group][crate::client::MigrationCenter::delete_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2530,7 +2530,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_group][super::super::client::MigrationCenter::delete_group].
+        /// on [delete_group][crate::client::MigrationCenter::delete_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_group(self.0.request, self.0.options)
@@ -2595,7 +2595,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::add_assets_to_group][super::super::client::MigrationCenter::add_assets_to_group] calls.
+    /// The request builder for [MigrationCenter::add_assets_to_group][crate::client::MigrationCenter::add_assets_to_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2643,7 +2643,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [add_assets_to_group][super::super::client::MigrationCenter::add_assets_to_group].
+        /// on [add_assets_to_group][crate::client::MigrationCenter::add_assets_to_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .add_assets_to_group(self.0.request, self.0.options)
@@ -2734,7 +2734,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::remove_assets_from_group][super::super::client::MigrationCenter::remove_assets_from_group] calls.
+    /// The request builder for [MigrationCenter::remove_assets_from_group][crate::client::MigrationCenter::remove_assets_from_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2782,7 +2782,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [remove_assets_from_group][super::super::client::MigrationCenter::remove_assets_from_group].
+        /// on [remove_assets_from_group][crate::client::MigrationCenter::remove_assets_from_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .remove_assets_from_group(self.0.request, self.0.options)
@@ -2873,7 +2873,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_error_frames][super::super::client::MigrationCenter::list_error_frames] calls.
+    /// The request builder for [MigrationCenter::list_error_frames][crate::client::MigrationCenter::list_error_frames] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2982,7 +2982,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_error_frame][super::super::client::MigrationCenter::get_error_frame] calls.
+    /// The request builder for [MigrationCenter::get_error_frame][crate::client::MigrationCenter::get_error_frame] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3051,7 +3051,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_sources][super::super::client::MigrationCenter::list_sources] calls.
+    /// The request builder for [MigrationCenter::list_sources][crate::client::MigrationCenter::list_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3166,7 +3166,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_source][super::super::client::MigrationCenter::get_source] calls.
+    /// The request builder for [MigrationCenter::get_source][crate::client::MigrationCenter::get_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3229,7 +3229,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::create_source][super::super::client::MigrationCenter::create_source] calls.
+    /// The request builder for [MigrationCenter::create_source][crate::client::MigrationCenter::create_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3274,7 +3274,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_source][super::super::client::MigrationCenter::create_source].
+        /// on [create_source][crate::client::MigrationCenter::create_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_source(self.0.request, self.0.options)
@@ -3367,7 +3367,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::update_source][super::super::client::MigrationCenter::update_source] calls.
+    /// The request builder for [MigrationCenter::update_source][crate::client::MigrationCenter::update_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3412,7 +3412,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_source][super::super::client::MigrationCenter::update_source].
+        /// on [update_source][crate::client::MigrationCenter::update_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_source(self.0.request, self.0.options)
@@ -3511,7 +3511,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_source][super::super::client::MigrationCenter::delete_source] calls.
+    /// The request builder for [MigrationCenter::delete_source][crate::client::MigrationCenter::delete_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3556,7 +3556,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_source][super::super::client::MigrationCenter::delete_source].
+        /// on [delete_source][crate::client::MigrationCenter::delete_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_source(self.0.request, self.0.options)
@@ -3621,7 +3621,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_preference_sets][super::super::client::MigrationCenter::list_preference_sets] calls.
+    /// The request builder for [MigrationCenter::list_preference_sets][crate::client::MigrationCenter::list_preference_sets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3735,7 +3735,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_preference_set][super::super::client::MigrationCenter::get_preference_set] calls.
+    /// The request builder for [MigrationCenter::get_preference_set][crate::client::MigrationCenter::get_preference_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3801,7 +3801,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::create_preference_set][super::super::client::MigrationCenter::create_preference_set] calls.
+    /// The request builder for [MigrationCenter::create_preference_set][crate::client::MigrationCenter::create_preference_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3849,7 +3849,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_preference_set][super::super::client::MigrationCenter::create_preference_set].
+        /// on [create_preference_set][crate::client::MigrationCenter::create_preference_set].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_preference_set(self.0.request, self.0.options)
@@ -3945,7 +3945,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::update_preference_set][super::super::client::MigrationCenter::update_preference_set] calls.
+    /// The request builder for [MigrationCenter::update_preference_set][crate::client::MigrationCenter::update_preference_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3993,7 +3993,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_preference_set][super::super::client::MigrationCenter::update_preference_set].
+        /// on [update_preference_set][crate::client::MigrationCenter::update_preference_set].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_preference_set(self.0.request, self.0.options)
@@ -4095,7 +4095,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_preference_set][super::super::client::MigrationCenter::delete_preference_set] calls.
+    /// The request builder for [MigrationCenter::delete_preference_set][crate::client::MigrationCenter::delete_preference_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4143,7 +4143,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_preference_set][super::super::client::MigrationCenter::delete_preference_set].
+        /// on [delete_preference_set][crate::client::MigrationCenter::delete_preference_set].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_preference_set(self.0.request, self.0.options)
@@ -4208,7 +4208,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_settings][super::super::client::MigrationCenter::get_settings] calls.
+    /// The request builder for [MigrationCenter::get_settings][crate::client::MigrationCenter::get_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4271,7 +4271,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::update_settings][super::super::client::MigrationCenter::update_settings] calls.
+    /// The request builder for [MigrationCenter::update_settings][crate::client::MigrationCenter::update_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4316,7 +4316,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_settings][super::super::client::MigrationCenter::update_settings].
+        /// on [update_settings][crate::client::MigrationCenter::update_settings].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_settings(self.0.request, self.0.options)
@@ -4415,7 +4415,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::create_report_config][super::super::client::MigrationCenter::create_report_config] calls.
+    /// The request builder for [MigrationCenter::create_report_config][crate::client::MigrationCenter::create_report_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4463,7 +4463,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_report_config][super::super::client::MigrationCenter::create_report_config].
+        /// on [create_report_config][crate::client::MigrationCenter::create_report_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_report_config(self.0.request, self.0.options)
@@ -4558,7 +4558,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_report_config][super::super::client::MigrationCenter::get_report_config] calls.
+    /// The request builder for [MigrationCenter::get_report_config][crate::client::MigrationCenter::get_report_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4621,7 +4621,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_report_configs][super::super::client::MigrationCenter::list_report_configs] calls.
+    /// The request builder for [MigrationCenter::list_report_configs][crate::client::MigrationCenter::list_report_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4739,7 +4739,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_report_config][super::super::client::MigrationCenter::delete_report_config] calls.
+    /// The request builder for [MigrationCenter::delete_report_config][crate::client::MigrationCenter::delete_report_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4787,7 +4787,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_report_config][super::super::client::MigrationCenter::delete_report_config].
+        /// on [delete_report_config][crate::client::MigrationCenter::delete_report_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_report_config(self.0.request, self.0.options)
@@ -4858,7 +4858,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::create_report][super::super::client::MigrationCenter::create_report] calls.
+    /// The request builder for [MigrationCenter::create_report][crate::client::MigrationCenter::create_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4903,7 +4903,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_report][super::super::client::MigrationCenter::create_report].
+        /// on [create_report][crate::client::MigrationCenter::create_report].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_report(self.0.request, self.0.options)
@@ -4996,7 +4996,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_report][super::super::client::MigrationCenter::get_report] calls.
+    /// The request builder for [MigrationCenter::get_report][crate::client::MigrationCenter::get_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5065,7 +5065,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_reports][super::super::client::MigrationCenter::list_reports] calls.
+    /// The request builder for [MigrationCenter::list_reports][crate::client::MigrationCenter::list_reports] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5186,7 +5186,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_report][super::super::client::MigrationCenter::delete_report] calls.
+    /// The request builder for [MigrationCenter::delete_report][crate::client::MigrationCenter::delete_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5231,7 +5231,7 @@ pub mod migration_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_report][super::super::client::MigrationCenter::delete_report].
+        /// on [delete_report][crate::client::MigrationCenter::delete_report].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_report(self.0.request, self.0.options)
@@ -5296,7 +5296,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_locations][super::super::client::MigrationCenter::list_locations] calls.
+    /// The request builder for [MigrationCenter::list_locations][crate::client::MigrationCenter::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5406,7 +5406,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_location][super::super::client::MigrationCenter::get_location] calls.
+    /// The request builder for [MigrationCenter::get_location][crate::client::MigrationCenter::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5467,7 +5467,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::list_operations][super::super::client::MigrationCenter::list_operations] calls.
+    /// The request builder for [MigrationCenter::list_operations][crate::client::MigrationCenter::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5579,7 +5579,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::get_operation][super::super::client::MigrationCenter::get_operation] calls.
+    /// The request builder for [MigrationCenter::get_operation][crate::client::MigrationCenter::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5643,7 +5643,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::delete_operation][super::super::client::MigrationCenter::delete_operation] calls.
+    /// The request builder for [MigrationCenter::delete_operation][crate::client::MigrationCenter::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5707,7 +5707,7 @@ pub mod migration_center {
         }
     }
 
-    /// The request builder for [MigrationCenter::cancel_operation][super::super::client::MigrationCenter::cancel_operation] calls.
+    /// The request builder for [MigrationCenter::cancel_operation][crate::client::MigrationCenter::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/modelarmor/v1/src/builder.rs
+++ b/src/generated/cloud/modelarmor/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod model_armor {
     use crate::Result;
 
-    /// A builder for [ModelArmor][super::super::client::ModelArmor].
+    /// A builder for [ModelArmor][crate::client::ModelArmor].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod model_armor {
         }
     }
 
-    /// Common implementation for [super::super::client::ModelArmor] request builders.
+    /// Common implementation for [crate::client::ModelArmor] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ModelArmor>,
@@ -68,7 +68,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::list_templates][super::super::client::ModelArmor::list_templates] calls.
+    /// The request builder for [ModelArmor::list_templates][crate::client::ModelArmor::list_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::get_template][super::super::client::ModelArmor::get_template] calls.
+    /// The request builder for [ModelArmor::get_template][crate::client::ModelArmor::get_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::create_template][super::super::client::ModelArmor::create_template] calls.
+    /// The request builder for [ModelArmor::create_template][crate::client::ModelArmor::create_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -345,7 +345,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::update_template][super::super::client::ModelArmor::update_template] calls.
+    /// The request builder for [ModelArmor::update_template][crate::client::ModelArmor::update_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -450,7 +450,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::delete_template][super::super::client::ModelArmor::delete_template] calls.
+    /// The request builder for [ModelArmor::delete_template][crate::client::ModelArmor::delete_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -519,7 +519,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::get_floor_setting][super::super::client::ModelArmor::get_floor_setting] calls.
+    /// The request builder for [ModelArmor::get_floor_setting][crate::client::ModelArmor::get_floor_setting] calls.
     ///
     /// # Example
     /// ```no_run
@@ -582,7 +582,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::update_floor_setting][super::super::client::ModelArmor::update_floor_setting] calls.
+    /// The request builder for [ModelArmor::update_floor_setting][crate::client::ModelArmor::update_floor_setting] calls.
     ///
     /// # Example
     /// ```no_run
@@ -680,7 +680,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::sanitize_user_prompt][super::super::client::ModelArmor::sanitize_user_prompt] calls.
+    /// The request builder for [ModelArmor::sanitize_user_prompt][crate::client::ModelArmor::sanitize_user_prompt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -768,7 +768,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::sanitize_model_response][super::super::client::ModelArmor::sanitize_model_response] calls.
+    /// The request builder for [ModelArmor::sanitize_model_response][crate::client::ModelArmor::sanitize_model_response] calls.
     ///
     /// # Example
     /// ```no_run
@@ -862,7 +862,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::list_locations][super::super::client::ModelArmor::list_locations] calls.
+    /// The request builder for [ModelArmor::list_locations][crate::client::ModelArmor::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -972,7 +972,7 @@ pub mod model_armor {
         }
     }
 
-    /// The request builder for [ModelArmor::get_location][super::super::client::ModelArmor::get_location] calls.
+    /// The request builder for [ModelArmor::get_location][crate::client::ModelArmor::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/netapp/v1/src/builder.rs
+++ b/src/generated/cloud/netapp/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod net_app {
     use crate::Result;
 
-    /// A builder for [NetApp][super::super::client::NetApp].
+    /// A builder for [NetApp][crate::client::NetApp].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod net_app {
         }
     }
 
-    /// Common implementation for [super::super::client::NetApp] request builders.
+    /// Common implementation for [crate::client::NetApp] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::NetApp>,
@@ -66,7 +66,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_storage_pools][super::super::client::NetApp::list_storage_pools] calls.
+    /// The request builder for [NetApp::list_storage_pools][crate::client::NetApp::list_storage_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -182,7 +182,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_storage_pool][super::super::client::NetApp::create_storage_pool] calls.
+    /// The request builder for [NetApp::create_storage_pool][crate::client::NetApp::create_storage_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -228,7 +228,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_storage_pool][super::super::client::NetApp::create_storage_pool].
+        /// on [create_storage_pool][crate::client::NetApp::create_storage_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_storage_pool(self.0.request, self.0.options)
@@ -317,7 +317,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_storage_pool][super::super::client::NetApp::get_storage_pool] calls.
+    /// The request builder for [NetApp::get_storage_pool][crate::client::NetApp::get_storage_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -378,7 +378,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_storage_pool][super::super::client::NetApp::update_storage_pool] calls.
+    /// The request builder for [NetApp::update_storage_pool][crate::client::NetApp::update_storage_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -424,7 +424,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_storage_pool][super::super::client::NetApp::update_storage_pool].
+        /// on [update_storage_pool][crate::client::NetApp::update_storage_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_storage_pool(self.0.request, self.0.options)
@@ -519,7 +519,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_storage_pool][super::super::client::NetApp::delete_storage_pool] calls.
+    /// The request builder for [NetApp::delete_storage_pool][crate::client::NetApp::delete_storage_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -565,7 +565,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_storage_pool][super::super::client::NetApp::delete_storage_pool].
+        /// on [delete_storage_pool][crate::client::NetApp::delete_storage_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_storage_pool(self.0.request, self.0.options)
@@ -624,7 +624,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::validate_directory_service][super::super::client::NetApp::validate_directory_service] calls.
+    /// The request builder for [NetApp::validate_directory_service][crate::client::NetApp::validate_directory_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -672,7 +672,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [validate_directory_service][super::super::client::NetApp::validate_directory_service].
+        /// on [validate_directory_service][crate::client::NetApp::validate_directory_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .validate_directory_service(self.0.request, self.0.options)
@@ -740,7 +740,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::switch_active_replica_zone][super::super::client::NetApp::switch_active_replica_zone] calls.
+    /// The request builder for [NetApp::switch_active_replica_zone][crate::client::NetApp::switch_active_replica_zone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -788,7 +788,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [switch_active_replica_zone][super::super::client::NetApp::switch_active_replica_zone].
+        /// on [switch_active_replica_zone][crate::client::NetApp::switch_active_replica_zone].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .switch_active_replica_zone(self.0.request, self.0.options)
@@ -847,7 +847,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_volumes][super::super::client::NetApp::list_volumes] calls.
+    /// The request builder for [NetApp::list_volumes][crate::client::NetApp::list_volumes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -960,7 +960,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_volume][super::super::client::NetApp::get_volume] calls.
+    /// The request builder for [NetApp::get_volume][crate::client::NetApp::get_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1021,7 +1021,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_volume][super::super::client::NetApp::create_volume] calls.
+    /// The request builder for [NetApp::create_volume][crate::client::NetApp::create_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1064,7 +1064,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_volume][super::super::client::NetApp::create_volume].
+        /// on [create_volume][crate::client::NetApp::create_volume].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_volume(self.0.request, self.0.options)
@@ -1151,7 +1151,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_volume][super::super::client::NetApp::update_volume] calls.
+    /// The request builder for [NetApp::update_volume][crate::client::NetApp::update_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1194,7 +1194,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_volume][super::super::client::NetApp::update_volume].
+        /// on [update_volume][crate::client::NetApp::update_volume].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_volume(self.0.request, self.0.options)
@@ -1287,7 +1287,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_volume][super::super::client::NetApp::delete_volume] calls.
+    /// The request builder for [NetApp::delete_volume][crate::client::NetApp::delete_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1330,7 +1330,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_volume][super::super::client::NetApp::delete_volume].
+        /// on [delete_volume][crate::client::NetApp::delete_volume].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_volume(self.0.request, self.0.options)
@@ -1395,7 +1395,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::revert_volume][super::super::client::NetApp::revert_volume] calls.
+    /// The request builder for [NetApp::revert_volume][crate::client::NetApp::revert_volume] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1438,7 +1438,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [revert_volume][super::super::client::NetApp::revert_volume].
+        /// on [revert_volume][crate::client::NetApp::revert_volume].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .revert_volume(self.0.request, self.0.options)
@@ -1503,7 +1503,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_snapshots][super::super::client::NetApp::list_snapshots] calls.
+    /// The request builder for [NetApp::list_snapshots][crate::client::NetApp::list_snapshots] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1616,7 +1616,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_snapshot][super::super::client::NetApp::get_snapshot] calls.
+    /// The request builder for [NetApp::get_snapshot][crate::client::NetApp::get_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1677,7 +1677,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_snapshot][super::super::client::NetApp::create_snapshot] calls.
+    /// The request builder for [NetApp::create_snapshot][crate::client::NetApp::create_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1720,7 +1720,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_snapshot][super::super::client::NetApp::create_snapshot].
+        /// on [create_snapshot][crate::client::NetApp::create_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_snapshot(self.0.request, self.0.options)
@@ -1807,7 +1807,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_snapshot][super::super::client::NetApp::delete_snapshot] calls.
+    /// The request builder for [NetApp::delete_snapshot][crate::client::NetApp::delete_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1850,7 +1850,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_snapshot][super::super::client::NetApp::delete_snapshot].
+        /// on [delete_snapshot][crate::client::NetApp::delete_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_snapshot(self.0.request, self.0.options)
@@ -1909,7 +1909,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_snapshot][super::super::client::NetApp::update_snapshot] calls.
+    /// The request builder for [NetApp::update_snapshot][crate::client::NetApp::update_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1952,7 +1952,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_snapshot][super::super::client::NetApp::update_snapshot].
+        /// on [update_snapshot][crate::client::NetApp::update_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_snapshot(self.0.request, self.0.options)
@@ -2045,7 +2045,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_active_directories][super::super::client::NetApp::list_active_directories] calls.
+    /// The request builder for [NetApp::list_active_directories][crate::client::NetApp::list_active_directories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2163,7 +2163,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_active_directory][super::super::client::NetApp::get_active_directory] calls.
+    /// The request builder for [NetApp::get_active_directory][crate::client::NetApp::get_active_directory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2227,7 +2227,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_active_directory][super::super::client::NetApp::create_active_directory] calls.
+    /// The request builder for [NetApp::create_active_directory][crate::client::NetApp::create_active_directory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2273,7 +2273,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_active_directory][super::super::client::NetApp::create_active_directory].
+        /// on [create_active_directory][crate::client::NetApp::create_active_directory].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_active_directory(self.0.request, self.0.options)
@@ -2363,7 +2363,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_active_directory][super::super::client::NetApp::update_active_directory] calls.
+    /// The request builder for [NetApp::update_active_directory][crate::client::NetApp::update_active_directory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2409,7 +2409,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_active_directory][super::super::client::NetApp::update_active_directory].
+        /// on [update_active_directory][crate::client::NetApp::update_active_directory].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_active_directory(self.0.request, self.0.options)
@@ -2505,7 +2505,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_active_directory][super::super::client::NetApp::delete_active_directory] calls.
+    /// The request builder for [NetApp::delete_active_directory][crate::client::NetApp::delete_active_directory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2551,7 +2551,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_active_directory][super::super::client::NetApp::delete_active_directory].
+        /// on [delete_active_directory][crate::client::NetApp::delete_active_directory].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_active_directory(self.0.request, self.0.options)
@@ -2610,7 +2610,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_kms_configs][super::super::client::NetApp::list_kms_configs] calls.
+    /// The request builder for [NetApp::list_kms_configs][crate::client::NetApp::list_kms_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2723,7 +2723,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_kms_config][super::super::client::NetApp::create_kms_config] calls.
+    /// The request builder for [NetApp::create_kms_config][crate::client::NetApp::create_kms_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2766,7 +2766,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_kms_config][super::super::client::NetApp::create_kms_config].
+        /// on [create_kms_config][crate::client::NetApp::create_kms_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_kms_config(self.0.request, self.0.options)
@@ -2853,7 +2853,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_kms_config][super::super::client::NetApp::get_kms_config] calls.
+    /// The request builder for [NetApp::get_kms_config][crate::client::NetApp::get_kms_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2914,7 +2914,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_kms_config][super::super::client::NetApp::update_kms_config] calls.
+    /// The request builder for [NetApp::update_kms_config][crate::client::NetApp::update_kms_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2957,7 +2957,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_kms_config][super::super::client::NetApp::update_kms_config].
+        /// on [update_kms_config][crate::client::NetApp::update_kms_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_kms_config(self.0.request, self.0.options)
@@ -3050,7 +3050,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::encrypt_volumes][super::super::client::NetApp::encrypt_volumes] calls.
+    /// The request builder for [NetApp::encrypt_volumes][crate::client::NetApp::encrypt_volumes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3093,7 +3093,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [encrypt_volumes][super::super::client::NetApp::encrypt_volumes].
+        /// on [encrypt_volumes][crate::client::NetApp::encrypt_volumes].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .encrypt_volumes(self.0.request, self.0.options)
@@ -3150,7 +3150,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::verify_kms_config][super::super::client::NetApp::verify_kms_config] calls.
+    /// The request builder for [NetApp::verify_kms_config][crate::client::NetApp::verify_kms_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3211,7 +3211,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_kms_config][super::super::client::NetApp::delete_kms_config] calls.
+    /// The request builder for [NetApp::delete_kms_config][crate::client::NetApp::delete_kms_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3254,7 +3254,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_kms_config][super::super::client::NetApp::delete_kms_config].
+        /// on [delete_kms_config][crate::client::NetApp::delete_kms_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_kms_config(self.0.request, self.0.options)
@@ -3313,7 +3313,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_replications][super::super::client::NetApp::list_replications] calls.
+    /// The request builder for [NetApp::list_replications][crate::client::NetApp::list_replications] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3429,7 +3429,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_replication][super::super::client::NetApp::get_replication] calls.
+    /// The request builder for [NetApp::get_replication][crate::client::NetApp::get_replication] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3490,7 +3490,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_replication][super::super::client::NetApp::create_replication] calls.
+    /// The request builder for [NetApp::create_replication][crate::client::NetApp::create_replication] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3536,7 +3536,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_replication][super::super::client::NetApp::create_replication].
+        /// on [create_replication][crate::client::NetApp::create_replication].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_replication(self.0.request, self.0.options)
@@ -3625,7 +3625,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_replication][super::super::client::NetApp::delete_replication] calls.
+    /// The request builder for [NetApp::delete_replication][crate::client::NetApp::delete_replication] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3671,7 +3671,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_replication][super::super::client::NetApp::delete_replication].
+        /// on [delete_replication][crate::client::NetApp::delete_replication].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_replication(self.0.request, self.0.options)
@@ -3730,7 +3730,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_replication][super::super::client::NetApp::update_replication] calls.
+    /// The request builder for [NetApp::update_replication][crate::client::NetApp::update_replication] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3776,7 +3776,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_replication][super::super::client::NetApp::update_replication].
+        /// on [update_replication][crate::client::NetApp::update_replication].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_replication(self.0.request, self.0.options)
@@ -3871,7 +3871,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::stop_replication][super::super::client::NetApp::stop_replication] calls.
+    /// The request builder for [NetApp::stop_replication][crate::client::NetApp::stop_replication] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3914,7 +3914,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_replication][super::super::client::NetApp::stop_replication].
+        /// on [stop_replication][crate::client::NetApp::stop_replication].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_replication(self.0.request, self.0.options)
@@ -3979,7 +3979,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::resume_replication][super::super::client::NetApp::resume_replication] calls.
+    /// The request builder for [NetApp::resume_replication][crate::client::NetApp::resume_replication] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4025,7 +4025,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [resume_replication][super::super::client::NetApp::resume_replication].
+        /// on [resume_replication][crate::client::NetApp::resume_replication].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .resume_replication(self.0.request, self.0.options)
@@ -4084,7 +4084,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::reverse_replication_direction][super::super::client::NetApp::reverse_replication_direction] calls.
+    /// The request builder for [NetApp::reverse_replication_direction][crate::client::NetApp::reverse_replication_direction] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4132,7 +4132,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reverse_replication_direction][super::super::client::NetApp::reverse_replication_direction].
+        /// on [reverse_replication_direction][crate::client::NetApp::reverse_replication_direction].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reverse_replication_direction(self.0.request, self.0.options)
@@ -4191,7 +4191,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::establish_peering][super::super::client::NetApp::establish_peering] calls.
+    /// The request builder for [NetApp::establish_peering][crate::client::NetApp::establish_peering] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4237,7 +4237,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [establish_peering][super::super::client::NetApp::establish_peering].
+        /// on [establish_peering][crate::client::NetApp::establish_peering].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .establish_peering(self.0.request, self.0.options)
@@ -4331,7 +4331,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::sync_replication][super::super::client::NetApp::sync_replication] calls.
+    /// The request builder for [NetApp::sync_replication][crate::client::NetApp::sync_replication] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4374,7 +4374,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [sync_replication][super::super::client::NetApp::sync_replication].
+        /// on [sync_replication][crate::client::NetApp::sync_replication].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .sync_replication(self.0.request, self.0.options)
@@ -4433,7 +4433,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_backup_vault][super::super::client::NetApp::create_backup_vault] calls.
+    /// The request builder for [NetApp::create_backup_vault][crate::client::NetApp::create_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4479,7 +4479,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup_vault][super::super::client::NetApp::create_backup_vault].
+        /// on [create_backup_vault][crate::client::NetApp::create_backup_vault].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup_vault(self.0.request, self.0.options)
@@ -4568,7 +4568,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_backup_vault][super::super::client::NetApp::get_backup_vault] calls.
+    /// The request builder for [NetApp::get_backup_vault][crate::client::NetApp::get_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4629,7 +4629,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_backup_vaults][super::super::client::NetApp::list_backup_vaults] calls.
+    /// The request builder for [NetApp::list_backup_vaults][crate::client::NetApp::list_backup_vaults] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4745,7 +4745,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_backup_vault][super::super::client::NetApp::update_backup_vault] calls.
+    /// The request builder for [NetApp::update_backup_vault][crate::client::NetApp::update_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4791,7 +4791,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup_vault][super::super::client::NetApp::update_backup_vault].
+        /// on [update_backup_vault][crate::client::NetApp::update_backup_vault].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup_vault(self.0.request, self.0.options)
@@ -4886,7 +4886,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_backup_vault][super::super::client::NetApp::delete_backup_vault] calls.
+    /// The request builder for [NetApp::delete_backup_vault][crate::client::NetApp::delete_backup_vault] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4932,7 +4932,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup_vault][super::super::client::NetApp::delete_backup_vault].
+        /// on [delete_backup_vault][crate::client::NetApp::delete_backup_vault].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup_vault(self.0.request, self.0.options)
@@ -4991,7 +4991,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_backup][super::super::client::NetApp::create_backup] calls.
+    /// The request builder for [NetApp::create_backup][crate::client::NetApp::create_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5034,7 +5034,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup][super::super::client::NetApp::create_backup].
+        /// on [create_backup][crate::client::NetApp::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
@@ -5121,7 +5121,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_backup][super::super::client::NetApp::get_backup] calls.
+    /// The request builder for [NetApp::get_backup][crate::client::NetApp::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5182,7 +5182,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_backups][super::super::client::NetApp::list_backups] calls.
+    /// The request builder for [NetApp::list_backups][crate::client::NetApp::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5295,7 +5295,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_backup][super::super::client::NetApp::delete_backup] calls.
+    /// The request builder for [NetApp::delete_backup][crate::client::NetApp::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5338,7 +5338,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::NetApp::delete_backup].
+        /// on [delete_backup][crate::client::NetApp::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -5397,7 +5397,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_backup][super::super::client::NetApp::update_backup] calls.
+    /// The request builder for [NetApp::update_backup][crate::client::NetApp::update_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5440,7 +5440,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup][super::super::client::NetApp::update_backup].
+        /// on [update_backup][crate::client::NetApp::update_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup(self.0.request, self.0.options)
@@ -5533,7 +5533,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_backup_policy][super::super::client::NetApp::create_backup_policy] calls.
+    /// The request builder for [NetApp::create_backup_policy][crate::client::NetApp::create_backup_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5579,7 +5579,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup_policy][super::super::client::NetApp::create_backup_policy].
+        /// on [create_backup_policy][crate::client::NetApp::create_backup_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup_policy(self.0.request, self.0.options)
@@ -5668,7 +5668,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_backup_policy][super::super::client::NetApp::get_backup_policy] calls.
+    /// The request builder for [NetApp::get_backup_policy][crate::client::NetApp::get_backup_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5729,7 +5729,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_backup_policies][super::super::client::NetApp::list_backup_policies] calls.
+    /// The request builder for [NetApp::list_backup_policies][crate::client::NetApp::list_backup_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5847,7 +5847,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_backup_policy][super::super::client::NetApp::update_backup_policy] calls.
+    /// The request builder for [NetApp::update_backup_policy][crate::client::NetApp::update_backup_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5893,7 +5893,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_backup_policy][super::super::client::NetApp::update_backup_policy].
+        /// on [update_backup_policy][crate::client::NetApp::update_backup_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_backup_policy(self.0.request, self.0.options)
@@ -5988,7 +5988,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_backup_policy][super::super::client::NetApp::delete_backup_policy] calls.
+    /// The request builder for [NetApp::delete_backup_policy][crate::client::NetApp::delete_backup_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6034,7 +6034,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup_policy][super::super::client::NetApp::delete_backup_policy].
+        /// on [delete_backup_policy][crate::client::NetApp::delete_backup_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup_policy(self.0.request, self.0.options)
@@ -6093,7 +6093,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_quota_rules][super::super::client::NetApp::list_quota_rules] calls.
+    /// The request builder for [NetApp::list_quota_rules][crate::client::NetApp::list_quota_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6206,7 +6206,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_quota_rule][super::super::client::NetApp::get_quota_rule] calls.
+    /// The request builder for [NetApp::get_quota_rule][crate::client::NetApp::get_quota_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6267,7 +6267,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::create_quota_rule][super::super::client::NetApp::create_quota_rule] calls.
+    /// The request builder for [NetApp::create_quota_rule][crate::client::NetApp::create_quota_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6310,7 +6310,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_quota_rule][super::super::client::NetApp::create_quota_rule].
+        /// on [create_quota_rule][crate::client::NetApp::create_quota_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_quota_rule(self.0.request, self.0.options)
@@ -6397,7 +6397,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::update_quota_rule][super::super::client::NetApp::update_quota_rule] calls.
+    /// The request builder for [NetApp::update_quota_rule][crate::client::NetApp::update_quota_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6440,7 +6440,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_quota_rule][super::super::client::NetApp::update_quota_rule].
+        /// on [update_quota_rule][crate::client::NetApp::update_quota_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_quota_rule(self.0.request, self.0.options)
@@ -6529,7 +6529,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_quota_rule][super::super::client::NetApp::delete_quota_rule] calls.
+    /// The request builder for [NetApp::delete_quota_rule][crate::client::NetApp::delete_quota_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6572,7 +6572,7 @@ pub mod net_app {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_quota_rule][super::super::client::NetApp::delete_quota_rule].
+        /// on [delete_quota_rule][crate::client::NetApp::delete_quota_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_quota_rule(self.0.request, self.0.options)
@@ -6631,7 +6631,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_locations][super::super::client::NetApp::list_locations] calls.
+    /// The request builder for [NetApp::list_locations][crate::client::NetApp::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6739,7 +6739,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_location][super::super::client::NetApp::get_location] calls.
+    /// The request builder for [NetApp::get_location][crate::client::NetApp::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6798,7 +6798,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::list_operations][super::super::client::NetApp::list_operations] calls.
+    /// The request builder for [NetApp::list_operations][crate::client::NetApp::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6908,7 +6908,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::get_operation][super::super::client::NetApp::get_operation] calls.
+    /// The request builder for [NetApp::get_operation][crate::client::NetApp::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6970,7 +6970,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::delete_operation][super::super::client::NetApp::delete_operation] calls.
+    /// The request builder for [NetApp::delete_operation][crate::client::NetApp::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7032,7 +7032,7 @@ pub mod net_app {
         }
     }
 
-    /// The request builder for [NetApp::cancel_operation][super::super::client::NetApp::cancel_operation] calls.
+    /// The request builder for [NetApp::cancel_operation][crate::client::NetApp::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/networkconnectivity/v1/src/builder.rs
+++ b/src/generated/cloud/networkconnectivity/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cross_network_automation_service {
     use crate::Result;
 
-    /// A builder for [CrossNetworkAutomationService][super::super::client::CrossNetworkAutomationService].
+    /// A builder for [CrossNetworkAutomationService][crate::client::CrossNetworkAutomationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CrossNetworkAutomationService] request builders.
+    /// Common implementation for [crate::client::CrossNetworkAutomationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CrossNetworkAutomationService>,
@@ -68,7 +68,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::list_service_connection_maps][super::super::client::CrossNetworkAutomationService::list_service_connection_maps] calls.
+    /// The request builder for [CrossNetworkAutomationService::list_service_connection_maps][crate::client::CrossNetworkAutomationService::list_service_connection_maps] calls.
     ///
     /// # Example
     /// ```no_run
@@ -192,7 +192,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::get_service_connection_map][super::super::client::CrossNetworkAutomationService::get_service_connection_map] calls.
+    /// The request builder for [CrossNetworkAutomationService::get_service_connection_map][crate::client::CrossNetworkAutomationService::get_service_connection_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -260,7 +260,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::create_service_connection_map][super::super::client::CrossNetworkAutomationService::create_service_connection_map] calls.
+    /// The request builder for [CrossNetworkAutomationService::create_service_connection_map][crate::client::CrossNetworkAutomationService::create_service_connection_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -310,7 +310,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service_connection_map][super::super::client::CrossNetworkAutomationService::create_service_connection_map].
+        /// on [create_service_connection_map][crate::client::CrossNetworkAutomationService::create_service_connection_map].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service_connection_map(self.0.request, self.0.options)
@@ -404,7 +404,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::update_service_connection_map][super::super::client::CrossNetworkAutomationService::update_service_connection_map] calls.
+    /// The request builder for [CrossNetworkAutomationService::update_service_connection_map][crate::client::CrossNetworkAutomationService::update_service_connection_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -454,7 +454,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service_connection_map][super::super::client::CrossNetworkAutomationService::update_service_connection_map].
+        /// on [update_service_connection_map][crate::client::CrossNetworkAutomationService::update_service_connection_map].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service_connection_map(self.0.request, self.0.options)
@@ -552,7 +552,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_map][super::super::client::CrossNetworkAutomationService::delete_service_connection_map] calls.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_map][crate::client::CrossNetworkAutomationService::delete_service_connection_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -602,7 +602,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service_connection_map][super::super::client::CrossNetworkAutomationService::delete_service_connection_map].
+        /// on [delete_service_connection_map][crate::client::CrossNetworkAutomationService::delete_service_connection_map].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service_connection_map(self.0.request, self.0.options)
@@ -685,7 +685,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::list_service_connection_policies][super::super::client::CrossNetworkAutomationService::list_service_connection_policies] calls.
+    /// The request builder for [CrossNetworkAutomationService::list_service_connection_policies][crate::client::CrossNetworkAutomationService::list_service_connection_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -809,7 +809,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::get_service_connection_policy][super::super::client::CrossNetworkAutomationService::get_service_connection_policy] calls.
+    /// The request builder for [CrossNetworkAutomationService::get_service_connection_policy][crate::client::CrossNetworkAutomationService::get_service_connection_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -877,7 +877,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::create_service_connection_policy][super::super::client::CrossNetworkAutomationService::create_service_connection_policy] calls.
+    /// The request builder for [CrossNetworkAutomationService::create_service_connection_policy][crate::client::CrossNetworkAutomationService::create_service_connection_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -927,7 +927,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service_connection_policy][super::super::client::CrossNetworkAutomationService::create_service_connection_policy].
+        /// on [create_service_connection_policy][crate::client::CrossNetworkAutomationService::create_service_connection_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service_connection_policy(self.0.request, self.0.options)
@@ -1027,7 +1027,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::update_service_connection_policy][super::super::client::CrossNetworkAutomationService::update_service_connection_policy] calls.
+    /// The request builder for [CrossNetworkAutomationService::update_service_connection_policy][crate::client::CrossNetworkAutomationService::update_service_connection_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1077,7 +1077,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service_connection_policy][super::super::client::CrossNetworkAutomationService::update_service_connection_policy].
+        /// on [update_service_connection_policy][crate::client::CrossNetworkAutomationService::update_service_connection_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service_connection_policy(self.0.request, self.0.options)
@@ -1178,7 +1178,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_policy][super::super::client::CrossNetworkAutomationService::delete_service_connection_policy] calls.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_policy][crate::client::CrossNetworkAutomationService::delete_service_connection_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1228,7 +1228,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service_connection_policy][super::super::client::CrossNetworkAutomationService::delete_service_connection_policy].
+        /// on [delete_service_connection_policy][crate::client::CrossNetworkAutomationService::delete_service_connection_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service_connection_policy(self.0.request, self.0.options)
@@ -1311,7 +1311,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::list_service_classes][super::super::client::CrossNetworkAutomationService::list_service_classes] calls.
+    /// The request builder for [CrossNetworkAutomationService::list_service_classes][crate::client::CrossNetworkAutomationService::list_service_classes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1431,7 +1431,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::get_service_class][super::super::client::CrossNetworkAutomationService::get_service_class] calls.
+    /// The request builder for [CrossNetworkAutomationService::get_service_class][crate::client::CrossNetworkAutomationService::get_service_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1494,7 +1494,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::update_service_class][super::super::client::CrossNetworkAutomationService::update_service_class] calls.
+    /// The request builder for [CrossNetworkAutomationService::update_service_class][crate::client::CrossNetworkAutomationService::update_service_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1542,7 +1542,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service_class][super::super::client::CrossNetworkAutomationService::update_service_class].
+        /// on [update_service_class][crate::client::CrossNetworkAutomationService::update_service_class].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service_class(self.0.request, self.0.options)
@@ -1639,7 +1639,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::delete_service_class][super::super::client::CrossNetworkAutomationService::delete_service_class] calls.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_class][crate::client::CrossNetworkAutomationService::delete_service_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1687,7 +1687,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service_class][super::super::client::CrossNetworkAutomationService::delete_service_class].
+        /// on [delete_service_class][crate::client::CrossNetworkAutomationService::delete_service_class].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service_class(self.0.request, self.0.options)
@@ -1770,7 +1770,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::get_service_connection_token][super::super::client::CrossNetworkAutomationService::get_service_connection_token] calls.
+    /// The request builder for [CrossNetworkAutomationService::get_service_connection_token][crate::client::CrossNetworkAutomationService::get_service_connection_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1838,7 +1838,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::list_service_connection_tokens][super::super::client::CrossNetworkAutomationService::list_service_connection_tokens] calls.
+    /// The request builder for [CrossNetworkAutomationService::list_service_connection_tokens][crate::client::CrossNetworkAutomationService::list_service_connection_tokens] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1962,7 +1962,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::create_service_connection_token][super::super::client::CrossNetworkAutomationService::create_service_connection_token] calls.
+    /// The request builder for [CrossNetworkAutomationService::create_service_connection_token][crate::client::CrossNetworkAutomationService::create_service_connection_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2012,7 +2012,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service_connection_token][super::super::client::CrossNetworkAutomationService::create_service_connection_token].
+        /// on [create_service_connection_token][crate::client::CrossNetworkAutomationService::create_service_connection_token].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service_connection_token(self.0.request, self.0.options)
@@ -2109,7 +2109,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_token][super::super::client::CrossNetworkAutomationService::delete_service_connection_token] calls.
+    /// The request builder for [CrossNetworkAutomationService::delete_service_connection_token][crate::client::CrossNetworkAutomationService::delete_service_connection_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2159,7 +2159,7 @@ pub mod cross_network_automation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service_connection_token][super::super::client::CrossNetworkAutomationService::delete_service_connection_token].
+        /// on [delete_service_connection_token][crate::client::CrossNetworkAutomationService::delete_service_connection_token].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service_connection_token(self.0.request, self.0.options)
@@ -2242,7 +2242,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::list_locations][super::super::client::CrossNetworkAutomationService::list_locations] calls.
+    /// The request builder for [CrossNetworkAutomationService::list_locations][crate::client::CrossNetworkAutomationService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2352,7 +2352,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::get_location][super::super::client::CrossNetworkAutomationService::get_location] calls.
+    /// The request builder for [CrossNetworkAutomationService::get_location][crate::client::CrossNetworkAutomationService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2413,7 +2413,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::set_iam_policy][super::super::client::CrossNetworkAutomationService::set_iam_policy] calls.
+    /// The request builder for [CrossNetworkAutomationService::set_iam_policy][crate::client::CrossNetworkAutomationService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2516,7 +2516,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::get_iam_policy][super::super::client::CrossNetworkAutomationService::get_iam_policy] calls.
+    /// The request builder for [CrossNetworkAutomationService::get_iam_policy][crate::client::CrossNetworkAutomationService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2597,7 +2597,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::test_iam_permissions][super::super::client::CrossNetworkAutomationService::test_iam_permissions] calls.
+    /// The request builder for [CrossNetworkAutomationService::test_iam_permissions][crate::client::CrossNetworkAutomationService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2676,7 +2676,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::list_operations][super::super::client::CrossNetworkAutomationService::list_operations] calls.
+    /// The request builder for [CrossNetworkAutomationService::list_operations][crate::client::CrossNetworkAutomationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2788,7 +2788,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::get_operation][super::super::client::CrossNetworkAutomationService::get_operation] calls.
+    /// The request builder for [CrossNetworkAutomationService::get_operation][crate::client::CrossNetworkAutomationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2852,7 +2852,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::delete_operation][super::super::client::CrossNetworkAutomationService::delete_operation] calls.
+    /// The request builder for [CrossNetworkAutomationService::delete_operation][crate::client::CrossNetworkAutomationService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2916,7 +2916,7 @@ pub mod cross_network_automation_service {
         }
     }
 
-    /// The request builder for [CrossNetworkAutomationService::cancel_operation][super::super::client::CrossNetworkAutomationService::cancel_operation] calls.
+    /// The request builder for [CrossNetworkAutomationService::cancel_operation][crate::client::CrossNetworkAutomationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2984,7 +2984,7 @@ pub mod cross_network_automation_service {
 pub mod hub_service {
     use crate::Result;
 
-    /// A builder for [HubService][super::super::client::HubService].
+    /// A builder for [HubService][crate::client::HubService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3012,7 +3012,7 @@ pub mod hub_service {
         }
     }
 
-    /// Common implementation for [super::super::client::HubService] request builders.
+    /// Common implementation for [crate::client::HubService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::HubService>,
@@ -3035,7 +3035,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_hubs][super::super::client::HubService::list_hubs] calls.
+    /// The request builder for [HubService::list_hubs][crate::client::HubService::list_hubs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3150,7 +3150,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_hub][super::super::client::HubService::get_hub] calls.
+    /// The request builder for [HubService::get_hub][crate::client::HubService::get_hub] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3213,7 +3213,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::create_hub][super::super::client::HubService::create_hub] calls.
+    /// The request builder for [HubService::create_hub][crate::client::HubService::create_hub] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3258,7 +3258,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_hub][super::super::client::HubService::create_hub].
+        /// on [create_hub][crate::client::HubService::create_hub].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_hub(self.0.request, self.0.options)
@@ -3351,7 +3351,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::update_hub][super::super::client::HubService::update_hub] calls.
+    /// The request builder for [HubService::update_hub][crate::client::HubService::update_hub] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3396,7 +3396,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_hub][super::super::client::HubService::update_hub].
+        /// on [update_hub][crate::client::HubService::update_hub].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_hub(self.0.request, self.0.options)
@@ -3491,7 +3491,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::delete_hub][super::super::client::HubService::delete_hub] calls.
+    /// The request builder for [HubService::delete_hub][crate::client::HubService::delete_hub] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3536,7 +3536,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_hub][super::super::client::HubService::delete_hub].
+        /// on [delete_hub][crate::client::HubService::delete_hub].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_hub(self.0.request, self.0.options)
@@ -3601,7 +3601,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_hub_spokes][super::super::client::HubService::list_hub_spokes] calls.
+    /// The request builder for [HubService::list_hub_spokes][crate::client::HubService::list_hub_spokes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3736,7 +3736,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::query_hub_status][super::super::client::HubService::query_hub_status] calls.
+    /// The request builder for [HubService::query_hub_status][crate::client::HubService::query_hub_status] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3857,7 +3857,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_spokes][super::super::client::HubService::list_spokes] calls.
+    /// The request builder for [HubService::list_spokes][crate::client::HubService::list_spokes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3972,7 +3972,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_spoke][super::super::client::HubService::get_spoke] calls.
+    /// The request builder for [HubService::get_spoke][crate::client::HubService::get_spoke] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4035,7 +4035,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::create_spoke][super::super::client::HubService::create_spoke] calls.
+    /// The request builder for [HubService::create_spoke][crate::client::HubService::create_spoke] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4080,7 +4080,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_spoke][super::super::client::HubService::create_spoke].
+        /// on [create_spoke][crate::client::HubService::create_spoke].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_spoke(self.0.request, self.0.options)
@@ -4173,7 +4173,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::update_spoke][super::super::client::HubService::update_spoke] calls.
+    /// The request builder for [HubService::update_spoke][crate::client::HubService::update_spoke] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4218,7 +4218,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_spoke][super::super::client::HubService::update_spoke].
+        /// on [update_spoke][crate::client::HubService::update_spoke].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_spoke(self.0.request, self.0.options)
@@ -4313,7 +4313,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::reject_hub_spoke][super::super::client::HubService::reject_hub_spoke] calls.
+    /// The request builder for [HubService::reject_hub_spoke][crate::client::HubService::reject_hub_spoke] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4358,7 +4358,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reject_hub_spoke][super::super::client::HubService::reject_hub_spoke].
+        /// on [reject_hub_spoke][crate::client::HubService::reject_hub_spoke].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reject_hub_spoke(self.0.request, self.0.options)
@@ -4438,7 +4438,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::accept_hub_spoke][super::super::client::HubService::accept_hub_spoke] calls.
+    /// The request builder for [HubService::accept_hub_spoke][crate::client::HubService::accept_hub_spoke] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4483,7 +4483,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [accept_hub_spoke][super::super::client::HubService::accept_hub_spoke].
+        /// on [accept_hub_spoke][crate::client::HubService::accept_hub_spoke].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .accept_hub_spoke(self.0.request, self.0.options)
@@ -4557,7 +4557,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::accept_spoke_update][super::super::client::HubService::accept_spoke_update] calls.
+    /// The request builder for [HubService::accept_spoke_update][crate::client::HubService::accept_spoke_update] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4605,7 +4605,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [accept_spoke_update][super::super::client::HubService::accept_spoke_update].
+        /// on [accept_spoke_update][crate::client::HubService::accept_spoke_update].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .accept_spoke_update(self.0.request, self.0.options)
@@ -4687,7 +4687,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::reject_spoke_update][super::super::client::HubService::reject_spoke_update] calls.
+    /// The request builder for [HubService::reject_spoke_update][crate::client::HubService::reject_spoke_update] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4735,7 +4735,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reject_spoke_update][super::super::client::HubService::reject_spoke_update].
+        /// on [reject_spoke_update][crate::client::HubService::reject_spoke_update].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reject_spoke_update(self.0.request, self.0.options)
@@ -4823,7 +4823,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::delete_spoke][super::super::client::HubService::delete_spoke] calls.
+    /// The request builder for [HubService::delete_spoke][crate::client::HubService::delete_spoke] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4868,7 +4868,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_spoke][super::super::client::HubService::delete_spoke].
+        /// on [delete_spoke][crate::client::HubService::delete_spoke].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_spoke(self.0.request, self.0.options)
@@ -4933,7 +4933,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_route_table][super::super::client::HubService::get_route_table] calls.
+    /// The request builder for [HubService::get_route_table][crate::client::HubService::get_route_table] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4996,7 +4996,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_route][super::super::client::HubService::get_route] calls.
+    /// The request builder for [HubService::get_route][crate::client::HubService::get_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5059,7 +5059,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_routes][super::super::client::HubService::list_routes] calls.
+    /// The request builder for [HubService::list_routes][crate::client::HubService::list_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5174,7 +5174,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_route_tables][super::super::client::HubService::list_route_tables] calls.
+    /// The request builder for [HubService::list_route_tables][crate::client::HubService::list_route_tables] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5289,7 +5289,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_group][super::super::client::HubService::get_group] calls.
+    /// The request builder for [HubService::get_group][crate::client::HubService::get_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5352,7 +5352,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_groups][super::super::client::HubService::list_groups] calls.
+    /// The request builder for [HubService::list_groups][crate::client::HubService::list_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5467,7 +5467,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::update_group][super::super::client::HubService::update_group] calls.
+    /// The request builder for [HubService::update_group][crate::client::HubService::update_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5512,7 +5512,7 @@ pub mod hub_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_group][super::super::client::HubService::update_group].
+        /// on [update_group][crate::client::HubService::update_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_group(self.0.request, self.0.options)
@@ -5607,7 +5607,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_locations][super::super::client::HubService::list_locations] calls.
+    /// The request builder for [HubService::list_locations][crate::client::HubService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5717,7 +5717,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_location][super::super::client::HubService::get_location] calls.
+    /// The request builder for [HubService::get_location][crate::client::HubService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5778,7 +5778,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::set_iam_policy][super::super::client::HubService::set_iam_policy] calls.
+    /// The request builder for [HubService::set_iam_policy][crate::client::HubService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5881,7 +5881,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_iam_policy][super::super::client::HubService::get_iam_policy] calls.
+    /// The request builder for [HubService::get_iam_policy][crate::client::HubService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5962,7 +5962,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::test_iam_permissions][super::super::client::HubService::test_iam_permissions] calls.
+    /// The request builder for [HubService::test_iam_permissions][crate::client::HubService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6041,7 +6041,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::list_operations][super::super::client::HubService::list_operations] calls.
+    /// The request builder for [HubService::list_operations][crate::client::HubService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6153,7 +6153,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::get_operation][super::super::client::HubService::get_operation] calls.
+    /// The request builder for [HubService::get_operation][crate::client::HubService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6217,7 +6217,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::delete_operation][super::super::client::HubService::delete_operation] calls.
+    /// The request builder for [HubService::delete_operation][crate::client::HubService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6281,7 +6281,7 @@ pub mod hub_service {
         }
     }
 
-    /// The request builder for [HubService::cancel_operation][super::super::client::HubService::cancel_operation] calls.
+    /// The request builder for [HubService::cancel_operation][crate::client::HubService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6349,7 +6349,7 @@ pub mod hub_service {
 pub mod policy_based_routing_service {
     use crate::Result;
 
-    /// A builder for [PolicyBasedRoutingService][super::super::client::PolicyBasedRoutingService].
+    /// A builder for [PolicyBasedRoutingService][crate::client::PolicyBasedRoutingService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6377,7 +6377,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// Common implementation for [super::super::client::PolicyBasedRoutingService] request builders.
+    /// Common implementation for [crate::client::PolicyBasedRoutingService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PolicyBasedRoutingService>,
@@ -6400,7 +6400,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::list_policy_based_routes][super::super::client::PolicyBasedRoutingService::list_policy_based_routes] calls.
+    /// The request builder for [PolicyBasedRoutingService::list_policy_based_routes][crate::client::PolicyBasedRoutingService::list_policy_based_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6520,7 +6520,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::get_policy_based_route][super::super::client::PolicyBasedRoutingService::get_policy_based_route] calls.
+    /// The request builder for [PolicyBasedRoutingService::get_policy_based_route][crate::client::PolicyBasedRoutingService::get_policy_based_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6586,7 +6586,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::create_policy_based_route][super::super::client::PolicyBasedRoutingService::create_policy_based_route] calls.
+    /// The request builder for [PolicyBasedRoutingService::create_policy_based_route][crate::client::PolicyBasedRoutingService::create_policy_based_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6634,7 +6634,7 @@ pub mod policy_based_routing_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_policy_based_route][super::super::client::PolicyBasedRoutingService::create_policy_based_route].
+        /// on [create_policy_based_route][crate::client::PolicyBasedRoutingService::create_policy_based_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_policy_based_route(self.0.request, self.0.options)
@@ -6730,7 +6730,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::delete_policy_based_route][super::super::client::PolicyBasedRoutingService::delete_policy_based_route] calls.
+    /// The request builder for [PolicyBasedRoutingService::delete_policy_based_route][crate::client::PolicyBasedRoutingService::delete_policy_based_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6778,7 +6778,7 @@ pub mod policy_based_routing_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_policy_based_route][super::super::client::PolicyBasedRoutingService::delete_policy_based_route].
+        /// on [delete_policy_based_route][crate::client::PolicyBasedRoutingService::delete_policy_based_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_policy_based_route(self.0.request, self.0.options)
@@ -6843,7 +6843,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::list_locations][super::super::client::PolicyBasedRoutingService::list_locations] calls.
+    /// The request builder for [PolicyBasedRoutingService::list_locations][crate::client::PolicyBasedRoutingService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6953,7 +6953,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::get_location][super::super::client::PolicyBasedRoutingService::get_location] calls.
+    /// The request builder for [PolicyBasedRoutingService::get_location][crate::client::PolicyBasedRoutingService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7014,7 +7014,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::set_iam_policy][super::super::client::PolicyBasedRoutingService::set_iam_policy] calls.
+    /// The request builder for [PolicyBasedRoutingService::set_iam_policy][crate::client::PolicyBasedRoutingService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7117,7 +7117,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::get_iam_policy][super::super::client::PolicyBasedRoutingService::get_iam_policy] calls.
+    /// The request builder for [PolicyBasedRoutingService::get_iam_policy][crate::client::PolicyBasedRoutingService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7198,7 +7198,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::test_iam_permissions][super::super::client::PolicyBasedRoutingService::test_iam_permissions] calls.
+    /// The request builder for [PolicyBasedRoutingService::test_iam_permissions][crate::client::PolicyBasedRoutingService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7277,7 +7277,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::list_operations][super::super::client::PolicyBasedRoutingService::list_operations] calls.
+    /// The request builder for [PolicyBasedRoutingService::list_operations][crate::client::PolicyBasedRoutingService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7389,7 +7389,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::get_operation][super::super::client::PolicyBasedRoutingService::get_operation] calls.
+    /// The request builder for [PolicyBasedRoutingService::get_operation][crate::client::PolicyBasedRoutingService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7453,7 +7453,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::delete_operation][super::super::client::PolicyBasedRoutingService::delete_operation] calls.
+    /// The request builder for [PolicyBasedRoutingService::delete_operation][crate::client::PolicyBasedRoutingService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7517,7 +7517,7 @@ pub mod policy_based_routing_service {
         }
     }
 
-    /// The request builder for [PolicyBasedRoutingService::cancel_operation][super::super::client::PolicyBasedRoutingService::cancel_operation] calls.
+    /// The request builder for [PolicyBasedRoutingService::cancel_operation][crate::client::PolicyBasedRoutingService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/networkmanagement/v1/src/builder.rs
+++ b/src/generated/cloud/networkmanagement/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod reachability_service {
     use crate::Result;
 
-    /// A builder for [ReachabilityService][super::super::client::ReachabilityService].
+    /// A builder for [ReachabilityService][crate::client::ReachabilityService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod reachability_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ReachabilityService] request builders.
+    /// Common implementation for [crate::client::ReachabilityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ReachabilityService>,
@@ -68,7 +68,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::list_connectivity_tests][super::super::client::ReachabilityService::list_connectivity_tests] calls.
+    /// The request builder for [ReachabilityService::list_connectivity_tests][crate::client::ReachabilityService::list_connectivity_tests] calls.
     ///
     /// # Example
     /// ```no_run
@@ -188,7 +188,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::get_connectivity_test][super::super::client::ReachabilityService::get_connectivity_test] calls.
+    /// The request builder for [ReachabilityService::get_connectivity_test][crate::client::ReachabilityService::get_connectivity_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::create_connectivity_test][super::super::client::ReachabilityService::create_connectivity_test] calls.
+    /// The request builder for [ReachabilityService::create_connectivity_test][crate::client::ReachabilityService::create_connectivity_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -302,7 +302,7 @@ pub mod reachability_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_connectivity_test][super::super::client::ReachabilityService::create_connectivity_test].
+        /// on [create_connectivity_test][crate::client::ReachabilityService::create_connectivity_test].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_connectivity_test(self.0.request, self.0.options)
@@ -392,7 +392,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::update_connectivity_test][super::super::client::ReachabilityService::update_connectivity_test] calls.
+    /// The request builder for [ReachabilityService::update_connectivity_test][crate::client::ReachabilityService::update_connectivity_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -440,7 +440,7 @@ pub mod reachability_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_connectivity_test][super::super::client::ReachabilityService::update_connectivity_test].
+        /// on [update_connectivity_test][crate::client::ReachabilityService::update_connectivity_test].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_connectivity_test(self.0.request, self.0.options)
@@ -536,7 +536,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::rerun_connectivity_test][super::super::client::ReachabilityService::rerun_connectivity_test] calls.
+    /// The request builder for [ReachabilityService::rerun_connectivity_test][crate::client::ReachabilityService::rerun_connectivity_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -584,7 +584,7 @@ pub mod reachability_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [rerun_connectivity_test][super::super::client::ReachabilityService::rerun_connectivity_test].
+        /// on [rerun_connectivity_test][crate::client::ReachabilityService::rerun_connectivity_test].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .rerun_connectivity_test(self.0.request, self.0.options)
@@ -644,7 +644,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::delete_connectivity_test][super::super::client::ReachabilityService::delete_connectivity_test] calls.
+    /// The request builder for [ReachabilityService::delete_connectivity_test][crate::client::ReachabilityService::delete_connectivity_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -692,7 +692,7 @@ pub mod reachability_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_connectivity_test][super::super::client::ReachabilityService::delete_connectivity_test].
+        /// on [delete_connectivity_test][crate::client::ReachabilityService::delete_connectivity_test].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_connectivity_test(self.0.request, self.0.options)
@@ -751,7 +751,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::list_locations][super::super::client::ReachabilityService::list_locations] calls.
+    /// The request builder for [ReachabilityService::list_locations][crate::client::ReachabilityService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -861,7 +861,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::get_location][super::super::client::ReachabilityService::get_location] calls.
+    /// The request builder for [ReachabilityService::get_location][crate::client::ReachabilityService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -922,7 +922,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::set_iam_policy][super::super::client::ReachabilityService::set_iam_policy] calls.
+    /// The request builder for [ReachabilityService::set_iam_policy][crate::client::ReachabilityService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1025,7 +1025,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::get_iam_policy][super::super::client::ReachabilityService::get_iam_policy] calls.
+    /// The request builder for [ReachabilityService::get_iam_policy][crate::client::ReachabilityService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1106,7 +1106,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::test_iam_permissions][super::super::client::ReachabilityService::test_iam_permissions] calls.
+    /// The request builder for [ReachabilityService::test_iam_permissions][crate::client::ReachabilityService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1185,7 +1185,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::list_operations][super::super::client::ReachabilityService::list_operations] calls.
+    /// The request builder for [ReachabilityService::list_operations][crate::client::ReachabilityService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1297,7 +1297,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::get_operation][super::super::client::ReachabilityService::get_operation] calls.
+    /// The request builder for [ReachabilityService::get_operation][crate::client::ReachabilityService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1361,7 +1361,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::delete_operation][super::super::client::ReachabilityService::delete_operation] calls.
+    /// The request builder for [ReachabilityService::delete_operation][crate::client::ReachabilityService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1425,7 +1425,7 @@ pub mod reachability_service {
         }
     }
 
-    /// The request builder for [ReachabilityService::cancel_operation][super::super::client::ReachabilityService::cancel_operation] calls.
+    /// The request builder for [ReachabilityService::cancel_operation][crate::client::ReachabilityService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1493,7 +1493,7 @@ pub mod reachability_service {
 pub mod vpc_flow_logs_service {
     use crate::Result;
 
-    /// A builder for [VpcFlowLogsService][super::super::client::VpcFlowLogsService].
+    /// A builder for [VpcFlowLogsService][crate::client::VpcFlowLogsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1521,7 +1521,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// Common implementation for [super::super::client::VpcFlowLogsService] request builders.
+    /// Common implementation for [crate::client::VpcFlowLogsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VpcFlowLogsService>,
@@ -1544,7 +1544,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::list_vpc_flow_logs_configs][super::super::client::VpcFlowLogsService::list_vpc_flow_logs_configs] calls.
+    /// The request builder for [VpcFlowLogsService::list_vpc_flow_logs_configs][crate::client::VpcFlowLogsService::list_vpc_flow_logs_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1666,7 +1666,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::get_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::get_vpc_flow_logs_config] calls.
+    /// The request builder for [VpcFlowLogsService::get_vpc_flow_logs_config][crate::client::VpcFlowLogsService::get_vpc_flow_logs_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1732,7 +1732,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::create_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::create_vpc_flow_logs_config] calls.
+    /// The request builder for [VpcFlowLogsService::create_vpc_flow_logs_config][crate::client::VpcFlowLogsService::create_vpc_flow_logs_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1782,7 +1782,7 @@ pub mod vpc_flow_logs_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::create_vpc_flow_logs_config].
+        /// on [create_vpc_flow_logs_config][crate::client::VpcFlowLogsService::create_vpc_flow_logs_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_vpc_flow_logs_config(self.0.request, self.0.options)
@@ -1872,7 +1872,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::update_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::update_vpc_flow_logs_config] calls.
+    /// The request builder for [VpcFlowLogsService::update_vpc_flow_logs_config][crate::client::VpcFlowLogsService::update_vpc_flow_logs_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1922,7 +1922,7 @@ pub mod vpc_flow_logs_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::update_vpc_flow_logs_config].
+        /// on [update_vpc_flow_logs_config][crate::client::VpcFlowLogsService::update_vpc_flow_logs_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_vpc_flow_logs_config(self.0.request, self.0.options)
@@ -2018,7 +2018,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::delete_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::delete_vpc_flow_logs_config] calls.
+    /// The request builder for [VpcFlowLogsService::delete_vpc_flow_logs_config][crate::client::VpcFlowLogsService::delete_vpc_flow_logs_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2068,7 +2068,7 @@ pub mod vpc_flow_logs_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_vpc_flow_logs_config][super::super::client::VpcFlowLogsService::delete_vpc_flow_logs_config].
+        /// on [delete_vpc_flow_logs_config][crate::client::VpcFlowLogsService::delete_vpc_flow_logs_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_vpc_flow_logs_config(self.0.request, self.0.options)
@@ -2127,7 +2127,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::list_locations][super::super::client::VpcFlowLogsService::list_locations] calls.
+    /// The request builder for [VpcFlowLogsService::list_locations][crate::client::VpcFlowLogsService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2237,7 +2237,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::get_location][super::super::client::VpcFlowLogsService::get_location] calls.
+    /// The request builder for [VpcFlowLogsService::get_location][crate::client::VpcFlowLogsService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2298,7 +2298,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::set_iam_policy][super::super::client::VpcFlowLogsService::set_iam_policy] calls.
+    /// The request builder for [VpcFlowLogsService::set_iam_policy][crate::client::VpcFlowLogsService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2401,7 +2401,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::get_iam_policy][super::super::client::VpcFlowLogsService::get_iam_policy] calls.
+    /// The request builder for [VpcFlowLogsService::get_iam_policy][crate::client::VpcFlowLogsService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2482,7 +2482,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::test_iam_permissions][super::super::client::VpcFlowLogsService::test_iam_permissions] calls.
+    /// The request builder for [VpcFlowLogsService::test_iam_permissions][crate::client::VpcFlowLogsService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2561,7 +2561,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::list_operations][super::super::client::VpcFlowLogsService::list_operations] calls.
+    /// The request builder for [VpcFlowLogsService::list_operations][crate::client::VpcFlowLogsService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2673,7 +2673,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::get_operation][super::super::client::VpcFlowLogsService::get_operation] calls.
+    /// The request builder for [VpcFlowLogsService::get_operation][crate::client::VpcFlowLogsService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2737,7 +2737,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::delete_operation][super::super::client::VpcFlowLogsService::delete_operation] calls.
+    /// The request builder for [VpcFlowLogsService::delete_operation][crate::client::VpcFlowLogsService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2801,7 +2801,7 @@ pub mod vpc_flow_logs_service {
         }
     }
 
-    /// The request builder for [VpcFlowLogsService::cancel_operation][super::super::client::VpcFlowLogsService::cancel_operation] calls.
+    /// The request builder for [VpcFlowLogsService::cancel_operation][crate::client::VpcFlowLogsService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/networksecurity/v1/src/builder.rs
+++ b/src/generated/cloud/networksecurity/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod network_security {
     use crate::Result;
 
-    /// A builder for [NetworkSecurity][super::super::client::NetworkSecurity].
+    /// A builder for [NetworkSecurity][crate::client::NetworkSecurity].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod network_security {
         }
     }
 
-    /// Common implementation for [super::super::client::NetworkSecurity] request builders.
+    /// Common implementation for [crate::client::NetworkSecurity] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::NetworkSecurity>,
@@ -68,7 +68,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::list_authorization_policies][super::super::client::NetworkSecurity::list_authorization_policies] calls.
+    /// The request builder for [NetworkSecurity::list_authorization_policies][crate::client::NetworkSecurity::list_authorization_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -180,7 +180,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::get_authorization_policy][super::super::client::NetworkSecurity::get_authorization_policy] calls.
+    /// The request builder for [NetworkSecurity::get_authorization_policy][crate::client::NetworkSecurity::get_authorization_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::create_authorization_policy][super::super::client::NetworkSecurity::create_authorization_policy] calls.
+    /// The request builder for [NetworkSecurity::create_authorization_policy][crate::client::NetworkSecurity::create_authorization_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -296,7 +296,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_authorization_policy][super::super::client::NetworkSecurity::create_authorization_policy].
+        /// on [create_authorization_policy][crate::client::NetworkSecurity::create_authorization_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_authorization_policy(self.0.request, self.0.options)
@@ -386,7 +386,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::update_authorization_policy][super::super::client::NetworkSecurity::update_authorization_policy] calls.
+    /// The request builder for [NetworkSecurity::update_authorization_policy][crate::client::NetworkSecurity::update_authorization_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -436,7 +436,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_authorization_policy][super::super::client::NetworkSecurity::update_authorization_policy].
+        /// on [update_authorization_policy][crate::client::NetworkSecurity::update_authorization_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_authorization_policy(self.0.request, self.0.options)
@@ -528,7 +528,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::delete_authorization_policy][super::super::client::NetworkSecurity::delete_authorization_policy] calls.
+    /// The request builder for [NetworkSecurity::delete_authorization_policy][crate::client::NetworkSecurity::delete_authorization_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -578,7 +578,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_authorization_policy][super::super::client::NetworkSecurity::delete_authorization_policy].
+        /// on [delete_authorization_policy][crate::client::NetworkSecurity::delete_authorization_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_authorization_policy(self.0.request, self.0.options)
@@ -637,7 +637,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::list_server_tls_policies][super::super::client::NetworkSecurity::list_server_tls_policies] calls.
+    /// The request builder for [NetworkSecurity::list_server_tls_policies][crate::client::NetworkSecurity::list_server_tls_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -745,7 +745,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::get_server_tls_policy][super::super::client::NetworkSecurity::get_server_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::get_server_tls_policy][crate::client::NetworkSecurity::get_server_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -811,7 +811,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::create_server_tls_policy][super::super::client::NetworkSecurity::create_server_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::create_server_tls_policy][crate::client::NetworkSecurity::create_server_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -859,7 +859,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_server_tls_policy][super::super::client::NetworkSecurity::create_server_tls_policy].
+        /// on [create_server_tls_policy][crate::client::NetworkSecurity::create_server_tls_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_server_tls_policy(self.0.request, self.0.options)
@@ -949,7 +949,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::update_server_tls_policy][super::super::client::NetworkSecurity::update_server_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::update_server_tls_policy][crate::client::NetworkSecurity::update_server_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -997,7 +997,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_server_tls_policy][super::super::client::NetworkSecurity::update_server_tls_policy].
+        /// on [update_server_tls_policy][crate::client::NetworkSecurity::update_server_tls_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_server_tls_policy(self.0.request, self.0.options)
@@ -1089,7 +1089,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::delete_server_tls_policy][super::super::client::NetworkSecurity::delete_server_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::delete_server_tls_policy][crate::client::NetworkSecurity::delete_server_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1137,7 +1137,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_server_tls_policy][super::super::client::NetworkSecurity::delete_server_tls_policy].
+        /// on [delete_server_tls_policy][crate::client::NetworkSecurity::delete_server_tls_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_server_tls_policy(self.0.request, self.0.options)
@@ -1196,7 +1196,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::list_client_tls_policies][super::super::client::NetworkSecurity::list_client_tls_policies] calls.
+    /// The request builder for [NetworkSecurity::list_client_tls_policies][crate::client::NetworkSecurity::list_client_tls_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1304,7 +1304,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::get_client_tls_policy][super::super::client::NetworkSecurity::get_client_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::get_client_tls_policy][crate::client::NetworkSecurity::get_client_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1370,7 +1370,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::create_client_tls_policy][super::super::client::NetworkSecurity::create_client_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::create_client_tls_policy][crate::client::NetworkSecurity::create_client_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1418,7 +1418,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_client_tls_policy][super::super::client::NetworkSecurity::create_client_tls_policy].
+        /// on [create_client_tls_policy][crate::client::NetworkSecurity::create_client_tls_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_client_tls_policy(self.0.request, self.0.options)
@@ -1508,7 +1508,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::update_client_tls_policy][super::super::client::NetworkSecurity::update_client_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::update_client_tls_policy][crate::client::NetworkSecurity::update_client_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1556,7 +1556,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_client_tls_policy][super::super::client::NetworkSecurity::update_client_tls_policy].
+        /// on [update_client_tls_policy][crate::client::NetworkSecurity::update_client_tls_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_client_tls_policy(self.0.request, self.0.options)
@@ -1648,7 +1648,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::delete_client_tls_policy][super::super::client::NetworkSecurity::delete_client_tls_policy] calls.
+    /// The request builder for [NetworkSecurity::delete_client_tls_policy][crate::client::NetworkSecurity::delete_client_tls_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1696,7 +1696,7 @@ pub mod network_security {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_client_tls_policy][super::super::client::NetworkSecurity::delete_client_tls_policy].
+        /// on [delete_client_tls_policy][crate::client::NetworkSecurity::delete_client_tls_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_client_tls_policy(self.0.request, self.0.options)
@@ -1755,7 +1755,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::list_locations][super::super::client::NetworkSecurity::list_locations] calls.
+    /// The request builder for [NetworkSecurity::list_locations][crate::client::NetworkSecurity::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1865,7 +1865,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::get_location][super::super::client::NetworkSecurity::get_location] calls.
+    /// The request builder for [NetworkSecurity::get_location][crate::client::NetworkSecurity::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1926,7 +1926,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::set_iam_policy][super::super::client::NetworkSecurity::set_iam_policy] calls.
+    /// The request builder for [NetworkSecurity::set_iam_policy][crate::client::NetworkSecurity::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2029,7 +2029,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::get_iam_policy][super::super::client::NetworkSecurity::get_iam_policy] calls.
+    /// The request builder for [NetworkSecurity::get_iam_policy][crate::client::NetworkSecurity::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2110,7 +2110,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::test_iam_permissions][super::super::client::NetworkSecurity::test_iam_permissions] calls.
+    /// The request builder for [NetworkSecurity::test_iam_permissions][crate::client::NetworkSecurity::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2189,7 +2189,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::list_operations][super::super::client::NetworkSecurity::list_operations] calls.
+    /// The request builder for [NetworkSecurity::list_operations][crate::client::NetworkSecurity::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2301,7 +2301,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::get_operation][super::super::client::NetworkSecurity::get_operation] calls.
+    /// The request builder for [NetworkSecurity::get_operation][crate::client::NetworkSecurity::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2365,7 +2365,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::delete_operation][super::super::client::NetworkSecurity::delete_operation] calls.
+    /// The request builder for [NetworkSecurity::delete_operation][crate::client::NetworkSecurity::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2429,7 +2429,7 @@ pub mod network_security {
         }
     }
 
-    /// The request builder for [NetworkSecurity::cancel_operation][super::super::client::NetworkSecurity::cancel_operation] calls.
+    /// The request builder for [NetworkSecurity::cancel_operation][crate::client::NetworkSecurity::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/networkservices/v1/src/builder.rs
+++ b/src/generated/cloud/networkservices/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod dep_service {
     use crate::Result;
 
-    /// A builder for [DepService][super::super::client::DepService].
+    /// A builder for [DepService][crate::client::DepService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod dep_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DepService] request builders.
+    /// Common implementation for [crate::client::DepService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DepService>,
@@ -68,7 +68,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::list_lb_traffic_extensions][super::super::client::DepService::list_lb_traffic_extensions] calls.
+    /// The request builder for [DepService::list_lb_traffic_extensions][crate::client::DepService::list_lb_traffic_extensions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -192,7 +192,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::get_lb_traffic_extension][super::super::client::DepService::get_lb_traffic_extension] calls.
+    /// The request builder for [DepService::get_lb_traffic_extension][crate::client::DepService::get_lb_traffic_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -258,7 +258,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::create_lb_traffic_extension][super::super::client::DepService::create_lb_traffic_extension] calls.
+    /// The request builder for [DepService::create_lb_traffic_extension][crate::client::DepService::create_lb_traffic_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -308,7 +308,7 @@ pub mod dep_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_lb_traffic_extension][super::super::client::DepService::create_lb_traffic_extension].
+        /// on [create_lb_traffic_extension][crate::client::DepService::create_lb_traffic_extension].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_lb_traffic_extension(self.0.request, self.0.options)
@@ -404,7 +404,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::update_lb_traffic_extension][super::super::client::DepService::update_lb_traffic_extension] calls.
+    /// The request builder for [DepService::update_lb_traffic_extension][crate::client::DepService::update_lb_traffic_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -454,7 +454,7 @@ pub mod dep_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_lb_traffic_extension][super::super::client::DepService::update_lb_traffic_extension].
+        /// on [update_lb_traffic_extension][crate::client::DepService::update_lb_traffic_extension].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_lb_traffic_extension(self.0.request, self.0.options)
@@ -552,7 +552,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::delete_lb_traffic_extension][super::super::client::DepService::delete_lb_traffic_extension] calls.
+    /// The request builder for [DepService::delete_lb_traffic_extension][crate::client::DepService::delete_lb_traffic_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -602,7 +602,7 @@ pub mod dep_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_lb_traffic_extension][super::super::client::DepService::delete_lb_traffic_extension].
+        /// on [delete_lb_traffic_extension][crate::client::DepService::delete_lb_traffic_extension].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_lb_traffic_extension(self.0.request, self.0.options)
@@ -667,7 +667,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::list_lb_route_extensions][super::super::client::DepService::list_lb_route_extensions] calls.
+    /// The request builder for [DepService::list_lb_route_extensions][crate::client::DepService::list_lb_route_extensions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -787,7 +787,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::get_lb_route_extension][super::super::client::DepService::get_lb_route_extension] calls.
+    /// The request builder for [DepService::get_lb_route_extension][crate::client::DepService::get_lb_route_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -853,7 +853,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::create_lb_route_extension][super::super::client::DepService::create_lb_route_extension] calls.
+    /// The request builder for [DepService::create_lb_route_extension][crate::client::DepService::create_lb_route_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -901,7 +901,7 @@ pub mod dep_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_lb_route_extension][super::super::client::DepService::create_lb_route_extension].
+        /// on [create_lb_route_extension][crate::client::DepService::create_lb_route_extension].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_lb_route_extension(self.0.request, self.0.options)
@@ -997,7 +997,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::update_lb_route_extension][super::super::client::DepService::update_lb_route_extension] calls.
+    /// The request builder for [DepService::update_lb_route_extension][crate::client::DepService::update_lb_route_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1045,7 +1045,7 @@ pub mod dep_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_lb_route_extension][super::super::client::DepService::update_lb_route_extension].
+        /// on [update_lb_route_extension][crate::client::DepService::update_lb_route_extension].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_lb_route_extension(self.0.request, self.0.options)
@@ -1143,7 +1143,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::delete_lb_route_extension][super::super::client::DepService::delete_lb_route_extension] calls.
+    /// The request builder for [DepService::delete_lb_route_extension][crate::client::DepService::delete_lb_route_extension] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1191,7 +1191,7 @@ pub mod dep_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_lb_route_extension][super::super::client::DepService::delete_lb_route_extension].
+        /// on [delete_lb_route_extension][crate::client::DepService::delete_lb_route_extension].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_lb_route_extension(self.0.request, self.0.options)
@@ -1256,7 +1256,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::list_locations][super::super::client::DepService::list_locations] calls.
+    /// The request builder for [DepService::list_locations][crate::client::DepService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1366,7 +1366,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::get_location][super::super::client::DepService::get_location] calls.
+    /// The request builder for [DepService::get_location][crate::client::DepService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1427,7 +1427,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::set_iam_policy][super::super::client::DepService::set_iam_policy] calls.
+    /// The request builder for [DepService::set_iam_policy][crate::client::DepService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1530,7 +1530,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::get_iam_policy][super::super::client::DepService::get_iam_policy] calls.
+    /// The request builder for [DepService::get_iam_policy][crate::client::DepService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1611,7 +1611,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::test_iam_permissions][super::super::client::DepService::test_iam_permissions] calls.
+    /// The request builder for [DepService::test_iam_permissions][crate::client::DepService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1690,7 +1690,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::list_operations][super::super::client::DepService::list_operations] calls.
+    /// The request builder for [DepService::list_operations][crate::client::DepService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1802,7 +1802,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::get_operation][super::super::client::DepService::get_operation] calls.
+    /// The request builder for [DepService::get_operation][crate::client::DepService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1866,7 +1866,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::delete_operation][super::super::client::DepService::delete_operation] calls.
+    /// The request builder for [DepService::delete_operation][crate::client::DepService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1930,7 +1930,7 @@ pub mod dep_service {
         }
     }
 
-    /// The request builder for [DepService::cancel_operation][super::super::client::DepService::cancel_operation] calls.
+    /// The request builder for [DepService::cancel_operation][crate::client::DepService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1998,7 +1998,7 @@ pub mod dep_service {
 pub mod network_services {
     use crate::Result;
 
-    /// A builder for [NetworkServices][super::super::client::NetworkServices].
+    /// A builder for [NetworkServices][crate::client::NetworkServices].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2026,7 +2026,7 @@ pub mod network_services {
         }
     }
 
-    /// Common implementation for [super::super::client::NetworkServices] request builders.
+    /// Common implementation for [crate::client::NetworkServices] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::NetworkServices>,
@@ -2049,7 +2049,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_endpoint_policies][super::super::client::NetworkServices::list_endpoint_policies] calls.
+    /// The request builder for [NetworkServices::list_endpoint_policies][crate::client::NetworkServices::list_endpoint_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2157,7 +2157,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_endpoint_policy][super::super::client::NetworkServices::get_endpoint_policy] calls.
+    /// The request builder for [NetworkServices::get_endpoint_policy][crate::client::NetworkServices::get_endpoint_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2223,7 +2223,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_endpoint_policy][super::super::client::NetworkServices::create_endpoint_policy] calls.
+    /// The request builder for [NetworkServices::create_endpoint_policy][crate::client::NetworkServices::create_endpoint_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2271,7 +2271,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_endpoint_policy][super::super::client::NetworkServices::create_endpoint_policy].
+        /// on [create_endpoint_policy][crate::client::NetworkServices::create_endpoint_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_endpoint_policy(self.0.request, self.0.options)
@@ -2361,7 +2361,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::update_endpoint_policy][super::super::client::NetworkServices::update_endpoint_policy] calls.
+    /// The request builder for [NetworkServices::update_endpoint_policy][crate::client::NetworkServices::update_endpoint_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2409,7 +2409,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_endpoint_policy][super::super::client::NetworkServices::update_endpoint_policy].
+        /// on [update_endpoint_policy][crate::client::NetworkServices::update_endpoint_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_endpoint_policy(self.0.request, self.0.options)
@@ -2501,7 +2501,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_endpoint_policy][super::super::client::NetworkServices::delete_endpoint_policy] calls.
+    /// The request builder for [NetworkServices::delete_endpoint_policy][crate::client::NetworkServices::delete_endpoint_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2549,7 +2549,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_endpoint_policy][super::super::client::NetworkServices::delete_endpoint_policy].
+        /// on [delete_endpoint_policy][crate::client::NetworkServices::delete_endpoint_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_endpoint_policy(self.0.request, self.0.options)
@@ -2608,7 +2608,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_gateways][super::super::client::NetworkServices::list_gateways] calls.
+    /// The request builder for [NetworkServices::list_gateways][crate::client::NetworkServices::list_gateways] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2711,7 +2711,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_gateway][super::super::client::NetworkServices::get_gateway] calls.
+    /// The request builder for [NetworkServices::get_gateway][crate::client::NetworkServices::get_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2774,7 +2774,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_gateway][super::super::client::NetworkServices::create_gateway] calls.
+    /// The request builder for [NetworkServices::create_gateway][crate::client::NetworkServices::create_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2819,7 +2819,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_gateway][super::super::client::NetworkServices::create_gateway].
+        /// on [create_gateway][crate::client::NetworkServices::create_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_gateway(self.0.request, self.0.options)
@@ -2906,7 +2906,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::update_gateway][super::super::client::NetworkServices::update_gateway] calls.
+    /// The request builder for [NetworkServices::update_gateway][crate::client::NetworkServices::update_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2951,7 +2951,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_gateway][super::super::client::NetworkServices::update_gateway].
+        /// on [update_gateway][crate::client::NetworkServices::update_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_gateway(self.0.request, self.0.options)
@@ -3040,7 +3040,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_gateway][super::super::client::NetworkServices::delete_gateway] calls.
+    /// The request builder for [NetworkServices::delete_gateway][crate::client::NetworkServices::delete_gateway] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3085,7 +3085,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_gateway][super::super::client::NetworkServices::delete_gateway].
+        /// on [delete_gateway][crate::client::NetworkServices::delete_gateway].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_gateway(self.0.request, self.0.options)
@@ -3144,7 +3144,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_grpc_routes][super::super::client::NetworkServices::list_grpc_routes] calls.
+    /// The request builder for [NetworkServices::list_grpc_routes][crate::client::NetworkServices::list_grpc_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3247,7 +3247,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_grpc_route][super::super::client::NetworkServices::get_grpc_route] calls.
+    /// The request builder for [NetworkServices::get_grpc_route][crate::client::NetworkServices::get_grpc_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3310,7 +3310,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_grpc_route][super::super::client::NetworkServices::create_grpc_route] calls.
+    /// The request builder for [NetworkServices::create_grpc_route][crate::client::NetworkServices::create_grpc_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3355,7 +3355,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_grpc_route][super::super::client::NetworkServices::create_grpc_route].
+        /// on [create_grpc_route][crate::client::NetworkServices::create_grpc_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_grpc_route(self.0.request, self.0.options)
@@ -3442,7 +3442,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::update_grpc_route][super::super::client::NetworkServices::update_grpc_route] calls.
+    /// The request builder for [NetworkServices::update_grpc_route][crate::client::NetworkServices::update_grpc_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3487,7 +3487,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_grpc_route][super::super::client::NetworkServices::update_grpc_route].
+        /// on [update_grpc_route][crate::client::NetworkServices::update_grpc_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_grpc_route(self.0.request, self.0.options)
@@ -3576,7 +3576,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_grpc_route][super::super::client::NetworkServices::delete_grpc_route] calls.
+    /// The request builder for [NetworkServices::delete_grpc_route][crate::client::NetworkServices::delete_grpc_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3621,7 +3621,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_grpc_route][super::super::client::NetworkServices::delete_grpc_route].
+        /// on [delete_grpc_route][crate::client::NetworkServices::delete_grpc_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_grpc_route(self.0.request, self.0.options)
@@ -3680,7 +3680,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_http_routes][super::super::client::NetworkServices::list_http_routes] calls.
+    /// The request builder for [NetworkServices::list_http_routes][crate::client::NetworkServices::list_http_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3783,7 +3783,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_http_route][super::super::client::NetworkServices::get_http_route] calls.
+    /// The request builder for [NetworkServices::get_http_route][crate::client::NetworkServices::get_http_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3846,7 +3846,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_http_route][super::super::client::NetworkServices::create_http_route] calls.
+    /// The request builder for [NetworkServices::create_http_route][crate::client::NetworkServices::create_http_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3891,7 +3891,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_http_route][super::super::client::NetworkServices::create_http_route].
+        /// on [create_http_route][crate::client::NetworkServices::create_http_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_http_route(self.0.request, self.0.options)
@@ -3978,7 +3978,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::update_http_route][super::super::client::NetworkServices::update_http_route] calls.
+    /// The request builder for [NetworkServices::update_http_route][crate::client::NetworkServices::update_http_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4023,7 +4023,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_http_route][super::super::client::NetworkServices::update_http_route].
+        /// on [update_http_route][crate::client::NetworkServices::update_http_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_http_route(self.0.request, self.0.options)
@@ -4112,7 +4112,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_http_route][super::super::client::NetworkServices::delete_http_route] calls.
+    /// The request builder for [NetworkServices::delete_http_route][crate::client::NetworkServices::delete_http_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4157,7 +4157,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_http_route][super::super::client::NetworkServices::delete_http_route].
+        /// on [delete_http_route][crate::client::NetworkServices::delete_http_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_http_route(self.0.request, self.0.options)
@@ -4216,7 +4216,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_tcp_routes][super::super::client::NetworkServices::list_tcp_routes] calls.
+    /// The request builder for [NetworkServices::list_tcp_routes][crate::client::NetworkServices::list_tcp_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4319,7 +4319,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_tcp_route][super::super::client::NetworkServices::get_tcp_route] calls.
+    /// The request builder for [NetworkServices::get_tcp_route][crate::client::NetworkServices::get_tcp_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4382,7 +4382,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_tcp_route][super::super::client::NetworkServices::create_tcp_route] calls.
+    /// The request builder for [NetworkServices::create_tcp_route][crate::client::NetworkServices::create_tcp_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4427,7 +4427,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_tcp_route][super::super::client::NetworkServices::create_tcp_route].
+        /// on [create_tcp_route][crate::client::NetworkServices::create_tcp_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_tcp_route(self.0.request, self.0.options)
@@ -4514,7 +4514,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::update_tcp_route][super::super::client::NetworkServices::update_tcp_route] calls.
+    /// The request builder for [NetworkServices::update_tcp_route][crate::client::NetworkServices::update_tcp_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4559,7 +4559,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_tcp_route][super::super::client::NetworkServices::update_tcp_route].
+        /// on [update_tcp_route][crate::client::NetworkServices::update_tcp_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_tcp_route(self.0.request, self.0.options)
@@ -4648,7 +4648,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_tcp_route][super::super::client::NetworkServices::delete_tcp_route] calls.
+    /// The request builder for [NetworkServices::delete_tcp_route][crate::client::NetworkServices::delete_tcp_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4693,7 +4693,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tcp_route][super::super::client::NetworkServices::delete_tcp_route].
+        /// on [delete_tcp_route][crate::client::NetworkServices::delete_tcp_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tcp_route(self.0.request, self.0.options)
@@ -4752,7 +4752,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_tls_routes][super::super::client::NetworkServices::list_tls_routes] calls.
+    /// The request builder for [NetworkServices::list_tls_routes][crate::client::NetworkServices::list_tls_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4855,7 +4855,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_tls_route][super::super::client::NetworkServices::get_tls_route] calls.
+    /// The request builder for [NetworkServices::get_tls_route][crate::client::NetworkServices::get_tls_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4918,7 +4918,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_tls_route][super::super::client::NetworkServices::create_tls_route] calls.
+    /// The request builder for [NetworkServices::create_tls_route][crate::client::NetworkServices::create_tls_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4963,7 +4963,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_tls_route][super::super::client::NetworkServices::create_tls_route].
+        /// on [create_tls_route][crate::client::NetworkServices::create_tls_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_tls_route(self.0.request, self.0.options)
@@ -5050,7 +5050,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::update_tls_route][super::super::client::NetworkServices::update_tls_route] calls.
+    /// The request builder for [NetworkServices::update_tls_route][crate::client::NetworkServices::update_tls_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5095,7 +5095,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_tls_route][super::super::client::NetworkServices::update_tls_route].
+        /// on [update_tls_route][crate::client::NetworkServices::update_tls_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_tls_route(self.0.request, self.0.options)
@@ -5184,7 +5184,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_tls_route][super::super::client::NetworkServices::delete_tls_route] calls.
+    /// The request builder for [NetworkServices::delete_tls_route][crate::client::NetworkServices::delete_tls_route] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5229,7 +5229,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tls_route][super::super::client::NetworkServices::delete_tls_route].
+        /// on [delete_tls_route][crate::client::NetworkServices::delete_tls_route].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tls_route(self.0.request, self.0.options)
@@ -5288,7 +5288,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_service_bindings][super::super::client::NetworkServices::list_service_bindings] calls.
+    /// The request builder for [NetworkServices::list_service_bindings][crate::client::NetworkServices::list_service_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5396,7 +5396,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_service_binding][super::super::client::NetworkServices::get_service_binding] calls.
+    /// The request builder for [NetworkServices::get_service_binding][crate::client::NetworkServices::get_service_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5462,7 +5462,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_service_binding][super::super::client::NetworkServices::create_service_binding] calls.
+    /// The request builder for [NetworkServices::create_service_binding][crate::client::NetworkServices::create_service_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5510,7 +5510,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service_binding][super::super::client::NetworkServices::create_service_binding].
+        /// on [create_service_binding][crate::client::NetworkServices::create_service_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service_binding(self.0.request, self.0.options)
@@ -5600,7 +5600,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_service_binding][super::super::client::NetworkServices::delete_service_binding] calls.
+    /// The request builder for [NetworkServices::delete_service_binding][crate::client::NetworkServices::delete_service_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5648,7 +5648,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service_binding][super::super::client::NetworkServices::delete_service_binding].
+        /// on [delete_service_binding][crate::client::NetworkServices::delete_service_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service_binding(self.0.request, self.0.options)
@@ -5707,7 +5707,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_meshes][super::super::client::NetworkServices::list_meshes] calls.
+    /// The request builder for [NetworkServices::list_meshes][crate::client::NetworkServices::list_meshes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5810,7 +5810,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_mesh][super::super::client::NetworkServices::get_mesh] calls.
+    /// The request builder for [NetworkServices::get_mesh][crate::client::NetworkServices::get_mesh] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5873,7 +5873,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::create_mesh][super::super::client::NetworkServices::create_mesh] calls.
+    /// The request builder for [NetworkServices::create_mesh][crate::client::NetworkServices::create_mesh] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5918,7 +5918,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_mesh][super::super::client::NetworkServices::create_mesh].
+        /// on [create_mesh][crate::client::NetworkServices::create_mesh].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_mesh(self.0.request, self.0.options)
@@ -6005,7 +6005,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::update_mesh][super::super::client::NetworkServices::update_mesh] calls.
+    /// The request builder for [NetworkServices::update_mesh][crate::client::NetworkServices::update_mesh] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6050,7 +6050,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_mesh][super::super::client::NetworkServices::update_mesh].
+        /// on [update_mesh][crate::client::NetworkServices::update_mesh].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_mesh(self.0.request, self.0.options)
@@ -6139,7 +6139,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_mesh][super::super::client::NetworkServices::delete_mesh] calls.
+    /// The request builder for [NetworkServices::delete_mesh][crate::client::NetworkServices::delete_mesh] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6184,7 +6184,7 @@ pub mod network_services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_mesh][super::super::client::NetworkServices::delete_mesh].
+        /// on [delete_mesh][crate::client::NetworkServices::delete_mesh].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_mesh(self.0.request, self.0.options)
@@ -6243,7 +6243,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_locations][super::super::client::NetworkServices::list_locations] calls.
+    /// The request builder for [NetworkServices::list_locations][crate::client::NetworkServices::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6353,7 +6353,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_location][super::super::client::NetworkServices::get_location] calls.
+    /// The request builder for [NetworkServices::get_location][crate::client::NetworkServices::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6414,7 +6414,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::set_iam_policy][super::super::client::NetworkServices::set_iam_policy] calls.
+    /// The request builder for [NetworkServices::set_iam_policy][crate::client::NetworkServices::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6517,7 +6517,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_iam_policy][super::super::client::NetworkServices::get_iam_policy] calls.
+    /// The request builder for [NetworkServices::get_iam_policy][crate::client::NetworkServices::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6598,7 +6598,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::test_iam_permissions][super::super::client::NetworkServices::test_iam_permissions] calls.
+    /// The request builder for [NetworkServices::test_iam_permissions][crate::client::NetworkServices::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6677,7 +6677,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::list_operations][super::super::client::NetworkServices::list_operations] calls.
+    /// The request builder for [NetworkServices::list_operations][crate::client::NetworkServices::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6789,7 +6789,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::get_operation][super::super::client::NetworkServices::get_operation] calls.
+    /// The request builder for [NetworkServices::get_operation][crate::client::NetworkServices::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6853,7 +6853,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::delete_operation][super::super::client::NetworkServices::delete_operation] calls.
+    /// The request builder for [NetworkServices::delete_operation][crate::client::NetworkServices::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6917,7 +6917,7 @@ pub mod network_services {
         }
     }
 
-    /// The request builder for [NetworkServices::cancel_operation][super::super::client::NetworkServices::cancel_operation] calls.
+    /// The request builder for [NetworkServices::cancel_operation][crate::client::NetworkServices::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/notebooks/v2/src/builder.rs
+++ b/src/generated/cloud/notebooks/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod notebook_service {
     use crate::Result;
 
-    /// A builder for [NotebookService][super::super::client::NotebookService].
+    /// A builder for [NotebookService][crate::client::NotebookService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod notebook_service {
         }
     }
 
-    /// Common implementation for [super::super::client::NotebookService] request builders.
+    /// Common implementation for [crate::client::NotebookService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::NotebookService>,
@@ -68,7 +68,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_instances][super::super::client::NotebookService::list_instances] calls.
+    /// The request builder for [NotebookService::list_instances][crate::client::NotebookService::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_instance][super::super::client::NotebookService::get_instance] calls.
+    /// The request builder for [NotebookService::get_instance][crate::client::NotebookService::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::create_instance][super::super::client::NotebookService::create_instance] calls.
+    /// The request builder for [NotebookService::create_instance][crate::client::NotebookService::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::NotebookService::create_instance].
+        /// on [create_instance][crate::client::NotebookService::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::update_instance][super::super::client::NotebookService::update_instance] calls.
+    /// The request builder for [NotebookService::update_instance][crate::client::NotebookService::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::NotebookService::update_instance].
+        /// on [update_instance][crate::client::NotebookService::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -528,7 +528,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::delete_instance][super::super::client::NotebookService::delete_instance] calls.
+    /// The request builder for [NotebookService::delete_instance][crate::client::NotebookService::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -573,7 +573,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::NotebookService::delete_instance].
+        /// on [delete_instance][crate::client::NotebookService::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -638,7 +638,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::start_instance][super::super::client::NotebookService::start_instance] calls.
+    /// The request builder for [NotebookService::start_instance][crate::client::NotebookService::start_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -683,7 +683,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_instance][super::super::client::NotebookService::start_instance].
+        /// on [start_instance][crate::client::NotebookService::start_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_instance(self.0.request, self.0.options)
@@ -740,7 +740,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::stop_instance][super::super::client::NotebookService::stop_instance] calls.
+    /// The request builder for [NotebookService::stop_instance][crate::client::NotebookService::stop_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -785,7 +785,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_instance][super::super::client::NotebookService::stop_instance].
+        /// on [stop_instance][crate::client::NotebookService::stop_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_instance(self.0.request, self.0.options)
@@ -842,7 +842,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::reset_instance][super::super::client::NotebookService::reset_instance] calls.
+    /// The request builder for [NotebookService::reset_instance][crate::client::NotebookService::reset_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -887,7 +887,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reset_instance][super::super::client::NotebookService::reset_instance].
+        /// on [reset_instance][crate::client::NotebookService::reset_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reset_instance(self.0.request, self.0.options)
@@ -944,7 +944,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::check_instance_upgradability][super::super::client::NotebookService::check_instance_upgradability] calls.
+    /// The request builder for [NotebookService::check_instance_upgradability][crate::client::NotebookService::check_instance_upgradability] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1012,7 +1012,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::upgrade_instance][super::super::client::NotebookService::upgrade_instance] calls.
+    /// The request builder for [NotebookService::upgrade_instance][crate::client::NotebookService::upgrade_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1057,7 +1057,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upgrade_instance][super::super::client::NotebookService::upgrade_instance].
+        /// on [upgrade_instance][crate::client::NotebookService::upgrade_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upgrade_instance(self.0.request, self.0.options)
@@ -1114,7 +1114,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::rollback_instance][super::super::client::NotebookService::rollback_instance] calls.
+    /// The request builder for [NotebookService::rollback_instance][crate::client::NotebookService::rollback_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1162,7 +1162,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [rollback_instance][super::super::client::NotebookService::rollback_instance].
+        /// on [rollback_instance][crate::client::NotebookService::rollback_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .rollback_instance(self.0.request, self.0.options)
@@ -1235,7 +1235,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::diagnose_instance][super::super::client::NotebookService::diagnose_instance] calls.
+    /// The request builder for [NotebookService::diagnose_instance][crate::client::NotebookService::diagnose_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1283,7 +1283,7 @@ pub mod notebook_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [diagnose_instance][super::super::client::NotebookService::diagnose_instance].
+        /// on [diagnose_instance][crate::client::NotebookService::diagnose_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .diagnose_instance(self.0.request, self.0.options)
@@ -1368,7 +1368,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_locations][super::super::client::NotebookService::list_locations] calls.
+    /// The request builder for [NotebookService::list_locations][crate::client::NotebookService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1478,7 +1478,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_location][super::super::client::NotebookService::get_location] calls.
+    /// The request builder for [NotebookService::get_location][crate::client::NotebookService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1539,7 +1539,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::set_iam_policy][super::super::client::NotebookService::set_iam_policy] calls.
+    /// The request builder for [NotebookService::set_iam_policy][crate::client::NotebookService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1642,7 +1642,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_iam_policy][super::super::client::NotebookService::get_iam_policy] calls.
+    /// The request builder for [NotebookService::get_iam_policy][crate::client::NotebookService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1723,7 +1723,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::test_iam_permissions][super::super::client::NotebookService::test_iam_permissions] calls.
+    /// The request builder for [NotebookService::test_iam_permissions][crate::client::NotebookService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1802,7 +1802,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::list_operations][super::super::client::NotebookService::list_operations] calls.
+    /// The request builder for [NotebookService::list_operations][crate::client::NotebookService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1914,7 +1914,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::get_operation][super::super::client::NotebookService::get_operation] calls.
+    /// The request builder for [NotebookService::get_operation][crate::client::NotebookService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1978,7 +1978,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::delete_operation][super::super::client::NotebookService::delete_operation] calls.
+    /// The request builder for [NotebookService::delete_operation][crate::client::NotebookService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2042,7 +2042,7 @@ pub mod notebook_service {
         }
     }
 
-    /// The request builder for [NotebookService::cancel_operation][super::super::client::NotebookService::cancel_operation] calls.
+    /// The request builder for [NotebookService::cancel_operation][crate::client::NotebookService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/optimization/v1/src/builder.rs
+++ b/src/generated/cloud/optimization/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod fleet_routing {
     use crate::Result;
 
-    /// A builder for [FleetRouting][super::super::client::FleetRouting].
+    /// A builder for [FleetRouting][crate::client::FleetRouting].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod fleet_routing {
         }
     }
 
-    /// Common implementation for [super::super::client::FleetRouting] request builders.
+    /// Common implementation for [crate::client::FleetRouting] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FleetRouting>,
@@ -68,7 +68,7 @@ pub mod fleet_routing {
         }
     }
 
-    /// The request builder for [FleetRouting::optimize_tours][super::super::client::FleetRouting::optimize_tours] calls.
+    /// The request builder for [FleetRouting::optimize_tours][crate::client::FleetRouting::optimize_tours] calls.
     ///
     /// # Example
     /// ```no_run
@@ -325,7 +325,7 @@ pub mod fleet_routing {
         }
     }
 
-    /// The request builder for [FleetRouting::batch_optimize_tours][super::super::client::FleetRouting::batch_optimize_tours] calls.
+    /// The request builder for [FleetRouting::batch_optimize_tours][crate::client::FleetRouting::batch_optimize_tours] calls.
     ///
     /// # Example
     /// ```no_run
@@ -373,7 +373,7 @@ pub mod fleet_routing {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_optimize_tours][super::super::client::FleetRouting::batch_optimize_tours].
+        /// on [batch_optimize_tours][crate::client::FleetRouting::batch_optimize_tours].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_optimize_tours(self.0.request, self.0.options)
@@ -446,7 +446,7 @@ pub mod fleet_routing {
         }
     }
 
-    /// The request builder for [FleetRouting::get_operation][super::super::client::FleetRouting::get_operation] calls.
+    /// The request builder for [FleetRouting::get_operation][crate::client::FleetRouting::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/oracledatabase/v1/src/builder.rs
+++ b/src/generated/cloud/oracledatabase/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod oracle_database {
     use crate::Result;
 
-    /// A builder for [OracleDatabase][super::super::client::OracleDatabase].
+    /// A builder for [OracleDatabase][crate::client::OracleDatabase].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod oracle_database {
         }
     }
 
-    /// Common implementation for [super::super::client::OracleDatabase] request builders.
+    /// Common implementation for [crate::client::OracleDatabase] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::OracleDatabase>,
@@ -68,7 +68,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_cloud_exadata_infrastructures][super::super::client::OracleDatabase::list_cloud_exadata_infrastructures] calls.
+    /// The request builder for [OracleDatabase::list_cloud_exadata_infrastructures][crate::client::OracleDatabase::list_cloud_exadata_infrastructures] calls.
     ///
     /// # Example
     /// ```no_run
@@ -180,7 +180,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::get_cloud_exadata_infrastructure][super::super::client::OracleDatabase::get_cloud_exadata_infrastructure] calls.
+    /// The request builder for [OracleDatabase::get_cloud_exadata_infrastructure][crate::client::OracleDatabase::get_cloud_exadata_infrastructure] calls.
     ///
     /// # Example
     /// ```no_run
@@ -248,7 +248,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::create_cloud_exadata_infrastructure][super::super::client::OracleDatabase::create_cloud_exadata_infrastructure] calls.
+    /// The request builder for [OracleDatabase::create_cloud_exadata_infrastructure][crate::client::OracleDatabase::create_cloud_exadata_infrastructure] calls.
     ///
     /// # Example
     /// ```no_run
@@ -298,7 +298,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cloud_exadata_infrastructure][super::super::client::OracleDatabase::create_cloud_exadata_infrastructure].
+        /// on [create_cloud_exadata_infrastructure][crate::client::OracleDatabase::create_cloud_exadata_infrastructure].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cloud_exadata_infrastructure(self.0.request, self.0.options)
@@ -400,7 +400,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::delete_cloud_exadata_infrastructure][super::super::client::OracleDatabase::delete_cloud_exadata_infrastructure] calls.
+    /// The request builder for [OracleDatabase::delete_cloud_exadata_infrastructure][crate::client::OracleDatabase::delete_cloud_exadata_infrastructure] calls.
     ///
     /// # Example
     /// ```no_run
@@ -450,7 +450,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cloud_exadata_infrastructure][super::super::client::OracleDatabase::delete_cloud_exadata_infrastructure].
+        /// on [delete_cloud_exadata_infrastructure][crate::client::OracleDatabase::delete_cloud_exadata_infrastructure].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cloud_exadata_infrastructure(self.0.request, self.0.options)
@@ -521,7 +521,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_cloud_vm_clusters][super::super::client::OracleDatabase::list_cloud_vm_clusters] calls.
+    /// The request builder for [OracleDatabase::list_cloud_vm_clusters][crate::client::OracleDatabase::list_cloud_vm_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -635,7 +635,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::get_cloud_vm_cluster][super::super::client::OracleDatabase::get_cloud_vm_cluster] calls.
+    /// The request builder for [OracleDatabase::get_cloud_vm_cluster][crate::client::OracleDatabase::get_cloud_vm_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -701,7 +701,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::create_cloud_vm_cluster][super::super::client::OracleDatabase::create_cloud_vm_cluster] calls.
+    /// The request builder for [OracleDatabase::create_cloud_vm_cluster][crate::client::OracleDatabase::create_cloud_vm_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -749,7 +749,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cloud_vm_cluster][super::super::client::OracleDatabase::create_cloud_vm_cluster].
+        /// on [create_cloud_vm_cluster][crate::client::OracleDatabase::create_cloud_vm_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cloud_vm_cluster(self.0.request, self.0.options)
@@ -845,7 +845,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::delete_cloud_vm_cluster][super::super::client::OracleDatabase::delete_cloud_vm_cluster] calls.
+    /// The request builder for [OracleDatabase::delete_cloud_vm_cluster][crate::client::OracleDatabase::delete_cloud_vm_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -893,7 +893,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cloud_vm_cluster][super::super::client::OracleDatabase::delete_cloud_vm_cluster].
+        /// on [delete_cloud_vm_cluster][crate::client::OracleDatabase::delete_cloud_vm_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cloud_vm_cluster(self.0.request, self.0.options)
@@ -964,7 +964,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_entitlements][super::super::client::OracleDatabase::list_entitlements] calls.
+    /// The request builder for [OracleDatabase::list_entitlements][crate::client::OracleDatabase::list_entitlements] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1070,7 +1070,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_db_servers][super::super::client::OracleDatabase::list_db_servers] calls.
+    /// The request builder for [OracleDatabase::list_db_servers][crate::client::OracleDatabase::list_db_servers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1173,7 +1173,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_db_nodes][super::super::client::OracleDatabase::list_db_nodes] calls.
+    /// The request builder for [OracleDatabase::list_db_nodes][crate::client::OracleDatabase::list_db_nodes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1276,7 +1276,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_gi_versions][super::super::client::OracleDatabase::list_gi_versions] calls.
+    /// The request builder for [OracleDatabase::list_gi_versions][crate::client::OracleDatabase::list_gi_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1379,7 +1379,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_db_system_shapes][super::super::client::OracleDatabase::list_db_system_shapes] calls.
+    /// The request builder for [OracleDatabase::list_db_system_shapes][crate::client::OracleDatabase::list_db_system_shapes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1487,7 +1487,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_autonomous_databases][super::super::client::OracleDatabase::list_autonomous_databases] calls.
+    /// The request builder for [OracleDatabase::list_autonomous_databases][crate::client::OracleDatabase::list_autonomous_databases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1611,7 +1611,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::get_autonomous_database][super::super::client::OracleDatabase::get_autonomous_database] calls.
+    /// The request builder for [OracleDatabase::get_autonomous_database][crate::client::OracleDatabase::get_autonomous_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1677,7 +1677,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::create_autonomous_database][super::super::client::OracleDatabase::create_autonomous_database] calls.
+    /// The request builder for [OracleDatabase::create_autonomous_database][crate::client::OracleDatabase::create_autonomous_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1727,7 +1727,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_autonomous_database][super::super::client::OracleDatabase::create_autonomous_database].
+        /// on [create_autonomous_database][crate::client::OracleDatabase::create_autonomous_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_autonomous_database(self.0.request, self.0.options)
@@ -1823,7 +1823,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::delete_autonomous_database][super::super::client::OracleDatabase::delete_autonomous_database] calls.
+    /// The request builder for [OracleDatabase::delete_autonomous_database][crate::client::OracleDatabase::delete_autonomous_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1873,7 +1873,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_autonomous_database][super::super::client::OracleDatabase::delete_autonomous_database].
+        /// on [delete_autonomous_database][crate::client::OracleDatabase::delete_autonomous_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_autonomous_database(self.0.request, self.0.options)
@@ -1938,7 +1938,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::restore_autonomous_database][super::super::client::OracleDatabase::restore_autonomous_database] calls.
+    /// The request builder for [OracleDatabase::restore_autonomous_database][crate::client::OracleDatabase::restore_autonomous_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1988,7 +1988,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_autonomous_database][super::super::client::OracleDatabase::restore_autonomous_database].
+        /// on [restore_autonomous_database][crate::client::OracleDatabase::restore_autonomous_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_autonomous_database(self.0.request, self.0.options)
@@ -2070,7 +2070,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::generate_autonomous_database_wallet][super::super::client::OracleDatabase::generate_autonomous_database_wallet] calls.
+    /// The request builder for [OracleDatabase::generate_autonomous_database_wallet][crate::client::OracleDatabase::generate_autonomous_database_wallet] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2158,7 +2158,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_autonomous_db_versions][super::super::client::OracleDatabase::list_autonomous_db_versions] calls.
+    /// The request builder for [OracleDatabase::list_autonomous_db_versions][crate::client::OracleDatabase::list_autonomous_db_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2270,7 +2270,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_autonomous_database_character_sets][super::super::client::OracleDatabase::list_autonomous_database_character_sets] calls.
+    /// The request builder for [OracleDatabase::list_autonomous_database_character_sets][crate::client::OracleDatabase::list_autonomous_database_character_sets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2390,7 +2390,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_autonomous_database_backups][super::super::client::OracleDatabase::list_autonomous_database_backups] calls.
+    /// The request builder for [OracleDatabase::list_autonomous_database_backups][crate::client::OracleDatabase::list_autonomous_database_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2508,7 +2508,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::stop_autonomous_database][super::super::client::OracleDatabase::stop_autonomous_database] calls.
+    /// The request builder for [OracleDatabase::stop_autonomous_database][crate::client::OracleDatabase::stop_autonomous_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2556,7 +2556,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_autonomous_database][super::super::client::OracleDatabase::stop_autonomous_database].
+        /// on [stop_autonomous_database][crate::client::OracleDatabase::stop_autonomous_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_autonomous_database(self.0.request, self.0.options)
@@ -2616,7 +2616,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::start_autonomous_database][super::super::client::OracleDatabase::start_autonomous_database] calls.
+    /// The request builder for [OracleDatabase::start_autonomous_database][crate::client::OracleDatabase::start_autonomous_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2666,7 +2666,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_autonomous_database][super::super::client::OracleDatabase::start_autonomous_database].
+        /// on [start_autonomous_database][crate::client::OracleDatabase::start_autonomous_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_autonomous_database(self.0.request, self.0.options)
@@ -2726,7 +2726,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::restart_autonomous_database][super::super::client::OracleDatabase::restart_autonomous_database] calls.
+    /// The request builder for [OracleDatabase::restart_autonomous_database][crate::client::OracleDatabase::restart_autonomous_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2776,7 +2776,7 @@ pub mod oracle_database {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restart_autonomous_database][super::super::client::OracleDatabase::restart_autonomous_database].
+        /// on [restart_autonomous_database][crate::client::OracleDatabase::restart_autonomous_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restart_autonomous_database(self.0.request, self.0.options)
@@ -2836,7 +2836,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_locations][super::super::client::OracleDatabase::list_locations] calls.
+    /// The request builder for [OracleDatabase::list_locations][crate::client::OracleDatabase::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2946,7 +2946,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::get_location][super::super::client::OracleDatabase::get_location] calls.
+    /// The request builder for [OracleDatabase::get_location][crate::client::OracleDatabase::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3007,7 +3007,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::list_operations][super::super::client::OracleDatabase::list_operations] calls.
+    /// The request builder for [OracleDatabase::list_operations][crate::client::OracleDatabase::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3119,7 +3119,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::get_operation][super::super::client::OracleDatabase::get_operation] calls.
+    /// The request builder for [OracleDatabase::get_operation][crate::client::OracleDatabase::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3183,7 +3183,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::delete_operation][super::super::client::OracleDatabase::delete_operation] calls.
+    /// The request builder for [OracleDatabase::delete_operation][crate::client::OracleDatabase::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3247,7 +3247,7 @@ pub mod oracle_database {
         }
     }
 
-    /// The request builder for [OracleDatabase::cancel_operation][super::super::client::OracleDatabase::cancel_operation] calls.
+    /// The request builder for [OracleDatabase::cancel_operation][crate::client::OracleDatabase::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
+++ b/src/generated/cloud/orchestration/airflow/service/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod environments {
     use crate::Result;
 
-    /// A builder for [Environments][super::super::client::Environments].
+    /// A builder for [Environments][crate::client::Environments].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod environments {
         }
     }
 
-    /// Common implementation for [super::super::client::Environments] request builders.
+    /// Common implementation for [crate::client::Environments] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Environments>,
@@ -68,7 +68,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::create_environment][super::super::client::Environments::create_environment] calls.
+    /// The request builder for [Environments::create_environment][crate::client::Environments::create_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -116,7 +116,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_environment][super::super::client::Environments::create_environment].
+        /// on [create_environment][crate::client::Environments::create_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_environment(self.0.request, self.0.options)
@@ -191,7 +191,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_environment][super::super::client::Environments::get_environment] calls.
+    /// The request builder for [Environments::get_environment][crate::client::Environments::get_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_environments][super::super::client::Environments::list_environments] calls.
+    /// The request builder for [Environments::list_environments][crate::client::Environments::list_environments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -356,7 +356,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::update_environment][super::super::client::Environments::update_environment] calls.
+    /// The request builder for [Environments::update_environment][crate::client::Environments::update_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -404,7 +404,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_environment][super::super::client::Environments::update_environment].
+        /// on [update_environment][crate::client::Environments::update_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_environment(self.0.request, self.0.options)
@@ -497,7 +497,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::delete_environment][super::super::client::Environments::delete_environment] calls.
+    /// The request builder for [Environments::delete_environment][crate::client::Environments::delete_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -545,7 +545,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_environment][super::super::client::Environments::delete_environment].
+        /// on [delete_environment][crate::client::Environments::delete_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_environment(self.0.request, self.0.options)
@@ -602,7 +602,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::execute_airflow_command][super::super::client::Environments::execute_airflow_command] calls.
+    /// The request builder for [Environments::execute_airflow_command][crate::client::Environments::execute_airflow_command] calls.
     ///
     /// # Example
     /// ```no_run
@@ -689,7 +689,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::stop_airflow_command][super::super::client::Environments::stop_airflow_command] calls.
+    /// The request builder for [Environments::stop_airflow_command][crate::client::Environments::stop_airflow_command] calls.
     ///
     /// # Example
     /// ```no_run
@@ -777,7 +777,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::poll_airflow_command][super::super::client::Environments::poll_airflow_command] calls.
+    /// The request builder for [Environments::poll_airflow_command][crate::client::Environments::poll_airflow_command] calls.
     ///
     /// # Example
     /// ```no_run
@@ -865,7 +865,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_workloads][super::super::client::Environments::list_workloads] calls.
+    /// The request builder for [Environments::list_workloads][crate::client::Environments::list_workloads] calls.
     ///
     /// # Example
     /// ```no_run
@@ -974,7 +974,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::check_upgrade][super::super::client::Environments::check_upgrade] calls.
+    /// The request builder for [Environments::check_upgrade][crate::client::Environments::check_upgrade] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1019,7 +1019,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [check_upgrade][super::super::client::Environments::check_upgrade].
+        /// on [check_upgrade][crate::client::Environments::check_upgrade].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .check_upgrade(self.0.request, self.0.options)
@@ -1085,7 +1085,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::create_user_workloads_secret][super::super::client::Environments::create_user_workloads_secret] calls.
+    /// The request builder for [Environments::create_user_workloads_secret][crate::client::Environments::create_user_workloads_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1175,7 +1175,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_user_workloads_secret][super::super::client::Environments::get_user_workloads_secret] calls.
+    /// The request builder for [Environments::get_user_workloads_secret][crate::client::Environments::get_user_workloads_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1241,7 +1241,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_user_workloads_secrets][super::super::client::Environments::list_user_workloads_secrets] calls.
+    /// The request builder for [Environments::list_user_workloads_secrets][crate::client::Environments::list_user_workloads_secrets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1353,7 +1353,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::update_user_workloads_secret][super::super::client::Environments::update_user_workloads_secret] calls.
+    /// The request builder for [Environments::update_user_workloads_secret][crate::client::Environments::update_user_workloads_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1431,7 +1431,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::delete_user_workloads_secret][super::super::client::Environments::delete_user_workloads_secret] calls.
+    /// The request builder for [Environments::delete_user_workloads_secret][crate::client::Environments::delete_user_workloads_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1499,7 +1499,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::create_user_workloads_config_map][super::super::client::Environments::create_user_workloads_config_map] calls.
+    /// The request builder for [Environments::create_user_workloads_config_map][crate::client::Environments::create_user_workloads_config_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1592,7 +1592,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_user_workloads_config_map][super::super::client::Environments::get_user_workloads_config_map] calls.
+    /// The request builder for [Environments::get_user_workloads_config_map][crate::client::Environments::get_user_workloads_config_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1660,7 +1660,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_user_workloads_config_maps][super::super::client::Environments::list_user_workloads_config_maps] calls.
+    /// The request builder for [Environments::list_user_workloads_config_maps][crate::client::Environments::list_user_workloads_config_maps] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1772,7 +1772,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::update_user_workloads_config_map][super::super::client::Environments::update_user_workloads_config_map] calls.
+    /// The request builder for [Environments::update_user_workloads_config_map][crate::client::Environments::update_user_workloads_config_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1853,7 +1853,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::delete_user_workloads_config_map][super::super::client::Environments::delete_user_workloads_config_map] calls.
+    /// The request builder for [Environments::delete_user_workloads_config_map][crate::client::Environments::delete_user_workloads_config_map] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1921,7 +1921,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::save_snapshot][super::super::client::Environments::save_snapshot] calls.
+    /// The request builder for [Environments::save_snapshot][crate::client::Environments::save_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1966,7 +1966,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [save_snapshot][super::super::client::Environments::save_snapshot].
+        /// on [save_snapshot][crate::client::Environments::save_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .save_snapshot(self.0.request, self.0.options)
@@ -2030,7 +2030,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::load_snapshot][super::super::client::Environments::load_snapshot] calls.
+    /// The request builder for [Environments::load_snapshot][crate::client::Environments::load_snapshot] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2075,7 +2075,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [load_snapshot][super::super::client::Environments::load_snapshot].
+        /// on [load_snapshot][crate::client::Environments::load_snapshot].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .load_snapshot(self.0.request, self.0.options)
@@ -2163,7 +2163,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::database_failover][super::super::client::Environments::database_failover] calls.
+    /// The request builder for [Environments::database_failover][crate::client::Environments::database_failover] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2211,7 +2211,7 @@ pub mod environments {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [database_failover][super::super::client::Environments::database_failover].
+        /// on [database_failover][crate::client::Environments::database_failover].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .database_failover(self.0.request, self.0.options)
@@ -2269,7 +2269,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::fetch_database_properties][super::super::client::Environments::fetch_database_properties] calls.
+    /// The request builder for [Environments::fetch_database_properties][crate::client::Environments::fetch_database_properties] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2337,7 +2337,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::list_operations][super::super::client::Environments::list_operations] calls.
+    /// The request builder for [Environments::list_operations][crate::client::Environments::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2449,7 +2449,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::get_operation][super::super::client::Environments::get_operation] calls.
+    /// The request builder for [Environments::get_operation][crate::client::Environments::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2513,7 +2513,7 @@ pub mod environments {
         }
     }
 
-    /// The request builder for [Environments::delete_operation][super::super::client::Environments::delete_operation] calls.
+    /// The request builder for [Environments::delete_operation][crate::client::Environments::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2581,7 +2581,7 @@ pub mod environments {
 pub mod image_versions {
     use crate::Result;
 
-    /// A builder for [ImageVersions][super::super::client::ImageVersions].
+    /// A builder for [ImageVersions][crate::client::ImageVersions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2609,7 +2609,7 @@ pub mod image_versions {
         }
     }
 
-    /// Common implementation for [super::super::client::ImageVersions] request builders.
+    /// Common implementation for [crate::client::ImageVersions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ImageVersions>,
@@ -2632,7 +2632,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for [ImageVersions::list_image_versions][super::super::client::ImageVersions::list_image_versions] calls.
+    /// The request builder for [ImageVersions::list_image_versions][crate::client::ImageVersions::list_image_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2742,7 +2742,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for [ImageVersions::list_operations][super::super::client::ImageVersions::list_operations] calls.
+    /// The request builder for [ImageVersions::list_operations][crate::client::ImageVersions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2854,7 +2854,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for [ImageVersions::get_operation][super::super::client::ImageVersions::get_operation] calls.
+    /// The request builder for [ImageVersions::get_operation][crate::client::ImageVersions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2918,7 +2918,7 @@ pub mod image_versions {
         }
     }
 
-    /// The request builder for [ImageVersions::delete_operation][super::super::client::ImageVersions::delete_operation] calls.
+    /// The request builder for [ImageVersions::delete_operation][crate::client::ImageVersions::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/orgpolicy/v2/src/builder.rs
+++ b/src/generated/cloud/orgpolicy/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod org_policy {
     use crate::Result;
 
-    /// A builder for [OrgPolicy][super::super::client::OrgPolicy].
+    /// A builder for [OrgPolicy][crate::client::OrgPolicy].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod org_policy {
         }
     }
 
-    /// Common implementation for [super::super::client::OrgPolicy] request builders.
+    /// Common implementation for [crate::client::OrgPolicy] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::OrgPolicy>,
@@ -68,7 +68,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::list_constraints][super::super::client::OrgPolicy::list_constraints] calls.
+    /// The request builder for [OrgPolicy::list_constraints][crate::client::OrgPolicy::list_constraints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::list_policies][super::super::client::OrgPolicy::list_policies] calls.
+    /// The request builder for [OrgPolicy::list_policies][crate::client::OrgPolicy::list_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -274,7 +274,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::get_policy][super::super::client::OrgPolicy::get_policy] calls.
+    /// The request builder for [OrgPolicy::get_policy][crate::client::OrgPolicy::get_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -337,7 +337,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::get_effective_policy][super::super::client::OrgPolicy::get_effective_policy] calls.
+    /// The request builder for [OrgPolicy::get_effective_policy][crate::client::OrgPolicy::get_effective_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -403,7 +403,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::create_policy][super::super::client::OrgPolicy::create_policy] calls.
+    /// The request builder for [OrgPolicy::create_policy][crate::client::OrgPolicy::create_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -488,7 +488,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::update_policy][super::super::client::OrgPolicy::update_policy] calls.
+    /// The request builder for [OrgPolicy::update_policy][crate::client::OrgPolicy::update_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -583,7 +583,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::delete_policy][super::super::client::OrgPolicy::delete_policy] calls.
+    /// The request builder for [OrgPolicy::delete_policy][crate::client::OrgPolicy::delete_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -652,7 +652,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::create_custom_constraint][super::super::client::OrgPolicy::create_custom_constraint] calls.
+    /// The request builder for [OrgPolicy::create_custom_constraint][crate::client::OrgPolicy::create_custom_constraint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -740,7 +740,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::update_custom_constraint][super::super::client::OrgPolicy::update_custom_constraint] calls.
+    /// The request builder for [OrgPolicy::update_custom_constraint][crate::client::OrgPolicy::update_custom_constraint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -820,7 +820,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::get_custom_constraint][super::super::client::OrgPolicy::get_custom_constraint] calls.
+    /// The request builder for [OrgPolicy::get_custom_constraint][crate::client::OrgPolicy::get_custom_constraint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -886,7 +886,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::list_custom_constraints][super::super::client::OrgPolicy::list_custom_constraints] calls.
+    /// The request builder for [OrgPolicy::list_custom_constraints][crate::client::OrgPolicy::list_custom_constraints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -994,7 +994,7 @@ pub mod org_policy {
         }
     }
 
-    /// The request builder for [OrgPolicy::delete_custom_constraint][super::super::client::OrgPolicy::delete_custom_constraint] calls.
+    /// The request builder for [OrgPolicy::delete_custom_constraint][crate::client::OrgPolicy::delete_custom_constraint] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/osconfig/v1/src/builder.rs
+++ b/src/generated/cloud/osconfig/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod os_config_service {
     use crate::Result;
 
-    /// A builder for [OsConfigService][super::super::client::OsConfigService].
+    /// A builder for [OsConfigService][crate::client::OsConfigService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod os_config_service {
         }
     }
 
-    /// Common implementation for [super::super::client::OsConfigService] request builders.
+    /// Common implementation for [crate::client::OsConfigService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::OsConfigService>,
@@ -68,7 +68,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::execute_patch_job][super::super::client::OsConfigService::execute_patch_job] calls.
+    /// The request builder for [OsConfigService::execute_patch_job][crate::client::OsConfigService::execute_patch_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -225,7 +225,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::get_patch_job][super::super::client::OsConfigService::get_patch_job] calls.
+    /// The request builder for [OsConfigService::get_patch_job][crate::client::OsConfigService::get_patch_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -288,7 +288,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::cancel_patch_job][super::super::client::OsConfigService::cancel_patch_job] calls.
+    /// The request builder for [OsConfigService::cancel_patch_job][crate::client::OsConfigService::cancel_patch_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -351,7 +351,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::list_patch_jobs][super::super::client::OsConfigService::list_patch_jobs] calls.
+    /// The request builder for [OsConfigService::list_patch_jobs][crate::client::OsConfigService::list_patch_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -460,7 +460,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::list_patch_job_instance_details][super::super::client::OsConfigService::list_patch_job_instance_details] calls.
+    /// The request builder for [OsConfigService::list_patch_job_instance_details][crate::client::OsConfigService::list_patch_job_instance_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -578,7 +578,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::create_patch_deployment][super::super::client::OsConfigService::create_patch_deployment] calls.
+    /// The request builder for [OsConfigService::create_patch_deployment][crate::client::OsConfigService::create_patch_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -674,7 +674,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::get_patch_deployment][super::super::client::OsConfigService::get_patch_deployment] calls.
+    /// The request builder for [OsConfigService::get_patch_deployment][crate::client::OsConfigService::get_patch_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -740,7 +740,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::list_patch_deployments][super::super::client::OsConfigService::list_patch_deployments] calls.
+    /// The request builder for [OsConfigService::list_patch_deployments][crate::client::OsConfigService::list_patch_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -848,7 +848,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::delete_patch_deployment][super::super::client::OsConfigService::delete_patch_deployment] calls.
+    /// The request builder for [OsConfigService::delete_patch_deployment][crate::client::OsConfigService::delete_patch_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -914,7 +914,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::update_patch_deployment][super::super::client::OsConfigService::update_patch_deployment] calls.
+    /// The request builder for [OsConfigService::update_patch_deployment][crate::client::OsConfigService::update_patch_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1012,7 +1012,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::pause_patch_deployment][super::super::client::OsConfigService::pause_patch_deployment] calls.
+    /// The request builder for [OsConfigService::pause_patch_deployment][crate::client::OsConfigService::pause_patch_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1078,7 +1078,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::resume_patch_deployment][super::super::client::OsConfigService::resume_patch_deployment] calls.
+    /// The request builder for [OsConfigService::resume_patch_deployment][crate::client::OsConfigService::resume_patch_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1144,7 +1144,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::get_operation][super::super::client::OsConfigService::get_operation] calls.
+    /// The request builder for [OsConfigService::get_operation][crate::client::OsConfigService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1208,7 +1208,7 @@ pub mod os_config_service {
         }
     }
 
-    /// The request builder for [OsConfigService::cancel_operation][super::super::client::OsConfigService::cancel_operation] calls.
+    /// The request builder for [OsConfigService::cancel_operation][crate::client::OsConfigService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1276,7 +1276,7 @@ pub mod os_config_service {
 pub mod os_config_zonal_service {
     use crate::Result;
 
-    /// A builder for [OsConfigZonalService][super::super::client::OsConfigZonalService].
+    /// A builder for [OsConfigZonalService][crate::client::OsConfigZonalService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1304,7 +1304,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// Common implementation for [super::super::client::OsConfigZonalService] request builders.
+    /// Common implementation for [crate::client::OsConfigZonalService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::OsConfigZonalService>,
@@ -1327,7 +1327,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::create_os_policy_assignment][super::super::client::OsConfigZonalService::create_os_policy_assignment] calls.
+    /// The request builder for [OsConfigZonalService::create_os_policy_assignment][crate::client::OsConfigZonalService::create_os_policy_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1377,7 +1377,7 @@ pub mod os_config_zonal_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_os_policy_assignment][super::super::client::OsConfigZonalService::create_os_policy_assignment].
+        /// on [create_os_policy_assignment][crate::client::OsConfigZonalService::create_os_policy_assignment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_os_policy_assignment(self.0.request, self.0.options)
@@ -1469,7 +1469,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::update_os_policy_assignment][super::super::client::OsConfigZonalService::update_os_policy_assignment] calls.
+    /// The request builder for [OsConfigZonalService::update_os_policy_assignment][crate::client::OsConfigZonalService::update_os_policy_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1519,7 +1519,7 @@ pub mod os_config_zonal_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_os_policy_assignment][super::super::client::OsConfigZonalService::update_os_policy_assignment].
+        /// on [update_os_policy_assignment][crate::client::OsConfigZonalService::update_os_policy_assignment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_os_policy_assignment(self.0.request, self.0.options)
@@ -1613,7 +1613,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::get_os_policy_assignment][super::super::client::OsConfigZonalService::get_os_policy_assignment] calls.
+    /// The request builder for [OsConfigZonalService::get_os_policy_assignment][crate::client::OsConfigZonalService::get_os_policy_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1679,7 +1679,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::list_os_policy_assignments][super::super::client::OsConfigZonalService::list_os_policy_assignments] calls.
+    /// The request builder for [OsConfigZonalService::list_os_policy_assignments][crate::client::OsConfigZonalService::list_os_policy_assignments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1791,7 +1791,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::list_os_policy_assignment_revisions][super::super::client::OsConfigZonalService::list_os_policy_assignment_revisions] calls.
+    /// The request builder for [OsConfigZonalService::list_os_policy_assignment_revisions][crate::client::OsConfigZonalService::list_os_policy_assignment_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1903,7 +1903,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::delete_os_policy_assignment][super::super::client::OsConfigZonalService::delete_os_policy_assignment] calls.
+    /// The request builder for [OsConfigZonalService::delete_os_policy_assignment][crate::client::OsConfigZonalService::delete_os_policy_assignment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1953,7 +1953,7 @@ pub mod os_config_zonal_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_os_policy_assignment][super::super::client::OsConfigZonalService::delete_os_policy_assignment].
+        /// on [delete_os_policy_assignment][crate::client::OsConfigZonalService::delete_os_policy_assignment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_os_policy_assignment(self.0.request, self.0.options)
@@ -2017,7 +2017,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::get_os_policy_assignment_report][super::super::client::OsConfigZonalService::get_os_policy_assignment_report] calls.
+    /// The request builder for [OsConfigZonalService::get_os_policy_assignment_report][crate::client::OsConfigZonalService::get_os_policy_assignment_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2085,7 +2085,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::list_os_policy_assignment_reports][super::super::client::OsConfigZonalService::list_os_policy_assignment_reports] calls.
+    /// The request builder for [OsConfigZonalService::list_os_policy_assignment_reports][crate::client::OsConfigZonalService::list_os_policy_assignment_reports] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2203,7 +2203,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::get_inventory][super::super::client::OsConfigZonalService::get_inventory] calls.
+    /// The request builder for [OsConfigZonalService::get_inventory][crate::client::OsConfigZonalService::get_inventory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2272,7 +2272,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::list_inventories][super::super::client::OsConfigZonalService::list_inventories] calls.
+    /// The request builder for [OsConfigZonalService::list_inventories][crate::client::OsConfigZonalService::list_inventories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2387,7 +2387,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::get_vulnerability_report][super::super::client::OsConfigZonalService::get_vulnerability_report] calls.
+    /// The request builder for [OsConfigZonalService::get_vulnerability_report][crate::client::OsConfigZonalService::get_vulnerability_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2453,7 +2453,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::list_vulnerability_reports][super::super::client::OsConfigZonalService::list_vulnerability_reports] calls.
+    /// The request builder for [OsConfigZonalService::list_vulnerability_reports][crate::client::OsConfigZonalService::list_vulnerability_reports] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2571,7 +2571,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::get_operation][super::super::client::OsConfigZonalService::get_operation] calls.
+    /// The request builder for [OsConfigZonalService::get_operation][crate::client::OsConfigZonalService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2635,7 +2635,7 @@ pub mod os_config_zonal_service {
         }
     }
 
-    /// The request builder for [OsConfigZonalService::cancel_operation][super::super::client::OsConfigZonalService::cancel_operation] calls.
+    /// The request builder for [OsConfigZonalService::cancel_operation][crate::client::OsConfigZonalService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/oslogin/v1/src/builder.rs
+++ b/src/generated/cloud/oslogin/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod os_login_service {
     use crate::Result;
 
-    /// A builder for [OsLoginService][super::super::client::OsLoginService].
+    /// A builder for [OsLoginService][crate::client::OsLoginService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod os_login_service {
         }
     }
 
-    /// Common implementation for [super::super::client::OsLoginService] request builders.
+    /// Common implementation for [crate::client::OsLoginService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::OsLoginService>,
@@ -68,7 +68,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for [OsLoginService::create_ssh_public_key][super::super::client::OsLoginService::create_ssh_public_key] calls.
+    /// The request builder for [OsLoginService::create_ssh_public_key][crate::client::OsLoginService::create_ssh_public_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -156,7 +156,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for [OsLoginService::delete_posix_account][super::super::client::OsLoginService::delete_posix_account] calls.
+    /// The request builder for [OsLoginService::delete_posix_account][crate::client::OsLoginService::delete_posix_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -222,7 +222,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for [OsLoginService::delete_ssh_public_key][super::super::client::OsLoginService::delete_ssh_public_key] calls.
+    /// The request builder for [OsLoginService::delete_ssh_public_key][crate::client::OsLoginService::delete_ssh_public_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -288,7 +288,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for [OsLoginService::get_login_profile][super::super::client::OsLoginService::get_login_profile] calls.
+    /// The request builder for [OsLoginService::get_login_profile][crate::client::OsLoginService::get_login_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -363,7 +363,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for [OsLoginService::get_ssh_public_key][super::super::client::OsLoginService::get_ssh_public_key] calls.
+    /// The request builder for [OsLoginService::get_ssh_public_key][crate::client::OsLoginService::get_ssh_public_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -426,7 +426,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for [OsLoginService::import_ssh_public_key][super::super::client::OsLoginService::import_ssh_public_key] calls.
+    /// The request builder for [OsLoginService::import_ssh_public_key][crate::client::OsLoginService::import_ssh_public_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -527,7 +527,7 @@ pub mod os_login_service {
         }
     }
 
-    /// The request builder for [OsLoginService::update_ssh_public_key][super::super::client::OsLoginService::update_ssh_public_key] calls.
+    /// The request builder for [OsLoginService::update_ssh_public_key][crate::client::OsLoginService::update_ssh_public_key] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/parallelstore/v1/src/builder.rs
+++ b/src/generated/cloud/parallelstore/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod parallelstore {
     use crate::Result;
 
-    /// A builder for [Parallelstore][super::super::client::Parallelstore].
+    /// A builder for [Parallelstore][crate::client::Parallelstore].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod parallelstore {
         }
     }
 
-    /// Common implementation for [super::super::client::Parallelstore] request builders.
+    /// Common implementation for [crate::client::Parallelstore] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Parallelstore>,
@@ -68,7 +68,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::list_instances][super::super::client::Parallelstore::list_instances] calls.
+    /// The request builder for [Parallelstore::list_instances][crate::client::Parallelstore::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::get_instance][super::super::client::Parallelstore::get_instance] calls.
+    /// The request builder for [Parallelstore::get_instance][crate::client::Parallelstore::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::create_instance][super::super::client::Parallelstore::create_instance] calls.
+    /// The request builder for [Parallelstore::create_instance][crate::client::Parallelstore::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod parallelstore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::Parallelstore::create_instance].
+        /// on [create_instance][crate::client::Parallelstore::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::update_instance][super::super::client::Parallelstore::update_instance] calls.
+    /// The request builder for [Parallelstore::update_instance][crate::client::Parallelstore::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod parallelstore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::Parallelstore::update_instance].
+        /// on [update_instance][crate::client::Parallelstore::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -528,7 +528,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::delete_instance][super::super::client::Parallelstore::delete_instance] calls.
+    /// The request builder for [Parallelstore::delete_instance][crate::client::Parallelstore::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -573,7 +573,7 @@ pub mod parallelstore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::Parallelstore::delete_instance].
+        /// on [delete_instance][crate::client::Parallelstore::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -638,7 +638,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::import_data][super::super::client::Parallelstore::import_data] calls.
+    /// The request builder for [Parallelstore::import_data][crate::client::Parallelstore::import_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -683,7 +683,7 @@ pub mod parallelstore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_data][super::super::client::Parallelstore::import_data].
+        /// on [import_data][crate::client::Parallelstore::import_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_data(self.0.request, self.0.options)
@@ -809,7 +809,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::export_data][super::super::client::Parallelstore::export_data] calls.
+    /// The request builder for [Parallelstore::export_data][crate::client::Parallelstore::export_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -854,7 +854,7 @@ pub mod parallelstore {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_data][super::super::client::Parallelstore::export_data].
+        /// on [export_data][crate::client::Parallelstore::export_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_data(self.0.request, self.0.options)
@@ -980,7 +980,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::list_locations][super::super::client::Parallelstore::list_locations] calls.
+    /// The request builder for [Parallelstore::list_locations][crate::client::Parallelstore::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1090,7 +1090,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::get_location][super::super::client::Parallelstore::get_location] calls.
+    /// The request builder for [Parallelstore::get_location][crate::client::Parallelstore::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1151,7 +1151,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::list_operations][super::super::client::Parallelstore::list_operations] calls.
+    /// The request builder for [Parallelstore::list_operations][crate::client::Parallelstore::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1263,7 +1263,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::get_operation][super::super::client::Parallelstore::get_operation] calls.
+    /// The request builder for [Parallelstore::get_operation][crate::client::Parallelstore::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1327,7 +1327,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::delete_operation][super::super::client::Parallelstore::delete_operation] calls.
+    /// The request builder for [Parallelstore::delete_operation][crate::client::Parallelstore::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1391,7 +1391,7 @@ pub mod parallelstore {
         }
     }
 
-    /// The request builder for [Parallelstore::cancel_operation][super::super::client::Parallelstore::cancel_operation] calls.
+    /// The request builder for [Parallelstore::cancel_operation][crate::client::Parallelstore::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/parametermanager/v1/src/builder.rs
+++ b/src/generated/cloud/parametermanager/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod parameter_manager {
     use crate::Result;
 
-    /// A builder for [ParameterManager][super::super::client::ParameterManager].
+    /// A builder for [ParameterManager][crate::client::ParameterManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::ParameterManager] request builders.
+    /// Common implementation for [crate::client::ParameterManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ParameterManager>,
@@ -68,7 +68,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::list_parameters][super::super::client::ParameterManager::list_parameters] calls.
+    /// The request builder for [ParameterManager::list_parameters][crate::client::ParameterManager::list_parameters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::get_parameter][super::super::client::ParameterManager::get_parameter] calls.
+    /// The request builder for [ParameterManager::get_parameter][crate::client::ParameterManager::get_parameter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::create_parameter][super::super::client::ParameterManager::create_parameter] calls.
+    /// The request builder for [ParameterManager::create_parameter][crate::client::ParameterManager::create_parameter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -345,7 +345,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::update_parameter][super::super::client::ParameterManager::update_parameter] calls.
+    /// The request builder for [ParameterManager::update_parameter][crate::client::ParameterManager::update_parameter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -446,7 +446,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::delete_parameter][super::super::client::ParameterManager::delete_parameter] calls.
+    /// The request builder for [ParameterManager::delete_parameter][crate::client::ParameterManager::delete_parameter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -515,7 +515,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::list_parameter_versions][super::super::client::ParameterManager::list_parameter_versions] calls.
+    /// The request builder for [ParameterManager::list_parameter_versions][crate::client::ParameterManager::list_parameter_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -635,7 +635,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::get_parameter_version][super::super::client::ParameterManager::get_parameter_version] calls.
+    /// The request builder for [ParameterManager::get_parameter_version][crate::client::ParameterManager::get_parameter_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -707,7 +707,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::render_parameter_version][super::super::client::ParameterManager::render_parameter_version] calls.
+    /// The request builder for [ParameterManager::render_parameter_version][crate::client::ParameterManager::render_parameter_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -773,7 +773,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::create_parameter_version][super::super::client::ParameterManager::create_parameter_version] calls.
+    /// The request builder for [ParameterManager::create_parameter_version][crate::client::ParameterManager::create_parameter_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -875,7 +875,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::update_parameter_version][super::super::client::ParameterManager::update_parameter_version] calls.
+    /// The request builder for [ParameterManager::update_parameter_version][crate::client::ParameterManager::update_parameter_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -979,7 +979,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::delete_parameter_version][super::super::client::ParameterManager::delete_parameter_version] calls.
+    /// The request builder for [ParameterManager::delete_parameter_version][crate::client::ParameterManager::delete_parameter_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1051,7 +1051,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::list_locations][super::super::client::ParameterManager::list_locations] calls.
+    /// The request builder for [ParameterManager::list_locations][crate::client::ParameterManager::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1161,7 +1161,7 @@ pub mod parameter_manager {
         }
     }
 
-    /// The request builder for [ParameterManager::get_location][super::super::client::ParameterManager::get_location] calls.
+    /// The request builder for [ParameterManager::get_location][crate::client::ParameterManager::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/policysimulator/v1/src/builder.rs
+++ b/src/generated/cloud/policysimulator/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod simulator {
     use crate::Result;
 
-    /// A builder for [Simulator][super::super::client::Simulator].
+    /// A builder for [Simulator][crate::client::Simulator].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod simulator {
         }
     }
 
-    /// Common implementation for [super::super::client::Simulator] request builders.
+    /// Common implementation for [crate::client::Simulator] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Simulator>,
@@ -68,7 +68,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for [Simulator::get_replay][super::super::client::Simulator::get_replay] calls.
+    /// The request builder for [Simulator::get_replay][crate::client::Simulator::get_replay] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for [Simulator::create_replay][super::super::client::Simulator::create_replay] calls.
+    /// The request builder for [Simulator::create_replay][crate::client::Simulator::create_replay] calls.
     ///
     /// # Example
     /// ```no_run
@@ -176,7 +176,7 @@ pub mod simulator {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_replay][super::super::client::Simulator::create_replay].
+        /// on [create_replay][crate::client::Simulator::create_replay].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_replay(self.0.request, self.0.options)
@@ -257,7 +257,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for [Simulator::list_replay_results][super::super::client::Simulator::list_replay_results] calls.
+    /// The request builder for [Simulator::list_replay_results][crate::client::Simulator::list_replay_results] calls.
     ///
     /// # Example
     /// ```no_run
@@ -363,7 +363,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for [Simulator::list_operations][super::super::client::Simulator::list_operations] calls.
+    /// The request builder for [Simulator::list_operations][crate::client::Simulator::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -475,7 +475,7 @@ pub mod simulator {
         }
     }
 
-    /// The request builder for [Simulator::get_operation][super::super::client::Simulator::get_operation] calls.
+    /// The request builder for [Simulator::get_operation][crate::client::Simulator::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/iam/v3/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod policy_troubleshooter {
     use crate::Result;
 
-    /// A builder for [PolicyTroubleshooter][super::super::client::PolicyTroubleshooter].
+    /// A builder for [PolicyTroubleshooter][crate::client::PolicyTroubleshooter].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod policy_troubleshooter {
         }
     }
 
-    /// Common implementation for [super::super::client::PolicyTroubleshooter] request builders.
+    /// Common implementation for [crate::client::PolicyTroubleshooter] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PolicyTroubleshooter>,
@@ -68,7 +68,7 @@ pub mod policy_troubleshooter {
         }
     }
 
-    /// The request builder for [PolicyTroubleshooter::troubleshoot_iam_policy][super::super::client::PolicyTroubleshooter::troubleshoot_iam_policy] calls.
+    /// The request builder for [PolicyTroubleshooter::troubleshoot_iam_policy][crate::client::PolicyTroubleshooter::troubleshoot_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
+++ b/src/generated/cloud/policytroubleshooter/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod iam_checker {
     use crate::Result;
 
-    /// A builder for [IamChecker][super::super::client::IamChecker].
+    /// A builder for [IamChecker][crate::client::IamChecker].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod iam_checker {
         }
     }
 
-    /// Common implementation for [super::super::client::IamChecker] request builders.
+    /// Common implementation for [crate::client::IamChecker] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::IamChecker>,
@@ -68,7 +68,7 @@ pub mod iam_checker {
         }
     }
 
-    /// The request builder for [IamChecker::troubleshoot_iam_policy][super::super::client::IamChecker::troubleshoot_iam_policy] calls.
+    /// The request builder for [IamChecker::troubleshoot_iam_policy][crate::client::IamChecker::troubleshoot_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
+++ b/src/generated/cloud/privilegedaccessmanager/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod privileged_access_manager {
     use crate::Result;
 
-    /// A builder for [PrivilegedAccessManager][super::super::client::PrivilegedAccessManager].
+    /// A builder for [PrivilegedAccessManager][crate::client::PrivilegedAccessManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::PrivilegedAccessManager] request builders.
+    /// Common implementation for [crate::client::PrivilegedAccessManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PrivilegedAccessManager>,
@@ -68,7 +68,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::check_onboarding_status][super::super::client::PrivilegedAccessManager::check_onboarding_status] calls.
+    /// The request builder for [PrivilegedAccessManager::check_onboarding_status][crate::client::PrivilegedAccessManager::check_onboarding_status] calls.
     ///
     /// # Example
     /// ```no_run
@@ -134,7 +134,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::list_entitlements][super::super::client::PrivilegedAccessManager::list_entitlements] calls.
+    /// The request builder for [PrivilegedAccessManager::list_entitlements][crate::client::PrivilegedAccessManager::list_entitlements] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::search_entitlements][super::super::client::PrivilegedAccessManager::search_entitlements] calls.
+    /// The request builder for [PrivilegedAccessManager::search_entitlements][crate::client::PrivilegedAccessManager::search_entitlements] calls.
     ///
     /// # Example
     /// ```no_run
@@ -379,7 +379,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::get_entitlement][super::super::client::PrivilegedAccessManager::get_entitlement] calls.
+    /// The request builder for [PrivilegedAccessManager::get_entitlement][crate::client::PrivilegedAccessManager::get_entitlement] calls.
     ///
     /// # Example
     /// ```no_run
@@ -442,7 +442,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::create_entitlement][super::super::client::PrivilegedAccessManager::create_entitlement] calls.
+    /// The request builder for [PrivilegedAccessManager::create_entitlement][crate::client::PrivilegedAccessManager::create_entitlement] calls.
     ///
     /// # Example
     /// ```no_run
@@ -490,7 +490,7 @@ pub mod privileged_access_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_entitlement][super::super::client::PrivilegedAccessManager::create_entitlement].
+        /// on [create_entitlement][crate::client::PrivilegedAccessManager::create_entitlement].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_entitlement(self.0.request, self.0.options)
@@ -585,7 +585,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::delete_entitlement][super::super::client::PrivilegedAccessManager::delete_entitlement] calls.
+    /// The request builder for [PrivilegedAccessManager::delete_entitlement][crate::client::PrivilegedAccessManager::delete_entitlement] calls.
     ///
     /// # Example
     /// ```no_run
@@ -633,7 +633,7 @@ pub mod privileged_access_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_entitlement][super::super::client::PrivilegedAccessManager::delete_entitlement].
+        /// on [delete_entitlement][crate::client::PrivilegedAccessManager::delete_entitlement].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_entitlement(self.0.request, self.0.options)
@@ -704,7 +704,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::update_entitlement][super::super::client::PrivilegedAccessManager::update_entitlement] calls.
+    /// The request builder for [PrivilegedAccessManager::update_entitlement][crate::client::PrivilegedAccessManager::update_entitlement] calls.
     ///
     /// # Example
     /// ```no_run
@@ -752,7 +752,7 @@ pub mod privileged_access_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_entitlement][super::super::client::PrivilegedAccessManager::update_entitlement].
+        /// on [update_entitlement][crate::client::PrivilegedAccessManager::update_entitlement].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_entitlement(self.0.request, self.0.options)
@@ -847,7 +847,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::list_grants][super::super::client::PrivilegedAccessManager::list_grants] calls.
+    /// The request builder for [PrivilegedAccessManager::list_grants][crate::client::PrivilegedAccessManager::list_grants] calls.
     ///
     /// # Example
     /// ```no_run
@@ -962,7 +962,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::search_grants][super::super::client::PrivilegedAccessManager::search_grants] calls.
+    /// The request builder for [PrivilegedAccessManager::search_grants][crate::client::PrivilegedAccessManager::search_grants] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1084,7 +1084,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::get_grant][super::super::client::PrivilegedAccessManager::get_grant] calls.
+    /// The request builder for [PrivilegedAccessManager::get_grant][crate::client::PrivilegedAccessManager::get_grant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1147,7 +1147,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::create_grant][super::super::client::PrivilegedAccessManager::create_grant] calls.
+    /// The request builder for [PrivilegedAccessManager::create_grant][crate::client::PrivilegedAccessManager::create_grant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1238,7 +1238,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::approve_grant][super::super::client::PrivilegedAccessManager::approve_grant] calls.
+    /// The request builder for [PrivilegedAccessManager::approve_grant][crate::client::PrivilegedAccessManager::approve_grant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1307,7 +1307,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::deny_grant][super::super::client::PrivilegedAccessManager::deny_grant] calls.
+    /// The request builder for [PrivilegedAccessManager::deny_grant][crate::client::PrivilegedAccessManager::deny_grant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1376,7 +1376,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::revoke_grant][super::super::client::PrivilegedAccessManager::revoke_grant] calls.
+    /// The request builder for [PrivilegedAccessManager::revoke_grant][crate::client::PrivilegedAccessManager::revoke_grant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1421,7 +1421,7 @@ pub mod privileged_access_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [revoke_grant][super::super::client::PrivilegedAccessManager::revoke_grant].
+        /// on [revoke_grant][crate::client::PrivilegedAccessManager::revoke_grant].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .revoke_grant(self.0.request, self.0.options)
@@ -1484,7 +1484,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::list_locations][super::super::client::PrivilegedAccessManager::list_locations] calls.
+    /// The request builder for [PrivilegedAccessManager::list_locations][crate::client::PrivilegedAccessManager::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1594,7 +1594,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::get_location][super::super::client::PrivilegedAccessManager::get_location] calls.
+    /// The request builder for [PrivilegedAccessManager::get_location][crate::client::PrivilegedAccessManager::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1655,7 +1655,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::list_operations][super::super::client::PrivilegedAccessManager::list_operations] calls.
+    /// The request builder for [PrivilegedAccessManager::list_operations][crate::client::PrivilegedAccessManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1767,7 +1767,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::get_operation][super::super::client::PrivilegedAccessManager::get_operation] calls.
+    /// The request builder for [PrivilegedAccessManager::get_operation][crate::client::PrivilegedAccessManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1831,7 +1831,7 @@ pub mod privileged_access_manager {
         }
     }
 
-    /// The request builder for [PrivilegedAccessManager::delete_operation][super::super::client::PrivilegedAccessManager::delete_operation] calls.
+    /// The request builder for [PrivilegedAccessManager::delete_operation][crate::client::PrivilegedAccessManager::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
+++ b/src/generated/cloud/rapidmigrationassessment/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod rapid_migration_assessment {
     use crate::Result;
 
-    /// A builder for [RapidMigrationAssessment][super::super::client::RapidMigrationAssessment].
+    /// A builder for [RapidMigrationAssessment][crate::client::RapidMigrationAssessment].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// Common implementation for [super::super::client::RapidMigrationAssessment] request builders.
+    /// Common implementation for [crate::client::RapidMigrationAssessment] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RapidMigrationAssessment>,
@@ -68,7 +68,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::create_collector][super::super::client::RapidMigrationAssessment::create_collector] calls.
+    /// The request builder for [RapidMigrationAssessment::create_collector][crate::client::RapidMigrationAssessment::create_collector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod rapid_migration_assessment {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_collector][super::super::client::RapidMigrationAssessment::create_collector].
+        /// on [create_collector][crate::client::RapidMigrationAssessment::create_collector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_collector(self.0.request, self.0.options)
@@ -206,7 +206,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::create_annotation][super::super::client::RapidMigrationAssessment::create_annotation] calls.
+    /// The request builder for [RapidMigrationAssessment::create_annotation][crate::client::RapidMigrationAssessment::create_annotation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -254,7 +254,7 @@ pub mod rapid_migration_assessment {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_annotation][super::super::client::RapidMigrationAssessment::create_annotation].
+        /// on [create_annotation][crate::client::RapidMigrationAssessment::create_annotation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_annotation(self.0.request, self.0.options)
@@ -339,7 +339,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::get_annotation][super::super::client::RapidMigrationAssessment::get_annotation] calls.
+    /// The request builder for [RapidMigrationAssessment::get_annotation][crate::client::RapidMigrationAssessment::get_annotation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -402,7 +402,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::list_collectors][super::super::client::RapidMigrationAssessment::list_collectors] calls.
+    /// The request builder for [RapidMigrationAssessment::list_collectors][crate::client::RapidMigrationAssessment::list_collectors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -517,7 +517,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::get_collector][super::super::client::RapidMigrationAssessment::get_collector] calls.
+    /// The request builder for [RapidMigrationAssessment::get_collector][crate::client::RapidMigrationAssessment::get_collector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -580,7 +580,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::update_collector][super::super::client::RapidMigrationAssessment::update_collector] calls.
+    /// The request builder for [RapidMigrationAssessment::update_collector][crate::client::RapidMigrationAssessment::update_collector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -625,7 +625,7 @@ pub mod rapid_migration_assessment {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_collector][super::super::client::RapidMigrationAssessment::update_collector].
+        /// on [update_collector][crate::client::RapidMigrationAssessment::update_collector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_collector(self.0.request, self.0.options)
@@ -724,7 +724,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::delete_collector][super::super::client::RapidMigrationAssessment::delete_collector] calls.
+    /// The request builder for [RapidMigrationAssessment::delete_collector][crate::client::RapidMigrationAssessment::delete_collector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -769,7 +769,7 @@ pub mod rapid_migration_assessment {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_collector][super::super::client::RapidMigrationAssessment::delete_collector].
+        /// on [delete_collector][crate::client::RapidMigrationAssessment::delete_collector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_collector(self.0.request, self.0.options)
@@ -832,7 +832,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::resume_collector][super::super::client::RapidMigrationAssessment::resume_collector] calls.
+    /// The request builder for [RapidMigrationAssessment::resume_collector][crate::client::RapidMigrationAssessment::resume_collector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -877,7 +877,7 @@ pub mod rapid_migration_assessment {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [resume_collector][super::super::client::RapidMigrationAssessment::resume_collector].
+        /// on [resume_collector][crate::client::RapidMigrationAssessment::resume_collector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .resume_collector(self.0.request, self.0.options)
@@ -940,7 +940,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::register_collector][super::super::client::RapidMigrationAssessment::register_collector] calls.
+    /// The request builder for [RapidMigrationAssessment::register_collector][crate::client::RapidMigrationAssessment::register_collector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -988,7 +988,7 @@ pub mod rapid_migration_assessment {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [register_collector][super::super::client::RapidMigrationAssessment::register_collector].
+        /// on [register_collector][crate::client::RapidMigrationAssessment::register_collector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .register_collector(self.0.request, self.0.options)
@@ -1051,7 +1051,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::pause_collector][super::super::client::RapidMigrationAssessment::pause_collector] calls.
+    /// The request builder for [RapidMigrationAssessment::pause_collector][crate::client::RapidMigrationAssessment::pause_collector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1096,7 +1096,7 @@ pub mod rapid_migration_assessment {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [pause_collector][super::super::client::RapidMigrationAssessment::pause_collector].
+        /// on [pause_collector][crate::client::RapidMigrationAssessment::pause_collector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .pause_collector(self.0.request, self.0.options)
@@ -1159,7 +1159,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::list_locations][super::super::client::RapidMigrationAssessment::list_locations] calls.
+    /// The request builder for [RapidMigrationAssessment::list_locations][crate::client::RapidMigrationAssessment::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1269,7 +1269,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::get_location][super::super::client::RapidMigrationAssessment::get_location] calls.
+    /// The request builder for [RapidMigrationAssessment::get_location][crate::client::RapidMigrationAssessment::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1330,7 +1330,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::list_operations][super::super::client::RapidMigrationAssessment::list_operations] calls.
+    /// The request builder for [RapidMigrationAssessment::list_operations][crate::client::RapidMigrationAssessment::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1442,7 +1442,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::get_operation][super::super::client::RapidMigrationAssessment::get_operation] calls.
+    /// The request builder for [RapidMigrationAssessment::get_operation][crate::client::RapidMigrationAssessment::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1506,7 +1506,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::delete_operation][super::super::client::RapidMigrationAssessment::delete_operation] calls.
+    /// The request builder for [RapidMigrationAssessment::delete_operation][crate::client::RapidMigrationAssessment::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1570,7 +1570,7 @@ pub mod rapid_migration_assessment {
         }
     }
 
-    /// The request builder for [RapidMigrationAssessment::cancel_operation][super::super::client::RapidMigrationAssessment::cancel_operation] calls.
+    /// The request builder for [RapidMigrationAssessment::cancel_operation][crate::client::RapidMigrationAssessment::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
+++ b/src/generated/cloud/recaptchaenterprise/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod recaptcha_enterprise_service {
     use crate::Result;
 
-    /// A builder for [RecaptchaEnterpriseService][super::super::client::RecaptchaEnterpriseService].
+    /// A builder for [RecaptchaEnterpriseService][crate::client::RecaptchaEnterpriseService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RecaptchaEnterpriseService] request builders.
+    /// Common implementation for [crate::client::RecaptchaEnterpriseService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RecaptchaEnterpriseService>,
@@ -68,7 +68,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::create_assessment][super::super::client::RecaptchaEnterpriseService::create_assessment] calls.
+    /// The request builder for [RecaptchaEnterpriseService::create_assessment][crate::client::RecaptchaEnterpriseService::create_assessment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -156,7 +156,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::annotate_assessment][super::super::client::RecaptchaEnterpriseService::annotate_assessment] calls.
+    /// The request builder for [RecaptchaEnterpriseService::annotate_assessment][crate::client::RecaptchaEnterpriseService::annotate_assessment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -272,7 +272,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::create_key][super::super::client::RecaptchaEnterpriseService::create_key] calls.
+    /// The request builder for [RecaptchaEnterpriseService::create_key][crate::client::RecaptchaEnterpriseService::create_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -357,7 +357,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::list_keys][super::super::client::RecaptchaEnterpriseService::list_keys] calls.
+    /// The request builder for [RecaptchaEnterpriseService::list_keys][crate::client::RecaptchaEnterpriseService::list_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -460,7 +460,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::retrieve_legacy_secret_key][super::super::client::RecaptchaEnterpriseService::retrieve_legacy_secret_key] calls.
+    /// The request builder for [RecaptchaEnterpriseService::retrieve_legacy_secret_key][crate::client::RecaptchaEnterpriseService::retrieve_legacy_secret_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -528,7 +528,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::get_key][super::super::client::RecaptchaEnterpriseService::get_key] calls.
+    /// The request builder for [RecaptchaEnterpriseService::get_key][crate::client::RecaptchaEnterpriseService::get_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -591,7 +591,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::update_key][super::super::client::RecaptchaEnterpriseService::update_key] calls.
+    /// The request builder for [RecaptchaEnterpriseService::update_key][crate::client::RecaptchaEnterpriseService::update_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -686,7 +686,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::delete_key][super::super::client::RecaptchaEnterpriseService::delete_key] calls.
+    /// The request builder for [RecaptchaEnterpriseService::delete_key][crate::client::RecaptchaEnterpriseService::delete_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -749,7 +749,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::migrate_key][super::super::client::RecaptchaEnterpriseService::migrate_key] calls.
+    /// The request builder for [RecaptchaEnterpriseService::migrate_key][crate::client::RecaptchaEnterpriseService::migrate_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -818,7 +818,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::add_ip_override][super::super::client::RecaptchaEnterpriseService::add_ip_override] calls.
+    /// The request builder for [RecaptchaEnterpriseService::add_ip_override][crate::client::RecaptchaEnterpriseService::add_ip_override] calls.
     ///
     /// # Example
     /// ```no_run
@@ -903,7 +903,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::remove_ip_override][super::super::client::RecaptchaEnterpriseService::remove_ip_override] calls.
+    /// The request builder for [RecaptchaEnterpriseService::remove_ip_override][crate::client::RecaptchaEnterpriseService::remove_ip_override] calls.
     ///
     /// # Example
     /// ```no_run
@@ -991,7 +991,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::list_ip_overrides][super::super::client::RecaptchaEnterpriseService::list_ip_overrides] calls.
+    /// The request builder for [RecaptchaEnterpriseService::list_ip_overrides][crate::client::RecaptchaEnterpriseService::list_ip_overrides] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1094,7 +1094,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::get_metrics][super::super::client::RecaptchaEnterpriseService::get_metrics] calls.
+    /// The request builder for [RecaptchaEnterpriseService::get_metrics][crate::client::RecaptchaEnterpriseService::get_metrics] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1157,7 +1157,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::create_firewall_policy][super::super::client::RecaptchaEnterpriseService::create_firewall_policy] calls.
+    /// The request builder for [RecaptchaEnterpriseService::create_firewall_policy][crate::client::RecaptchaEnterpriseService::create_firewall_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1245,7 +1245,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::list_firewall_policies][super::super::client::RecaptchaEnterpriseService::list_firewall_policies] calls.
+    /// The request builder for [RecaptchaEnterpriseService::list_firewall_policies][crate::client::RecaptchaEnterpriseService::list_firewall_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1353,7 +1353,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::get_firewall_policy][super::super::client::RecaptchaEnterpriseService::get_firewall_policy] calls.
+    /// The request builder for [RecaptchaEnterpriseService::get_firewall_policy][crate::client::RecaptchaEnterpriseService::get_firewall_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1419,7 +1419,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::update_firewall_policy][super::super::client::RecaptchaEnterpriseService::update_firewall_policy] calls.
+    /// The request builder for [RecaptchaEnterpriseService::update_firewall_policy][crate::client::RecaptchaEnterpriseService::update_firewall_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1517,7 +1517,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::delete_firewall_policy][super::super::client::RecaptchaEnterpriseService::delete_firewall_policy] calls.
+    /// The request builder for [RecaptchaEnterpriseService::delete_firewall_policy][crate::client::RecaptchaEnterpriseService::delete_firewall_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1583,7 +1583,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::reorder_firewall_policies][super::super::client::RecaptchaEnterpriseService::reorder_firewall_policies] calls.
+    /// The request builder for [RecaptchaEnterpriseService::reorder_firewall_policies][crate::client::RecaptchaEnterpriseService::reorder_firewall_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1664,7 +1664,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::list_related_account_groups][super::super::client::RecaptchaEnterpriseService::list_related_account_groups] calls.
+    /// The request builder for [RecaptchaEnterpriseService::list_related_account_groups][crate::client::RecaptchaEnterpriseService::list_related_account_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1776,7 +1776,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::list_related_account_group_memberships][super::super::client::RecaptchaEnterpriseService::list_related_account_group_memberships] calls.
+    /// The request builder for [RecaptchaEnterpriseService::list_related_account_group_memberships][crate::client::RecaptchaEnterpriseService::list_related_account_group_memberships] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1890,7 +1890,7 @@ pub mod recaptcha_enterprise_service {
         }
     }
 
-    /// The request builder for [RecaptchaEnterpriseService::search_related_account_group_memberships][super::super::client::RecaptchaEnterpriseService::search_related_account_group_memberships] calls.
+    /// The request builder for [RecaptchaEnterpriseService::search_related_account_group_memberships][crate::client::RecaptchaEnterpriseService::search_related_account_group_memberships] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/recommender/v1/src/builder.rs
+++ b/src/generated/cloud/recommender/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod recommender {
     use crate::Result;
 
-    /// A builder for [Recommender][super::super::client::Recommender].
+    /// A builder for [Recommender][crate::client::Recommender].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod recommender {
         }
     }
 
-    /// Common implementation for [super::super::client::Recommender] request builders.
+    /// Common implementation for [crate::client::Recommender] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Recommender>,
@@ -68,7 +68,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::list_insights][super::super::client::Recommender::list_insights] calls.
+    /// The request builder for [Recommender::list_insights][crate::client::Recommender::list_insights] calls.
     ///
     /// # Example
     /// ```no_run
@@ -177,7 +177,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::get_insight][super::super::client::Recommender::get_insight] calls.
+    /// The request builder for [Recommender::get_insight][crate::client::Recommender::get_insight] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::mark_insight_accepted][super::super::client::Recommender::mark_insight_accepted] calls.
+    /// The request builder for [Recommender::mark_insight_accepted][crate::client::Recommender::mark_insight_accepted] calls.
     ///
     /// # Example
     /// ```no_run
@@ -326,7 +326,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::list_recommendations][super::super::client::Recommender::list_recommendations] calls.
+    /// The request builder for [Recommender::list_recommendations][crate::client::Recommender::list_recommendations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -440,7 +440,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::get_recommendation][super::super::client::Recommender::get_recommendation] calls.
+    /// The request builder for [Recommender::get_recommendation][crate::client::Recommender::get_recommendation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -506,7 +506,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::mark_recommendation_dismissed][super::super::client::Recommender::mark_recommendation_dismissed] calls.
+    /// The request builder for [Recommender::mark_recommendation_dismissed][crate::client::Recommender::mark_recommendation_dismissed] calls.
     ///
     /// # Example
     /// ```no_run
@@ -580,7 +580,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::mark_recommendation_claimed][super::super::client::Recommender::mark_recommendation_claimed] calls.
+    /// The request builder for [Recommender::mark_recommendation_claimed][crate::client::Recommender::mark_recommendation_claimed] calls.
     ///
     /// # Example
     /// ```no_run
@@ -668,7 +668,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::mark_recommendation_succeeded][super::super::client::Recommender::mark_recommendation_succeeded] calls.
+    /// The request builder for [Recommender::mark_recommendation_succeeded][crate::client::Recommender::mark_recommendation_succeeded] calls.
     ///
     /// # Example
     /// ```no_run
@@ -756,7 +756,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::mark_recommendation_failed][super::super::client::Recommender::mark_recommendation_failed] calls.
+    /// The request builder for [Recommender::mark_recommendation_failed][crate::client::Recommender::mark_recommendation_failed] calls.
     ///
     /// # Example
     /// ```no_run
@@ -844,7 +844,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::get_recommender_config][super::super::client::Recommender::get_recommender_config] calls.
+    /// The request builder for [Recommender::get_recommender_config][crate::client::Recommender::get_recommender_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -910,7 +910,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::update_recommender_config][super::super::client::Recommender::update_recommender_config] calls.
+    /// The request builder for [Recommender::update_recommender_config][crate::client::Recommender::update_recommender_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1016,7 +1016,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::get_insight_type_config][super::super::client::Recommender::get_insight_type_config] calls.
+    /// The request builder for [Recommender::get_insight_type_config][crate::client::Recommender::get_insight_type_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1082,7 +1082,7 @@ pub mod recommender {
         }
     }
 
-    /// The request builder for [Recommender::update_insight_type_config][super::super::client::Recommender::update_insight_type_config] calls.
+    /// The request builder for [Recommender::update_insight_type_config][crate::client::Recommender::update_insight_type_config] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/redis/cluster/v1/src/builder.rs
+++ b/src/generated/cloud/redis/cluster/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_redis_cluster {
     use crate::Result;
 
-    /// A builder for [CloudRedisCluster][super::super::client::CloudRedisCluster].
+    /// A builder for [CloudRedisCluster][crate::client::CloudRedisCluster].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudRedisCluster] request builders.
+    /// Common implementation for [crate::client::CloudRedisCluster] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudRedisCluster>,
@@ -68,7 +68,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::list_clusters][super::super::client::CloudRedisCluster::list_clusters] calls.
+    /// The request builder for [CloudRedisCluster::list_clusters][crate::client::CloudRedisCluster::list_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::get_cluster][super::super::client::CloudRedisCluster::get_cluster] calls.
+    /// The request builder for [CloudRedisCluster::get_cluster][crate::client::CloudRedisCluster::get_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -234,7 +234,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::update_cluster][super::super::client::CloudRedisCluster::update_cluster] calls.
+    /// The request builder for [CloudRedisCluster::update_cluster][crate::client::CloudRedisCluster::update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -279,7 +279,7 @@ pub mod cloud_redis_cluster {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_cluster][super::super::client::CloudRedisCluster::update_cluster].
+        /// on [update_cluster][crate::client::CloudRedisCluster::update_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_cluster(self.0.request, self.0.options)
@@ -375,7 +375,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::delete_cluster][super::super::client::CloudRedisCluster::delete_cluster] calls.
+    /// The request builder for [CloudRedisCluster::delete_cluster][crate::client::CloudRedisCluster::delete_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -420,7 +420,7 @@ pub mod cloud_redis_cluster {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cluster][super::super::client::CloudRedisCluster::delete_cluster].
+        /// on [delete_cluster][crate::client::CloudRedisCluster::delete_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cluster(self.0.request, self.0.options)
@@ -485,7 +485,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::create_cluster][super::super::client::CloudRedisCluster::create_cluster] calls.
+    /// The request builder for [CloudRedisCluster::create_cluster][crate::client::CloudRedisCluster::create_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -530,7 +530,7 @@ pub mod cloud_redis_cluster {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cluster][super::super::client::CloudRedisCluster::create_cluster].
+        /// on [create_cluster][crate::client::CloudRedisCluster::create_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cluster(self.0.request, self.0.options)
@@ -620,7 +620,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::get_cluster_certificate_authority][super::super::client::CloudRedisCluster::get_cluster_certificate_authority] calls.
+    /// The request builder for [CloudRedisCluster::get_cluster_certificate_authority][crate::client::CloudRedisCluster::get_cluster_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -688,7 +688,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::reschedule_cluster_maintenance][super::super::client::CloudRedisCluster::reschedule_cluster_maintenance] calls.
+    /// The request builder for [CloudRedisCluster::reschedule_cluster_maintenance][crate::client::CloudRedisCluster::reschedule_cluster_maintenance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -738,7 +738,7 @@ pub mod cloud_redis_cluster {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reschedule_cluster_maintenance][super::super::client::CloudRedisCluster::reschedule_cluster_maintenance].
+        /// on [reschedule_cluster_maintenance][crate::client::CloudRedisCluster::reschedule_cluster_maintenance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reschedule_cluster_maintenance(self.0.request, self.0.options)
@@ -823,7 +823,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::list_backup_collections][super::super::client::CloudRedisCluster::list_backup_collections] calls.
+    /// The request builder for [CloudRedisCluster::list_backup_collections][crate::client::CloudRedisCluster::list_backup_collections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -931,7 +931,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::get_backup_collection][super::super::client::CloudRedisCluster::get_backup_collection] calls.
+    /// The request builder for [CloudRedisCluster::get_backup_collection][crate::client::CloudRedisCluster::get_backup_collection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -997,7 +997,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::list_backups][super::super::client::CloudRedisCluster::list_backups] calls.
+    /// The request builder for [CloudRedisCluster::list_backups][crate::client::CloudRedisCluster::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1100,7 +1100,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::get_backup][super::super::client::CloudRedisCluster::get_backup] calls.
+    /// The request builder for [CloudRedisCluster::get_backup][crate::client::CloudRedisCluster::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1163,7 +1163,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::delete_backup][super::super::client::CloudRedisCluster::delete_backup] calls.
+    /// The request builder for [CloudRedisCluster::delete_backup][crate::client::CloudRedisCluster::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1208,7 +1208,7 @@ pub mod cloud_redis_cluster {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_backup][super::super::client::CloudRedisCluster::delete_backup].
+        /// on [delete_backup][crate::client::CloudRedisCluster::delete_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_backup(self.0.request, self.0.options)
@@ -1273,7 +1273,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::export_backup][super::super::client::CloudRedisCluster::export_backup] calls.
+    /// The request builder for [CloudRedisCluster::export_backup][crate::client::CloudRedisCluster::export_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1318,7 +1318,7 @@ pub mod cloud_redis_cluster {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_backup][super::super::client::CloudRedisCluster::export_backup].
+        /// on [export_backup][crate::client::CloudRedisCluster::export_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_backup(self.0.request, self.0.options)
@@ -1396,7 +1396,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::backup_cluster][super::super::client::CloudRedisCluster::backup_cluster] calls.
+    /// The request builder for [CloudRedisCluster::backup_cluster][crate::client::CloudRedisCluster::backup_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1441,7 +1441,7 @@ pub mod cloud_redis_cluster {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [backup_cluster][super::super::client::CloudRedisCluster::backup_cluster].
+        /// on [backup_cluster][crate::client::CloudRedisCluster::backup_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .backup_cluster(self.0.request, self.0.options)
@@ -1531,7 +1531,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::list_locations][super::super::client::CloudRedisCluster::list_locations] calls.
+    /// The request builder for [CloudRedisCluster::list_locations][crate::client::CloudRedisCluster::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1641,7 +1641,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::get_location][super::super::client::CloudRedisCluster::get_location] calls.
+    /// The request builder for [CloudRedisCluster::get_location][crate::client::CloudRedisCluster::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1702,7 +1702,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::list_operations][super::super::client::CloudRedisCluster::list_operations] calls.
+    /// The request builder for [CloudRedisCluster::list_operations][crate::client::CloudRedisCluster::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1814,7 +1814,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::get_operation][super::super::client::CloudRedisCluster::get_operation] calls.
+    /// The request builder for [CloudRedisCluster::get_operation][crate::client::CloudRedisCluster::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1878,7 +1878,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::delete_operation][super::super::client::CloudRedisCluster::delete_operation] calls.
+    /// The request builder for [CloudRedisCluster::delete_operation][crate::client::CloudRedisCluster::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1942,7 +1942,7 @@ pub mod cloud_redis_cluster {
         }
     }
 
-    /// The request builder for [CloudRedisCluster::cancel_operation][super::super::client::CloudRedisCluster::cancel_operation] calls.
+    /// The request builder for [CloudRedisCluster::cancel_operation][crate::client::CloudRedisCluster::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/redis/v1/src/builder.rs
+++ b/src/generated/cloud/redis/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_redis {
     use crate::Result;
 
-    /// A builder for [CloudRedis][super::super::client::CloudRedis].
+    /// A builder for [CloudRedis][crate::client::CloudRedis].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudRedis] request builders.
+    /// Common implementation for [crate::client::CloudRedis] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudRedis>,
@@ -68,7 +68,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::list_instances][super::super::client::CloudRedis::list_instances] calls.
+    /// The request builder for [CloudRedis::list_instances][crate::client::CloudRedis::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::get_instance][super::super::client::CloudRedis::get_instance] calls.
+    /// The request builder for [CloudRedis::get_instance][crate::client::CloudRedis::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -234,7 +234,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::get_instance_auth_string][super::super::client::CloudRedis::get_instance_auth_string] calls.
+    /// The request builder for [CloudRedis::get_instance_auth_string][crate::client::CloudRedis::get_instance_auth_string] calls.
     ///
     /// # Example
     /// ```no_run
@@ -300,7 +300,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::create_instance][super::super::client::CloudRedis::create_instance] calls.
+    /// The request builder for [CloudRedis::create_instance][crate::client::CloudRedis::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -345,7 +345,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::CloudRedis::create_instance].
+        /// on [create_instance][crate::client::CloudRedis::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -432,7 +432,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::update_instance][super::super::client::CloudRedis::update_instance] calls.
+    /// The request builder for [CloudRedis::update_instance][crate::client::CloudRedis::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -477,7 +477,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::CloudRedis::update_instance].
+        /// on [update_instance][crate::client::CloudRedis::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -570,7 +570,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::upgrade_instance][super::super::client::CloudRedis::upgrade_instance] calls.
+    /// The request builder for [CloudRedis::upgrade_instance][crate::client::CloudRedis::upgrade_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -615,7 +615,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upgrade_instance][super::super::client::CloudRedis::upgrade_instance].
+        /// on [upgrade_instance][crate::client::CloudRedis::upgrade_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upgrade_instance(self.0.request, self.0.options)
@@ -680,7 +680,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::import_instance][super::super::client::CloudRedis::import_instance] calls.
+    /// The request builder for [CloudRedis::import_instance][crate::client::CloudRedis::import_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -725,7 +725,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_instance][super::super::client::CloudRedis::import_instance].
+        /// on [import_instance][crate::client::CloudRedis::import_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_instance(self.0.request, self.0.options)
@@ -804,7 +804,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::export_instance][super::super::client::CloudRedis::export_instance] calls.
+    /// The request builder for [CloudRedis::export_instance][crate::client::CloudRedis::export_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -849,7 +849,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_instance][super::super::client::CloudRedis::export_instance].
+        /// on [export_instance][crate::client::CloudRedis::export_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_instance(self.0.request, self.0.options)
@@ -928,7 +928,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::failover_instance][super::super::client::CloudRedis::failover_instance] calls.
+    /// The request builder for [CloudRedis::failover_instance][crate::client::CloudRedis::failover_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -976,7 +976,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [failover_instance][super::super::client::CloudRedis::failover_instance].
+        /// on [failover_instance][crate::client::CloudRedis::failover_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .failover_instance(self.0.request, self.0.options)
@@ -1044,7 +1044,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::delete_instance][super::super::client::CloudRedis::delete_instance] calls.
+    /// The request builder for [CloudRedis::delete_instance][crate::client::CloudRedis::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1089,7 +1089,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::CloudRedis::delete_instance].
+        /// on [delete_instance][crate::client::CloudRedis::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -1148,7 +1148,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::reschedule_maintenance][super::super::client::CloudRedis::reschedule_maintenance] calls.
+    /// The request builder for [CloudRedis::reschedule_maintenance][crate::client::CloudRedis::reschedule_maintenance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1196,7 +1196,7 @@ pub mod cloud_redis {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reschedule_maintenance][super::super::client::CloudRedis::reschedule_maintenance].
+        /// on [reschedule_maintenance][crate::client::CloudRedis::reschedule_maintenance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reschedule_maintenance(self.0.request, self.0.options)
@@ -1284,7 +1284,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::list_locations][super::super::client::CloudRedis::list_locations] calls.
+    /// The request builder for [CloudRedis::list_locations][crate::client::CloudRedis::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1394,7 +1394,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::get_location][super::super::client::CloudRedis::get_location] calls.
+    /// The request builder for [CloudRedis::get_location][crate::client::CloudRedis::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1455,7 +1455,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::list_operations][super::super::client::CloudRedis::list_operations] calls.
+    /// The request builder for [CloudRedis::list_operations][crate::client::CloudRedis::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1567,7 +1567,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::get_operation][super::super::client::CloudRedis::get_operation] calls.
+    /// The request builder for [CloudRedis::get_operation][crate::client::CloudRedis::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1631,7 +1631,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::delete_operation][super::super::client::CloudRedis::delete_operation] calls.
+    /// The request builder for [CloudRedis::delete_operation][crate::client::CloudRedis::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1695,7 +1695,7 @@ pub mod cloud_redis {
         }
     }
 
-    /// The request builder for [CloudRedis::cancel_operation][super::super::client::CloudRedis::cancel_operation] calls.
+    /// The request builder for [CloudRedis::cancel_operation][crate::client::CloudRedis::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/resourcemanager/v3/src/builder.rs
+++ b/src/generated/cloud/resourcemanager/v3/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod folders {
     use crate::Result;
 
-    /// A builder for [Folders][super::super::client::Folders].
+    /// A builder for [Folders][crate::client::Folders].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod folders {
         }
     }
 
-    /// Common implementation for [super::super::client::Folders] request builders.
+    /// Common implementation for [crate::client::Folders] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Folders>,
@@ -66,7 +66,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::get_folder][super::super::client::Folders::get_folder] calls.
+    /// The request builder for [Folders::get_folder][crate::client::Folders::get_folder] calls.
     ///
     /// # Example
     /// ```no_run
@@ -127,7 +127,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::list_folders][super::super::client::Folders::list_folders] calls.
+    /// The request builder for [Folders::list_folders][crate::client::Folders::list_folders] calls.
     ///
     /// # Example
     /// ```no_run
@@ -234,7 +234,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::search_folders][super::super::client::Folders::search_folders] calls.
+    /// The request builder for [Folders::search_folders][crate::client::Folders::search_folders] calls.
     ///
     /// # Example
     /// ```no_run
@@ -333,7 +333,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::create_folder][super::super::client::Folders::create_folder] calls.
+    /// The request builder for [Folders::create_folder][crate::client::Folders::create_folder] calls.
     ///
     /// # Example
     /// ```no_run
@@ -376,7 +376,7 @@ pub mod folders {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_folder][super::super::client::Folders::create_folder].
+        /// on [create_folder][crate::client::Folders::create_folder].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_folder(self.0.request, self.0.options)
@@ -447,7 +447,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::update_folder][super::super::client::Folders::update_folder] calls.
+    /// The request builder for [Folders::update_folder][crate::client::Folders::update_folder] calls.
     ///
     /// # Example
     /// ```no_run
@@ -490,7 +490,7 @@ pub mod folders {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_folder][super::super::client::Folders::update_folder].
+        /// on [update_folder][crate::client::Folders::update_folder].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_folder(self.0.request, self.0.options)
@@ -583,7 +583,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::move_folder][super::super::client::Folders::move_folder] calls.
+    /// The request builder for [Folders::move_folder][crate::client::Folders::move_folder] calls.
     ///
     /// # Example
     /// ```no_run
@@ -626,7 +626,7 @@ pub mod folders {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [move_folder][super::super::client::Folders::move_folder].
+        /// on [move_folder][crate::client::Folders::move_folder].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .move_folder(self.0.request, self.0.options)
@@ -691,7 +691,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::delete_folder][super::super::client::Folders::delete_folder] calls.
+    /// The request builder for [Folders::delete_folder][crate::client::Folders::delete_folder] calls.
     ///
     /// # Example
     /// ```no_run
@@ -734,7 +734,7 @@ pub mod folders {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_folder][super::super::client::Folders::delete_folder].
+        /// on [delete_folder][crate::client::Folders::delete_folder].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_folder(self.0.request, self.0.options)
@@ -791,7 +791,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::undelete_folder][super::super::client::Folders::undelete_folder] calls.
+    /// The request builder for [Folders::undelete_folder][crate::client::Folders::undelete_folder] calls.
     ///
     /// # Example
     /// ```no_run
@@ -834,7 +834,7 @@ pub mod folders {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_folder][super::super::client::Folders::undelete_folder].
+        /// on [undelete_folder][crate::client::Folders::undelete_folder].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_folder(self.0.request, self.0.options)
@@ -893,7 +893,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::get_iam_policy][super::super::client::Folders::get_iam_policy] calls.
+    /// The request builder for [Folders::get_iam_policy][crate::client::Folders::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -972,7 +972,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::set_iam_policy][super::super::client::Folders::set_iam_policy] calls.
+    /// The request builder for [Folders::set_iam_policy][crate::client::Folders::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1073,7 +1073,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::test_iam_permissions][super::super::client::Folders::test_iam_permissions] calls.
+    /// The request builder for [Folders::test_iam_permissions][crate::client::Folders::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1150,7 +1150,7 @@ pub mod folders {
         }
     }
 
-    /// The request builder for [Folders::get_operation][super::super::client::Folders::get_operation] calls.
+    /// The request builder for [Folders::get_operation][crate::client::Folders::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1216,7 +1216,7 @@ pub mod folders {
 pub mod organizations {
     use crate::Result;
 
-    /// A builder for [Organizations][super::super::client::Organizations].
+    /// A builder for [Organizations][crate::client::Organizations].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1244,7 +1244,7 @@ pub mod organizations {
         }
     }
 
-    /// Common implementation for [super::super::client::Organizations] request builders.
+    /// Common implementation for [crate::client::Organizations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Organizations>,
@@ -1267,7 +1267,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for [Organizations::get_organization][super::super::client::Organizations::get_organization] calls.
+    /// The request builder for [Organizations::get_organization][crate::client::Organizations::get_organization] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1330,7 +1330,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for [Organizations::search_organizations][super::super::client::Organizations::search_organizations] calls.
+    /// The request builder for [Organizations::search_organizations][crate::client::Organizations::search_organizations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1436,7 +1436,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for [Organizations::get_iam_policy][super::super::client::Organizations::get_iam_policy] calls.
+    /// The request builder for [Organizations::get_iam_policy][crate::client::Organizations::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1517,7 +1517,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for [Organizations::set_iam_policy][super::super::client::Organizations::set_iam_policy] calls.
+    /// The request builder for [Organizations::set_iam_policy][crate::client::Organizations::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1620,7 +1620,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for [Organizations::test_iam_permissions][super::super::client::Organizations::test_iam_permissions] calls.
+    /// The request builder for [Organizations::test_iam_permissions][crate::client::Organizations::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1699,7 +1699,7 @@ pub mod organizations {
         }
     }
 
-    /// The request builder for [Organizations::get_operation][super::super::client::Organizations::get_operation] calls.
+    /// The request builder for [Organizations::get_operation][crate::client::Organizations::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1767,7 +1767,7 @@ pub mod organizations {
 pub mod projects {
     use crate::Result;
 
-    /// A builder for [Projects][super::super::client::Projects].
+    /// A builder for [Projects][crate::client::Projects].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1795,7 +1795,7 @@ pub mod projects {
         }
     }
 
-    /// Common implementation for [super::super::client::Projects] request builders.
+    /// Common implementation for [crate::client::Projects] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Projects>,
@@ -1816,7 +1816,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::get_project][super::super::client::Projects::get_project] calls.
+    /// The request builder for [Projects::get_project][crate::client::Projects::get_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1877,7 +1877,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::list_projects][super::super::client::Projects::list_projects] calls.
+    /// The request builder for [Projects::list_projects][crate::client::Projects::list_projects] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1984,7 +1984,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::search_projects][super::super::client::Projects::search_projects] calls.
+    /// The request builder for [Projects::search_projects][crate::client::Projects::search_projects] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2083,7 +2083,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::create_project][super::super::client::Projects::create_project] calls.
+    /// The request builder for [Projects::create_project][crate::client::Projects::create_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2126,7 +2126,7 @@ pub mod projects {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_project][super::super::client::Projects::create_project].
+        /// on [create_project][crate::client::Projects::create_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_project(self.0.request, self.0.options)
@@ -2199,7 +2199,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::update_project][super::super::client::Projects::update_project] calls.
+    /// The request builder for [Projects::update_project][crate::client::Projects::update_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2242,7 +2242,7 @@ pub mod projects {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_project][super::super::client::Projects::update_project].
+        /// on [update_project][crate::client::Projects::update_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_project(self.0.request, self.0.options)
@@ -2333,7 +2333,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::move_project][super::super::client::Projects::move_project] calls.
+    /// The request builder for [Projects::move_project][crate::client::Projects::move_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2376,7 +2376,7 @@ pub mod projects {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [move_project][super::super::client::Projects::move_project].
+        /// on [move_project][crate::client::Projects::move_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .move_project(self.0.request, self.0.options)
@@ -2441,7 +2441,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::delete_project][super::super::client::Projects::delete_project] calls.
+    /// The request builder for [Projects::delete_project][crate::client::Projects::delete_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2484,7 +2484,7 @@ pub mod projects {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_project][super::super::client::Projects::delete_project].
+        /// on [delete_project][crate::client::Projects::delete_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_project(self.0.request, self.0.options)
@@ -2543,7 +2543,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::undelete_project][super::super::client::Projects::undelete_project] calls.
+    /// The request builder for [Projects::undelete_project][crate::client::Projects::undelete_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2586,7 +2586,7 @@ pub mod projects {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_project][super::super::client::Projects::undelete_project].
+        /// on [undelete_project][crate::client::Projects::undelete_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_project(self.0.request, self.0.options)
@@ -2646,7 +2646,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::get_iam_policy][super::super::client::Projects::get_iam_policy] calls.
+    /// The request builder for [Projects::get_iam_policy][crate::client::Projects::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2725,7 +2725,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::set_iam_policy][super::super::client::Projects::set_iam_policy] calls.
+    /// The request builder for [Projects::set_iam_policy][crate::client::Projects::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2826,7 +2826,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::test_iam_permissions][super::super::client::Projects::test_iam_permissions] calls.
+    /// The request builder for [Projects::test_iam_permissions][crate::client::Projects::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2903,7 +2903,7 @@ pub mod projects {
         }
     }
 
-    /// The request builder for [Projects::get_operation][super::super::client::Projects::get_operation] calls.
+    /// The request builder for [Projects::get_operation][crate::client::Projects::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2969,7 +2969,7 @@ pub mod projects {
 pub mod tag_bindings {
     use crate::Result;
 
-    /// A builder for [TagBindings][super::super::client::TagBindings].
+    /// A builder for [TagBindings][crate::client::TagBindings].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2997,7 +2997,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// Common implementation for [super::super::client::TagBindings] request builders.
+    /// Common implementation for [crate::client::TagBindings] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TagBindings>,
@@ -3020,7 +3020,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for [TagBindings::list_tag_bindings][super::super::client::TagBindings::list_tag_bindings] calls.
+    /// The request builder for [TagBindings::list_tag_bindings][crate::client::TagBindings::list_tag_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3123,7 +3123,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for [TagBindings::create_tag_binding][super::super::client::TagBindings::create_tag_binding] calls.
+    /// The request builder for [TagBindings::create_tag_binding][crate::client::TagBindings::create_tag_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3171,7 +3171,7 @@ pub mod tag_bindings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_tag_binding][super::super::client::TagBindings::create_tag_binding].
+        /// on [create_tag_binding][crate::client::TagBindings::create_tag_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_tag_binding(self.0.request, self.0.options)
@@ -3251,7 +3251,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for [TagBindings::delete_tag_binding][super::super::client::TagBindings::delete_tag_binding] calls.
+    /// The request builder for [TagBindings::delete_tag_binding][crate::client::TagBindings::delete_tag_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3299,7 +3299,7 @@ pub mod tag_bindings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tag_binding][super::super::client::TagBindings::delete_tag_binding].
+        /// on [delete_tag_binding][crate::client::TagBindings::delete_tag_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tag_binding(self.0.request, self.0.options)
@@ -3359,7 +3359,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for [TagBindings::list_effective_tags][super::super::client::TagBindings::list_effective_tags] calls.
+    /// The request builder for [TagBindings::list_effective_tags][crate::client::TagBindings::list_effective_tags] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3465,7 +3465,7 @@ pub mod tag_bindings {
         }
     }
 
-    /// The request builder for [TagBindings::get_operation][super::super::client::TagBindings::get_operation] calls.
+    /// The request builder for [TagBindings::get_operation][crate::client::TagBindings::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3533,7 +3533,7 @@ pub mod tag_bindings {
 pub mod tag_holds {
     use crate::Result;
 
-    /// A builder for [TagHolds][super::super::client::TagHolds].
+    /// A builder for [TagHolds][crate::client::TagHolds].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3561,7 +3561,7 @@ pub mod tag_holds {
         }
     }
 
-    /// Common implementation for [super::super::client::TagHolds] request builders.
+    /// Common implementation for [crate::client::TagHolds] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TagHolds>,
@@ -3582,7 +3582,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for [TagHolds::create_tag_hold][super::super::client::TagHolds::create_tag_hold] calls.
+    /// The request builder for [TagHolds::create_tag_hold][crate::client::TagHolds::create_tag_hold] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3625,7 +3625,7 @@ pub mod tag_holds {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_tag_hold][super::super::client::TagHolds::create_tag_hold].
+        /// on [create_tag_hold][crate::client::TagHolds::create_tag_hold].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_tag_hold(self.0.request, self.0.options)
@@ -3712,7 +3712,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for [TagHolds::delete_tag_hold][super::super::client::TagHolds::delete_tag_hold] calls.
+    /// The request builder for [TagHolds::delete_tag_hold][crate::client::TagHolds::delete_tag_hold] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3755,7 +3755,7 @@ pub mod tag_holds {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tag_hold][super::super::client::TagHolds::delete_tag_hold].
+        /// on [delete_tag_hold][crate::client::TagHolds::delete_tag_hold].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tag_hold(self.0.request, self.0.options)
@@ -3821,7 +3821,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for [TagHolds::list_tag_holds][super::super::client::TagHolds::list_tag_holds] calls.
+    /// The request builder for [TagHolds::list_tag_holds][crate::client::TagHolds::list_tag_holds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3928,7 +3928,7 @@ pub mod tag_holds {
         }
     }
 
-    /// The request builder for [TagHolds::get_operation][super::super::client::TagHolds::get_operation] calls.
+    /// The request builder for [TagHolds::get_operation][crate::client::TagHolds::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3994,7 +3994,7 @@ pub mod tag_holds {
 pub mod tag_keys {
     use crate::Result;
 
-    /// A builder for [TagKeys][super::super::client::TagKeys].
+    /// A builder for [TagKeys][crate::client::TagKeys].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4022,7 +4022,7 @@ pub mod tag_keys {
         }
     }
 
-    /// Common implementation for [super::super::client::TagKeys] request builders.
+    /// Common implementation for [crate::client::TagKeys] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TagKeys>,
@@ -4043,7 +4043,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::list_tag_keys][super::super::client::TagKeys::list_tag_keys] calls.
+    /// The request builder for [TagKeys::list_tag_keys][crate::client::TagKeys::list_tag_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4144,7 +4144,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::get_tag_key][super::super::client::TagKeys::get_tag_key] calls.
+    /// The request builder for [TagKeys::get_tag_key][crate::client::TagKeys::get_tag_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4205,7 +4205,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::get_namespaced_tag_key][super::super::client::TagKeys::get_namespaced_tag_key] calls.
+    /// The request builder for [TagKeys::get_namespaced_tag_key][crate::client::TagKeys::get_namespaced_tag_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4269,7 +4269,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::create_tag_key][super::super::client::TagKeys::create_tag_key] calls.
+    /// The request builder for [TagKeys::create_tag_key][crate::client::TagKeys::create_tag_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4312,7 +4312,7 @@ pub mod tag_keys {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_tag_key][super::super::client::TagKeys::create_tag_key].
+        /// on [create_tag_key][crate::client::TagKeys::create_tag_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_tag_key(self.0.request, self.0.options)
@@ -4389,7 +4389,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::update_tag_key][super::super::client::TagKeys::update_tag_key] calls.
+    /// The request builder for [TagKeys::update_tag_key][crate::client::TagKeys::update_tag_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4432,7 +4432,7 @@ pub mod tag_keys {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_tag_key][super::super::client::TagKeys::update_tag_key].
+        /// on [update_tag_key][crate::client::TagKeys::update_tag_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_tag_key(self.0.request, self.0.options)
@@ -4527,7 +4527,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::delete_tag_key][super::super::client::TagKeys::delete_tag_key] calls.
+    /// The request builder for [TagKeys::delete_tag_key][crate::client::TagKeys::delete_tag_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4570,7 +4570,7 @@ pub mod tag_keys {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tag_key][super::super::client::TagKeys::delete_tag_key].
+        /// on [delete_tag_key][crate::client::TagKeys::delete_tag_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tag_key(self.0.request, self.0.options)
@@ -4639,7 +4639,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::get_iam_policy][super::super::client::TagKeys::get_iam_policy] calls.
+    /// The request builder for [TagKeys::get_iam_policy][crate::client::TagKeys::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4718,7 +4718,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::set_iam_policy][super::super::client::TagKeys::set_iam_policy] calls.
+    /// The request builder for [TagKeys::set_iam_policy][crate::client::TagKeys::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4819,7 +4819,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::test_iam_permissions][super::super::client::TagKeys::test_iam_permissions] calls.
+    /// The request builder for [TagKeys::test_iam_permissions][crate::client::TagKeys::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4896,7 +4896,7 @@ pub mod tag_keys {
         }
     }
 
-    /// The request builder for [TagKeys::get_operation][super::super::client::TagKeys::get_operation] calls.
+    /// The request builder for [TagKeys::get_operation][crate::client::TagKeys::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4962,7 +4962,7 @@ pub mod tag_keys {
 pub mod tag_values {
     use crate::Result;
 
-    /// A builder for [TagValues][super::super::client::TagValues].
+    /// A builder for [TagValues][crate::client::TagValues].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4990,7 +4990,7 @@ pub mod tag_values {
         }
     }
 
-    /// Common implementation for [super::super::client::TagValues] request builders.
+    /// Common implementation for [crate::client::TagValues] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TagValues>,
@@ -5013,7 +5013,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::list_tag_values][super::super::client::TagValues::list_tag_values] calls.
+    /// The request builder for [TagValues::list_tag_values][crate::client::TagValues::list_tag_values] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5116,7 +5116,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::get_tag_value][super::super::client::TagValues::get_tag_value] calls.
+    /// The request builder for [TagValues::get_tag_value][crate::client::TagValues::get_tag_value] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5179,7 +5179,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::get_namespaced_tag_value][super::super::client::TagValues::get_namespaced_tag_value] calls.
+    /// The request builder for [TagValues::get_namespaced_tag_value][crate::client::TagValues::get_namespaced_tag_value] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5245,7 +5245,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::create_tag_value][super::super::client::TagValues::create_tag_value] calls.
+    /// The request builder for [TagValues::create_tag_value][crate::client::TagValues::create_tag_value] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5290,7 +5290,7 @@ pub mod tag_values {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_tag_value][super::super::client::TagValues::create_tag_value].
+        /// on [create_tag_value][crate::client::TagValues::create_tag_value].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_tag_value(self.0.request, self.0.options)
@@ -5370,7 +5370,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::update_tag_value][super::super::client::TagValues::update_tag_value] calls.
+    /// The request builder for [TagValues::update_tag_value][crate::client::TagValues::update_tag_value] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5415,7 +5415,7 @@ pub mod tag_values {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_tag_value][super::super::client::TagValues::update_tag_value].
+        /// on [update_tag_value][crate::client::TagValues::update_tag_value].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_tag_value(self.0.request, self.0.options)
@@ -5513,7 +5513,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::delete_tag_value][super::super::client::TagValues::delete_tag_value] calls.
+    /// The request builder for [TagValues::delete_tag_value][crate::client::TagValues::delete_tag_value] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5558,7 +5558,7 @@ pub mod tag_values {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_tag_value][super::super::client::TagValues::delete_tag_value].
+        /// on [delete_tag_value][crate::client::TagValues::delete_tag_value].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_tag_value(self.0.request, self.0.options)
@@ -5630,7 +5630,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::get_iam_policy][super::super::client::TagValues::get_iam_policy] calls.
+    /// The request builder for [TagValues::get_iam_policy][crate::client::TagValues::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5711,7 +5711,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::set_iam_policy][super::super::client::TagValues::set_iam_policy] calls.
+    /// The request builder for [TagValues::set_iam_policy][crate::client::TagValues::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5814,7 +5814,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::test_iam_permissions][super::super::client::TagValues::test_iam_permissions] calls.
+    /// The request builder for [TagValues::test_iam_permissions][crate::client::TagValues::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5893,7 +5893,7 @@ pub mod tag_values {
         }
     }
 
-    /// The request builder for [TagValues::get_operation][super::super::client::TagValues::get_operation] calls.
+    /// The request builder for [TagValues::get_operation][crate::client::TagValues::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/retail/v2/src/builder.rs
+++ b/src/generated/cloud/retail/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod analytics_service {
     use crate::Result;
 
-    /// A builder for [AnalyticsService][super::super::client::AnalyticsService].
+    /// A builder for [AnalyticsService][crate::client::AnalyticsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod analytics_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AnalyticsService] request builders.
+    /// Common implementation for [crate::client::AnalyticsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AnalyticsService>,
@@ -68,7 +68,7 @@ pub mod analytics_service {
         }
     }
 
-    /// The request builder for [AnalyticsService::export_analytics_metrics][super::super::client::AnalyticsService::export_analytics_metrics] calls.
+    /// The request builder for [AnalyticsService::export_analytics_metrics][crate::client::AnalyticsService::export_analytics_metrics] calls.
     ///
     /// # Example
     /// ```no_run
@@ -116,7 +116,7 @@ pub mod analytics_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_analytics_metrics][super::super::client::AnalyticsService::export_analytics_metrics].
+        /// on [export_analytics_metrics][crate::client::AnalyticsService::export_analytics_metrics].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_analytics_metrics(self.0.request, self.0.options)
@@ -204,7 +204,7 @@ pub mod analytics_service {
         }
     }
 
-    /// The request builder for [AnalyticsService::list_operations][super::super::client::AnalyticsService::list_operations] calls.
+    /// The request builder for [AnalyticsService::list_operations][crate::client::AnalyticsService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -316,7 +316,7 @@ pub mod analytics_service {
         }
     }
 
-    /// The request builder for [AnalyticsService::get_operation][super::super::client::AnalyticsService::get_operation] calls.
+    /// The request builder for [AnalyticsService::get_operation][crate::client::AnalyticsService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -384,7 +384,7 @@ pub mod analytics_service {
 pub mod catalog_service {
     use crate::Result;
 
-    /// A builder for [CatalogService][super::super::client::CatalogService].
+    /// A builder for [CatalogService][crate::client::CatalogService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -412,7 +412,7 @@ pub mod catalog_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CatalogService] request builders.
+    /// Common implementation for [crate::client::CatalogService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CatalogService>,
@@ -435,7 +435,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_catalogs][super::super::client::CatalogService::list_catalogs] calls.
+    /// The request builder for [CatalogService::list_catalogs][crate::client::CatalogService::list_catalogs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -538,7 +538,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::update_catalog][super::super::client::CatalogService::update_catalog] calls.
+    /// The request builder for [CatalogService::update_catalog][crate::client::CatalogService::update_catalog] calls.
     ///
     /// # Example
     /// ```no_run
@@ -633,7 +633,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::set_default_branch][super::super::client::CatalogService::set_default_branch] calls.
+    /// The request builder for [CatalogService::set_default_branch][crate::client::CatalogService::set_default_branch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -715,7 +715,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_default_branch][super::super::client::CatalogService::get_default_branch] calls.
+    /// The request builder for [CatalogService::get_default_branch][crate::client::CatalogService::get_default_branch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -779,7 +779,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_completion_config][super::super::client::CatalogService::get_completion_config] calls.
+    /// The request builder for [CatalogService::get_completion_config][crate::client::CatalogService::get_completion_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -845,7 +845,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::update_completion_config][super::super::client::CatalogService::update_completion_config] calls.
+    /// The request builder for [CatalogService::update_completion_config][crate::client::CatalogService::update_completion_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -943,7 +943,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_attributes_config][super::super::client::CatalogService::get_attributes_config] calls.
+    /// The request builder for [CatalogService::get_attributes_config][crate::client::CatalogService::get_attributes_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1009,7 +1009,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::update_attributes_config][super::super::client::CatalogService::update_attributes_config] calls.
+    /// The request builder for [CatalogService::update_attributes_config][crate::client::CatalogService::update_attributes_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1107,7 +1107,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::add_catalog_attribute][super::super::client::CatalogService::add_catalog_attribute] calls.
+    /// The request builder for [CatalogService::add_catalog_attribute][crate::client::CatalogService::add_catalog_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1195,7 +1195,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::remove_catalog_attribute][super::super::client::CatalogService::remove_catalog_attribute] calls.
+    /// The request builder for [CatalogService::remove_catalog_attribute][crate::client::CatalogService::remove_catalog_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1269,7 +1269,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::replace_catalog_attribute][super::super::client::CatalogService::replace_catalog_attribute] calls.
+    /// The request builder for [CatalogService::replace_catalog_attribute][crate::client::CatalogService::replace_catalog_attribute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1377,7 +1377,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::list_operations][super::super::client::CatalogService::list_operations] calls.
+    /// The request builder for [CatalogService::list_operations][crate::client::CatalogService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1489,7 +1489,7 @@ pub mod catalog_service {
         }
     }
 
-    /// The request builder for [CatalogService::get_operation][super::super::client::CatalogService::get_operation] calls.
+    /// The request builder for [CatalogService::get_operation][crate::client::CatalogService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1557,7 +1557,7 @@ pub mod catalog_service {
 pub mod completion_service {
     use crate::Result;
 
-    /// A builder for [CompletionService][super::super::client::CompletionService].
+    /// A builder for [CompletionService][crate::client::CompletionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1585,7 +1585,7 @@ pub mod completion_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CompletionService] request builders.
+    /// Common implementation for [crate::client::CompletionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CompletionService>,
@@ -1608,7 +1608,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::complete_query][super::super::client::CompletionService::complete_query] calls.
+    /// The request builder for [CompletionService::complete_query][crate::client::CompletionService::complete_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1726,7 +1726,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::import_completion_data][super::super::client::CompletionService::import_completion_data] calls.
+    /// The request builder for [CompletionService::import_completion_data][crate::client::CompletionService::import_completion_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1774,7 +1774,7 @@ pub mod completion_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_completion_data][super::super::client::CompletionService::import_completion_data].
+        /// on [import_completion_data][crate::client::CompletionService::import_completion_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_completion_data(self.0.request, self.0.options)
@@ -1862,7 +1862,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::list_operations][super::super::client::CompletionService::list_operations] calls.
+    /// The request builder for [CompletionService::list_operations][crate::client::CompletionService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1974,7 +1974,7 @@ pub mod completion_service {
         }
     }
 
-    /// The request builder for [CompletionService::get_operation][super::super::client::CompletionService::get_operation] calls.
+    /// The request builder for [CompletionService::get_operation][crate::client::CompletionService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2042,7 +2042,7 @@ pub mod completion_service {
 pub mod control_service {
     use crate::Result;
 
-    /// A builder for [ControlService][super::super::client::ControlService].
+    /// A builder for [ControlService][crate::client::ControlService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2070,7 +2070,7 @@ pub mod control_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ControlService] request builders.
+    /// Common implementation for [crate::client::ControlService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ControlService>,
@@ -2093,7 +2093,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::create_control][super::super::client::ControlService::create_control] calls.
+    /// The request builder for [ControlService::create_control][crate::client::ControlService::create_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2186,7 +2186,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::delete_control][super::super::client::ControlService::delete_control] calls.
+    /// The request builder for [ControlService::delete_control][crate::client::ControlService::delete_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2249,7 +2249,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::update_control][super::super::client::ControlService::update_control] calls.
+    /// The request builder for [ControlService::update_control][crate::client::ControlService::update_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2344,7 +2344,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::get_control][super::super::client::ControlService::get_control] calls.
+    /// The request builder for [ControlService::get_control][crate::client::ControlService::get_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2407,7 +2407,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::list_controls][super::super::client::ControlService::list_controls] calls.
+    /// The request builder for [ControlService::list_controls][crate::client::ControlService::list_controls] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2516,7 +2516,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::list_operations][super::super::client::ControlService::list_operations] calls.
+    /// The request builder for [ControlService::list_operations][crate::client::ControlService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2628,7 +2628,7 @@ pub mod control_service {
         }
     }
 
-    /// The request builder for [ControlService::get_operation][super::super::client::ControlService::get_operation] calls.
+    /// The request builder for [ControlService::get_operation][crate::client::ControlService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2696,7 +2696,7 @@ pub mod control_service {
 pub mod generative_question_service {
     use crate::Result;
 
-    /// A builder for [GenerativeQuestionService][super::super::client::GenerativeQuestionService].
+    /// A builder for [GenerativeQuestionService][crate::client::GenerativeQuestionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2724,7 +2724,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// Common implementation for [super::super::client::GenerativeQuestionService] request builders.
+    /// Common implementation for [crate::client::GenerativeQuestionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GenerativeQuestionService>,
@@ -2747,7 +2747,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for [GenerativeQuestionService::update_generative_questions_feature_config][super::super::client::GenerativeQuestionService::update_generative_questions_feature_config] calls.
+    /// The request builder for [GenerativeQuestionService::update_generative_questions_feature_config][crate::client::GenerativeQuestionService::update_generative_questions_feature_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2853,7 +2853,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for [GenerativeQuestionService::get_generative_questions_feature_config][super::super::client::GenerativeQuestionService::get_generative_questions_feature_config] calls.
+    /// The request builder for [GenerativeQuestionService::get_generative_questions_feature_config][crate::client::GenerativeQuestionService::get_generative_questions_feature_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2921,7 +2921,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for [GenerativeQuestionService::list_generative_question_configs][super::super::client::GenerativeQuestionService::list_generative_question_configs] calls.
+    /// The request builder for [GenerativeQuestionService::list_generative_question_configs][crate::client::GenerativeQuestionService::list_generative_question_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2989,7 +2989,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for [GenerativeQuestionService::update_generative_question_config][super::super::client::GenerativeQuestionService::update_generative_question_config] calls.
+    /// The request builder for [GenerativeQuestionService::update_generative_question_config][crate::client::GenerativeQuestionService::update_generative_question_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3092,7 +3092,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for [GenerativeQuestionService::batch_update_generative_question_configs][super::super::client::GenerativeQuestionService::batch_update_generative_question_configs] calls.
+    /// The request builder for [GenerativeQuestionService::batch_update_generative_question_configs][crate::client::GenerativeQuestionService::batch_update_generative_question_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3173,7 +3173,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for [GenerativeQuestionService::list_operations][super::super::client::GenerativeQuestionService::list_operations] calls.
+    /// The request builder for [GenerativeQuestionService::list_operations][crate::client::GenerativeQuestionService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3285,7 +3285,7 @@ pub mod generative_question_service {
         }
     }
 
-    /// The request builder for [GenerativeQuestionService::get_operation][super::super::client::GenerativeQuestionService::get_operation] calls.
+    /// The request builder for [GenerativeQuestionService::get_operation][crate::client::GenerativeQuestionService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3353,7 +3353,7 @@ pub mod generative_question_service {
 pub mod model_service {
     use crate::Result;
 
-    /// A builder for [ModelService][super::super::client::ModelService].
+    /// A builder for [ModelService][crate::client::ModelService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3381,7 +3381,7 @@ pub mod model_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ModelService] request builders.
+    /// Common implementation for [crate::client::ModelService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ModelService>,
@@ -3404,7 +3404,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::create_model][super::super::client::ModelService::create_model] calls.
+    /// The request builder for [ModelService::create_model][crate::client::ModelService::create_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3449,7 +3449,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_model][super::super::client::ModelService::create_model].
+        /// on [create_model][crate::client::ModelService::create_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_model(self.0.request, self.0.options)
@@ -3534,7 +3534,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_model][super::super::client::ModelService::get_model] calls.
+    /// The request builder for [ModelService::get_model][crate::client::ModelService::get_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3597,7 +3597,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::pause_model][super::super::client::ModelService::pause_model] calls.
+    /// The request builder for [ModelService::pause_model][crate::client::ModelService::pause_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3660,7 +3660,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::resume_model][super::super::client::ModelService::resume_model] calls.
+    /// The request builder for [ModelService::resume_model][crate::client::ModelService::resume_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3723,7 +3723,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::delete_model][super::super::client::ModelService::delete_model] calls.
+    /// The request builder for [ModelService::delete_model][crate::client::ModelService::delete_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3786,7 +3786,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_models][super::super::client::ModelService::list_models] calls.
+    /// The request builder for [ModelService::list_models][crate::client::ModelService::list_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3889,7 +3889,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::update_model][super::super::client::ModelService::update_model] calls.
+    /// The request builder for [ModelService::update_model][crate::client::ModelService::update_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3984,7 +3984,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::tune_model][super::super::client::ModelService::tune_model] calls.
+    /// The request builder for [ModelService::tune_model][crate::client::ModelService::tune_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4029,7 +4029,7 @@ pub mod model_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [tune_model][super::super::client::ModelService::tune_model].
+        /// on [tune_model][crate::client::ModelService::tune_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .tune_model(self.0.request, self.0.options)
@@ -4089,7 +4089,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::list_operations][super::super::client::ModelService::list_operations] calls.
+    /// The request builder for [ModelService::list_operations][crate::client::ModelService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4201,7 +4201,7 @@ pub mod model_service {
         }
     }
 
-    /// The request builder for [ModelService::get_operation][super::super::client::ModelService::get_operation] calls.
+    /// The request builder for [ModelService::get_operation][crate::client::ModelService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4269,7 +4269,7 @@ pub mod model_service {
 pub mod prediction_service {
     use crate::Result;
 
-    /// A builder for [PredictionService][super::super::client::PredictionService].
+    /// A builder for [PredictionService][crate::client::PredictionService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4297,7 +4297,7 @@ pub mod prediction_service {
         }
     }
 
-    /// Common implementation for [super::super::client::PredictionService] request builders.
+    /// Common implementation for [crate::client::PredictionService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PredictionService>,
@@ -4320,7 +4320,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::predict][super::super::client::PredictionService::predict] calls.
+    /// The request builder for [PredictionService::predict][crate::client::PredictionService::predict] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4452,7 +4452,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::list_operations][super::super::client::PredictionService::list_operations] calls.
+    /// The request builder for [PredictionService::list_operations][crate::client::PredictionService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4564,7 +4564,7 @@ pub mod prediction_service {
         }
     }
 
-    /// The request builder for [PredictionService::get_operation][super::super::client::PredictionService::get_operation] calls.
+    /// The request builder for [PredictionService::get_operation][crate::client::PredictionService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4632,7 +4632,7 @@ pub mod prediction_service {
 pub mod product_service {
     use crate::Result;
 
-    /// A builder for [ProductService][super::super::client::ProductService].
+    /// A builder for [ProductService][crate::client::ProductService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4660,7 +4660,7 @@ pub mod product_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ProductService] request builders.
+    /// Common implementation for [crate::client::ProductService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ProductService>,
@@ -4683,7 +4683,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::create_product][super::super::client::ProductService::create_product] calls.
+    /// The request builder for [ProductService::create_product][crate::client::ProductService::create_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4776,7 +4776,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::get_product][super::super::client::ProductService::get_product] calls.
+    /// The request builder for [ProductService::get_product][crate::client::ProductService::get_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4839,7 +4839,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::list_products][super::super::client::ProductService::list_products] calls.
+    /// The request builder for [ProductService::list_products][crate::client::ProductService::list_products] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4966,7 +4966,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::update_product][super::super::client::ProductService::update_product] calls.
+    /// The request builder for [ProductService::update_product][crate::client::ProductService::update_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5067,7 +5067,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::delete_product][super::super::client::ProductService::delete_product] calls.
+    /// The request builder for [ProductService::delete_product][crate::client::ProductService::delete_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5130,7 +5130,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::purge_products][super::super::client::ProductService::purge_products] calls.
+    /// The request builder for [ProductService::purge_products][crate::client::ProductService::purge_products] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5175,7 +5175,7 @@ pub mod product_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_products][super::super::client::ProductService::purge_products].
+        /// on [purge_products][crate::client::ProductService::purge_products].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_products(self.0.request, self.0.options)
@@ -5249,7 +5249,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::import_products][super::super::client::ProductService::import_products] calls.
+    /// The request builder for [ProductService::import_products][crate::client::ProductService::import_products] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5294,7 +5294,7 @@ pub mod product_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_products][super::super::client::ProductService::import_products].
+        /// on [import_products][crate::client::ProductService::import_products].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_products(self.0.request, self.0.options)
@@ -5436,7 +5436,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::set_inventory][super::super::client::ProductService::set_inventory] calls.
+    /// The request builder for [ProductService::set_inventory][crate::client::ProductService::set_inventory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5481,7 +5481,7 @@ pub mod product_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [set_inventory][super::super::client::ProductService::set_inventory].
+        /// on [set_inventory][crate::client::ProductService::set_inventory].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .set_inventory(self.0.request, self.0.options)
@@ -5597,7 +5597,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::add_fulfillment_places][super::super::client::ProductService::add_fulfillment_places] calls.
+    /// The request builder for [ProductService::add_fulfillment_places][crate::client::ProductService::add_fulfillment_places] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5645,7 +5645,7 @@ pub mod product_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [add_fulfillment_places][super::super::client::ProductService::add_fulfillment_places].
+        /// on [add_fulfillment_places][crate::client::ProductService::add_fulfillment_places].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .add_fulfillment_places(self.0.request, self.0.options)
@@ -5752,7 +5752,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::remove_fulfillment_places][super::super::client::ProductService::remove_fulfillment_places] calls.
+    /// The request builder for [ProductService::remove_fulfillment_places][crate::client::ProductService::remove_fulfillment_places] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5802,7 +5802,7 @@ pub mod product_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [remove_fulfillment_places][super::super::client::ProductService::remove_fulfillment_places].
+        /// on [remove_fulfillment_places][crate::client::ProductService::remove_fulfillment_places].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .remove_fulfillment_places(self.0.request, self.0.options)
@@ -5909,7 +5909,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::add_local_inventories][super::super::client::ProductService::add_local_inventories] calls.
+    /// The request builder for [ProductService::add_local_inventories][crate::client::ProductService::add_local_inventories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5957,7 +5957,7 @@ pub mod product_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [add_local_inventories][super::super::client::ProductService::add_local_inventories].
+        /// on [add_local_inventories][crate::client::ProductService::add_local_inventories].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .add_local_inventories(self.0.request, self.0.options)
@@ -6074,7 +6074,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::remove_local_inventories][super::super::client::ProductService::remove_local_inventories] calls.
+    /// The request builder for [ProductService::remove_local_inventories][crate::client::ProductService::remove_local_inventories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6122,7 +6122,7 @@ pub mod product_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [remove_local_inventories][super::super::client::ProductService::remove_local_inventories].
+        /// on [remove_local_inventories][crate::client::ProductService::remove_local_inventories].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .remove_local_inventories(self.0.request, self.0.options)
@@ -6221,7 +6221,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::list_operations][super::super::client::ProductService::list_operations] calls.
+    /// The request builder for [ProductService::list_operations][crate::client::ProductService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6333,7 +6333,7 @@ pub mod product_service {
         }
     }
 
-    /// The request builder for [ProductService::get_operation][super::super::client::ProductService::get_operation] calls.
+    /// The request builder for [ProductService::get_operation][crate::client::ProductService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6401,7 +6401,7 @@ pub mod product_service {
 pub mod search_service {
     use crate::Result;
 
-    /// A builder for [SearchService][super::super::client::SearchService].
+    /// A builder for [SearchService][crate::client::SearchService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6429,7 +6429,7 @@ pub mod search_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SearchService] request builders.
+    /// Common implementation for [crate::client::SearchService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SearchService>,
@@ -6452,7 +6452,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::search][super::super::client::SearchService::search] calls.
+    /// The request builder for [SearchService::search][crate::client::SearchService::search] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6825,7 +6825,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::list_operations][super::super::client::SearchService::list_operations] calls.
+    /// The request builder for [SearchService::list_operations][crate::client::SearchService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6937,7 +6937,7 @@ pub mod search_service {
         }
     }
 
-    /// The request builder for [SearchService::get_operation][super::super::client::SearchService::get_operation] calls.
+    /// The request builder for [SearchService::get_operation][crate::client::SearchService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7005,7 +7005,7 @@ pub mod search_service {
 pub mod serving_config_service {
     use crate::Result;
 
-    /// A builder for [ServingConfigService][super::super::client::ServingConfigService].
+    /// A builder for [ServingConfigService][crate::client::ServingConfigService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7033,7 +7033,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ServingConfigService] request builders.
+    /// Common implementation for [crate::client::ServingConfigService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServingConfigService>,
@@ -7056,7 +7056,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::create_serving_config][super::super::client::ServingConfigService::create_serving_config] calls.
+    /// The request builder for [ServingConfigService::create_serving_config][crate::client::ServingConfigService::create_serving_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7152,7 +7152,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::delete_serving_config][super::super::client::ServingConfigService::delete_serving_config] calls.
+    /// The request builder for [ServingConfigService::delete_serving_config][crate::client::ServingConfigService::delete_serving_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7218,7 +7218,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::update_serving_config][super::super::client::ServingConfigService::update_serving_config] calls.
+    /// The request builder for [ServingConfigService::update_serving_config][crate::client::ServingConfigService::update_serving_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7316,7 +7316,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::get_serving_config][super::super::client::ServingConfigService::get_serving_config] calls.
+    /// The request builder for [ServingConfigService::get_serving_config][crate::client::ServingConfigService::get_serving_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7382,7 +7382,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::list_serving_configs][super::super::client::ServingConfigService::list_serving_configs] calls.
+    /// The request builder for [ServingConfigService::list_serving_configs][crate::client::ServingConfigService::list_serving_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7490,7 +7490,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::add_control][super::super::client::ServingConfigService::add_control] calls.
+    /// The request builder for [ServingConfigService::add_control][crate::client::ServingConfigService::add_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7561,7 +7561,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::remove_control][super::super::client::ServingConfigService::remove_control] calls.
+    /// The request builder for [ServingConfigService::remove_control][crate::client::ServingConfigService::remove_control] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7632,7 +7632,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::list_operations][super::super::client::ServingConfigService::list_operations] calls.
+    /// The request builder for [ServingConfigService::list_operations][crate::client::ServingConfigService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7744,7 +7744,7 @@ pub mod serving_config_service {
         }
     }
 
-    /// The request builder for [ServingConfigService::get_operation][super::super::client::ServingConfigService::get_operation] calls.
+    /// The request builder for [ServingConfigService::get_operation][crate::client::ServingConfigService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7812,7 +7812,7 @@ pub mod serving_config_service {
 pub mod user_event_service {
     use crate::Result;
 
-    /// A builder for [UserEventService][super::super::client::UserEventService].
+    /// A builder for [UserEventService][crate::client::UserEventService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7840,7 +7840,7 @@ pub mod user_event_service {
         }
     }
 
-    /// Common implementation for [super::super::client::UserEventService] request builders.
+    /// Common implementation for [crate::client::UserEventService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::UserEventService>,
@@ -7863,7 +7863,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::write_user_event][super::super::client::UserEventService::write_user_event] calls.
+    /// The request builder for [UserEventService::write_user_event][crate::client::UserEventService::write_user_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7954,7 +7954,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::collect_user_event][super::super::client::UserEventService::collect_user_event] calls.
+    /// The request builder for [UserEventService::collect_user_event][crate::client::UserEventService::collect_user_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8073,7 +8073,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::purge_user_events][super::super::client::UserEventService::purge_user_events] calls.
+    /// The request builder for [UserEventService::purge_user_events][crate::client::UserEventService::purge_user_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8118,7 +8118,7 @@ pub mod user_event_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_user_events][super::super::client::UserEventService::purge_user_events].
+        /// on [purge_user_events][crate::client::UserEventService::purge_user_events].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_user_events(self.0.request, self.0.options)
@@ -8192,7 +8192,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::import_user_events][super::super::client::UserEventService::import_user_events] calls.
+    /// The request builder for [UserEventService::import_user_events][crate::client::UserEventService::import_user_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8240,7 +8240,7 @@ pub mod user_event_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_user_events][super::super::client::UserEventService::import_user_events].
+        /// on [import_user_events][crate::client::UserEventService::import_user_events].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_user_events(self.0.request, self.0.options)
@@ -8340,7 +8340,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::rejoin_user_events][super::super::client::UserEventService::rejoin_user_events] calls.
+    /// The request builder for [UserEventService::rejoin_user_events][crate::client::UserEventService::rejoin_user_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8388,7 +8388,7 @@ pub mod user_event_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [rejoin_user_events][super::super::client::UserEventService::rejoin_user_events].
+        /// on [rejoin_user_events][crate::client::UserEventService::rejoin_user_events].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .rejoin_user_events(self.0.request, self.0.options)
@@ -8461,7 +8461,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::list_operations][super::super::client::UserEventService::list_operations] calls.
+    /// The request builder for [UserEventService::list_operations][crate::client::UserEventService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8573,7 +8573,7 @@ pub mod user_event_service {
         }
     }
 
-    /// The request builder for [UserEventService::get_operation][super::super::client::UserEventService::get_operation] calls.
+    /// The request builder for [UserEventService::get_operation][crate::client::UserEventService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/run/v2/src/builder.rs
+++ b/src/generated/cloud/run/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod builds {
     use crate::Result;
 
-    /// A builder for [Builds][super::super::client::Builds].
+    /// A builder for [Builds][crate::client::Builds].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod builds {
         }
     }
 
-    /// Common implementation for [super::super::client::Builds] request builders.
+    /// Common implementation for [crate::client::Builds] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Builds>,
@@ -66,7 +66,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for [Builds::submit_build][super::super::client::Builds::submit_build] calls.
+    /// The request builder for [Builds::submit_build][crate::client::Builds::submit_build] calls.
     ///
     /// # Example
     /// ```no_run
@@ -229,7 +229,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for [Builds::list_operations][super::super::client::Builds::list_operations] calls.
+    /// The request builder for [Builds::list_operations][crate::client::Builds::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -339,7 +339,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for [Builds::get_operation][super::super::client::Builds::get_operation] calls.
+    /// The request builder for [Builds::get_operation][crate::client::Builds::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -401,7 +401,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for [Builds::delete_operation][super::super::client::Builds::delete_operation] calls.
+    /// The request builder for [Builds::delete_operation][crate::client::Builds::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -463,7 +463,7 @@ pub mod builds {
         }
     }
 
-    /// The request builder for [Builds::wait_operation][super::super::client::Builds::wait_operation] calls.
+    /// The request builder for [Builds::wait_operation][crate::client::Builds::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -547,7 +547,7 @@ pub mod builds {
 pub mod executions {
     use crate::Result;
 
-    /// A builder for [Executions][super::super::client::Executions].
+    /// A builder for [Executions][crate::client::Executions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -575,7 +575,7 @@ pub mod executions {
         }
     }
 
-    /// Common implementation for [super::super::client::Executions] request builders.
+    /// Common implementation for [crate::client::Executions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Executions>,
@@ -598,7 +598,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::get_execution][super::super::client::Executions::get_execution] calls.
+    /// The request builder for [Executions::get_execution][crate::client::Executions::get_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -661,7 +661,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::list_executions][super::super::client::Executions::list_executions] calls.
+    /// The request builder for [Executions::list_executions][crate::client::Executions::list_executions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -770,7 +770,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::delete_execution][super::super::client::Executions::delete_execution] calls.
+    /// The request builder for [Executions::delete_execution][crate::client::Executions::delete_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -815,7 +815,7 @@ pub mod executions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_execution][super::super::client::Executions::delete_execution].
+        /// on [delete_execution][crate::client::Executions::delete_execution].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_execution(self.0.request, self.0.options)
@@ -882,7 +882,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::cancel_execution][super::super::client::Executions::cancel_execution] calls.
+    /// The request builder for [Executions::cancel_execution][crate::client::Executions::cancel_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -927,7 +927,7 @@ pub mod executions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [cancel_execution][super::super::client::Executions::cancel_execution].
+        /// on [cancel_execution][crate::client::Executions::cancel_execution].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .cancel_execution(self.0.request, self.0.options)
@@ -994,7 +994,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::list_operations][super::super::client::Executions::list_operations] calls.
+    /// The request builder for [Executions::list_operations][crate::client::Executions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1106,7 +1106,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::get_operation][super::super::client::Executions::get_operation] calls.
+    /// The request builder for [Executions::get_operation][crate::client::Executions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1170,7 +1170,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::delete_operation][super::super::client::Executions::delete_operation] calls.
+    /// The request builder for [Executions::delete_operation][crate::client::Executions::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1234,7 +1234,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::wait_operation][super::super::client::Executions::wait_operation] calls.
+    /// The request builder for [Executions::wait_operation][crate::client::Executions::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1320,7 +1320,7 @@ pub mod executions {
 pub mod jobs {
     use crate::Result;
 
-    /// A builder for [Jobs][super::super::client::Jobs].
+    /// A builder for [Jobs][crate::client::Jobs].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1348,7 +1348,7 @@ pub mod jobs {
         }
     }
 
-    /// Common implementation for [super::super::client::Jobs] request builders.
+    /// Common implementation for [crate::client::Jobs] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Jobs>,
@@ -1369,7 +1369,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::create_job][super::super::client::Jobs::create_job] calls.
+    /// The request builder for [Jobs::create_job][crate::client::Jobs::create_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1412,7 +1412,7 @@ pub mod jobs {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_job][super::super::client::Jobs::create_job].
+        /// on [create_job][crate::client::Jobs::create_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_job(self.0.request, self.0.options)
@@ -1502,7 +1502,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::get_job][super::super::client::Jobs::get_job] calls.
+    /// The request builder for [Jobs::get_job][crate::client::Jobs::get_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1563,7 +1563,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::list_jobs][super::super::client::Jobs::list_jobs] calls.
+    /// The request builder for [Jobs::list_jobs][crate::client::Jobs::list_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1670,7 +1670,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::update_job][super::super::client::Jobs::update_job] calls.
+    /// The request builder for [Jobs::update_job][crate::client::Jobs::update_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1713,7 +1713,7 @@ pub mod jobs {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_job][super::super::client::Jobs::update_job].
+        /// on [update_job][crate::client::Jobs::update_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_job(self.0.request, self.0.options)
@@ -1793,7 +1793,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::delete_job][super::super::client::Jobs::delete_job] calls.
+    /// The request builder for [Jobs::delete_job][crate::client::Jobs::delete_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1836,7 +1836,7 @@ pub mod jobs {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_job][super::super::client::Jobs::delete_job].
+        /// on [delete_job][crate::client::Jobs::delete_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_job(self.0.request, self.0.options)
@@ -1902,7 +1902,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::run_job][super::super::client::Jobs::run_job] calls.
+    /// The request builder for [Jobs::run_job][crate::client::Jobs::run_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1945,7 +1945,7 @@ pub mod jobs {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [run_job][super::super::client::Jobs::run_job].
+        /// on [run_job][crate::client::Jobs::run_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .run_job(self.0.request, self.0.options)
@@ -2030,7 +2030,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::get_iam_policy][super::super::client::Jobs::get_iam_policy] calls.
+    /// The request builder for [Jobs::get_iam_policy][crate::client::Jobs::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2109,7 +2109,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::set_iam_policy][super::super::client::Jobs::set_iam_policy] calls.
+    /// The request builder for [Jobs::set_iam_policy][crate::client::Jobs::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2210,7 +2210,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::test_iam_permissions][super::super::client::Jobs::test_iam_permissions] calls.
+    /// The request builder for [Jobs::test_iam_permissions][crate::client::Jobs::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2287,7 +2287,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::list_operations][super::super::client::Jobs::list_operations] calls.
+    /// The request builder for [Jobs::list_operations][crate::client::Jobs::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2397,7 +2397,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::get_operation][super::super::client::Jobs::get_operation] calls.
+    /// The request builder for [Jobs::get_operation][crate::client::Jobs::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2459,7 +2459,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::delete_operation][super::super::client::Jobs::delete_operation] calls.
+    /// The request builder for [Jobs::delete_operation][crate::client::Jobs::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2521,7 +2521,7 @@ pub mod jobs {
         }
     }
 
-    /// The request builder for [Jobs::wait_operation][super::super::client::Jobs::wait_operation] calls.
+    /// The request builder for [Jobs::wait_operation][crate::client::Jobs::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2605,7 +2605,7 @@ pub mod jobs {
 pub mod revisions {
     use crate::Result;
 
-    /// A builder for [Revisions][super::super::client::Revisions].
+    /// A builder for [Revisions][crate::client::Revisions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2633,7 +2633,7 @@ pub mod revisions {
         }
     }
 
-    /// Common implementation for [super::super::client::Revisions] request builders.
+    /// Common implementation for [crate::client::Revisions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Revisions>,
@@ -2656,7 +2656,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for [Revisions::get_revision][super::super::client::Revisions::get_revision] calls.
+    /// The request builder for [Revisions::get_revision][crate::client::Revisions::get_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2719,7 +2719,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for [Revisions::list_revisions][super::super::client::Revisions::list_revisions] calls.
+    /// The request builder for [Revisions::list_revisions][crate::client::Revisions::list_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2828,7 +2828,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for [Revisions::delete_revision][super::super::client::Revisions::delete_revision] calls.
+    /// The request builder for [Revisions::delete_revision][crate::client::Revisions::delete_revision] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2873,7 +2873,7 @@ pub mod revisions {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_revision][super::super::client::Revisions::delete_revision].
+        /// on [delete_revision][crate::client::Revisions::delete_revision].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_revision(self.0.request, self.0.options)
@@ -2940,7 +2940,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for [Revisions::list_operations][super::super::client::Revisions::list_operations] calls.
+    /// The request builder for [Revisions::list_operations][crate::client::Revisions::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3052,7 +3052,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for [Revisions::get_operation][super::super::client::Revisions::get_operation] calls.
+    /// The request builder for [Revisions::get_operation][crate::client::Revisions::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3116,7 +3116,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for [Revisions::delete_operation][super::super::client::Revisions::delete_operation] calls.
+    /// The request builder for [Revisions::delete_operation][crate::client::Revisions::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3180,7 +3180,7 @@ pub mod revisions {
         }
     }
 
-    /// The request builder for [Revisions::wait_operation][super::super::client::Revisions::wait_operation] calls.
+    /// The request builder for [Revisions::wait_operation][crate::client::Revisions::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3266,7 +3266,7 @@ pub mod revisions {
 pub mod services {
     use crate::Result;
 
-    /// A builder for [Services][super::super::client::Services].
+    /// A builder for [Services][crate::client::Services].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3294,7 +3294,7 @@ pub mod services {
         }
     }
 
-    /// Common implementation for [super::super::client::Services] request builders.
+    /// Common implementation for [crate::client::Services] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Services>,
@@ -3315,7 +3315,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::create_service][super::super::client::Services::create_service] calls.
+    /// The request builder for [Services::create_service][crate::client::Services::create_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3358,7 +3358,7 @@ pub mod services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service][super::super::client::Services::create_service].
+        /// on [create_service][crate::client::Services::create_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service(self.0.request, self.0.options)
@@ -3448,7 +3448,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::get_service][super::super::client::Services::get_service] calls.
+    /// The request builder for [Services::get_service][crate::client::Services::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3509,7 +3509,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::list_services][super::super::client::Services::list_services] calls.
+    /// The request builder for [Services::list_services][crate::client::Services::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3616,7 +3616,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::update_service][super::super::client::Services::update_service] calls.
+    /// The request builder for [Services::update_service][crate::client::Services::update_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3659,7 +3659,7 @@ pub mod services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service][super::super::client::Services::update_service].
+        /// on [update_service][crate::client::Services::update_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service(self.0.request, self.0.options)
@@ -3757,7 +3757,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::delete_service][super::super::client::Services::delete_service] calls.
+    /// The request builder for [Services::delete_service][crate::client::Services::delete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3800,7 +3800,7 @@ pub mod services {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service][super::super::client::Services::delete_service].
+        /// on [delete_service][crate::client::Services::delete_service].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service(self.0.request, self.0.options)
@@ -3866,7 +3866,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::get_iam_policy][super::super::client::Services::get_iam_policy] calls.
+    /// The request builder for [Services::get_iam_policy][crate::client::Services::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3945,7 +3945,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::set_iam_policy][super::super::client::Services::set_iam_policy] calls.
+    /// The request builder for [Services::set_iam_policy][crate::client::Services::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4046,7 +4046,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::test_iam_permissions][super::super::client::Services::test_iam_permissions] calls.
+    /// The request builder for [Services::test_iam_permissions][crate::client::Services::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4123,7 +4123,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::list_operations][super::super::client::Services::list_operations] calls.
+    /// The request builder for [Services::list_operations][crate::client::Services::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4233,7 +4233,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::get_operation][super::super::client::Services::get_operation] calls.
+    /// The request builder for [Services::get_operation][crate::client::Services::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4295,7 +4295,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::delete_operation][super::super::client::Services::delete_operation] calls.
+    /// The request builder for [Services::delete_operation][crate::client::Services::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4357,7 +4357,7 @@ pub mod services {
         }
     }
 
-    /// The request builder for [Services::wait_operation][super::super::client::Services::wait_operation] calls.
+    /// The request builder for [Services::wait_operation][crate::client::Services::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4441,7 +4441,7 @@ pub mod services {
 pub mod tasks {
     use crate::Result;
 
-    /// A builder for [Tasks][super::super::client::Tasks].
+    /// A builder for [Tasks][crate::client::Tasks].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4469,7 +4469,7 @@ pub mod tasks {
         }
     }
 
-    /// Common implementation for [super::super::client::Tasks] request builders.
+    /// Common implementation for [crate::client::Tasks] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Tasks>,
@@ -4490,7 +4490,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for [Tasks::get_task][super::super::client::Tasks::get_task] calls.
+    /// The request builder for [Tasks::get_task][crate::client::Tasks::get_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4551,7 +4551,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for [Tasks::list_tasks][super::super::client::Tasks::list_tasks] calls.
+    /// The request builder for [Tasks::list_tasks][crate::client::Tasks::list_tasks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4658,7 +4658,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for [Tasks::list_operations][super::super::client::Tasks::list_operations] calls.
+    /// The request builder for [Tasks::list_operations][crate::client::Tasks::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4768,7 +4768,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for [Tasks::get_operation][super::super::client::Tasks::get_operation] calls.
+    /// The request builder for [Tasks::get_operation][crate::client::Tasks::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4830,7 +4830,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for [Tasks::delete_operation][super::super::client::Tasks::delete_operation] calls.
+    /// The request builder for [Tasks::delete_operation][crate::client::Tasks::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4892,7 +4892,7 @@ pub mod tasks {
         }
     }
 
-    /// The request builder for [Tasks::wait_operation][super::super::client::Tasks::wait_operation] calls.
+    /// The request builder for [Tasks::wait_operation][crate::client::Tasks::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/scheduler/v1/src/builder.rs
+++ b/src/generated/cloud/scheduler/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_scheduler {
     use crate::Result;
 
-    /// A builder for [CloudScheduler][super::super::client::CloudScheduler].
+    /// A builder for [CloudScheduler][crate::client::CloudScheduler].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudScheduler] request builders.
+    /// Common implementation for [crate::client::CloudScheduler] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudScheduler>,
@@ -68,7 +68,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::list_jobs][super::super::client::CloudScheduler::list_jobs] calls.
+    /// The request builder for [CloudScheduler::list_jobs][crate::client::CloudScheduler::list_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::get_job][super::super::client::CloudScheduler::get_job] calls.
+    /// The request builder for [CloudScheduler::get_job][crate::client::CloudScheduler::get_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -234,7 +234,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::create_job][super::super::client::CloudScheduler::create_job] calls.
+    /// The request builder for [CloudScheduler::create_job][crate::client::CloudScheduler::create_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -319,7 +319,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::update_job][super::super::client::CloudScheduler::update_job] calls.
+    /// The request builder for [CloudScheduler::update_job][crate::client::CloudScheduler::update_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -414,7 +414,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::delete_job][super::super::client::CloudScheduler::delete_job] calls.
+    /// The request builder for [CloudScheduler::delete_job][crate::client::CloudScheduler::delete_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -477,7 +477,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::pause_job][super::super::client::CloudScheduler::pause_job] calls.
+    /// The request builder for [CloudScheduler::pause_job][crate::client::CloudScheduler::pause_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -540,7 +540,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::resume_job][super::super::client::CloudScheduler::resume_job] calls.
+    /// The request builder for [CloudScheduler::resume_job][crate::client::CloudScheduler::resume_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -603,7 +603,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::run_job][super::super::client::CloudScheduler::run_job] calls.
+    /// The request builder for [CloudScheduler::run_job][crate::client::CloudScheduler::run_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -666,7 +666,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::list_locations][super::super::client::CloudScheduler::list_locations] calls.
+    /// The request builder for [CloudScheduler::list_locations][crate::client::CloudScheduler::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -776,7 +776,7 @@ pub mod cloud_scheduler {
         }
     }
 
-    /// The request builder for [CloudScheduler::get_location][super::super::client::CloudScheduler::get_location] calls.
+    /// The request builder for [CloudScheduler::get_location][crate::client::CloudScheduler::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/secretmanager/v1/src/builder.rs
+++ b/src/generated/cloud/secretmanager/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod secret_manager_service {
     use crate::Result;
 
-    /// A builder for [SecretManagerService][super::super::client::SecretManagerService].
+    /// A builder for [SecretManagerService][crate::client::SecretManagerService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SecretManagerService] request builders.
+    /// Common implementation for [crate::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SecretManagerService>,
@@ -68,7 +68,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
+    /// The request builder for [SecretManagerService::list_secrets][crate::client::SecretManagerService::list_secrets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -177,7 +177,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
+    /// The request builder for [SecretManagerService::create_secret][crate::client::SecretManagerService::create_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -270,7 +270,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
+    /// The request builder for [SecretManagerService::add_secret_version][crate::client::SecretManagerService::add_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -358,7 +358,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
+    /// The request builder for [SecretManagerService::get_secret][crate::client::SecretManagerService::get_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -421,7 +421,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
+    /// The request builder for [SecretManagerService::update_secret][crate::client::SecretManagerService::update_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -520,7 +520,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
+    /// The request builder for [SecretManagerService::delete_secret][crate::client::SecretManagerService::delete_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -589,7 +589,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
+    /// The request builder for [SecretManagerService::list_secret_versions][crate::client::SecretManagerService::list_secret_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -703,7 +703,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
+    /// The request builder for [SecretManagerService::get_secret_version][crate::client::SecretManagerService::get_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -769,7 +769,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
+    /// The request builder for [SecretManagerService::access_secret_version][crate::client::SecretManagerService::access_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -835,7 +835,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
+    /// The request builder for [SecretManagerService::disable_secret_version][crate::client::SecretManagerService::disable_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -907,7 +907,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
+    /// The request builder for [SecretManagerService::enable_secret_version][crate::client::SecretManagerService::enable_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -979,7 +979,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
+    /// The request builder for [SecretManagerService::destroy_secret_version][crate::client::SecretManagerService::destroy_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1051,7 +1051,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
+    /// The request builder for [SecretManagerService::set_iam_policy][crate::client::SecretManagerService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1154,7 +1154,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
+    /// The request builder for [SecretManagerService::get_iam_policy][crate::client::SecretManagerService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1235,7 +1235,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
+    /// The request builder for [SecretManagerService::test_iam_permissions][crate::client::SecretManagerService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1314,7 +1314,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
+    /// The request builder for [SecretManagerService::list_locations][crate::client::SecretManagerService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1424,7 +1424,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
+    /// The request builder for [SecretManagerService::get_location][crate::client::SecretManagerService::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/securesourcemanager/v1/src/builder.rs
+++ b/src/generated/cloud/securesourcemanager/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod secure_source_manager {
     use crate::Result;
 
-    /// A builder for [SecureSourceManager][super::super::client::SecureSourceManager].
+    /// A builder for [SecureSourceManager][crate::client::SecureSourceManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::SecureSourceManager] request builders.
+    /// Common implementation for [crate::client::SecureSourceManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SecureSourceManager>,
@@ -68,7 +68,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::list_instances][super::super::client::SecureSourceManager::list_instances] calls.
+    /// The request builder for [SecureSourceManager::list_instances][crate::client::SecureSourceManager::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::get_instance][super::super::client::SecureSourceManager::get_instance] calls.
+    /// The request builder for [SecureSourceManager::get_instance][crate::client::SecureSourceManager::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::create_instance][super::super::client::SecureSourceManager::create_instance] calls.
+    /// The request builder for [SecureSourceManager::create_instance][crate::client::SecureSourceManager::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod secure_source_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::SecureSourceManager::create_instance].
+        /// on [create_instance][crate::client::SecureSourceManager::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::delete_instance][super::super::client::SecureSourceManager::delete_instance] calls.
+    /// The request builder for [SecureSourceManager::delete_instance][crate::client::SecureSourceManager::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod secure_source_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_instance][super::super::client::SecureSourceManager::delete_instance].
+        /// on [delete_instance][crate::client::SecureSourceManager::delete_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_instance(self.0.request, self.0.options)
@@ -494,7 +494,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::list_repositories][super::super::client::SecureSourceManager::list_repositories] calls.
+    /// The request builder for [SecureSourceManager::list_repositories][crate::client::SecureSourceManager::list_repositories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -612,7 +612,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::get_repository][super::super::client::SecureSourceManager::get_repository] calls.
+    /// The request builder for [SecureSourceManager::get_repository][crate::client::SecureSourceManager::get_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -675,7 +675,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::create_repository][super::super::client::SecureSourceManager::create_repository] calls.
+    /// The request builder for [SecureSourceManager::create_repository][crate::client::SecureSourceManager::create_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -723,7 +723,7 @@ pub mod secure_source_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_repository][super::super::client::SecureSourceManager::create_repository].
+        /// on [create_repository][crate::client::SecureSourceManager::create_repository].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_repository(self.0.request, self.0.options)
@@ -810,7 +810,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::delete_repository][super::super::client::SecureSourceManager::delete_repository] calls.
+    /// The request builder for [SecureSourceManager::delete_repository][crate::client::SecureSourceManager::delete_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -858,7 +858,7 @@ pub mod secure_source_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_repository][super::super::client::SecureSourceManager::delete_repository].
+        /// on [delete_repository][crate::client::SecureSourceManager::delete_repository].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_repository(self.0.request, self.0.options)
@@ -923,7 +923,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::get_iam_policy_repo][super::super::client::SecureSourceManager::get_iam_policy_repo] calls.
+    /// The request builder for [SecureSourceManager::get_iam_policy_repo][crate::client::SecureSourceManager::get_iam_policy_repo] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1004,7 +1004,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::set_iam_policy_repo][super::super::client::SecureSourceManager::set_iam_policy_repo] calls.
+    /// The request builder for [SecureSourceManager::set_iam_policy_repo][crate::client::SecureSourceManager::set_iam_policy_repo] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1107,7 +1107,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::test_iam_permissions_repo][super::super::client::SecureSourceManager::test_iam_permissions_repo] calls.
+    /// The request builder for [SecureSourceManager::test_iam_permissions_repo][crate::client::SecureSourceManager::test_iam_permissions_repo] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1186,7 +1186,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::create_branch_rule][super::super::client::SecureSourceManager::create_branch_rule] calls.
+    /// The request builder for [SecureSourceManager::create_branch_rule][crate::client::SecureSourceManager::create_branch_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1234,7 +1234,7 @@ pub mod secure_source_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_branch_rule][super::super::client::SecureSourceManager::create_branch_rule].
+        /// on [create_branch_rule][crate::client::SecureSourceManager::create_branch_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_branch_rule(self.0.request, self.0.options)
@@ -1321,7 +1321,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::list_branch_rules][super::super::client::SecureSourceManager::list_branch_rules] calls.
+    /// The request builder for [SecureSourceManager::list_branch_rules][crate::client::SecureSourceManager::list_branch_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1424,7 +1424,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::get_branch_rule][super::super::client::SecureSourceManager::get_branch_rule] calls.
+    /// The request builder for [SecureSourceManager::get_branch_rule][crate::client::SecureSourceManager::get_branch_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1487,7 +1487,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::update_branch_rule][super::super::client::SecureSourceManager::update_branch_rule] calls.
+    /// The request builder for [SecureSourceManager::update_branch_rule][crate::client::SecureSourceManager::update_branch_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1535,7 +1535,7 @@ pub mod secure_source_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_branch_rule][super::super::client::SecureSourceManager::update_branch_rule].
+        /// on [update_branch_rule][crate::client::SecureSourceManager::update_branch_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_branch_rule(self.0.request, self.0.options)
@@ -1634,7 +1634,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::delete_branch_rule][super::super::client::SecureSourceManager::delete_branch_rule] calls.
+    /// The request builder for [SecureSourceManager::delete_branch_rule][crate::client::SecureSourceManager::delete_branch_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1682,7 +1682,7 @@ pub mod secure_source_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_branch_rule][super::super::client::SecureSourceManager::delete_branch_rule].
+        /// on [delete_branch_rule][crate::client::SecureSourceManager::delete_branch_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_branch_rule(self.0.request, self.0.options)
@@ -1747,7 +1747,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::list_locations][super::super::client::SecureSourceManager::list_locations] calls.
+    /// The request builder for [SecureSourceManager::list_locations][crate::client::SecureSourceManager::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1857,7 +1857,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::get_location][super::super::client::SecureSourceManager::get_location] calls.
+    /// The request builder for [SecureSourceManager::get_location][crate::client::SecureSourceManager::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1918,7 +1918,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::set_iam_policy][super::super::client::SecureSourceManager::set_iam_policy] calls.
+    /// The request builder for [SecureSourceManager::set_iam_policy][crate::client::SecureSourceManager::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2021,7 +2021,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::get_iam_policy][super::super::client::SecureSourceManager::get_iam_policy] calls.
+    /// The request builder for [SecureSourceManager::get_iam_policy][crate::client::SecureSourceManager::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2102,7 +2102,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::test_iam_permissions][super::super::client::SecureSourceManager::test_iam_permissions] calls.
+    /// The request builder for [SecureSourceManager::test_iam_permissions][crate::client::SecureSourceManager::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2181,7 +2181,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::list_operations][super::super::client::SecureSourceManager::list_operations] calls.
+    /// The request builder for [SecureSourceManager::list_operations][crate::client::SecureSourceManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2293,7 +2293,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::get_operation][super::super::client::SecureSourceManager::get_operation] calls.
+    /// The request builder for [SecureSourceManager::get_operation][crate::client::SecureSourceManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2357,7 +2357,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::delete_operation][super::super::client::SecureSourceManager::delete_operation] calls.
+    /// The request builder for [SecureSourceManager::delete_operation][crate::client::SecureSourceManager::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2421,7 +2421,7 @@ pub mod secure_source_manager {
         }
     }
 
-    /// The request builder for [SecureSourceManager::cancel_operation][super::super::client::SecureSourceManager::cancel_operation] calls.
+    /// The request builder for [SecureSourceManager::cancel_operation][crate::client::SecureSourceManager::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/security/privateca/v1/src/builder.rs
+++ b/src/generated/cloud/security/privateca/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod certificate_authority_service {
     use crate::Result;
 
-    /// A builder for [CertificateAuthorityService][super::super::client::CertificateAuthorityService].
+    /// A builder for [CertificateAuthorityService][crate::client::CertificateAuthorityService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CertificateAuthorityService] request builders.
+    /// Common implementation for [crate::client::CertificateAuthorityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CertificateAuthorityService>,
@@ -68,7 +68,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::create_certificate][super::super::client::CertificateAuthorityService::create_certificate] calls.
+    /// The request builder for [CertificateAuthorityService::create_certificate][crate::client::CertificateAuthorityService::create_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_certificate][super::super::client::CertificateAuthorityService::get_certificate] calls.
+    /// The request builder for [CertificateAuthorityService::get_certificate][crate::client::CertificateAuthorityService::get_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::list_certificates][super::super::client::CertificateAuthorityService::list_certificates] calls.
+    /// The request builder for [CertificateAuthorityService::list_certificates][crate::client::CertificateAuthorityService::list_certificates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -364,7 +364,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::revoke_certificate][super::super::client::CertificateAuthorityService::revoke_certificate] calls.
+    /// The request builder for [CertificateAuthorityService::revoke_certificate][crate::client::CertificateAuthorityService::revoke_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -444,7 +444,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::update_certificate][super::super::client::CertificateAuthorityService::update_certificate] calls.
+    /// The request builder for [CertificateAuthorityService::update_certificate][crate::client::CertificateAuthorityService::update_certificate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -552,7 +552,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::activate_certificate_authority][super::super::client::CertificateAuthorityService::activate_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::activate_certificate_authority][crate::client::CertificateAuthorityService::activate_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -602,7 +602,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [activate_certificate_authority][super::super::client::CertificateAuthorityService::activate_certificate_authority].
+        /// on [activate_certificate_authority][crate::client::CertificateAuthorityService::activate_certificate_authority].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .activate_certificate_authority(self.0.request, self.0.options)
@@ -698,7 +698,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::create_certificate_authority][super::super::client::CertificateAuthorityService::create_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::create_certificate_authority][crate::client::CertificateAuthorityService::create_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -748,7 +748,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_certificate_authority][super::super::client::CertificateAuthorityService::create_certificate_authority].
+        /// on [create_certificate_authority][crate::client::CertificateAuthorityService::create_certificate_authority].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_certificate_authority(self.0.request, self.0.options)
@@ -844,7 +844,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::disable_certificate_authority][super::super::client::CertificateAuthorityService::disable_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::disable_certificate_authority][crate::client::CertificateAuthorityService::disable_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -894,7 +894,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [disable_certificate_authority][super::super::client::CertificateAuthorityService::disable_certificate_authority].
+        /// on [disable_certificate_authority][crate::client::CertificateAuthorityService::disable_certificate_authority].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .disable_certificate_authority(self.0.request, self.0.options)
@@ -966,7 +966,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::enable_certificate_authority][super::super::client::CertificateAuthorityService::enable_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::enable_certificate_authority][crate::client::CertificateAuthorityService::enable_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1016,7 +1016,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [enable_certificate_authority][super::super::client::CertificateAuthorityService::enable_certificate_authority].
+        /// on [enable_certificate_authority][crate::client::CertificateAuthorityService::enable_certificate_authority].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .enable_certificate_authority(self.0.request, self.0.options)
@@ -1082,7 +1082,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::fetch_certificate_authority_csr][super::super::client::CertificateAuthorityService::fetch_certificate_authority_csr] calls.
+    /// The request builder for [CertificateAuthorityService::fetch_certificate_authority_csr][crate::client::CertificateAuthorityService::fetch_certificate_authority_csr] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1150,7 +1150,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_certificate_authority][super::super::client::CertificateAuthorityService::get_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::get_certificate_authority][crate::client::CertificateAuthorityService::get_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1218,7 +1218,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::list_certificate_authorities][super::super::client::CertificateAuthorityService::list_certificate_authorities] calls.
+    /// The request builder for [CertificateAuthorityService::list_certificate_authorities][crate::client::CertificateAuthorityService::list_certificate_authorities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1342,7 +1342,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::undelete_certificate_authority][super::super::client::CertificateAuthorityService::undelete_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::undelete_certificate_authority][crate::client::CertificateAuthorityService::undelete_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1392,7 +1392,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_certificate_authority][super::super::client::CertificateAuthorityService::undelete_certificate_authority].
+        /// on [undelete_certificate_authority][crate::client::CertificateAuthorityService::undelete_certificate_authority].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_certificate_authority(self.0.request, self.0.options)
@@ -1458,7 +1458,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::delete_certificate_authority][super::super::client::CertificateAuthorityService::delete_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::delete_certificate_authority][crate::client::CertificateAuthorityService::delete_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1508,7 +1508,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_certificate_authority][super::super::client::CertificateAuthorityService::delete_certificate_authority].
+        /// on [delete_certificate_authority][crate::client::CertificateAuthorityService::delete_certificate_authority].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_certificate_authority(self.0.request, self.0.options)
@@ -1592,7 +1592,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::update_certificate_authority][super::super::client::CertificateAuthorityService::update_certificate_authority] calls.
+    /// The request builder for [CertificateAuthorityService::update_certificate_authority][crate::client::CertificateAuthorityService::update_certificate_authority] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1642,7 +1642,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_certificate_authority][super::super::client::CertificateAuthorityService::update_certificate_authority].
+        /// on [update_certificate_authority][crate::client::CertificateAuthorityService::update_certificate_authority].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_certificate_authority(self.0.request, self.0.options)
@@ -1744,7 +1744,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::create_ca_pool][super::super::client::CertificateAuthorityService::create_ca_pool] calls.
+    /// The request builder for [CertificateAuthorityService::create_ca_pool][crate::client::CertificateAuthorityService::create_ca_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1789,7 +1789,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_ca_pool][super::super::client::CertificateAuthorityService::create_ca_pool].
+        /// on [create_ca_pool][crate::client::CertificateAuthorityService::create_ca_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_ca_pool(self.0.request, self.0.options)
@@ -1882,7 +1882,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::update_ca_pool][super::super::client::CertificateAuthorityService::update_ca_pool] calls.
+    /// The request builder for [CertificateAuthorityService::update_ca_pool][crate::client::CertificateAuthorityService::update_ca_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1927,7 +1927,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_ca_pool][super::super::client::CertificateAuthorityService::update_ca_pool].
+        /// on [update_ca_pool][crate::client::CertificateAuthorityService::update_ca_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_ca_pool(self.0.request, self.0.options)
@@ -2026,7 +2026,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_ca_pool][super::super::client::CertificateAuthorityService::get_ca_pool] calls.
+    /// The request builder for [CertificateAuthorityService::get_ca_pool][crate::client::CertificateAuthorityService::get_ca_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2089,7 +2089,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::list_ca_pools][super::super::client::CertificateAuthorityService::list_ca_pools] calls.
+    /// The request builder for [CertificateAuthorityService::list_ca_pools][crate::client::CertificateAuthorityService::list_ca_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2204,7 +2204,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::delete_ca_pool][super::super::client::CertificateAuthorityService::delete_ca_pool] calls.
+    /// The request builder for [CertificateAuthorityService::delete_ca_pool][crate::client::CertificateAuthorityService::delete_ca_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2249,7 +2249,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_ca_pool][super::super::client::CertificateAuthorityService::delete_ca_pool].
+        /// on [delete_ca_pool][crate::client::CertificateAuthorityService::delete_ca_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_ca_pool(self.0.request, self.0.options)
@@ -2320,7 +2320,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::fetch_ca_certs][super::super::client::CertificateAuthorityService::fetch_ca_certs] calls.
+    /// The request builder for [CertificateAuthorityService::fetch_ca_certs][crate::client::CertificateAuthorityService::fetch_ca_certs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2389,7 +2389,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_certificate_revocation_list][super::super::client::CertificateAuthorityService::get_certificate_revocation_list] calls.
+    /// The request builder for [CertificateAuthorityService::get_certificate_revocation_list][crate::client::CertificateAuthorityService::get_certificate_revocation_list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2457,7 +2457,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::list_certificate_revocation_lists][super::super::client::CertificateAuthorityService::list_certificate_revocation_lists] calls.
+    /// The request builder for [CertificateAuthorityService::list_certificate_revocation_lists][crate::client::CertificateAuthorityService::list_certificate_revocation_lists] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2581,7 +2581,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::update_certificate_revocation_list][super::super::client::CertificateAuthorityService::update_certificate_revocation_list] calls.
+    /// The request builder for [CertificateAuthorityService::update_certificate_revocation_list][crate::client::CertificateAuthorityService::update_certificate_revocation_list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2631,7 +2631,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_certificate_revocation_list][super::super::client::CertificateAuthorityService::update_certificate_revocation_list].
+        /// on [update_certificate_revocation_list][crate::client::CertificateAuthorityService::update_certificate_revocation_list].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_certificate_revocation_list(self.0.request, self.0.options)
@@ -2736,7 +2736,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::create_certificate_template][super::super::client::CertificateAuthorityService::create_certificate_template] calls.
+    /// The request builder for [CertificateAuthorityService::create_certificate_template][crate::client::CertificateAuthorityService::create_certificate_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2786,7 +2786,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_certificate_template][super::super::client::CertificateAuthorityService::create_certificate_template].
+        /// on [create_certificate_template][crate::client::CertificateAuthorityService::create_certificate_template].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_certificate_template(self.0.request, self.0.options)
@@ -2882,7 +2882,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::delete_certificate_template][super::super::client::CertificateAuthorityService::delete_certificate_template] calls.
+    /// The request builder for [CertificateAuthorityService::delete_certificate_template][crate::client::CertificateAuthorityService::delete_certificate_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2932,7 +2932,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_certificate_template][super::super::client::CertificateAuthorityService::delete_certificate_template].
+        /// on [delete_certificate_template][crate::client::CertificateAuthorityService::delete_certificate_template].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_certificate_template(self.0.request, self.0.options)
@@ -2997,7 +2997,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_certificate_template][super::super::client::CertificateAuthorityService::get_certificate_template] calls.
+    /// The request builder for [CertificateAuthorityService::get_certificate_template][crate::client::CertificateAuthorityService::get_certificate_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3063,7 +3063,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::list_certificate_templates][super::super::client::CertificateAuthorityService::list_certificate_templates] calls.
+    /// The request builder for [CertificateAuthorityService::list_certificate_templates][crate::client::CertificateAuthorityService::list_certificate_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3187,7 +3187,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::update_certificate_template][super::super::client::CertificateAuthorityService::update_certificate_template] calls.
+    /// The request builder for [CertificateAuthorityService::update_certificate_template][crate::client::CertificateAuthorityService::update_certificate_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3237,7 +3237,7 @@ pub mod certificate_authority_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_certificate_template][super::super::client::CertificateAuthorityService::update_certificate_template].
+        /// on [update_certificate_template][crate::client::CertificateAuthorityService::update_certificate_template].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_certificate_template(self.0.request, self.0.options)
@@ -3339,7 +3339,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::list_locations][super::super::client::CertificateAuthorityService::list_locations] calls.
+    /// The request builder for [CertificateAuthorityService::list_locations][crate::client::CertificateAuthorityService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3449,7 +3449,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_location][super::super::client::CertificateAuthorityService::get_location] calls.
+    /// The request builder for [CertificateAuthorityService::get_location][crate::client::CertificateAuthorityService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3510,7 +3510,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::set_iam_policy][super::super::client::CertificateAuthorityService::set_iam_policy] calls.
+    /// The request builder for [CertificateAuthorityService::set_iam_policy][crate::client::CertificateAuthorityService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3613,7 +3613,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_iam_policy][super::super::client::CertificateAuthorityService::get_iam_policy] calls.
+    /// The request builder for [CertificateAuthorityService::get_iam_policy][crate::client::CertificateAuthorityService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3694,7 +3694,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::test_iam_permissions][super::super::client::CertificateAuthorityService::test_iam_permissions] calls.
+    /// The request builder for [CertificateAuthorityService::test_iam_permissions][crate::client::CertificateAuthorityService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3773,7 +3773,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::list_operations][super::super::client::CertificateAuthorityService::list_operations] calls.
+    /// The request builder for [CertificateAuthorityService::list_operations][crate::client::CertificateAuthorityService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3885,7 +3885,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::get_operation][super::super::client::CertificateAuthorityService::get_operation] calls.
+    /// The request builder for [CertificateAuthorityService::get_operation][crate::client::CertificateAuthorityService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3949,7 +3949,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::delete_operation][super::super::client::CertificateAuthorityService::delete_operation] calls.
+    /// The request builder for [CertificateAuthorityService::delete_operation][crate::client::CertificateAuthorityService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4013,7 +4013,7 @@ pub mod certificate_authority_service {
         }
     }
 
-    /// The request builder for [CertificateAuthorityService::cancel_operation][super::super::client::CertificateAuthorityService::cancel_operation] calls.
+    /// The request builder for [CertificateAuthorityService::cancel_operation][crate::client::CertificateAuthorityService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/security/publicca/v1/src/builder.rs
+++ b/src/generated/cloud/security/publicca/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod public_certificate_authority_service {
     use crate::Result;
 
-    /// A builder for [PublicCertificateAuthorityService][super::super::client::PublicCertificateAuthorityService].
+    /// A builder for [PublicCertificateAuthorityService][crate::client::PublicCertificateAuthorityService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod public_certificate_authority_service {
         }
     }
 
-    /// Common implementation for [super::super::client::PublicCertificateAuthorityService] request builders.
+    /// Common implementation for [crate::client::PublicCertificateAuthorityService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PublicCertificateAuthorityService>,
@@ -70,7 +70,7 @@ pub mod public_certificate_authority_service {
         }
     }
 
-    /// The request builder for [PublicCertificateAuthorityService::create_external_account_key][super::super::client::PublicCertificateAuthorityService::create_external_account_key] calls.
+    /// The request builder for [PublicCertificateAuthorityService::create_external_account_key][crate::client::PublicCertificateAuthorityService::create_external_account_key] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/securitycenter/v2/src/builder.rs
+++ b/src/generated/cloud/securitycenter/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod security_center {
     use crate::Result;
 
-    /// A builder for [SecurityCenter][super::super::client::SecurityCenter].
+    /// A builder for [SecurityCenter][crate::client::SecurityCenter].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod security_center {
         }
     }
 
-    /// Common implementation for [super::super::client::SecurityCenter] request builders.
+    /// Common implementation for [crate::client::SecurityCenter] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SecurityCenter>,
@@ -68,7 +68,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::batch_create_resource_value_configs][super::super::client::SecurityCenter::batch_create_resource_value_configs] calls.
+    /// The request builder for [SecurityCenter::batch_create_resource_value_configs][crate::client::SecurityCenter::batch_create_resource_value_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -149,7 +149,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::bulk_mute_findings][super::super::client::SecurityCenter::bulk_mute_findings] calls.
+    /// The request builder for [SecurityCenter::bulk_mute_findings][crate::client::SecurityCenter::bulk_mute_findings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -197,7 +197,7 @@ pub mod security_center {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [bulk_mute_findings][super::super::client::SecurityCenter::bulk_mute_findings].
+        /// on [bulk_mute_findings][crate::client::SecurityCenter::bulk_mute_findings].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .bulk_mute_findings(self.0.request, self.0.options)
@@ -272,7 +272,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::create_big_query_export][super::super::client::SecurityCenter::create_big_query_export] calls.
+    /// The request builder for [SecurityCenter::create_big_query_export][crate::client::SecurityCenter::create_big_query_export] calls.
     ///
     /// # Example
     /// ```no_run
@@ -368,7 +368,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::create_finding][super::super::client::SecurityCenter::create_finding] calls.
+    /// The request builder for [SecurityCenter::create_finding][crate::client::SecurityCenter::create_finding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -461,7 +461,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::create_mute_config][super::super::client::SecurityCenter::create_mute_config] calls.
+    /// The request builder for [SecurityCenter::create_mute_config][crate::client::SecurityCenter::create_mute_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -557,7 +557,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::create_notification_config][super::super::client::SecurityCenter::create_notification_config] calls.
+    /// The request builder for [SecurityCenter::create_notification_config][crate::client::SecurityCenter::create_notification_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -655,7 +655,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::create_source][super::super::client::SecurityCenter::create_source] calls.
+    /// The request builder for [SecurityCenter::create_source][crate::client::SecurityCenter::create_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -740,7 +740,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::delete_big_query_export][super::super::client::SecurityCenter::delete_big_query_export] calls.
+    /// The request builder for [SecurityCenter::delete_big_query_export][crate::client::SecurityCenter::delete_big_query_export] calls.
     ///
     /// # Example
     /// ```no_run
@@ -806,7 +806,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::delete_mute_config][super::super::client::SecurityCenter::delete_mute_config] calls.
+    /// The request builder for [SecurityCenter::delete_mute_config][crate::client::SecurityCenter::delete_mute_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -872,7 +872,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::delete_notification_config][super::super::client::SecurityCenter::delete_notification_config] calls.
+    /// The request builder for [SecurityCenter::delete_notification_config][crate::client::SecurityCenter::delete_notification_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -940,7 +940,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::delete_resource_value_config][super::super::client::SecurityCenter::delete_resource_value_config] calls.
+    /// The request builder for [SecurityCenter::delete_resource_value_config][crate::client::SecurityCenter::delete_resource_value_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1008,7 +1008,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_big_query_export][super::super::client::SecurityCenter::get_big_query_export] calls.
+    /// The request builder for [SecurityCenter::get_big_query_export][crate::client::SecurityCenter::get_big_query_export] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1074,7 +1074,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_simulation][super::super::client::SecurityCenter::get_simulation] calls.
+    /// The request builder for [SecurityCenter::get_simulation][crate::client::SecurityCenter::get_simulation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1137,7 +1137,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_valued_resource][super::super::client::SecurityCenter::get_valued_resource] calls.
+    /// The request builder for [SecurityCenter::get_valued_resource][crate::client::SecurityCenter::get_valued_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1203,7 +1203,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_iam_policy][super::super::client::SecurityCenter::get_iam_policy] calls.
+    /// The request builder for [SecurityCenter::get_iam_policy][crate::client::SecurityCenter::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1284,7 +1284,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_mute_config][super::super::client::SecurityCenter::get_mute_config] calls.
+    /// The request builder for [SecurityCenter::get_mute_config][crate::client::SecurityCenter::get_mute_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1347,7 +1347,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_notification_config][super::super::client::SecurityCenter::get_notification_config] calls.
+    /// The request builder for [SecurityCenter::get_notification_config][crate::client::SecurityCenter::get_notification_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1413,7 +1413,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_resource_value_config][super::super::client::SecurityCenter::get_resource_value_config] calls.
+    /// The request builder for [SecurityCenter::get_resource_value_config][crate::client::SecurityCenter::get_resource_value_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1479,7 +1479,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_source][super::super::client::SecurityCenter::get_source] calls.
+    /// The request builder for [SecurityCenter::get_source][crate::client::SecurityCenter::get_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1542,7 +1542,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::group_findings][super::super::client::SecurityCenter::group_findings] calls.
+    /// The request builder for [SecurityCenter::group_findings][crate::client::SecurityCenter::group_findings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1659,7 +1659,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_attack_paths][super::super::client::SecurityCenter::list_attack_paths] calls.
+    /// The request builder for [SecurityCenter::list_attack_paths][crate::client::SecurityCenter::list_attack_paths] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1768,7 +1768,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_big_query_exports][super::super::client::SecurityCenter::list_big_query_exports] calls.
+    /// The request builder for [SecurityCenter::list_big_query_exports][crate::client::SecurityCenter::list_big_query_exports] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1876,7 +1876,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_findings][super::super::client::SecurityCenter::list_findings] calls.
+    /// The request builder for [SecurityCenter::list_findings][crate::client::SecurityCenter::list_findings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2009,7 +2009,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_mute_configs][super::super::client::SecurityCenter::list_mute_configs] calls.
+    /// The request builder for [SecurityCenter::list_mute_configs][crate::client::SecurityCenter::list_mute_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2112,7 +2112,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_notification_configs][super::super::client::SecurityCenter::list_notification_configs] calls.
+    /// The request builder for [SecurityCenter::list_notification_configs][crate::client::SecurityCenter::list_notification_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2224,7 +2224,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_resource_value_configs][super::super::client::SecurityCenter::list_resource_value_configs] calls.
+    /// The request builder for [SecurityCenter::list_resource_value_configs][crate::client::SecurityCenter::list_resource_value_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2336,7 +2336,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_sources][super::super::client::SecurityCenter::list_sources] calls.
+    /// The request builder for [SecurityCenter::list_sources][crate::client::SecurityCenter::list_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2439,7 +2439,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_valued_resources][super::super::client::SecurityCenter::list_valued_resources] calls.
+    /// The request builder for [SecurityCenter::list_valued_resources][crate::client::SecurityCenter::list_valued_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2559,7 +2559,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::set_finding_state][super::super::client::SecurityCenter::set_finding_state] calls.
+    /// The request builder for [SecurityCenter::set_finding_state][crate::client::SecurityCenter::set_finding_state] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2630,7 +2630,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::set_iam_policy][super::super::client::SecurityCenter::set_iam_policy] calls.
+    /// The request builder for [SecurityCenter::set_iam_policy][crate::client::SecurityCenter::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2733,7 +2733,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::set_mute][super::super::client::SecurityCenter::set_mute] calls.
+    /// The request builder for [SecurityCenter::set_mute][crate::client::SecurityCenter::set_mute] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2804,7 +2804,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::test_iam_permissions][super::super::client::SecurityCenter::test_iam_permissions] calls.
+    /// The request builder for [SecurityCenter::test_iam_permissions][crate::client::SecurityCenter::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2883,7 +2883,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_big_query_export][super::super::client::SecurityCenter::update_big_query_export] calls.
+    /// The request builder for [SecurityCenter::update_big_query_export][crate::client::SecurityCenter::update_big_query_export] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2981,7 +2981,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_external_system][super::super::client::SecurityCenter::update_external_system] calls.
+    /// The request builder for [SecurityCenter::update_external_system][crate::client::SecurityCenter::update_external_system] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3079,7 +3079,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_finding][super::super::client::SecurityCenter::update_finding] calls.
+    /// The request builder for [SecurityCenter::update_finding][crate::client::SecurityCenter::update_finding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3174,7 +3174,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_mute_config][super::super::client::SecurityCenter::update_mute_config] calls.
+    /// The request builder for [SecurityCenter::update_mute_config][crate::client::SecurityCenter::update_mute_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3272,7 +3272,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_notification_config][super::super::client::SecurityCenter::update_notification_config] calls.
+    /// The request builder for [SecurityCenter::update_notification_config][crate::client::SecurityCenter::update_notification_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3372,7 +3372,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_resource_value_config][super::super::client::SecurityCenter::update_resource_value_config] calls.
+    /// The request builder for [SecurityCenter::update_resource_value_config][crate::client::SecurityCenter::update_resource_value_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3472,7 +3472,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_security_marks][super::super::client::SecurityCenter::update_security_marks] calls.
+    /// The request builder for [SecurityCenter::update_security_marks][crate::client::SecurityCenter::update_security_marks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3570,7 +3570,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::update_source][super::super::client::SecurityCenter::update_source] calls.
+    /// The request builder for [SecurityCenter::update_source][crate::client::SecurityCenter::update_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3665,7 +3665,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::list_operations][super::super::client::SecurityCenter::list_operations] calls.
+    /// The request builder for [SecurityCenter::list_operations][crate::client::SecurityCenter::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3777,7 +3777,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::get_operation][super::super::client::SecurityCenter::get_operation] calls.
+    /// The request builder for [SecurityCenter::get_operation][crate::client::SecurityCenter::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3841,7 +3841,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::delete_operation][super::super::client::SecurityCenter::delete_operation] calls.
+    /// The request builder for [SecurityCenter::delete_operation][crate::client::SecurityCenter::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3905,7 +3905,7 @@ pub mod security_center {
         }
     }
 
-    /// The request builder for [SecurityCenter::cancel_operation][super::super::client::SecurityCenter::cancel_operation] calls.
+    /// The request builder for [SecurityCenter::cancel_operation][crate::client::SecurityCenter::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/securityposture/v1/src/builder.rs
+++ b/src/generated/cloud/securityposture/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod security_posture {
     use crate::Result;
 
-    /// A builder for [SecurityPosture][super::super::client::SecurityPosture].
+    /// A builder for [SecurityPosture][crate::client::SecurityPosture].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod security_posture {
         }
     }
 
-    /// Common implementation for [super::super::client::SecurityPosture] request builders.
+    /// Common implementation for [crate::client::SecurityPosture] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SecurityPosture>,
@@ -68,7 +68,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::list_postures][super::super::client::SecurityPosture::list_postures] calls.
+    /// The request builder for [SecurityPosture::list_postures][crate::client::SecurityPosture::list_postures] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::list_posture_revisions][super::super::client::SecurityPosture::list_posture_revisions] calls.
+    /// The request builder for [SecurityPosture::list_posture_revisions][crate::client::SecurityPosture::list_posture_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -279,7 +279,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::get_posture][super::super::client::SecurityPosture::get_posture] calls.
+    /// The request builder for [SecurityPosture::get_posture][crate::client::SecurityPosture::get_posture] calls.
     ///
     /// # Example
     /// ```no_run
@@ -348,7 +348,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::create_posture][super::super::client::SecurityPosture::create_posture] calls.
+    /// The request builder for [SecurityPosture::create_posture][crate::client::SecurityPosture::create_posture] calls.
     ///
     /// # Example
     /// ```no_run
@@ -393,7 +393,7 @@ pub mod security_posture {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_posture][super::super::client::SecurityPosture::create_posture].
+        /// on [create_posture][crate::client::SecurityPosture::create_posture].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_posture(self.0.request, self.0.options)
@@ -480,7 +480,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::update_posture][super::super::client::SecurityPosture::update_posture] calls.
+    /// The request builder for [SecurityPosture::update_posture][crate::client::SecurityPosture::update_posture] calls.
     ///
     /// # Example
     /// ```no_run
@@ -525,7 +525,7 @@ pub mod security_posture {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_posture][super::super::client::SecurityPosture::update_posture].
+        /// on [update_posture][crate::client::SecurityPosture::update_posture].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_posture(self.0.request, self.0.options)
@@ -626,7 +626,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::delete_posture][super::super::client::SecurityPosture::delete_posture] calls.
+    /// The request builder for [SecurityPosture::delete_posture][crate::client::SecurityPosture::delete_posture] calls.
     ///
     /// # Example
     /// ```no_run
@@ -671,7 +671,7 @@ pub mod security_posture {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_posture][super::super::client::SecurityPosture::delete_posture].
+        /// on [delete_posture][crate::client::SecurityPosture::delete_posture].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_posture(self.0.request, self.0.options)
@@ -736,7 +736,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::extract_posture][super::super::client::SecurityPosture::extract_posture] calls.
+    /// The request builder for [SecurityPosture::extract_posture][crate::client::SecurityPosture::extract_posture] calls.
     ///
     /// # Example
     /// ```no_run
@@ -781,7 +781,7 @@ pub mod security_posture {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [extract_posture][super::super::client::SecurityPosture::extract_posture].
+        /// on [extract_posture][crate::client::SecurityPosture::extract_posture].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .extract_posture(self.0.request, self.0.options)
@@ -854,7 +854,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::list_posture_deployments][super::super::client::SecurityPosture::list_posture_deployments] calls.
+    /// The request builder for [SecurityPosture::list_posture_deployments][crate::client::SecurityPosture::list_posture_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -970,7 +970,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::get_posture_deployment][super::super::client::SecurityPosture::get_posture_deployment] calls.
+    /// The request builder for [SecurityPosture::get_posture_deployment][crate::client::SecurityPosture::get_posture_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1036,7 +1036,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::create_posture_deployment][super::super::client::SecurityPosture::create_posture_deployment] calls.
+    /// The request builder for [SecurityPosture::create_posture_deployment][crate::client::SecurityPosture::create_posture_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1086,7 +1086,7 @@ pub mod security_posture {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_posture_deployment][super::super::client::SecurityPosture::create_posture_deployment].
+        /// on [create_posture_deployment][crate::client::SecurityPosture::create_posture_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_posture_deployment(self.0.request, self.0.options)
@@ -1176,7 +1176,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::update_posture_deployment][super::super::client::SecurityPosture::update_posture_deployment] calls.
+    /// The request builder for [SecurityPosture::update_posture_deployment][crate::client::SecurityPosture::update_posture_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1226,7 +1226,7 @@ pub mod security_posture {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_posture_deployment][super::super::client::SecurityPosture::update_posture_deployment].
+        /// on [update_posture_deployment][crate::client::SecurityPosture::update_posture_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_posture_deployment(self.0.request, self.0.options)
@@ -1322,7 +1322,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::delete_posture_deployment][super::super::client::SecurityPosture::delete_posture_deployment] calls.
+    /// The request builder for [SecurityPosture::delete_posture_deployment][crate::client::SecurityPosture::delete_posture_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1372,7 +1372,7 @@ pub mod security_posture {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_posture_deployment][super::super::client::SecurityPosture::delete_posture_deployment].
+        /// on [delete_posture_deployment][crate::client::SecurityPosture::delete_posture_deployment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_posture_deployment(self.0.request, self.0.options)
@@ -1437,7 +1437,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::list_posture_templates][super::super::client::SecurityPosture::list_posture_templates] calls.
+    /// The request builder for [SecurityPosture::list_posture_templates][crate::client::SecurityPosture::list_posture_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1551,7 +1551,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::get_posture_template][super::super::client::SecurityPosture::get_posture_template] calls.
+    /// The request builder for [SecurityPosture::get_posture_template][crate::client::SecurityPosture::get_posture_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1623,7 +1623,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::list_locations][super::super::client::SecurityPosture::list_locations] calls.
+    /// The request builder for [SecurityPosture::list_locations][crate::client::SecurityPosture::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1733,7 +1733,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::get_location][super::super::client::SecurityPosture::get_location] calls.
+    /// The request builder for [SecurityPosture::get_location][crate::client::SecurityPosture::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1794,7 +1794,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::list_operations][super::super::client::SecurityPosture::list_operations] calls.
+    /// The request builder for [SecurityPosture::list_operations][crate::client::SecurityPosture::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1906,7 +1906,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::get_operation][super::super::client::SecurityPosture::get_operation] calls.
+    /// The request builder for [SecurityPosture::get_operation][crate::client::SecurityPosture::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1970,7 +1970,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::delete_operation][super::super::client::SecurityPosture::delete_operation] calls.
+    /// The request builder for [SecurityPosture::delete_operation][crate::client::SecurityPosture::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2034,7 +2034,7 @@ pub mod security_posture {
         }
     }
 
-    /// The request builder for [SecurityPosture::cancel_operation][super::super::client::SecurityPosture::cancel_operation] calls.
+    /// The request builder for [SecurityPosture::cancel_operation][crate::client::SecurityPosture::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/servicedirectory/v1/src/builder.rs
+++ b/src/generated/cloud/servicedirectory/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod lookup_service {
     use crate::Result;
 
-    /// A builder for [LookupService][super::super::client::LookupService].
+    /// A builder for [LookupService][crate::client::LookupService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod lookup_service {
         }
     }
 
-    /// Common implementation for [super::super::client::LookupService] request builders.
+    /// Common implementation for [crate::client::LookupService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LookupService>,
@@ -68,7 +68,7 @@ pub mod lookup_service {
         }
     }
 
-    /// The request builder for [LookupService::resolve_service][super::super::client::LookupService::resolve_service] calls.
+    /// The request builder for [LookupService::resolve_service][crate::client::LookupService::resolve_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -143,7 +143,7 @@ pub mod lookup_service {
         }
     }
 
-    /// The request builder for [LookupService::list_locations][super::super::client::LookupService::list_locations] calls.
+    /// The request builder for [LookupService::list_locations][crate::client::LookupService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -253,7 +253,7 @@ pub mod lookup_service {
         }
     }
 
-    /// The request builder for [LookupService::get_location][super::super::client::LookupService::get_location] calls.
+    /// The request builder for [LookupService::get_location][crate::client::LookupService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -318,7 +318,7 @@ pub mod lookup_service {
 pub mod registration_service {
     use crate::Result;
 
-    /// A builder for [RegistrationService][super::super::client::RegistrationService].
+    /// A builder for [RegistrationService][crate::client::RegistrationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -346,7 +346,7 @@ pub mod registration_service {
         }
     }
 
-    /// Common implementation for [super::super::client::RegistrationService] request builders.
+    /// Common implementation for [crate::client::RegistrationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RegistrationService>,
@@ -369,7 +369,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::create_namespace][super::super::client::RegistrationService::create_namespace] calls.
+    /// The request builder for [RegistrationService::create_namespace][crate::client::RegistrationService::create_namespace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -462,7 +462,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::list_namespaces][super::super::client::RegistrationService::list_namespaces] calls.
+    /// The request builder for [RegistrationService::list_namespaces][crate::client::RegistrationService::list_namespaces] calls.
     ///
     /// # Example
     /// ```no_run
@@ -577,7 +577,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::get_namespace][super::super::client::RegistrationService::get_namespace] calls.
+    /// The request builder for [RegistrationService::get_namespace][crate::client::RegistrationService::get_namespace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -640,7 +640,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::update_namespace][super::super::client::RegistrationService::update_namespace] calls.
+    /// The request builder for [RegistrationService::update_namespace][crate::client::RegistrationService::update_namespace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -739,7 +739,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::delete_namespace][super::super::client::RegistrationService::delete_namespace] calls.
+    /// The request builder for [RegistrationService::delete_namespace][crate::client::RegistrationService::delete_namespace] calls.
     ///
     /// # Example
     /// ```no_run
@@ -802,7 +802,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::create_service][super::super::client::RegistrationService::create_service] calls.
+    /// The request builder for [RegistrationService::create_service][crate::client::RegistrationService::create_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -895,7 +895,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::list_services][super::super::client::RegistrationService::list_services] calls.
+    /// The request builder for [RegistrationService::list_services][crate::client::RegistrationService::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1010,7 +1010,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::get_service][super::super::client::RegistrationService::get_service] calls.
+    /// The request builder for [RegistrationService::get_service][crate::client::RegistrationService::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1073,7 +1073,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::update_service][super::super::client::RegistrationService::update_service] calls.
+    /// The request builder for [RegistrationService::update_service][crate::client::RegistrationService::update_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1172,7 +1172,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::delete_service][super::super::client::RegistrationService::delete_service] calls.
+    /// The request builder for [RegistrationService::delete_service][crate::client::RegistrationService::delete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1235,7 +1235,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::create_endpoint][super::super::client::RegistrationService::create_endpoint] calls.
+    /// The request builder for [RegistrationService::create_endpoint][crate::client::RegistrationService::create_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1328,7 +1328,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::list_endpoints][super::super::client::RegistrationService::list_endpoints] calls.
+    /// The request builder for [RegistrationService::list_endpoints][crate::client::RegistrationService::list_endpoints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1443,7 +1443,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::get_endpoint][super::super::client::RegistrationService::get_endpoint] calls.
+    /// The request builder for [RegistrationService::get_endpoint][crate::client::RegistrationService::get_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1506,7 +1506,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::update_endpoint][super::super::client::RegistrationService::update_endpoint] calls.
+    /// The request builder for [RegistrationService::update_endpoint][crate::client::RegistrationService::update_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1605,7 +1605,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::delete_endpoint][super::super::client::RegistrationService::delete_endpoint] calls.
+    /// The request builder for [RegistrationService::delete_endpoint][crate::client::RegistrationService::delete_endpoint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1668,7 +1668,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::get_iam_policy][super::super::client::RegistrationService::get_iam_policy] calls.
+    /// The request builder for [RegistrationService::get_iam_policy][crate::client::RegistrationService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1749,7 +1749,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::set_iam_policy][super::super::client::RegistrationService::set_iam_policy] calls.
+    /// The request builder for [RegistrationService::set_iam_policy][crate::client::RegistrationService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1852,7 +1852,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::test_iam_permissions][super::super::client::RegistrationService::test_iam_permissions] calls.
+    /// The request builder for [RegistrationService::test_iam_permissions][crate::client::RegistrationService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1931,7 +1931,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::list_locations][super::super::client::RegistrationService::list_locations] calls.
+    /// The request builder for [RegistrationService::list_locations][crate::client::RegistrationService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2041,7 +2041,7 @@ pub mod registration_service {
         }
     }
 
-    /// The request builder for [RegistrationService::get_location][super::super::client::RegistrationService::get_location] calls.
+    /// The request builder for [RegistrationService::get_location][crate::client::RegistrationService::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/servicehealth/v1/src/builder.rs
+++ b/src/generated/cloud/servicehealth/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod service_health {
     use crate::Result;
 
-    /// A builder for [ServiceHealth][super::super::client::ServiceHealth].
+    /// A builder for [ServiceHealth][crate::client::ServiceHealth].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod service_health {
         }
     }
 
-    /// Common implementation for [super::super::client::ServiceHealth] request builders.
+    /// Common implementation for [crate::client::ServiceHealth] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServiceHealth>,
@@ -68,7 +68,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::list_events][super::super::client::ServiceHealth::list_events] calls.
+    /// The request builder for [ServiceHealth::list_events][crate::client::ServiceHealth::list_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::get_event][super::super::client::ServiceHealth::get_event] calls.
+    /// The request builder for [ServiceHealth::get_event][crate::client::ServiceHealth::get_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::list_organization_events][super::super::client::ServiceHealth::list_organization_events] calls.
+    /// The request builder for [ServiceHealth::list_organization_events][crate::client::ServiceHealth::list_organization_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -368,7 +368,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::get_organization_event][super::super::client::ServiceHealth::get_organization_event] calls.
+    /// The request builder for [ServiceHealth::get_organization_event][crate::client::ServiceHealth::get_organization_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -434,7 +434,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::list_organization_impacts][super::super::client::ServiceHealth::list_organization_impacts] calls.
+    /// The request builder for [ServiceHealth::list_organization_impacts][crate::client::ServiceHealth::list_organization_impacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -552,7 +552,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::get_organization_impact][super::super::client::ServiceHealth::get_organization_impact] calls.
+    /// The request builder for [ServiceHealth::get_organization_impact][crate::client::ServiceHealth::get_organization_impact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -618,7 +618,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::list_locations][super::super::client::ServiceHealth::list_locations] calls.
+    /// The request builder for [ServiceHealth::list_locations][crate::client::ServiceHealth::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -728,7 +728,7 @@ pub mod service_health {
         }
     }
 
-    /// The request builder for [ServiceHealth::get_location][super::super::client::ServiceHealth::get_location] calls.
+    /// The request builder for [ServiceHealth::get_location][crate::client::ServiceHealth::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/shell/v1/src/builder.rs
+++ b/src/generated/cloud/shell/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_shell_service {
     use crate::Result;
 
-    /// A builder for [CloudShellService][super::super::client::CloudShellService].
+    /// A builder for [CloudShellService][crate::client::CloudShellService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudShellService] request builders.
+    /// Common implementation for [crate::client::CloudShellService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudShellService>,
@@ -68,7 +68,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for [CloudShellService::get_environment][super::super::client::CloudShellService::get_environment] calls.
+    /// The request builder for [CloudShellService::get_environment][crate::client::CloudShellService::get_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for [CloudShellService::start_environment][super::super::client::CloudShellService::start_environment] calls.
+    /// The request builder for [CloudShellService::start_environment][crate::client::CloudShellService::start_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -179,7 +179,7 @@ pub mod cloud_shell_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_environment][super::super::client::CloudShellService::start_environment].
+        /// on [start_environment][crate::client::CloudShellService::start_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_environment(self.0.request, self.0.options)
@@ -256,7 +256,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for [CloudShellService::authorize_environment][super::super::client::CloudShellService::authorize_environment] calls.
+    /// The request builder for [CloudShellService::authorize_environment][crate::client::CloudShellService::authorize_environment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -304,7 +304,7 @@ pub mod cloud_shell_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [authorize_environment][super::super::client::CloudShellService::authorize_environment].
+        /// on [authorize_environment][crate::client::CloudShellService::authorize_environment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .authorize_environment(self.0.request, self.0.options)
@@ -394,7 +394,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for [CloudShellService::add_public_key][super::super::client::CloudShellService::add_public_key] calls.
+    /// The request builder for [CloudShellService::add_public_key][crate::client::CloudShellService::add_public_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -439,7 +439,7 @@ pub mod cloud_shell_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [add_public_key][super::super::client::CloudShellService::add_public_key].
+        /// on [add_public_key][crate::client::CloudShellService::add_public_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .add_public_key(self.0.request, self.0.options)
@@ -503,7 +503,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for [CloudShellService::remove_public_key][super::super::client::CloudShellService::remove_public_key] calls.
+    /// The request builder for [CloudShellService::remove_public_key][crate::client::CloudShellService::remove_public_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -548,7 +548,7 @@ pub mod cloud_shell_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [remove_public_key][super::super::client::CloudShellService::remove_public_key].
+        /// on [remove_public_key][crate::client::CloudShellService::remove_public_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .remove_public_key(self.0.request, self.0.options)
@@ -612,7 +612,7 @@ pub mod cloud_shell_service {
         }
     }
 
-    /// The request builder for [CloudShellService::get_operation][super::super::client::CloudShellService::get_operation] calls.
+    /// The request builder for [CloudShellService::get_operation][crate::client::CloudShellService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/speech/v2/src/builder.rs
+++ b/src/generated/cloud/speech/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod speech {
     use crate::Result;
 
-    /// A builder for [Speech][super::super::client::Speech].
+    /// A builder for [Speech][crate::client::Speech].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod speech {
         }
     }
 
-    /// Common implementation for [super::super::client::Speech] request builders.
+    /// Common implementation for [crate::client::Speech] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Speech>,
@@ -66,7 +66,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::create_recognizer][super::super::client::Speech::create_recognizer] calls.
+    /// The request builder for [Speech::create_recognizer][crate::client::Speech::create_recognizer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -112,7 +112,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_recognizer][super::super::client::Speech::create_recognizer].
+        /// on [create_recognizer][crate::client::Speech::create_recognizer].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_recognizer(self.0.request, self.0.options)
@@ -203,7 +203,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::list_recognizers][super::super::client::Speech::list_recognizers] calls.
+    /// The request builder for [Speech::list_recognizers][crate::client::Speech::list_recognizers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -310,7 +310,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::get_recognizer][super::super::client::Speech::get_recognizer] calls.
+    /// The request builder for [Speech::get_recognizer][crate::client::Speech::get_recognizer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -371,7 +371,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::update_recognizer][super::super::client::Speech::update_recognizer] calls.
+    /// The request builder for [Speech::update_recognizer][crate::client::Speech::update_recognizer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -417,7 +417,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_recognizer][super::super::client::Speech::update_recognizer].
+        /// on [update_recognizer][crate::client::Speech::update_recognizer].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_recognizer(self.0.request, self.0.options)
@@ -512,7 +512,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::delete_recognizer][super::super::client::Speech::delete_recognizer] calls.
+    /// The request builder for [Speech::delete_recognizer][crate::client::Speech::delete_recognizer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -558,7 +558,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_recognizer][super::super::client::Speech::delete_recognizer].
+        /// on [delete_recognizer][crate::client::Speech::delete_recognizer].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_recognizer(self.0.request, self.0.options)
@@ -633,7 +633,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::undelete_recognizer][super::super::client::Speech::undelete_recognizer] calls.
+    /// The request builder for [Speech::undelete_recognizer][crate::client::Speech::undelete_recognizer] calls.
     ///
     /// # Example
     /// ```no_run
@@ -679,7 +679,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_recognizer][super::super::client::Speech::undelete_recognizer].
+        /// on [undelete_recognizer][crate::client::Speech::undelete_recognizer].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_recognizer(self.0.request, self.0.options)
@@ -748,7 +748,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::recognize][super::super::client::Speech::recognize] calls.
+    /// The request builder for [Speech::recognize][crate::client::Speech::recognize] calls.
     ///
     /// # Example
     /// ```no_run
@@ -877,7 +877,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::batch_recognize][super::super::client::Speech::batch_recognize] calls.
+    /// The request builder for [Speech::batch_recognize][crate::client::Speech::batch_recognize] calls.
     ///
     /// # Example
     /// ```no_run
@@ -920,7 +920,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_recognize][super::super::client::Speech::batch_recognize].
+        /// on [batch_recognize][crate::client::Speech::batch_recognize].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_recognize(self.0.request, self.0.options)
@@ -1059,7 +1059,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::get_config][super::super::client::Speech::get_config] calls.
+    /// The request builder for [Speech::get_config][crate::client::Speech::get_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1120,7 +1120,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::update_config][super::super::client::Speech::update_config] calls.
+    /// The request builder for [Speech::update_config][crate::client::Speech::update_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1213,7 +1213,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::create_custom_class][super::super::client::Speech::create_custom_class] calls.
+    /// The request builder for [Speech::create_custom_class][crate::client::Speech::create_custom_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1259,7 +1259,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_custom_class][super::super::client::Speech::create_custom_class].
+        /// on [create_custom_class][crate::client::Speech::create_custom_class].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_custom_class(self.0.request, self.0.options)
@@ -1352,7 +1352,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::list_custom_classes][super::super::client::Speech::list_custom_classes] calls.
+    /// The request builder for [Speech::list_custom_classes][crate::client::Speech::list_custom_classes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1462,7 +1462,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::get_custom_class][super::super::client::Speech::get_custom_class] calls.
+    /// The request builder for [Speech::get_custom_class][crate::client::Speech::get_custom_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1523,7 +1523,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::update_custom_class][super::super::client::Speech::update_custom_class] calls.
+    /// The request builder for [Speech::update_custom_class][crate::client::Speech::update_custom_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1569,7 +1569,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_custom_class][super::super::client::Speech::update_custom_class].
+        /// on [update_custom_class][crate::client::Speech::update_custom_class].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_custom_class(self.0.request, self.0.options)
@@ -1666,7 +1666,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::delete_custom_class][super::super::client::Speech::delete_custom_class] calls.
+    /// The request builder for [Speech::delete_custom_class][crate::client::Speech::delete_custom_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1712,7 +1712,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_custom_class][super::super::client::Speech::delete_custom_class].
+        /// on [delete_custom_class][crate::client::Speech::delete_custom_class].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_custom_class(self.0.request, self.0.options)
@@ -1789,7 +1789,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::undelete_custom_class][super::super::client::Speech::undelete_custom_class] calls.
+    /// The request builder for [Speech::undelete_custom_class][crate::client::Speech::undelete_custom_class] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1835,7 +1835,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_custom_class][super::super::client::Speech::undelete_custom_class].
+        /// on [undelete_custom_class][crate::client::Speech::undelete_custom_class].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_custom_class(self.0.request, self.0.options)
@@ -1906,7 +1906,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::create_phrase_set][super::super::client::Speech::create_phrase_set] calls.
+    /// The request builder for [Speech::create_phrase_set][crate::client::Speech::create_phrase_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1949,7 +1949,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_phrase_set][super::super::client::Speech::create_phrase_set].
+        /// on [create_phrase_set][crate::client::Speech::create_phrase_set].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_phrase_set(self.0.request, self.0.options)
@@ -2040,7 +2040,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::list_phrase_sets][super::super::client::Speech::list_phrase_sets] calls.
+    /// The request builder for [Speech::list_phrase_sets][crate::client::Speech::list_phrase_sets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2147,7 +2147,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::get_phrase_set][super::super::client::Speech::get_phrase_set] calls.
+    /// The request builder for [Speech::get_phrase_set][crate::client::Speech::get_phrase_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2208,7 +2208,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::update_phrase_set][super::super::client::Speech::update_phrase_set] calls.
+    /// The request builder for [Speech::update_phrase_set][crate::client::Speech::update_phrase_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2251,7 +2251,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_phrase_set][super::super::client::Speech::update_phrase_set].
+        /// on [update_phrase_set][crate::client::Speech::update_phrase_set].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_phrase_set(self.0.request, self.0.options)
@@ -2346,7 +2346,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::delete_phrase_set][super::super::client::Speech::delete_phrase_set] calls.
+    /// The request builder for [Speech::delete_phrase_set][crate::client::Speech::delete_phrase_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2389,7 +2389,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_phrase_set][super::super::client::Speech::delete_phrase_set].
+        /// on [delete_phrase_set][crate::client::Speech::delete_phrase_set].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_phrase_set(self.0.request, self.0.options)
@@ -2464,7 +2464,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::undelete_phrase_set][super::super::client::Speech::undelete_phrase_set] calls.
+    /// The request builder for [Speech::undelete_phrase_set][crate::client::Speech::undelete_phrase_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2510,7 +2510,7 @@ pub mod speech {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_phrase_set][super::super::client::Speech::undelete_phrase_set].
+        /// on [undelete_phrase_set][crate::client::Speech::undelete_phrase_set].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_phrase_set(self.0.request, self.0.options)
@@ -2579,7 +2579,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::list_locations][super::super::client::Speech::list_locations] calls.
+    /// The request builder for [Speech::list_locations][crate::client::Speech::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2687,7 +2687,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::get_location][super::super::client::Speech::get_location] calls.
+    /// The request builder for [Speech::get_location][crate::client::Speech::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2746,7 +2746,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::list_operations][super::super::client::Speech::list_operations] calls.
+    /// The request builder for [Speech::list_operations][crate::client::Speech::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2856,7 +2856,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::get_operation][super::super::client::Speech::get_operation] calls.
+    /// The request builder for [Speech::get_operation][crate::client::Speech::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2918,7 +2918,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::delete_operation][super::super::client::Speech::delete_operation] calls.
+    /// The request builder for [Speech::delete_operation][crate::client::Speech::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2980,7 +2980,7 @@ pub mod speech {
         }
     }
 
-    /// The request builder for [Speech::cancel_operation][super::super::client::Speech::cancel_operation] calls.
+    /// The request builder for [Speech::cancel_operation][crate::client::Speech::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/sql/v1/src/builder.rs
+++ b/src/generated/cloud/sql/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod sql_backup_runs_service {
     use crate::Result;
 
-    /// A builder for [SqlBackupRunsService][super::super::client::SqlBackupRunsService].
+    /// A builder for [SqlBackupRunsService][crate::client::SqlBackupRunsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlBackupRunsService] request builders.
+    /// Common implementation for [crate::client::SqlBackupRunsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlBackupRunsService>,
@@ -68,7 +68,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for [SqlBackupRunsService::delete][super::super::client::SqlBackupRunsService::delete] calls.
+    /// The request builder for [SqlBackupRunsService::delete][crate::client::SqlBackupRunsService::delete] calls.
     ///
     /// # Example
     /// ```no_run
@@ -144,7 +144,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for [SqlBackupRunsService::get][super::super::client::SqlBackupRunsService::get] calls.
+    /// The request builder for [SqlBackupRunsService::get][crate::client::SqlBackupRunsService::get] calls.
     ///
     /// # Example
     /// ```no_run
@@ -220,7 +220,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for [SqlBackupRunsService::insert][super::super::client::SqlBackupRunsService::insert] calls.
+    /// The request builder for [SqlBackupRunsService::insert][crate::client::SqlBackupRunsService::insert] calls.
     ///
     /// # Example
     /// ```no_run
@@ -308,7 +308,7 @@ pub mod sql_backup_runs_service {
         }
     }
 
-    /// The request builder for [SqlBackupRunsService::list][super::super::client::SqlBackupRunsService::list] calls.
+    /// The request builder for [SqlBackupRunsService::list][crate::client::SqlBackupRunsService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -422,7 +422,7 @@ pub mod sql_backup_runs_service {
 pub mod sql_connect_service {
     use crate::Result;
 
-    /// A builder for [SqlConnectService][super::super::client::SqlConnectService].
+    /// A builder for [SqlConnectService][crate::client::SqlConnectService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -450,7 +450,7 @@ pub mod sql_connect_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlConnectService] request builders.
+    /// Common implementation for [crate::client::SqlConnectService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlConnectService>,
@@ -473,7 +473,7 @@ pub mod sql_connect_service {
         }
     }
 
-    /// The request builder for [SqlConnectService::get_connect_settings][super::super::client::SqlConnectService::get_connect_settings] calls.
+    /// The request builder for [SqlConnectService::get_connect_settings][crate::client::SqlConnectService::get_connect_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -561,7 +561,7 @@ pub mod sql_connect_service {
         }
     }
 
-    /// The request builder for [SqlConnectService::generate_ephemeral_cert][super::super::client::SqlConnectService::generate_ephemeral_cert] calls.
+    /// The request builder for [SqlConnectService::generate_ephemeral_cert][crate::client::SqlConnectService::generate_ephemeral_cert] calls.
     ///
     /// # Example
     /// ```no_run
@@ -683,7 +683,7 @@ pub mod sql_connect_service {
 pub mod sql_databases_service {
     use crate::Result;
 
-    /// A builder for [SqlDatabasesService][super::super::client::SqlDatabasesService].
+    /// A builder for [SqlDatabasesService][crate::client::SqlDatabasesService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -711,7 +711,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlDatabasesService] request builders.
+    /// Common implementation for [crate::client::SqlDatabasesService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlDatabasesService>,
@@ -734,7 +734,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for [SqlDatabasesService::delete][super::super::client::SqlDatabasesService::delete] calls.
+    /// The request builder for [SqlDatabasesService::delete][crate::client::SqlDatabasesService::delete] calls.
     ///
     /// # Example
     /// ```no_run
@@ -810,7 +810,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for [SqlDatabasesService::get][super::super::client::SqlDatabasesService::get] calls.
+    /// The request builder for [SqlDatabasesService::get][crate::client::SqlDatabasesService::get] calls.
     ///
     /// # Example
     /// ```no_run
@@ -883,7 +883,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for [SqlDatabasesService::insert][super::super::client::SqlDatabasesService::insert] calls.
+    /// The request builder for [SqlDatabasesService::insert][crate::client::SqlDatabasesService::insert] calls.
     ///
     /// # Example
     /// ```no_run
@@ -971,7 +971,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for [SqlDatabasesService::list][super::super::client::SqlDatabasesService::list] calls.
+    /// The request builder for [SqlDatabasesService::list][crate::client::SqlDatabasesService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1041,7 +1041,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for [SqlDatabasesService::patch][super::super::client::SqlDatabasesService::patch] calls.
+    /// The request builder for [SqlDatabasesService::patch][crate::client::SqlDatabasesService::patch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1135,7 +1135,7 @@ pub mod sql_databases_service {
         }
     }
 
-    /// The request builder for [SqlDatabasesService::update][super::super::client::SqlDatabasesService::update] calls.
+    /// The request builder for [SqlDatabasesService::update][crate::client::SqlDatabasesService::update] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1233,7 +1233,7 @@ pub mod sql_databases_service {
 pub mod sql_flags_service {
     use crate::Result;
 
-    /// A builder for [SqlFlagsService][super::super::client::SqlFlagsService].
+    /// A builder for [SqlFlagsService][crate::client::SqlFlagsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1261,7 +1261,7 @@ pub mod sql_flags_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlFlagsService] request builders.
+    /// Common implementation for [crate::client::SqlFlagsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlFlagsService>,
@@ -1284,7 +1284,7 @@ pub mod sql_flags_service {
         }
     }
 
-    /// The request builder for [SqlFlagsService::list][super::super::client::SqlFlagsService::list] calls.
+    /// The request builder for [SqlFlagsService::list][crate::client::SqlFlagsService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1349,7 +1349,7 @@ pub mod sql_flags_service {
 pub mod sql_instances_service {
     use crate::Result;
 
-    /// A builder for [SqlInstancesService][super::super::client::SqlInstancesService].
+    /// A builder for [SqlInstancesService][crate::client::SqlInstancesService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1377,7 +1377,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlInstancesService] request builders.
+    /// Common implementation for [crate::client::SqlInstancesService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlInstancesService>,
@@ -1400,7 +1400,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::add_server_ca][super::super::client::SqlInstancesService::add_server_ca] calls.
+    /// The request builder for [SqlInstancesService::add_server_ca][crate::client::SqlInstancesService::add_server_ca] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1470,7 +1470,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::clone][super::super::client::SqlInstancesService::clone] calls.
+    /// The request builder for [SqlInstancesService::clone][crate::client::SqlInstancesService::clone] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1558,7 +1558,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::delete][super::super::client::SqlInstancesService::delete] calls.
+    /// The request builder for [SqlInstancesService::delete][crate::client::SqlInstancesService::delete] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1628,7 +1628,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::demote_master][super::super::client::SqlInstancesService::demote_master] calls.
+    /// The request builder for [SqlInstancesService::demote_master][crate::client::SqlInstancesService::demote_master] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1716,7 +1716,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::demote][super::super::client::SqlInstancesService::demote] calls.
+    /// The request builder for [SqlInstancesService::demote][crate::client::SqlInstancesService::demote] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1812,7 +1812,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::export][super::super::client::SqlInstancesService::export] calls.
+    /// The request builder for [SqlInstancesService::export][crate::client::SqlInstancesService::export] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1900,7 +1900,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::failover][super::super::client::SqlInstancesService::failover] calls.
+    /// The request builder for [SqlInstancesService::failover][crate::client::SqlInstancesService::failover] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1988,7 +1988,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::reencrypt][super::super::client::SqlInstancesService::reencrypt] calls.
+    /// The request builder for [SqlInstancesService::reencrypt][crate::client::SqlInstancesService::reencrypt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2076,7 +2076,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::get][super::super::client::SqlInstancesService::get] calls.
+    /// The request builder for [SqlInstancesService::get][crate::client::SqlInstancesService::get] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2143,7 +2143,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::import][super::super::client::SqlInstancesService::import] calls.
+    /// The request builder for [SqlInstancesService::import][crate::client::SqlInstancesService::import] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2231,7 +2231,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::insert][super::super::client::SqlInstancesService::insert] calls.
+    /// The request builder for [SqlInstancesService::insert][crate::client::SqlInstancesService::insert] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2313,7 +2313,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::list][super::super::client::SqlInstancesService::list] calls.
+    /// The request builder for [SqlInstancesService::list][crate::client::SqlInstancesService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2423,7 +2423,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::list_server_cas][super::super::client::SqlInstancesService::list_server_cas] calls.
+    /// The request builder for [SqlInstancesService::list_server_cas][crate::client::SqlInstancesService::list_server_cas] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2493,7 +2493,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::patch][super::super::client::SqlInstancesService::patch] calls.
+    /// The request builder for [SqlInstancesService::patch][crate::client::SqlInstancesService::patch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2581,7 +2581,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::promote_replica][super::super::client::SqlInstancesService::promote_replica] calls.
+    /// The request builder for [SqlInstancesService::promote_replica][crate::client::SqlInstancesService::promote_replica] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2657,7 +2657,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::switchover][super::super::client::SqlInstancesService::switchover] calls.
+    /// The request builder for [SqlInstancesService::switchover][crate::client::SqlInstancesService::switchover] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2745,7 +2745,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::reset_ssl_config][super::super::client::SqlInstancesService::reset_ssl_config] calls.
+    /// The request builder for [SqlInstancesService::reset_ssl_config][crate::client::SqlInstancesService::reset_ssl_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2815,7 +2815,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::restart][super::super::client::SqlInstancesService::restart] calls.
+    /// The request builder for [SqlInstancesService::restart][crate::client::SqlInstancesService::restart] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2885,7 +2885,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::restore_backup][super::super::client::SqlInstancesService::restore_backup] calls.
+    /// The request builder for [SqlInstancesService::restore_backup][crate::client::SqlInstancesService::restore_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2973,7 +2973,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::rotate_server_ca][super::super::client::SqlInstancesService::rotate_server_ca] calls.
+    /// The request builder for [SqlInstancesService::rotate_server_ca][crate::client::SqlInstancesService::rotate_server_ca] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3061,7 +3061,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::start_replica][super::super::client::SqlInstancesService::start_replica] calls.
+    /// The request builder for [SqlInstancesService::start_replica][crate::client::SqlInstancesService::start_replica] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3131,7 +3131,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::stop_replica][super::super::client::SqlInstancesService::stop_replica] calls.
+    /// The request builder for [SqlInstancesService::stop_replica][crate::client::SqlInstancesService::stop_replica] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3201,7 +3201,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::truncate_log][super::super::client::SqlInstancesService::truncate_log] calls.
+    /// The request builder for [SqlInstancesService::truncate_log][crate::client::SqlInstancesService::truncate_log] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3289,7 +3289,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::update][super::super::client::SqlInstancesService::update] calls.
+    /// The request builder for [SqlInstancesService::update][crate::client::SqlInstancesService::update] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3377,7 +3377,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::create_ephemeral][super::super::client::SqlInstancesService::create_ephemeral] calls.
+    /// The request builder for [SqlInstancesService::create_ephemeral][crate::client::SqlInstancesService::create_ephemeral] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3467,7 +3467,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::reschedule_maintenance][super::super::client::SqlInstancesService::reschedule_maintenance] calls.
+    /// The request builder for [SqlInstancesService::reschedule_maintenance][crate::client::SqlInstancesService::reschedule_maintenance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3557,7 +3557,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::verify_external_sync_settings][super::super::client::SqlInstancesService::verify_external_sync_settings] calls.
+    /// The request builder for [SqlInstancesService::verify_external_sync_settings][crate::client::SqlInstancesService::verify_external_sync_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3711,7 +3711,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::start_external_sync][super::super::client::SqlInstancesService::start_external_sync] calls.
+    /// The request builder for [SqlInstancesService::start_external_sync][crate::client::SqlInstancesService::start_external_sync] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3851,7 +3851,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::perform_disk_shrink][super::super::client::SqlInstancesService::perform_disk_shrink] calls.
+    /// The request builder for [SqlInstancesService::perform_disk_shrink][crate::client::SqlInstancesService::perform_disk_shrink] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3941,7 +3941,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::get_disk_shrink_config][super::super::client::SqlInstancesService::get_disk_shrink_config] calls.
+    /// The request builder for [SqlInstancesService::get_disk_shrink_config][crate::client::SqlInstancesService::get_disk_shrink_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4013,7 +4013,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::reset_replica_size][super::super::client::SqlInstancesService::reset_replica_size] calls.
+    /// The request builder for [SqlInstancesService::reset_replica_size][crate::client::SqlInstancesService::reset_replica_size] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4083,7 +4083,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::get_latest_recovery_time][super::super::client::SqlInstancesService::get_latest_recovery_time] calls.
+    /// The request builder for [SqlInstancesService::get_latest_recovery_time][crate::client::SqlInstancesService::get_latest_recovery_time] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4155,7 +4155,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::acquire_ssrs_lease][super::super::client::SqlInstancesService::acquire_ssrs_lease] calls.
+    /// The request builder for [SqlInstancesService::acquire_ssrs_lease][crate::client::SqlInstancesService::acquire_ssrs_lease] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4251,7 +4251,7 @@ pub mod sql_instances_service {
         }
     }
 
-    /// The request builder for [SqlInstancesService::release_ssrs_lease][super::super::client::SqlInstancesService::release_ssrs_lease] calls.
+    /// The request builder for [SqlInstancesService::release_ssrs_lease][crate::client::SqlInstancesService::release_ssrs_lease] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4329,7 +4329,7 @@ pub mod sql_instances_service {
 pub mod sql_operations_service {
     use crate::Result;
 
-    /// A builder for [SqlOperationsService][super::super::client::SqlOperationsService].
+    /// A builder for [SqlOperationsService][crate::client::SqlOperationsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4357,7 +4357,7 @@ pub mod sql_operations_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlOperationsService] request builders.
+    /// Common implementation for [crate::client::SqlOperationsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlOperationsService>,
@@ -4380,7 +4380,7 @@ pub mod sql_operations_service {
         }
     }
 
-    /// The request builder for [SqlOperationsService::get][super::super::client::SqlOperationsService::get] calls.
+    /// The request builder for [SqlOperationsService::get][crate::client::SqlOperationsService::get] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4450,7 +4450,7 @@ pub mod sql_operations_service {
         }
     }
 
-    /// The request builder for [SqlOperationsService::list][super::super::client::SqlOperationsService::list] calls.
+    /// The request builder for [SqlOperationsService::list][crate::client::SqlOperationsService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4560,7 +4560,7 @@ pub mod sql_operations_service {
         }
     }
 
-    /// The request builder for [SqlOperationsService::cancel][super::super::client::SqlOperationsService::cancel] calls.
+    /// The request builder for [SqlOperationsService::cancel][crate::client::SqlOperationsService::cancel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4634,7 +4634,7 @@ pub mod sql_operations_service {
 pub mod sql_ssl_certs_service {
     use crate::Result;
 
-    /// A builder for [SqlSslCertsService][super::super::client::SqlSslCertsService].
+    /// A builder for [SqlSslCertsService][crate::client::SqlSslCertsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4662,7 +4662,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlSslCertsService] request builders.
+    /// Common implementation for [crate::client::SqlSslCertsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlSslCertsService>,
@@ -4685,7 +4685,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for [SqlSslCertsService::delete][super::super::client::SqlSslCertsService::delete] calls.
+    /// The request builder for [SqlSslCertsService::delete][crate::client::SqlSslCertsService::delete] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4761,7 +4761,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for [SqlSslCertsService::get][super::super::client::SqlSslCertsService::get] calls.
+    /// The request builder for [SqlSslCertsService::get][crate::client::SqlSslCertsService::get] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4834,7 +4834,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for [SqlSslCertsService::insert][super::super::client::SqlSslCertsService::insert] calls.
+    /// The request builder for [SqlSslCertsService::insert][crate::client::SqlSslCertsService::insert] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4922,7 +4922,7 @@ pub mod sql_ssl_certs_service {
         }
     }
 
-    /// The request builder for [SqlSslCertsService::list][super::super::client::SqlSslCertsService::list] calls.
+    /// The request builder for [SqlSslCertsService::list][crate::client::SqlSslCertsService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4993,7 +4993,7 @@ pub mod sql_ssl_certs_service {
 pub mod sql_tiers_service {
     use crate::Result;
 
-    /// A builder for [SqlTiersService][super::super::client::SqlTiersService].
+    /// A builder for [SqlTiersService][crate::client::SqlTiersService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5021,7 +5021,7 @@ pub mod sql_tiers_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlTiersService] request builders.
+    /// Common implementation for [crate::client::SqlTiersService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlTiersService>,
@@ -5044,7 +5044,7 @@ pub mod sql_tiers_service {
         }
     }
 
-    /// The request builder for [SqlTiersService::list][super::super::client::SqlTiersService::list] calls.
+    /// The request builder for [SqlTiersService::list][crate::client::SqlTiersService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5109,7 +5109,7 @@ pub mod sql_tiers_service {
 pub mod sql_users_service {
     use crate::Result;
 
-    /// A builder for [SqlUsersService][super::super::client::SqlUsersService].
+    /// A builder for [SqlUsersService][crate::client::SqlUsersService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5137,7 +5137,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SqlUsersService] request builders.
+    /// Common implementation for [crate::client::SqlUsersService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SqlUsersService>,
@@ -5160,7 +5160,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for [SqlUsersService::delete][super::super::client::SqlUsersService::delete] calls.
+    /// The request builder for [SqlUsersService::delete][crate::client::SqlUsersService::delete] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5239,7 +5239,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for [SqlUsersService::get][super::super::client::SqlUsersService::get] calls.
+    /// The request builder for [SqlUsersService::get][crate::client::SqlUsersService::get] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5318,7 +5318,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for [SqlUsersService::insert][super::super::client::SqlUsersService::insert] calls.
+    /// The request builder for [SqlUsersService::insert][crate::client::SqlUsersService::insert] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5403,7 +5403,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for [SqlUsersService::list][super::super::client::SqlUsersService::list] calls.
+    /// The request builder for [SqlUsersService::list][crate::client::SqlUsersService::list] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5470,7 +5470,7 @@ pub mod sql_users_service {
         }
     }
 
-    /// The request builder for [SqlUsersService::update][super::super::client::SqlUsersService::update] calls.
+    /// The request builder for [SqlUsersService::update][crate::client::SqlUsersService::update] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/storagebatchoperations/v1/src/builder.rs
+++ b/src/generated/cloud/storagebatchoperations/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod storage_batch_operations {
     use crate::Result;
 
-    /// A builder for [StorageBatchOperations][super::super::client::StorageBatchOperations].
+    /// A builder for [StorageBatchOperations][crate::client::StorageBatchOperations].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// Common implementation for [super::super::client::StorageBatchOperations] request builders.
+    /// Common implementation for [crate::client::StorageBatchOperations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::StorageBatchOperations>,
@@ -68,7 +68,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::list_jobs][super::super::client::StorageBatchOperations::list_jobs] calls.
+    /// The request builder for [StorageBatchOperations::list_jobs][crate::client::StorageBatchOperations::list_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::get_job][super::super::client::StorageBatchOperations::get_job] calls.
+    /// The request builder for [StorageBatchOperations::get_job][crate::client::StorageBatchOperations::get_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::create_job][super::super::client::StorageBatchOperations::create_job] calls.
+    /// The request builder for [StorageBatchOperations::create_job][crate::client::StorageBatchOperations::create_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -291,7 +291,7 @@ pub mod storage_batch_operations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_job][super::super::client::StorageBatchOperations::create_job].
+        /// on [create_job][crate::client::StorageBatchOperations::create_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_job(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::delete_job][super::super::client::StorageBatchOperations::delete_job] calls.
+    /// The request builder for [StorageBatchOperations::delete_job][crate::client::StorageBatchOperations::delete_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -453,7 +453,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::cancel_job][super::super::client::StorageBatchOperations::cancel_job] calls.
+    /// The request builder for [StorageBatchOperations::cancel_job][crate::client::StorageBatchOperations::cancel_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -522,7 +522,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::list_locations][super::super::client::StorageBatchOperations::list_locations] calls.
+    /// The request builder for [StorageBatchOperations::list_locations][crate::client::StorageBatchOperations::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -632,7 +632,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::get_location][super::super::client::StorageBatchOperations::get_location] calls.
+    /// The request builder for [StorageBatchOperations::get_location][crate::client::StorageBatchOperations::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -693,7 +693,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::list_operations][super::super::client::StorageBatchOperations::list_operations] calls.
+    /// The request builder for [StorageBatchOperations::list_operations][crate::client::StorageBatchOperations::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -805,7 +805,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::get_operation][super::super::client::StorageBatchOperations::get_operation] calls.
+    /// The request builder for [StorageBatchOperations::get_operation][crate::client::StorageBatchOperations::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -869,7 +869,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::delete_operation][super::super::client::StorageBatchOperations::delete_operation] calls.
+    /// The request builder for [StorageBatchOperations::delete_operation][crate::client::StorageBatchOperations::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -933,7 +933,7 @@ pub mod storage_batch_operations {
         }
     }
 
-    /// The request builder for [StorageBatchOperations::cancel_operation][super::super::client::StorageBatchOperations::cancel_operation] calls.
+    /// The request builder for [StorageBatchOperations::cancel_operation][crate::client::StorageBatchOperations::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/storageinsights/v1/src/builder.rs
+++ b/src/generated/cloud/storageinsights/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod storage_insights {
     use crate::Result;
 
-    /// A builder for [StorageInsights][super::super::client::StorageInsights].
+    /// A builder for [StorageInsights][crate::client::StorageInsights].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod storage_insights {
         }
     }
 
-    /// Common implementation for [super::super::client::StorageInsights] request builders.
+    /// Common implementation for [crate::client::StorageInsights] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::StorageInsights>,
@@ -68,7 +68,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::list_report_configs][super::super::client::StorageInsights::list_report_configs] calls.
+    /// The request builder for [StorageInsights::list_report_configs][crate::client::StorageInsights::list_report_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::get_report_config][super::super::client::StorageInsights::get_report_config] calls.
+    /// The request builder for [StorageInsights::get_report_config][crate::client::StorageInsights::get_report_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -249,7 +249,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::create_report_config][super::super::client::StorageInsights::create_report_config] calls.
+    /// The request builder for [StorageInsights::create_report_config][crate::client::StorageInsights::create_report_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -343,7 +343,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::update_report_config][super::super::client::StorageInsights::update_report_config] calls.
+    /// The request builder for [StorageInsights::update_report_config][crate::client::StorageInsights::update_report_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -451,7 +451,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::delete_report_config][super::super::client::StorageInsights::delete_report_config] calls.
+    /// The request builder for [StorageInsights::delete_report_config][crate::client::StorageInsights::delete_report_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -529,7 +529,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::list_report_details][super::super::client::StorageInsights::list_report_details] calls.
+    /// The request builder for [StorageInsights::list_report_details][crate::client::StorageInsights::list_report_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -647,7 +647,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::get_report_detail][super::super::client::StorageInsights::get_report_detail] calls.
+    /// The request builder for [StorageInsights::get_report_detail][crate::client::StorageInsights::get_report_detail] calls.
     ///
     /// # Example
     /// ```no_run
@@ -710,7 +710,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::list_locations][super::super::client::StorageInsights::list_locations] calls.
+    /// The request builder for [StorageInsights::list_locations][crate::client::StorageInsights::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -820,7 +820,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::get_location][super::super::client::StorageInsights::get_location] calls.
+    /// The request builder for [StorageInsights::get_location][crate::client::StorageInsights::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -881,7 +881,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::list_operations][super::super::client::StorageInsights::list_operations] calls.
+    /// The request builder for [StorageInsights::list_operations][crate::client::StorageInsights::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -993,7 +993,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::get_operation][super::super::client::StorageInsights::get_operation] calls.
+    /// The request builder for [StorageInsights::get_operation][crate::client::StorageInsights::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1057,7 +1057,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::delete_operation][super::super::client::StorageInsights::delete_operation] calls.
+    /// The request builder for [StorageInsights::delete_operation][crate::client::StorageInsights::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1121,7 +1121,7 @@ pub mod storage_insights {
         }
     }
 
-    /// The request builder for [StorageInsights::cancel_operation][super::super::client::StorageInsights::cancel_operation] calls.
+    /// The request builder for [StorageInsights::cancel_operation][crate::client::StorageInsights::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/support/v2/src/builder.rs
+++ b/src/generated/cloud/support/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod case_attachment_service {
     use crate::Result;
 
-    /// A builder for [CaseAttachmentService][super::super::client::CaseAttachmentService].
+    /// A builder for [CaseAttachmentService][crate::client::CaseAttachmentService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod case_attachment_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CaseAttachmentService] request builders.
+    /// Common implementation for [crate::client::CaseAttachmentService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CaseAttachmentService>,
@@ -68,7 +68,7 @@ pub mod case_attachment_service {
         }
     }
 
-    /// The request builder for [CaseAttachmentService::list_attachments][super::super::client::CaseAttachmentService::list_attachments] calls.
+    /// The request builder for [CaseAttachmentService::list_attachments][crate::client::CaseAttachmentService::list_attachments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -175,7 +175,7 @@ pub mod case_attachment_service {
 pub mod case_service {
     use crate::Result;
 
-    /// A builder for [CaseService][super::super::client::CaseService].
+    /// A builder for [CaseService][crate::client::CaseService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -203,7 +203,7 @@ pub mod case_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CaseService] request builders.
+    /// Common implementation for [crate::client::CaseService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CaseService>,
@@ -226,7 +226,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::get_case][super::super::client::CaseService::get_case] calls.
+    /// The request builder for [CaseService::get_case][crate::client::CaseService::get_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -289,7 +289,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::list_cases][super::super::client::CaseService::list_cases] calls.
+    /// The request builder for [CaseService::list_cases][crate::client::CaseService::list_cases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -398,7 +398,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::search_cases][super::super::client::CaseService::search_cases] calls.
+    /// The request builder for [CaseService::search_cases][crate::client::CaseService::search_cases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -505,7 +505,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::create_case][super::super::client::CaseService::create_case] calls.
+    /// The request builder for [CaseService::create_case][crate::client::CaseService::create_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -590,7 +590,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::update_case][super::super::client::CaseService::update_case] calls.
+    /// The request builder for [CaseService::update_case][crate::client::CaseService::update_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -685,7 +685,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::escalate_case][super::super::client::CaseService::escalate_case] calls.
+    /// The request builder for [CaseService::escalate_case][crate::client::CaseService::escalate_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -766,7 +766,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::close_case][super::super::client::CaseService::close_case] calls.
+    /// The request builder for [CaseService::close_case][crate::client::CaseService::close_case] calls.
     ///
     /// # Example
     /// ```no_run
@@ -829,7 +829,7 @@ pub mod case_service {
         }
     }
 
-    /// The request builder for [CaseService::search_case_classifications][super::super::client::CaseService::search_case_classifications] calls.
+    /// The request builder for [CaseService::search_case_classifications][crate::client::CaseService::search_case_classifications] calls.
     ///
     /// # Example
     /// ```no_run
@@ -943,7 +943,7 @@ pub mod case_service {
 pub mod comment_service {
     use crate::Result;
 
-    /// A builder for [CommentService][super::super::client::CommentService].
+    /// A builder for [CommentService][crate::client::CommentService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -971,7 +971,7 @@ pub mod comment_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CommentService] request builders.
+    /// Common implementation for [crate::client::CommentService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CommentService>,
@@ -994,7 +994,7 @@ pub mod comment_service {
         }
     }
 
-    /// The request builder for [CommentService::list_comments][super::super::client::CommentService::list_comments] calls.
+    /// The request builder for [CommentService::list_comments][crate::client::CommentService::list_comments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1097,7 +1097,7 @@ pub mod comment_service {
         }
     }
 
-    /// The request builder for [CommentService::create_comment][super::super::client::CommentService::create_comment] calls.
+    /// The request builder for [CommentService::create_comment][crate::client::CommentService::create_comment] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/talent/v4/src/builder.rs
+++ b/src/generated/cloud/talent/v4/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod company_service {
     use crate::Result;
 
-    /// A builder for [CompanyService][super::super::client::CompanyService].
+    /// A builder for [CompanyService][crate::client::CompanyService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod company_service {
         }
     }
 
-    /// Common implementation for [super::super::client::CompanyService] request builders.
+    /// Common implementation for [crate::client::CompanyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CompanyService>,
@@ -68,7 +68,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for [CompanyService::create_company][super::super::client::CompanyService::create_company] calls.
+    /// The request builder for [CompanyService::create_company][crate::client::CompanyService::create_company] calls.
     ///
     /// # Example
     /// ```no_run
@@ -153,7 +153,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for [CompanyService::get_company][super::super::client::CompanyService::get_company] calls.
+    /// The request builder for [CompanyService::get_company][crate::client::CompanyService::get_company] calls.
     ///
     /// # Example
     /// ```no_run
@@ -216,7 +216,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for [CompanyService::update_company][super::super::client::CompanyService::update_company] calls.
+    /// The request builder for [CompanyService::update_company][crate::client::CompanyService::update_company] calls.
     ///
     /// # Example
     /// ```no_run
@@ -311,7 +311,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for [CompanyService::delete_company][super::super::client::CompanyService::delete_company] calls.
+    /// The request builder for [CompanyService::delete_company][crate::client::CompanyService::delete_company] calls.
     ///
     /// # Example
     /// ```no_run
@@ -374,7 +374,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for [CompanyService::list_companies][super::super::client::CompanyService::list_companies] calls.
+    /// The request builder for [CompanyService::list_companies][crate::client::CompanyService::list_companies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -483,7 +483,7 @@ pub mod company_service {
         }
     }
 
-    /// The request builder for [CompanyService::get_operation][super::super::client::CompanyService::get_operation] calls.
+    /// The request builder for [CompanyService::get_operation][crate::client::CompanyService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -551,7 +551,7 @@ pub mod company_service {
 pub mod completion {
     use crate::Result;
 
-    /// A builder for [Completion][super::super::client::Completion].
+    /// A builder for [Completion][crate::client::Completion].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -579,7 +579,7 @@ pub mod completion {
         }
     }
 
-    /// Common implementation for [super::super::client::Completion] request builders.
+    /// Common implementation for [crate::client::Completion] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Completion>,
@@ -602,7 +602,7 @@ pub mod completion {
         }
     }
 
-    /// The request builder for [Completion::complete_query][super::super::client::Completion::complete_query] calls.
+    /// The request builder for [Completion::complete_query][crate::client::Completion::complete_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -716,7 +716,7 @@ pub mod completion {
         }
     }
 
-    /// The request builder for [Completion::get_operation][super::super::client::Completion::get_operation] calls.
+    /// The request builder for [Completion::get_operation][crate::client::Completion::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -784,7 +784,7 @@ pub mod completion {
 pub mod event_service {
     use crate::Result;
 
-    /// A builder for [EventService][super::super::client::EventService].
+    /// A builder for [EventService][crate::client::EventService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -812,7 +812,7 @@ pub mod event_service {
         }
     }
 
-    /// Common implementation for [super::super::client::EventService] request builders.
+    /// Common implementation for [crate::client::EventService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::EventService>,
@@ -835,7 +835,7 @@ pub mod event_service {
         }
     }
 
-    /// The request builder for [EventService::create_client_event][super::super::client::EventService::create_client_event] calls.
+    /// The request builder for [EventService::create_client_event][crate::client::EventService::create_client_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -923,7 +923,7 @@ pub mod event_service {
         }
     }
 
-    /// The request builder for [EventService::get_operation][super::super::client::EventService::get_operation] calls.
+    /// The request builder for [EventService::get_operation][crate::client::EventService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -991,7 +991,7 @@ pub mod event_service {
 pub mod job_service {
     use crate::Result;
 
-    /// A builder for [JobService][super::super::client::JobService].
+    /// A builder for [JobService][crate::client::JobService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1019,7 +1019,7 @@ pub mod job_service {
         }
     }
 
-    /// Common implementation for [super::super::client::JobService] request builders.
+    /// Common implementation for [crate::client::JobService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::JobService>,
@@ -1042,7 +1042,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::create_job][super::super::client::JobService::create_job] calls.
+    /// The request builder for [JobService::create_job][crate::client::JobService::create_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1127,7 +1127,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::batch_create_jobs][super::super::client::JobService::batch_create_jobs] calls.
+    /// The request builder for [JobService::batch_create_jobs][crate::client::JobService::batch_create_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1172,7 +1172,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_create_jobs][super::super::client::JobService::batch_create_jobs].
+        /// on [batch_create_jobs][crate::client::JobService::batch_create_jobs].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_create_jobs(self.0.request, self.0.options)
@@ -1245,7 +1245,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_job][super::super::client::JobService::get_job] calls.
+    /// The request builder for [JobService::get_job][crate::client::JobService::get_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1308,7 +1308,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::update_job][super::super::client::JobService::update_job] calls.
+    /// The request builder for [JobService::update_job][crate::client::JobService::update_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1403,7 +1403,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::batch_update_jobs][super::super::client::JobService::batch_update_jobs] calls.
+    /// The request builder for [JobService::batch_update_jobs][crate::client::JobService::batch_update_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1448,7 +1448,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_update_jobs][super::super::client::JobService::batch_update_jobs].
+        /// on [batch_update_jobs][crate::client::JobService::batch_update_jobs].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_update_jobs(self.0.request, self.0.options)
@@ -1539,7 +1539,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::delete_job][super::super::client::JobService::delete_job] calls.
+    /// The request builder for [JobService::delete_job][crate::client::JobService::delete_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1602,7 +1602,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::batch_delete_jobs][super::super::client::JobService::batch_delete_jobs] calls.
+    /// The request builder for [JobService::batch_delete_jobs][crate::client::JobService::batch_delete_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1647,7 +1647,7 @@ pub mod job_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_delete_jobs][super::super::client::JobService::batch_delete_jobs].
+        /// on [batch_delete_jobs][crate::client::JobService::batch_delete_jobs].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_delete_jobs(self.0.request, self.0.options)
@@ -1718,7 +1718,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::list_jobs][super::super::client::JobService::list_jobs] calls.
+    /// The request builder for [JobService::list_jobs][crate::client::JobService::list_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1835,7 +1835,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::search_jobs][super::super::client::JobService::search_jobs] calls.
+    /// The request builder for [JobService::search_jobs][crate::client::JobService::search_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2052,7 +2052,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::search_jobs_for_alert][super::super::client::JobService::search_jobs_for_alert] calls.
+    /// The request builder for [JobService::search_jobs_for_alert][crate::client::JobService::search_jobs_for_alert] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2269,7 +2269,7 @@ pub mod job_service {
         }
     }
 
-    /// The request builder for [JobService::get_operation][super::super::client::JobService::get_operation] calls.
+    /// The request builder for [JobService::get_operation][crate::client::JobService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2337,7 +2337,7 @@ pub mod job_service {
 pub mod tenant_service {
     use crate::Result;
 
-    /// A builder for [TenantService][super::super::client::TenantService].
+    /// A builder for [TenantService][crate::client::TenantService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2365,7 +2365,7 @@ pub mod tenant_service {
         }
     }
 
-    /// Common implementation for [super::super::client::TenantService] request builders.
+    /// Common implementation for [crate::client::TenantService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TenantService>,
@@ -2388,7 +2388,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for [TenantService::create_tenant][super::super::client::TenantService::create_tenant] calls.
+    /// The request builder for [TenantService::create_tenant][crate::client::TenantService::create_tenant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2473,7 +2473,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for [TenantService::get_tenant][super::super::client::TenantService::get_tenant] calls.
+    /// The request builder for [TenantService::get_tenant][crate::client::TenantService::get_tenant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2536,7 +2536,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for [TenantService::update_tenant][super::super::client::TenantService::update_tenant] calls.
+    /// The request builder for [TenantService::update_tenant][crate::client::TenantService::update_tenant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2631,7 +2631,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for [TenantService::delete_tenant][super::super::client::TenantService::delete_tenant] calls.
+    /// The request builder for [TenantService::delete_tenant][crate::client::TenantService::delete_tenant] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2694,7 +2694,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for [TenantService::list_tenants][super::super::client::TenantService::list_tenants] calls.
+    /// The request builder for [TenantService::list_tenants][crate::client::TenantService::list_tenants] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2797,7 +2797,7 @@ pub mod tenant_service {
         }
     }
 
-    /// The request builder for [TenantService::get_operation][super::super::client::TenantService::get_operation] calls.
+    /// The request builder for [TenantService::get_operation][crate::client::TenantService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/tasks/v2/src/builder.rs
+++ b/src/generated/cloud/tasks/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_tasks {
     use crate::Result;
 
-    /// A builder for [CloudTasks][super::super::client::CloudTasks].
+    /// A builder for [CloudTasks][crate::client::CloudTasks].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudTasks] request builders.
+    /// Common implementation for [crate::client::CloudTasks] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudTasks>,
@@ -68,7 +68,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::list_queues][super::super::client::CloudTasks::list_queues] calls.
+    /// The request builder for [CloudTasks::list_queues][crate::client::CloudTasks::list_queues] calls.
     ///
     /// # Example
     /// ```no_run
@@ -177,7 +177,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::get_queue][super::super::client::CloudTasks::get_queue] calls.
+    /// The request builder for [CloudTasks::get_queue][crate::client::CloudTasks::get_queue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::create_queue][super::super::client::CloudTasks::create_queue] calls.
+    /// The request builder for [CloudTasks::create_queue][crate::client::CloudTasks::create_queue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -325,7 +325,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::update_queue][super::super::client::CloudTasks::update_queue] calls.
+    /// The request builder for [CloudTasks::update_queue][crate::client::CloudTasks::update_queue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -420,7 +420,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::delete_queue][super::super::client::CloudTasks::delete_queue] calls.
+    /// The request builder for [CloudTasks::delete_queue][crate::client::CloudTasks::delete_queue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -483,7 +483,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::purge_queue][super::super::client::CloudTasks::purge_queue] calls.
+    /// The request builder for [CloudTasks::purge_queue][crate::client::CloudTasks::purge_queue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -546,7 +546,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::pause_queue][super::super::client::CloudTasks::pause_queue] calls.
+    /// The request builder for [CloudTasks::pause_queue][crate::client::CloudTasks::pause_queue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -609,7 +609,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::resume_queue][super::super::client::CloudTasks::resume_queue] calls.
+    /// The request builder for [CloudTasks::resume_queue][crate::client::CloudTasks::resume_queue] calls.
     ///
     /// # Example
     /// ```no_run
@@ -672,7 +672,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::get_iam_policy][super::super::client::CloudTasks::get_iam_policy] calls.
+    /// The request builder for [CloudTasks::get_iam_policy][crate::client::CloudTasks::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -753,7 +753,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::set_iam_policy][super::super::client::CloudTasks::set_iam_policy] calls.
+    /// The request builder for [CloudTasks::set_iam_policy][crate::client::CloudTasks::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -856,7 +856,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::test_iam_permissions][super::super::client::CloudTasks::test_iam_permissions] calls.
+    /// The request builder for [CloudTasks::test_iam_permissions][crate::client::CloudTasks::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -935,7 +935,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::list_tasks][super::super::client::CloudTasks::list_tasks] calls.
+    /// The request builder for [CloudTasks::list_tasks][crate::client::CloudTasks::list_tasks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1044,7 +1044,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::get_task][super::super::client::CloudTasks::get_task] calls.
+    /// The request builder for [CloudTasks::get_task][crate::client::CloudTasks::get_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1113,7 +1113,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::create_task][super::super::client::CloudTasks::create_task] calls.
+    /// The request builder for [CloudTasks::create_task][crate::client::CloudTasks::create_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1204,7 +1204,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::delete_task][super::super::client::CloudTasks::delete_task] calls.
+    /// The request builder for [CloudTasks::delete_task][crate::client::CloudTasks::delete_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1267,7 +1267,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::run_task][super::super::client::CloudTasks::run_task] calls.
+    /// The request builder for [CloudTasks::run_task][crate::client::CloudTasks::run_task] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1336,7 +1336,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::list_locations][super::super::client::CloudTasks::list_locations] calls.
+    /// The request builder for [CloudTasks::list_locations][crate::client::CloudTasks::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1446,7 +1446,7 @@ pub mod cloud_tasks {
         }
     }
 
-    /// The request builder for [CloudTasks::get_location][super::super::client::CloudTasks::get_location] calls.
+    /// The request builder for [CloudTasks::get_location][crate::client::CloudTasks::get_location] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/telcoautomation/v1/src/builder.rs
+++ b/src/generated/cloud/telcoautomation/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod telco_automation {
     use crate::Result;
 
-    /// A builder for [TelcoAutomation][super::super::client::TelcoAutomation].
+    /// A builder for [TelcoAutomation][crate::client::TelcoAutomation].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod telco_automation {
         }
     }
 
-    /// Common implementation for [super::super::client::TelcoAutomation] request builders.
+    /// Common implementation for [crate::client::TelcoAutomation] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TelcoAutomation>,
@@ -68,7 +68,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_orchestration_clusters][super::super::client::TelcoAutomation::list_orchestration_clusters] calls.
+    /// The request builder for [TelcoAutomation::list_orchestration_clusters][crate::client::TelcoAutomation::list_orchestration_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -192,7 +192,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_orchestration_cluster][super::super::client::TelcoAutomation::get_orchestration_cluster] calls.
+    /// The request builder for [TelcoAutomation::get_orchestration_cluster][crate::client::TelcoAutomation::get_orchestration_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -260,7 +260,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::create_orchestration_cluster][super::super::client::TelcoAutomation::create_orchestration_cluster] calls.
+    /// The request builder for [TelcoAutomation::create_orchestration_cluster][crate::client::TelcoAutomation::create_orchestration_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -310,7 +310,7 @@ pub mod telco_automation {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_orchestration_cluster][super::super::client::TelcoAutomation::create_orchestration_cluster].
+        /// on [create_orchestration_cluster][crate::client::TelcoAutomation::create_orchestration_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_orchestration_cluster(self.0.request, self.0.options)
@@ -406,7 +406,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::delete_orchestration_cluster][super::super::client::TelcoAutomation::delete_orchestration_cluster] calls.
+    /// The request builder for [TelcoAutomation::delete_orchestration_cluster][crate::client::TelcoAutomation::delete_orchestration_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -456,7 +456,7 @@ pub mod telco_automation {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_orchestration_cluster][super::super::client::TelcoAutomation::delete_orchestration_cluster].
+        /// on [delete_orchestration_cluster][crate::client::TelcoAutomation::delete_orchestration_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_orchestration_cluster(self.0.request, self.0.options)
@@ -521,7 +521,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_edge_slms][super::super::client::TelcoAutomation::list_edge_slms] calls.
+    /// The request builder for [TelcoAutomation::list_edge_slms][crate::client::TelcoAutomation::list_edge_slms] calls.
     ///
     /// # Example
     /// ```no_run
@@ -636,7 +636,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_edge_slm][super::super::client::TelcoAutomation::get_edge_slm] calls.
+    /// The request builder for [TelcoAutomation::get_edge_slm][crate::client::TelcoAutomation::get_edge_slm] calls.
     ///
     /// # Example
     /// ```no_run
@@ -699,7 +699,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::create_edge_slm][super::super::client::TelcoAutomation::create_edge_slm] calls.
+    /// The request builder for [TelcoAutomation::create_edge_slm][crate::client::TelcoAutomation::create_edge_slm] calls.
     ///
     /// # Example
     /// ```no_run
@@ -744,7 +744,7 @@ pub mod telco_automation {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_edge_slm][super::super::client::TelcoAutomation::create_edge_slm].
+        /// on [create_edge_slm][crate::client::TelcoAutomation::create_edge_slm].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_edge_slm(self.0.request, self.0.options)
@@ -837,7 +837,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::delete_edge_slm][super::super::client::TelcoAutomation::delete_edge_slm] calls.
+    /// The request builder for [TelcoAutomation::delete_edge_slm][crate::client::TelcoAutomation::delete_edge_slm] calls.
     ///
     /// # Example
     /// ```no_run
@@ -882,7 +882,7 @@ pub mod telco_automation {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_edge_slm][super::super::client::TelcoAutomation::delete_edge_slm].
+        /// on [delete_edge_slm][crate::client::TelcoAutomation::delete_edge_slm].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_edge_slm(self.0.request, self.0.options)
@@ -947,7 +947,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::create_blueprint][super::super::client::TelcoAutomation::create_blueprint] calls.
+    /// The request builder for [TelcoAutomation::create_blueprint][crate::client::TelcoAutomation::create_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1038,7 +1038,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::update_blueprint][super::super::client::TelcoAutomation::update_blueprint] calls.
+    /// The request builder for [TelcoAutomation::update_blueprint][crate::client::TelcoAutomation::update_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1137,7 +1137,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_blueprint][super::super::client::TelcoAutomation::get_blueprint] calls.
+    /// The request builder for [TelcoAutomation::get_blueprint][crate::client::TelcoAutomation::get_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1206,7 +1206,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::delete_blueprint][super::super::client::TelcoAutomation::delete_blueprint] calls.
+    /// The request builder for [TelcoAutomation::delete_blueprint][crate::client::TelcoAutomation::delete_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1269,7 +1269,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_blueprints][super::super::client::TelcoAutomation::list_blueprints] calls.
+    /// The request builder for [TelcoAutomation::list_blueprints][crate::client::TelcoAutomation::list_blueprints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1378,7 +1378,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::approve_blueprint][super::super::client::TelcoAutomation::approve_blueprint] calls.
+    /// The request builder for [TelcoAutomation::approve_blueprint][crate::client::TelcoAutomation::approve_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1444,7 +1444,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::propose_blueprint][super::super::client::TelcoAutomation::propose_blueprint] calls.
+    /// The request builder for [TelcoAutomation::propose_blueprint][crate::client::TelcoAutomation::propose_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1510,7 +1510,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::reject_blueprint][super::super::client::TelcoAutomation::reject_blueprint] calls.
+    /// The request builder for [TelcoAutomation::reject_blueprint][crate::client::TelcoAutomation::reject_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1573,7 +1573,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_blueprint_revisions][super::super::client::TelcoAutomation::list_blueprint_revisions] calls.
+    /// The request builder for [TelcoAutomation::list_blueprint_revisions][crate::client::TelcoAutomation::list_blueprint_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1683,7 +1683,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::search_blueprint_revisions][super::super::client::TelcoAutomation::search_blueprint_revisions] calls.
+    /// The request builder for [TelcoAutomation::search_blueprint_revisions][crate::client::TelcoAutomation::search_blueprint_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1803,7 +1803,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::search_deployment_revisions][super::super::client::TelcoAutomation::search_deployment_revisions] calls.
+    /// The request builder for [TelcoAutomation::search_deployment_revisions][crate::client::TelcoAutomation::search_deployment_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1923,7 +1923,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::discard_blueprint_changes][super::super::client::TelcoAutomation::discard_blueprint_changes] calls.
+    /// The request builder for [TelcoAutomation::discard_blueprint_changes][crate::client::TelcoAutomation::discard_blueprint_changes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1991,7 +1991,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_public_blueprints][super::super::client::TelcoAutomation::list_public_blueprints] calls.
+    /// The request builder for [TelcoAutomation::list_public_blueprints][crate::client::TelcoAutomation::list_public_blueprints] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2099,7 +2099,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_public_blueprint][super::super::client::TelcoAutomation::get_public_blueprint] calls.
+    /// The request builder for [TelcoAutomation::get_public_blueprint][crate::client::TelcoAutomation::get_public_blueprint] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2165,7 +2165,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::create_deployment][super::super::client::TelcoAutomation::create_deployment] calls.
+    /// The request builder for [TelcoAutomation::create_deployment][crate::client::TelcoAutomation::create_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2259,7 +2259,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::update_deployment][super::super::client::TelcoAutomation::update_deployment] calls.
+    /// The request builder for [TelcoAutomation::update_deployment][crate::client::TelcoAutomation::update_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2361,7 +2361,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_deployment][super::super::client::TelcoAutomation::get_deployment] calls.
+    /// The request builder for [TelcoAutomation::get_deployment][crate::client::TelcoAutomation::get_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2430,7 +2430,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::remove_deployment][super::super::client::TelcoAutomation::remove_deployment] calls.
+    /// The request builder for [TelcoAutomation::remove_deployment][crate::client::TelcoAutomation::remove_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2496,7 +2496,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_deployments][super::super::client::TelcoAutomation::list_deployments] calls.
+    /// The request builder for [TelcoAutomation::list_deployments][crate::client::TelcoAutomation::list_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2605,7 +2605,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_deployment_revisions][super::super::client::TelcoAutomation::list_deployment_revisions] calls.
+    /// The request builder for [TelcoAutomation::list_deployment_revisions][crate::client::TelcoAutomation::list_deployment_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2717,7 +2717,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::discard_deployment_changes][super::super::client::TelcoAutomation::discard_deployment_changes] calls.
+    /// The request builder for [TelcoAutomation::discard_deployment_changes][crate::client::TelcoAutomation::discard_deployment_changes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2785,7 +2785,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::apply_deployment][super::super::client::TelcoAutomation::apply_deployment] calls.
+    /// The request builder for [TelcoAutomation::apply_deployment][crate::client::TelcoAutomation::apply_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2848,7 +2848,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::compute_deployment_status][super::super::client::TelcoAutomation::compute_deployment_status] calls.
+    /// The request builder for [TelcoAutomation::compute_deployment_status][crate::client::TelcoAutomation::compute_deployment_status] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2916,7 +2916,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::rollback_deployment][super::super::client::TelcoAutomation::rollback_deployment] calls.
+    /// The request builder for [TelcoAutomation::rollback_deployment][crate::client::TelcoAutomation::rollback_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2990,7 +2990,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_hydrated_deployment][super::super::client::TelcoAutomation::get_hydrated_deployment] calls.
+    /// The request builder for [TelcoAutomation::get_hydrated_deployment][crate::client::TelcoAutomation::get_hydrated_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3056,7 +3056,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_hydrated_deployments][super::super::client::TelcoAutomation::list_hydrated_deployments] calls.
+    /// The request builder for [TelcoAutomation::list_hydrated_deployments][crate::client::TelcoAutomation::list_hydrated_deployments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3168,7 +3168,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::update_hydrated_deployment][super::super::client::TelcoAutomation::update_hydrated_deployment] calls.
+    /// The request builder for [TelcoAutomation::update_hydrated_deployment][crate::client::TelcoAutomation::update_hydrated_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3272,7 +3272,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::apply_hydrated_deployment][super::super::client::TelcoAutomation::apply_hydrated_deployment] calls.
+    /// The request builder for [TelcoAutomation::apply_hydrated_deployment][crate::client::TelcoAutomation::apply_hydrated_deployment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3340,7 +3340,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_locations][super::super::client::TelcoAutomation::list_locations] calls.
+    /// The request builder for [TelcoAutomation::list_locations][crate::client::TelcoAutomation::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3450,7 +3450,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_location][super::super::client::TelcoAutomation::get_location] calls.
+    /// The request builder for [TelcoAutomation::get_location][crate::client::TelcoAutomation::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3511,7 +3511,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::list_operations][super::super::client::TelcoAutomation::list_operations] calls.
+    /// The request builder for [TelcoAutomation::list_operations][crate::client::TelcoAutomation::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3623,7 +3623,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::get_operation][super::super::client::TelcoAutomation::get_operation] calls.
+    /// The request builder for [TelcoAutomation::get_operation][crate::client::TelcoAutomation::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3687,7 +3687,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::delete_operation][super::super::client::TelcoAutomation::delete_operation] calls.
+    /// The request builder for [TelcoAutomation::delete_operation][crate::client::TelcoAutomation::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3751,7 +3751,7 @@ pub mod telco_automation {
         }
     }
 
-    /// The request builder for [TelcoAutomation::cancel_operation][super::super::client::TelcoAutomation::cancel_operation] calls.
+    /// The request builder for [TelcoAutomation::cancel_operation][crate::client::TelcoAutomation::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/texttospeech/v1/src/builder.rs
+++ b/src/generated/cloud/texttospeech/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod text_to_speech {
     use crate::Result;
 
-    /// A builder for [TextToSpeech][super::super::client::TextToSpeech].
+    /// A builder for [TextToSpeech][crate::client::TextToSpeech].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// Common implementation for [super::super::client::TextToSpeech] request builders.
+    /// Common implementation for [crate::client::TextToSpeech] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TextToSpeech>,
@@ -68,7 +68,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for [TextToSpeech::list_voices][super::super::client::TextToSpeech::list_voices] calls.
+    /// The request builder for [TextToSpeech::list_voices][crate::client::TextToSpeech::list_voices] calls.
     ///
     /// # Example
     /// ```no_run
@@ -129,7 +129,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for [TextToSpeech::synthesize_speech][super::super::client::TextToSpeech::synthesize_speech] calls.
+    /// The request builder for [TextToSpeech::synthesize_speech][crate::client::TextToSpeech::synthesize_speech] calls.
     ///
     /// # Example
     /// ```no_run
@@ -271,7 +271,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for [TextToSpeech::list_operations][super::super::client::TextToSpeech::list_operations] calls.
+    /// The request builder for [TextToSpeech::list_operations][crate::client::TextToSpeech::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -383,7 +383,7 @@ pub mod text_to_speech {
         }
     }
 
-    /// The request builder for [TextToSpeech::get_operation][super::super::client::TextToSpeech::get_operation] calls.
+    /// The request builder for [TextToSpeech::get_operation][crate::client::TextToSpeech::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -451,7 +451,7 @@ pub mod text_to_speech {
 pub mod text_to_speech_long_audio_synthesize {
     use crate::Result;
 
-    /// A builder for [TextToSpeechLongAudioSynthesize][super::super::client::TextToSpeechLongAudioSynthesize].
+    /// A builder for [TextToSpeechLongAudioSynthesize][crate::client::TextToSpeechLongAudioSynthesize].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -479,7 +479,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    /// Common implementation for [super::super::client::TextToSpeechLongAudioSynthesize] request builders.
+    /// Common implementation for [crate::client::TextToSpeechLongAudioSynthesize] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TextToSpeechLongAudioSynthesize>,
@@ -502,7 +502,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    /// The request builder for [TextToSpeechLongAudioSynthesize::synthesize_long_audio][super::super::client::TextToSpeechLongAudioSynthesize::synthesize_long_audio] calls.
+    /// The request builder for [TextToSpeechLongAudioSynthesize::synthesize_long_audio][crate::client::TextToSpeechLongAudioSynthesize::synthesize_long_audio] calls.
     ///
     /// # Example
     /// ```no_run
@@ -550,7 +550,7 @@ pub mod text_to_speech_long_audio_synthesize {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [synthesize_long_audio][super::super::client::TextToSpeechLongAudioSynthesize::synthesize_long_audio].
+        /// on [synthesize_long_audio][crate::client::TextToSpeechLongAudioSynthesize::synthesize_long_audio].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .synthesize_long_audio(self.0.request, self.0.options)
@@ -684,7 +684,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    /// The request builder for [TextToSpeechLongAudioSynthesize::list_operations][super::super::client::TextToSpeechLongAudioSynthesize::list_operations] calls.
+    /// The request builder for [TextToSpeechLongAudioSynthesize::list_operations][crate::client::TextToSpeechLongAudioSynthesize::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -796,7 +796,7 @@ pub mod text_to_speech_long_audio_synthesize {
         }
     }
 
-    /// The request builder for [TextToSpeechLongAudioSynthesize::get_operation][super::super::client::TextToSpeechLongAudioSynthesize::get_operation] calls.
+    /// The request builder for [TextToSpeechLongAudioSynthesize::get_operation][crate::client::TextToSpeechLongAudioSynthesize::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
+++ b/src/generated/cloud/timeseriesinsights/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod timeseries_insights_controller {
     use crate::Result;
 
-    /// A builder for [TimeseriesInsightsController][super::super::client::TimeseriesInsightsController].
+    /// A builder for [TimeseriesInsightsController][crate::client::TimeseriesInsightsController].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// Common implementation for [super::super::client::TimeseriesInsightsController] request builders.
+    /// Common implementation for [crate::client::TimeseriesInsightsController] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TimeseriesInsightsController>,
@@ -68,7 +68,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for [TimeseriesInsightsController::list_data_sets][super::super::client::TimeseriesInsightsController::list_data_sets] calls.
+    /// The request builder for [TimeseriesInsightsController::list_data_sets][crate::client::TimeseriesInsightsController::list_data_sets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for [TimeseriesInsightsController::create_data_set][super::super::client::TimeseriesInsightsController::create_data_set] calls.
+    /// The request builder for [TimeseriesInsightsController::create_data_set][crate::client::TimeseriesInsightsController::create_data_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -256,7 +256,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for [TimeseriesInsightsController::delete_data_set][super::super::client::TimeseriesInsightsController::delete_data_set] calls.
+    /// The request builder for [TimeseriesInsightsController::delete_data_set][crate::client::TimeseriesInsightsController::delete_data_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -319,7 +319,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for [TimeseriesInsightsController::append_events][super::super::client::TimeseriesInsightsController::append_events] calls.
+    /// The request builder for [TimeseriesInsightsController::append_events][crate::client::TimeseriesInsightsController::append_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -393,7 +393,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for [TimeseriesInsightsController::query_data_set][super::super::client::TimeseriesInsightsController::query_data_set] calls.
+    /// The request builder for [TimeseriesInsightsController::query_data_set][crate::client::TimeseriesInsightsController::query_data_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -556,7 +556,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for [TimeseriesInsightsController::evaluate_slice][super::super::client::TimeseriesInsightsController::evaluate_slice] calls.
+    /// The request builder for [TimeseriesInsightsController::evaluate_slice][crate::client::TimeseriesInsightsController::evaluate_slice] calls.
     ///
     /// # Example
     /// ```no_run
@@ -690,7 +690,7 @@ pub mod timeseries_insights_controller {
         }
     }
 
-    /// The request builder for [TimeseriesInsightsController::evaluate_timeseries][super::super::client::TimeseriesInsightsController::evaluate_timeseries] calls.
+    /// The request builder for [TimeseriesInsightsController::evaluate_timeseries][crate::client::TimeseriesInsightsController::evaluate_timeseries] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/tpu/v2/src/builder.rs
+++ b/src/generated/cloud/tpu/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod tpu {
     use crate::Result;
 
-    /// A builder for [Tpu][super::super::client::Tpu].
+    /// A builder for [Tpu][crate::client::Tpu].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod tpu {
         }
     }
 
-    /// Common implementation for [super::super::client::Tpu] request builders.
+    /// Common implementation for [crate::client::Tpu] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Tpu>,
@@ -66,7 +66,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::list_nodes][super::super::client::Tpu::list_nodes] calls.
+    /// The request builder for [Tpu::list_nodes][crate::client::Tpu::list_nodes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -167,7 +167,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::get_node][super::super::client::Tpu::get_node] calls.
+    /// The request builder for [Tpu::get_node][crate::client::Tpu::get_node] calls.
     ///
     /// # Example
     /// ```no_run
@@ -228,7 +228,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::create_node][super::super::client::Tpu::create_node] calls.
+    /// The request builder for [Tpu::create_node][crate::client::Tpu::create_node] calls.
     ///
     /// # Example
     /// ```no_run
@@ -271,7 +271,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_node][super::super::client::Tpu::create_node].
+        /// on [create_node][crate::client::Tpu::create_node].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_node(self.0.request, self.0.options)
@@ -356,7 +356,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::delete_node][super::super::client::Tpu::delete_node] calls.
+    /// The request builder for [Tpu::delete_node][crate::client::Tpu::delete_node] calls.
     ///
     /// # Example
     /// ```no_run
@@ -399,7 +399,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_node][super::super::client::Tpu::delete_node].
+        /// on [delete_node][crate::client::Tpu::delete_node].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_node(self.0.request, self.0.options)
@@ -458,7 +458,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::stop_node][super::super::client::Tpu::stop_node] calls.
+    /// The request builder for [Tpu::stop_node][crate::client::Tpu::stop_node] calls.
     ///
     /// # Example
     /// ```no_run
@@ -501,7 +501,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_node][super::super::client::Tpu::stop_node].
+        /// on [stop_node][crate::client::Tpu::stop_node].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_node(self.0.request, self.0.options)
@@ -558,7 +558,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::start_node][super::super::client::Tpu::start_node] calls.
+    /// The request builder for [Tpu::start_node][crate::client::Tpu::start_node] calls.
     ///
     /// # Example
     /// ```no_run
@@ -601,7 +601,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_node][super::super::client::Tpu::start_node].
+        /// on [start_node][crate::client::Tpu::start_node].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_node(self.0.request, self.0.options)
@@ -658,7 +658,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::update_node][super::super::client::Tpu::update_node] calls.
+    /// The request builder for [Tpu::update_node][crate::client::Tpu::update_node] calls.
     ///
     /// # Example
     /// ```no_run
@@ -701,7 +701,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_node][super::super::client::Tpu::update_node].
+        /// on [update_node][crate::client::Tpu::update_node].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_node(self.0.request, self.0.options)
@@ -794,7 +794,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::list_queued_resources][super::super::client::Tpu::list_queued_resources] calls.
+    /// The request builder for [Tpu::list_queued_resources][crate::client::Tpu::list_queued_resources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -900,7 +900,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::get_queued_resource][super::super::client::Tpu::get_queued_resource] calls.
+    /// The request builder for [Tpu::get_queued_resource][crate::client::Tpu::get_queued_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -964,7 +964,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::create_queued_resource][super::super::client::Tpu::create_queued_resource] calls.
+    /// The request builder for [Tpu::create_queued_resource][crate::client::Tpu::create_queued_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1010,7 +1010,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_queued_resource][super::super::client::Tpu::create_queued_resource].
+        /// on [create_queued_resource][crate::client::Tpu::create_queued_resource].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_queued_resource(self.0.request, self.0.options)
@@ -1104,7 +1104,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::delete_queued_resource][super::super::client::Tpu::delete_queued_resource] calls.
+    /// The request builder for [Tpu::delete_queued_resource][crate::client::Tpu::delete_queued_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1150,7 +1150,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_queued_resource][super::super::client::Tpu::delete_queued_resource].
+        /// on [delete_queued_resource][crate::client::Tpu::delete_queued_resource].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_queued_resource(self.0.request, self.0.options)
@@ -1221,7 +1221,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::reset_queued_resource][super::super::client::Tpu::reset_queued_resource] calls.
+    /// The request builder for [Tpu::reset_queued_resource][crate::client::Tpu::reset_queued_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1267,7 +1267,7 @@ pub mod tpu {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reset_queued_resource][super::super::client::Tpu::reset_queued_resource].
+        /// on [reset_queued_resource][crate::client::Tpu::reset_queued_resource].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reset_queued_resource(self.0.request, self.0.options)
@@ -1327,7 +1327,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::generate_service_identity][super::super::client::Tpu::generate_service_identity] calls.
+    /// The request builder for [Tpu::generate_service_identity][crate::client::Tpu::generate_service_identity] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1393,7 +1393,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::list_accelerator_types][super::super::client::Tpu::list_accelerator_types] calls.
+    /// The request builder for [Tpu::list_accelerator_types][crate::client::Tpu::list_accelerator_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1511,7 +1511,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::get_accelerator_type][super::super::client::Tpu::get_accelerator_type] calls.
+    /// The request builder for [Tpu::get_accelerator_type][crate::client::Tpu::get_accelerator_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1575,7 +1575,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::list_runtime_versions][super::super::client::Tpu::list_runtime_versions] calls.
+    /// The request builder for [Tpu::list_runtime_versions][crate::client::Tpu::list_runtime_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1693,7 +1693,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::get_runtime_version][super::super::client::Tpu::get_runtime_version] calls.
+    /// The request builder for [Tpu::get_runtime_version][crate::client::Tpu::get_runtime_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1757,7 +1757,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::get_guest_attributes][super::super::client::Tpu::get_guest_attributes] calls.
+    /// The request builder for [Tpu::get_guest_attributes][crate::client::Tpu::get_guest_attributes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1838,7 +1838,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::list_locations][super::super::client::Tpu::list_locations] calls.
+    /// The request builder for [Tpu::list_locations][crate::client::Tpu::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1946,7 +1946,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::get_location][super::super::client::Tpu::get_location] calls.
+    /// The request builder for [Tpu::get_location][crate::client::Tpu::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2005,7 +2005,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::list_operations][super::super::client::Tpu::list_operations] calls.
+    /// The request builder for [Tpu::list_operations][crate::client::Tpu::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2115,7 +2115,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::get_operation][super::super::client::Tpu::get_operation] calls.
+    /// The request builder for [Tpu::get_operation][crate::client::Tpu::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2177,7 +2177,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::delete_operation][super::super::client::Tpu::delete_operation] calls.
+    /// The request builder for [Tpu::delete_operation][crate::client::Tpu::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2239,7 +2239,7 @@ pub mod tpu {
         }
     }
 
-    /// The request builder for [Tpu::cancel_operation][super::super::client::Tpu::cancel_operation] calls.
+    /// The request builder for [Tpu::cancel_operation][crate::client::Tpu::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/translate/v3/src/builder.rs
+++ b/src/generated/cloud/translate/v3/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod translation_service {
     use crate::Result;
 
-    /// A builder for [TranslationService][super::super::client::TranslationService].
+    /// A builder for [TranslationService][crate::client::TranslationService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod translation_service {
         }
     }
 
-    /// Common implementation for [super::super::client::TranslationService] request builders.
+    /// Common implementation for [crate::client::TranslationService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TranslationService>,
@@ -68,7 +68,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::translate_text][super::super::client::TranslationService::translate_text] calls.
+    /// The request builder for [TranslationService::translate_text][crate::client::TranslationService::translate_text] calls.
     ///
     /// # Example
     /// ```no_run
@@ -217,7 +217,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::romanize_text][super::super::client::TranslationService::romanize_text] calls.
+    /// The request builder for [TranslationService::romanize_text][crate::client::TranslationService::romanize_text] calls.
     ///
     /// # Example
     /// ```no_run
@@ -299,7 +299,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::detect_language][super::super::client::TranslationService::detect_language] calls.
+    /// The request builder for [TranslationService::detect_language][crate::client::TranslationService::detect_language] calls.
     ///
     /// # Example
     /// ```no_run
@@ -407,7 +407,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_supported_languages][super::super::client::TranslationService::get_supported_languages] calls.
+    /// The request builder for [TranslationService::get_supported_languages][crate::client::TranslationService::get_supported_languages] calls.
     ///
     /// # Example
     /// ```no_run
@@ -485,7 +485,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::translate_document][super::super::client::TranslationService::translate_document] calls.
+    /// The request builder for [TranslationService::translate_document][crate::client::TranslationService::translate_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -664,7 +664,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::batch_translate_text][super::super::client::TranslationService::batch_translate_text] calls.
+    /// The request builder for [TranslationService::batch_translate_text][crate::client::TranslationService::batch_translate_text] calls.
     ///
     /// # Example
     /// ```no_run
@@ -712,7 +712,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_translate_text][super::super::client::TranslationService::batch_translate_text].
+        /// on [batch_translate_text][crate::client::TranslationService::batch_translate_text].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_translate_text(self.0.request, self.0.options)
@@ -861,7 +861,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::batch_translate_document][super::super::client::TranslationService::batch_translate_document] calls.
+    /// The request builder for [TranslationService::batch_translate_document][crate::client::TranslationService::batch_translate_document] calls.
     ///
     /// # Example
     /// ```no_run
@@ -909,7 +909,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_translate_document][super::super::client::TranslationService::batch_translate_document].
+        /// on [batch_translate_document][crate::client::TranslationService::batch_translate_document].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_translate_document(self.0.request, self.0.options)
@@ -1079,7 +1079,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::create_glossary][super::super::client::TranslationService::create_glossary] calls.
+    /// The request builder for [TranslationService::create_glossary][crate::client::TranslationService::create_glossary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1124,7 +1124,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_glossary][super::super::client::TranslationService::create_glossary].
+        /// on [create_glossary][crate::client::TranslationService::create_glossary].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_glossary(self.0.request, self.0.options)
@@ -1206,7 +1206,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::update_glossary][super::super::client::TranslationService::update_glossary] calls.
+    /// The request builder for [TranslationService::update_glossary][crate::client::TranslationService::update_glossary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1251,7 +1251,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_glossary][super::super::client::TranslationService::update_glossary].
+        /// on [update_glossary][crate::client::TranslationService::update_glossary].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_glossary(self.0.request, self.0.options)
@@ -1343,7 +1343,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_glossaries][super::super::client::TranslationService::list_glossaries] calls.
+    /// The request builder for [TranslationService::list_glossaries][crate::client::TranslationService::list_glossaries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1452,7 +1452,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_glossary][super::super::client::TranslationService::get_glossary] calls.
+    /// The request builder for [TranslationService::get_glossary][crate::client::TranslationService::get_glossary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1515,7 +1515,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::delete_glossary][super::super::client::TranslationService::delete_glossary] calls.
+    /// The request builder for [TranslationService::delete_glossary][crate::client::TranslationService::delete_glossary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1560,7 +1560,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_glossary][super::super::client::TranslationService::delete_glossary].
+        /// on [delete_glossary][crate::client::TranslationService::delete_glossary].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_glossary(self.0.request, self.0.options)
@@ -1620,7 +1620,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_glossary_entry][super::super::client::TranslationService::get_glossary_entry] calls.
+    /// The request builder for [TranslationService::get_glossary_entry][crate::client::TranslationService::get_glossary_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1686,7 +1686,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_glossary_entries][super::super::client::TranslationService::list_glossary_entries] calls.
+    /// The request builder for [TranslationService::list_glossary_entries][crate::client::TranslationService::list_glossary_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1794,7 +1794,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::create_glossary_entry][super::super::client::TranslationService::create_glossary_entry] calls.
+    /// The request builder for [TranslationService::create_glossary_entry][crate::client::TranslationService::create_glossary_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1882,7 +1882,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::update_glossary_entry][super::super::client::TranslationService::update_glossary_entry] calls.
+    /// The request builder for [TranslationService::update_glossary_entry][crate::client::TranslationService::update_glossary_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1962,7 +1962,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::delete_glossary_entry][super::super::client::TranslationService::delete_glossary_entry] calls.
+    /// The request builder for [TranslationService::delete_glossary_entry][crate::client::TranslationService::delete_glossary_entry] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2028,7 +2028,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::create_dataset][super::super::client::TranslationService::create_dataset] calls.
+    /// The request builder for [TranslationService::create_dataset][crate::client::TranslationService::create_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2073,7 +2073,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_dataset][super::super::client::TranslationService::create_dataset].
+        /// on [create_dataset][crate::client::TranslationService::create_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_dataset(self.0.request, self.0.options)
@@ -2154,7 +2154,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_dataset][super::super::client::TranslationService::get_dataset] calls.
+    /// The request builder for [TranslationService::get_dataset][crate::client::TranslationService::get_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2217,7 +2217,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_datasets][super::super::client::TranslationService::list_datasets] calls.
+    /// The request builder for [TranslationService::list_datasets][crate::client::TranslationService::list_datasets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2320,7 +2320,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::delete_dataset][super::super::client::TranslationService::delete_dataset] calls.
+    /// The request builder for [TranslationService::delete_dataset][crate::client::TranslationService::delete_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2365,7 +2365,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_dataset][super::super::client::TranslationService::delete_dataset].
+        /// on [delete_dataset][crate::client::TranslationService::delete_dataset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_dataset(self.0.request, self.0.options)
@@ -2425,7 +2425,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::create_adaptive_mt_dataset][super::super::client::TranslationService::create_adaptive_mt_dataset] calls.
+    /// The request builder for [TranslationService::create_adaptive_mt_dataset][crate::client::TranslationService::create_adaptive_mt_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2515,7 +2515,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::delete_adaptive_mt_dataset][super::super::client::TranslationService::delete_adaptive_mt_dataset] calls.
+    /// The request builder for [TranslationService::delete_adaptive_mt_dataset][crate::client::TranslationService::delete_adaptive_mt_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2583,7 +2583,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_adaptive_mt_dataset][super::super::client::TranslationService::get_adaptive_mt_dataset] calls.
+    /// The request builder for [TranslationService::get_adaptive_mt_dataset][crate::client::TranslationService::get_adaptive_mt_dataset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2649,7 +2649,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_adaptive_mt_datasets][super::super::client::TranslationService::list_adaptive_mt_datasets] calls.
+    /// The request builder for [TranslationService::list_adaptive_mt_datasets][crate::client::TranslationService::list_adaptive_mt_datasets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2765,7 +2765,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::adaptive_mt_translate][super::super::client::TranslationService::adaptive_mt_translate] calls.
+    /// The request builder for [TranslationService::adaptive_mt_translate][crate::client::TranslationService::adaptive_mt_translate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2895,7 +2895,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_adaptive_mt_file][super::super::client::TranslationService::get_adaptive_mt_file] calls.
+    /// The request builder for [TranslationService::get_adaptive_mt_file][crate::client::TranslationService::get_adaptive_mt_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2961,7 +2961,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::delete_adaptive_mt_file][super::super::client::TranslationService::delete_adaptive_mt_file] calls.
+    /// The request builder for [TranslationService::delete_adaptive_mt_file][crate::client::TranslationService::delete_adaptive_mt_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3027,7 +3027,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::import_adaptive_mt_file][super::super::client::TranslationService::import_adaptive_mt_file] calls.
+    /// The request builder for [TranslationService::import_adaptive_mt_file][crate::client::TranslationService::import_adaptive_mt_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3137,7 +3137,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_adaptive_mt_files][super::super::client::TranslationService::list_adaptive_mt_files] calls.
+    /// The request builder for [TranslationService::list_adaptive_mt_files][crate::client::TranslationService::list_adaptive_mt_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3245,7 +3245,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_adaptive_mt_sentences][super::super::client::TranslationService::list_adaptive_mt_sentences] calls.
+    /// The request builder for [TranslationService::list_adaptive_mt_sentences][crate::client::TranslationService::list_adaptive_mt_sentences] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3357,7 +3357,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::import_data][super::super::client::TranslationService::import_data] calls.
+    /// The request builder for [TranslationService::import_data][crate::client::TranslationService::import_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3402,7 +3402,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_data][super::super::client::TranslationService::import_data].
+        /// on [import_data][crate::client::TranslationService::import_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_data(self.0.request, self.0.options)
@@ -3483,7 +3483,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::export_data][super::super::client::TranslationService::export_data] calls.
+    /// The request builder for [TranslationService::export_data][crate::client::TranslationService::export_data] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3528,7 +3528,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_data][super::super::client::TranslationService::export_data].
+        /// on [export_data][crate::client::TranslationService::export_data].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_data(self.0.request, self.0.options)
@@ -3609,7 +3609,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_examples][super::super::client::TranslationService::list_examples] calls.
+    /// The request builder for [TranslationService::list_examples][crate::client::TranslationService::list_examples] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3718,7 +3718,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::create_model][super::super::client::TranslationService::create_model] calls.
+    /// The request builder for [TranslationService::create_model][crate::client::TranslationService::create_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3763,7 +3763,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_model][super::super::client::TranslationService::create_model].
+        /// on [create_model][crate::client::TranslationService::create_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_model(self.0.request, self.0.options)
@@ -3842,7 +3842,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_models][super::super::client::TranslationService::list_models] calls.
+    /// The request builder for [TranslationService::list_models][crate::client::TranslationService::list_models] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3951,7 +3951,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_model][super::super::client::TranslationService::get_model] calls.
+    /// The request builder for [TranslationService::get_model][crate::client::TranslationService::get_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4014,7 +4014,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::delete_model][super::super::client::TranslationService::delete_model] calls.
+    /// The request builder for [TranslationService::delete_model][crate::client::TranslationService::delete_model] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4059,7 +4059,7 @@ pub mod translation_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_model][super::super::client::TranslationService::delete_model].
+        /// on [delete_model][crate::client::TranslationService::delete_model].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_model(self.0.request, self.0.options)
@@ -4119,7 +4119,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_locations][super::super::client::TranslationService::list_locations] calls.
+    /// The request builder for [TranslationService::list_locations][crate::client::TranslationService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4229,7 +4229,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_location][super::super::client::TranslationService::get_location] calls.
+    /// The request builder for [TranslationService::get_location][crate::client::TranslationService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4290,7 +4290,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::list_operations][super::super::client::TranslationService::list_operations] calls.
+    /// The request builder for [TranslationService::list_operations][crate::client::TranslationService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4402,7 +4402,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::get_operation][super::super::client::TranslationService::get_operation] calls.
+    /// The request builder for [TranslationService::get_operation][crate::client::TranslationService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4466,7 +4466,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::delete_operation][super::super::client::TranslationService::delete_operation] calls.
+    /// The request builder for [TranslationService::delete_operation][crate::client::TranslationService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4530,7 +4530,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::cancel_operation][super::super::client::TranslationService::cancel_operation] calls.
+    /// The request builder for [TranslationService::cancel_operation][crate::client::TranslationService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4594,7 +4594,7 @@ pub mod translation_service {
         }
     }
 
-    /// The request builder for [TranslationService::wait_operation][super::super::client::TranslationService::wait_operation] calls.
+    /// The request builder for [TranslationService::wait_operation][crate::client::TranslationService::wait_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/video/livestream/v1/src/builder.rs
+++ b/src/generated/cloud/video/livestream/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod livestream_service {
     use crate::Result;
 
-    /// A builder for [LivestreamService][super::super::client::LivestreamService].
+    /// A builder for [LivestreamService][crate::client::LivestreamService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod livestream_service {
         }
     }
 
-    /// Common implementation for [super::super::client::LivestreamService] request builders.
+    /// Common implementation for [crate::client::LivestreamService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LivestreamService>,
@@ -68,7 +68,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::create_channel][super::super::client::LivestreamService::create_channel] calls.
+    /// The request builder for [LivestreamService::create_channel][crate::client::LivestreamService::create_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_channel][super::super::client::LivestreamService::create_channel].
+        /// on [create_channel][crate::client::LivestreamService::create_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_channel(self.0.request, self.0.options)
@@ -206,7 +206,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::list_channels][super::super::client::LivestreamService::list_channels] calls.
+    /// The request builder for [LivestreamService::list_channels][crate::client::LivestreamService::list_channels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -321,7 +321,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_channel][super::super::client::LivestreamService::get_channel] calls.
+    /// The request builder for [LivestreamService::get_channel][crate::client::LivestreamService::get_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -384,7 +384,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::delete_channel][super::super::client::LivestreamService::delete_channel] calls.
+    /// The request builder for [LivestreamService::delete_channel][crate::client::LivestreamService::delete_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_channel][super::super::client::LivestreamService::delete_channel].
+        /// on [delete_channel][crate::client::LivestreamService::delete_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_channel(self.0.request, self.0.options)
@@ -500,7 +500,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::update_channel][super::super::client::LivestreamService::update_channel] calls.
+    /// The request builder for [LivestreamService::update_channel][crate::client::LivestreamService::update_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -545,7 +545,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_channel][super::super::client::LivestreamService::update_channel].
+        /// on [update_channel][crate::client::LivestreamService::update_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_channel(self.0.request, self.0.options)
@@ -640,7 +640,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::start_channel][super::super::client::LivestreamService::start_channel] calls.
+    /// The request builder for [LivestreamService::start_channel][crate::client::LivestreamService::start_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -685,7 +685,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_channel][super::super::client::LivestreamService::start_channel].
+        /// on [start_channel][crate::client::LivestreamService::start_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_channel(self.0.request, self.0.options)
@@ -751,7 +751,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::stop_channel][super::super::client::LivestreamService::stop_channel] calls.
+    /// The request builder for [LivestreamService::stop_channel][crate::client::LivestreamService::stop_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -796,7 +796,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_channel][super::super::client::LivestreamService::stop_channel].
+        /// on [stop_channel][crate::client::LivestreamService::stop_channel].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_channel(self.0.request, self.0.options)
@@ -862,7 +862,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::create_input][super::super::client::LivestreamService::create_input] calls.
+    /// The request builder for [LivestreamService::create_input][crate::client::LivestreamService::create_input] calls.
     ///
     /// # Example
     /// ```no_run
@@ -907,7 +907,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_input][super::super::client::LivestreamService::create_input].
+        /// on [create_input][crate::client::LivestreamService::create_input].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_input(self.0.request, self.0.options)
@@ -1000,7 +1000,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::list_inputs][super::super::client::LivestreamService::list_inputs] calls.
+    /// The request builder for [LivestreamService::list_inputs][crate::client::LivestreamService::list_inputs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1115,7 +1115,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_input][super::super::client::LivestreamService::get_input] calls.
+    /// The request builder for [LivestreamService::get_input][crate::client::LivestreamService::get_input] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1178,7 +1178,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::delete_input][super::super::client::LivestreamService::delete_input] calls.
+    /// The request builder for [LivestreamService::delete_input][crate::client::LivestreamService::delete_input] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1223,7 +1223,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_input][super::super::client::LivestreamService::delete_input].
+        /// on [delete_input][crate::client::LivestreamService::delete_input].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_input(self.0.request, self.0.options)
@@ -1288,7 +1288,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::update_input][super::super::client::LivestreamService::update_input] calls.
+    /// The request builder for [LivestreamService::update_input][crate::client::LivestreamService::update_input] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1333,7 +1333,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_input][super::super::client::LivestreamService::update_input].
+        /// on [update_input][crate::client::LivestreamService::update_input].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_input(self.0.request, self.0.options)
@@ -1428,7 +1428,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::create_event][super::super::client::LivestreamService::create_event] calls.
+    /// The request builder for [LivestreamService::create_event][crate::client::LivestreamService::create_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1527,7 +1527,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::list_events][super::super::client::LivestreamService::list_events] calls.
+    /// The request builder for [LivestreamService::list_events][crate::client::LivestreamService::list_events] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1642,7 +1642,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_event][super::super::client::LivestreamService::get_event] calls.
+    /// The request builder for [LivestreamService::get_event][crate::client::LivestreamService::get_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1705,7 +1705,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::delete_event][super::super::client::LivestreamService::delete_event] calls.
+    /// The request builder for [LivestreamService::delete_event][crate::client::LivestreamService::delete_event] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1774,7 +1774,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::list_clips][super::super::client::LivestreamService::list_clips] calls.
+    /// The request builder for [LivestreamService::list_clips][crate::client::LivestreamService::list_clips] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1889,7 +1889,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_clip][super::super::client::LivestreamService::get_clip] calls.
+    /// The request builder for [LivestreamService::get_clip][crate::client::LivestreamService::get_clip] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1952,7 +1952,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::create_clip][super::super::client::LivestreamService::create_clip] calls.
+    /// The request builder for [LivestreamService::create_clip][crate::client::LivestreamService::create_clip] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1997,7 +1997,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_clip][super::super::client::LivestreamService::create_clip].
+        /// on [create_clip][crate::client::LivestreamService::create_clip].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_clip(self.0.request, self.0.options)
@@ -2090,7 +2090,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::delete_clip][super::super::client::LivestreamService::delete_clip] calls.
+    /// The request builder for [LivestreamService::delete_clip][crate::client::LivestreamService::delete_clip] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2135,7 +2135,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_clip][super::super::client::LivestreamService::delete_clip].
+        /// on [delete_clip][crate::client::LivestreamService::delete_clip].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_clip(self.0.request, self.0.options)
@@ -2200,7 +2200,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::create_asset][super::super::client::LivestreamService::create_asset] calls.
+    /// The request builder for [LivestreamService::create_asset][crate::client::LivestreamService::create_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2245,7 +2245,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_asset][super::super::client::LivestreamService::create_asset].
+        /// on [create_asset][crate::client::LivestreamService::create_asset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_asset(self.0.request, self.0.options)
@@ -2338,7 +2338,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::delete_asset][super::super::client::LivestreamService::delete_asset] calls.
+    /// The request builder for [LivestreamService::delete_asset][crate::client::LivestreamService::delete_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2383,7 +2383,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_asset][super::super::client::LivestreamService::delete_asset].
+        /// on [delete_asset][crate::client::LivestreamService::delete_asset].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_asset(self.0.request, self.0.options)
@@ -2448,7 +2448,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_asset][super::super::client::LivestreamService::get_asset] calls.
+    /// The request builder for [LivestreamService::get_asset][crate::client::LivestreamService::get_asset] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2511,7 +2511,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::list_assets][super::super::client::LivestreamService::list_assets] calls.
+    /// The request builder for [LivestreamService::list_assets][crate::client::LivestreamService::list_assets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2626,7 +2626,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_pool][super::super::client::LivestreamService::get_pool] calls.
+    /// The request builder for [LivestreamService::get_pool][crate::client::LivestreamService::get_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2689,7 +2689,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::update_pool][super::super::client::LivestreamService::update_pool] calls.
+    /// The request builder for [LivestreamService::update_pool][crate::client::LivestreamService::update_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2734,7 +2734,7 @@ pub mod livestream_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_pool][super::super::client::LivestreamService::update_pool].
+        /// on [update_pool][crate::client::LivestreamService::update_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_pool(self.0.request, self.0.options)
@@ -2829,7 +2829,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::list_locations][super::super::client::LivestreamService::list_locations] calls.
+    /// The request builder for [LivestreamService::list_locations][crate::client::LivestreamService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2939,7 +2939,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_location][super::super::client::LivestreamService::get_location] calls.
+    /// The request builder for [LivestreamService::get_location][crate::client::LivestreamService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3000,7 +3000,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::list_operations][super::super::client::LivestreamService::list_operations] calls.
+    /// The request builder for [LivestreamService::list_operations][crate::client::LivestreamService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3112,7 +3112,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::get_operation][super::super::client::LivestreamService::get_operation] calls.
+    /// The request builder for [LivestreamService::get_operation][crate::client::LivestreamService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3176,7 +3176,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::delete_operation][super::super::client::LivestreamService::delete_operation] calls.
+    /// The request builder for [LivestreamService::delete_operation][crate::client::LivestreamService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3240,7 +3240,7 @@ pub mod livestream_service {
         }
     }
 
-    /// The request builder for [LivestreamService::cancel_operation][super::super::client::LivestreamService::cancel_operation] calls.
+    /// The request builder for [LivestreamService::cancel_operation][crate::client::LivestreamService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/video/stitcher/v1/src/builder.rs
+++ b/src/generated/cloud/video/stitcher/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod video_stitcher_service {
     use crate::Result;
 
-    /// A builder for [VideoStitcherService][super::super::client::VideoStitcherService].
+    /// A builder for [VideoStitcherService][crate::client::VideoStitcherService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// Common implementation for [super::super::client::VideoStitcherService] request builders.
+    /// Common implementation for [crate::client::VideoStitcherService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VideoStitcherService>,
@@ -68,7 +68,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::create_cdn_key][super::super::client::VideoStitcherService::create_cdn_key] calls.
+    /// The request builder for [VideoStitcherService::create_cdn_key][crate::client::VideoStitcherService::create_cdn_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cdn_key][super::super::client::VideoStitcherService::create_cdn_key].
+        /// on [create_cdn_key][crate::client::VideoStitcherService::create_cdn_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cdn_key(self.0.request, self.0.options)
@@ -200,7 +200,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_cdn_keys][super::super::client::VideoStitcherService::list_cdn_keys] calls.
+    /// The request builder for [VideoStitcherService::list_cdn_keys][crate::client::VideoStitcherService::list_cdn_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -315,7 +315,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_cdn_key][super::super::client::VideoStitcherService::get_cdn_key] calls.
+    /// The request builder for [VideoStitcherService::get_cdn_key][crate::client::VideoStitcherService::get_cdn_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -378,7 +378,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::delete_cdn_key][super::super::client::VideoStitcherService::delete_cdn_key] calls.
+    /// The request builder for [VideoStitcherService::delete_cdn_key][crate::client::VideoStitcherService::delete_cdn_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -423,7 +423,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cdn_key][super::super::client::VideoStitcherService::delete_cdn_key].
+        /// on [delete_cdn_key][crate::client::VideoStitcherService::delete_cdn_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cdn_key(self.0.request, self.0.options)
@@ -482,7 +482,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::update_cdn_key][super::super::client::VideoStitcherService::update_cdn_key] calls.
+    /// The request builder for [VideoStitcherService::update_cdn_key][crate::client::VideoStitcherService::update_cdn_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -527,7 +527,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_cdn_key][super::super::client::VideoStitcherService::update_cdn_key].
+        /// on [update_cdn_key][crate::client::VideoStitcherService::update_cdn_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_cdn_key(self.0.request, self.0.options)
@@ -620,7 +620,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::create_vod_session][super::super::client::VideoStitcherService::create_vod_session] calls.
+    /// The request builder for [VideoStitcherService::create_vod_session][crate::client::VideoStitcherService::create_vod_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -708,7 +708,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_vod_session][super::super::client::VideoStitcherService::get_vod_session] calls.
+    /// The request builder for [VideoStitcherService::get_vod_session][crate::client::VideoStitcherService::get_vod_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -771,7 +771,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_vod_stitch_details][super::super::client::VideoStitcherService::list_vod_stitch_details] calls.
+    /// The request builder for [VideoStitcherService::list_vod_stitch_details][crate::client::VideoStitcherService::list_vod_stitch_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -879,7 +879,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_vod_stitch_detail][super::super::client::VideoStitcherService::get_vod_stitch_detail] calls.
+    /// The request builder for [VideoStitcherService::get_vod_stitch_detail][crate::client::VideoStitcherService::get_vod_stitch_detail] calls.
     ///
     /// # Example
     /// ```no_run
@@ -945,7 +945,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_vod_ad_tag_details][super::super::client::VideoStitcherService::list_vod_ad_tag_details] calls.
+    /// The request builder for [VideoStitcherService::list_vod_ad_tag_details][crate::client::VideoStitcherService::list_vod_ad_tag_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1053,7 +1053,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_vod_ad_tag_detail][super::super::client::VideoStitcherService::get_vod_ad_tag_detail] calls.
+    /// The request builder for [VideoStitcherService::get_vod_ad_tag_detail][crate::client::VideoStitcherService::get_vod_ad_tag_detail] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1119,7 +1119,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_live_ad_tag_details][super::super::client::VideoStitcherService::list_live_ad_tag_details] calls.
+    /// The request builder for [VideoStitcherService::list_live_ad_tag_details][crate::client::VideoStitcherService::list_live_ad_tag_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1227,7 +1227,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_live_ad_tag_detail][super::super::client::VideoStitcherService::get_live_ad_tag_detail] calls.
+    /// The request builder for [VideoStitcherService::get_live_ad_tag_detail][crate::client::VideoStitcherService::get_live_ad_tag_detail] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1293,7 +1293,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::create_slate][super::super::client::VideoStitcherService::create_slate] calls.
+    /// The request builder for [VideoStitcherService::create_slate][crate::client::VideoStitcherService::create_slate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1338,7 +1338,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_slate][super::super::client::VideoStitcherService::create_slate].
+        /// on [create_slate][crate::client::VideoStitcherService::create_slate].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_slate(self.0.request, self.0.options)
@@ -1431,7 +1431,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_slates][super::super::client::VideoStitcherService::list_slates] calls.
+    /// The request builder for [VideoStitcherService::list_slates][crate::client::VideoStitcherService::list_slates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1546,7 +1546,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_slate][super::super::client::VideoStitcherService::get_slate] calls.
+    /// The request builder for [VideoStitcherService::get_slate][crate::client::VideoStitcherService::get_slate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1609,7 +1609,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::update_slate][super::super::client::VideoStitcherService::update_slate] calls.
+    /// The request builder for [VideoStitcherService::update_slate][crate::client::VideoStitcherService::update_slate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1654,7 +1654,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_slate][super::super::client::VideoStitcherService::update_slate].
+        /// on [update_slate][crate::client::VideoStitcherService::update_slate].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_slate(self.0.request, self.0.options)
@@ -1747,7 +1747,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::delete_slate][super::super::client::VideoStitcherService::delete_slate] calls.
+    /// The request builder for [VideoStitcherService::delete_slate][crate::client::VideoStitcherService::delete_slate] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1792,7 +1792,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_slate][super::super::client::VideoStitcherService::delete_slate].
+        /// on [delete_slate][crate::client::VideoStitcherService::delete_slate].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_slate(self.0.request, self.0.options)
@@ -1851,7 +1851,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::create_live_session][super::super::client::VideoStitcherService::create_live_session] calls.
+    /// The request builder for [VideoStitcherService::create_live_session][crate::client::VideoStitcherService::create_live_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1939,7 +1939,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_live_session][super::super::client::VideoStitcherService::get_live_session] calls.
+    /// The request builder for [VideoStitcherService::get_live_session][crate::client::VideoStitcherService::get_live_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2002,7 +2002,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::create_live_config][super::super::client::VideoStitcherService::create_live_config] calls.
+    /// The request builder for [VideoStitcherService::create_live_config][crate::client::VideoStitcherService::create_live_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2050,7 +2050,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_live_config][super::super::client::VideoStitcherService::create_live_config].
+        /// on [create_live_config][crate::client::VideoStitcherService::create_live_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_live_config(self.0.request, self.0.options)
@@ -2143,7 +2143,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_live_configs][super::super::client::VideoStitcherService::list_live_configs] calls.
+    /// The request builder for [VideoStitcherService::list_live_configs][crate::client::VideoStitcherService::list_live_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2258,7 +2258,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_live_config][super::super::client::VideoStitcherService::get_live_config] calls.
+    /// The request builder for [VideoStitcherService::get_live_config][crate::client::VideoStitcherService::get_live_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2321,7 +2321,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::delete_live_config][super::super::client::VideoStitcherService::delete_live_config] calls.
+    /// The request builder for [VideoStitcherService::delete_live_config][crate::client::VideoStitcherService::delete_live_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2369,7 +2369,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_live_config][super::super::client::VideoStitcherService::delete_live_config].
+        /// on [delete_live_config][crate::client::VideoStitcherService::delete_live_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_live_config(self.0.request, self.0.options)
@@ -2428,7 +2428,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::update_live_config][super::super::client::VideoStitcherService::update_live_config] calls.
+    /// The request builder for [VideoStitcherService::update_live_config][crate::client::VideoStitcherService::update_live_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2476,7 +2476,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_live_config][super::super::client::VideoStitcherService::update_live_config].
+        /// on [update_live_config][crate::client::VideoStitcherService::update_live_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_live_config(self.0.request, self.0.options)
@@ -2569,7 +2569,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::create_vod_config][super::super::client::VideoStitcherService::create_vod_config] calls.
+    /// The request builder for [VideoStitcherService::create_vod_config][crate::client::VideoStitcherService::create_vod_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2614,7 +2614,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_vod_config][super::super::client::VideoStitcherService::create_vod_config].
+        /// on [create_vod_config][crate::client::VideoStitcherService::create_vod_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_vod_config(self.0.request, self.0.options)
@@ -2707,7 +2707,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_vod_configs][super::super::client::VideoStitcherService::list_vod_configs] calls.
+    /// The request builder for [VideoStitcherService::list_vod_configs][crate::client::VideoStitcherService::list_vod_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2822,7 +2822,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_vod_config][super::super::client::VideoStitcherService::get_vod_config] calls.
+    /// The request builder for [VideoStitcherService::get_vod_config][crate::client::VideoStitcherService::get_vod_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2885,7 +2885,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::delete_vod_config][super::super::client::VideoStitcherService::delete_vod_config] calls.
+    /// The request builder for [VideoStitcherService::delete_vod_config][crate::client::VideoStitcherService::delete_vod_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2930,7 +2930,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_vod_config][super::super::client::VideoStitcherService::delete_vod_config].
+        /// on [delete_vod_config][crate::client::VideoStitcherService::delete_vod_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_vod_config(self.0.request, self.0.options)
@@ -2989,7 +2989,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::update_vod_config][super::super::client::VideoStitcherService::update_vod_config] calls.
+    /// The request builder for [VideoStitcherService::update_vod_config][crate::client::VideoStitcherService::update_vod_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3034,7 +3034,7 @@ pub mod video_stitcher_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_vod_config][super::super::client::VideoStitcherService::update_vod_config].
+        /// on [update_vod_config][crate::client::VideoStitcherService::update_vod_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_vod_config(self.0.request, self.0.options)
@@ -3127,7 +3127,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::list_operations][super::super::client::VideoStitcherService::list_operations] calls.
+    /// The request builder for [VideoStitcherService::list_operations][crate::client::VideoStitcherService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3239,7 +3239,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::get_operation][super::super::client::VideoStitcherService::get_operation] calls.
+    /// The request builder for [VideoStitcherService::get_operation][crate::client::VideoStitcherService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3303,7 +3303,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::delete_operation][super::super::client::VideoStitcherService::delete_operation] calls.
+    /// The request builder for [VideoStitcherService::delete_operation][crate::client::VideoStitcherService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3367,7 +3367,7 @@ pub mod video_stitcher_service {
         }
     }
 
-    /// The request builder for [VideoStitcherService::cancel_operation][super::super::client::VideoStitcherService::cancel_operation] calls.
+    /// The request builder for [VideoStitcherService::cancel_operation][crate::client::VideoStitcherService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/video/transcoder/v1/src/builder.rs
+++ b/src/generated/cloud/video/transcoder/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod transcoder_service {
     use crate::Result;
 
-    /// A builder for [TranscoderService][super::super::client::TranscoderService].
+    /// A builder for [TranscoderService][crate::client::TranscoderService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// Common implementation for [super::super::client::TranscoderService] request builders.
+    /// Common implementation for [crate::client::TranscoderService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TranscoderService>,
@@ -68,7 +68,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::create_job][super::super::client::TranscoderService::create_job] calls.
+    /// The request builder for [TranscoderService::create_job][crate::client::TranscoderService::create_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -153,7 +153,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::list_jobs][super::super::client::TranscoderService::list_jobs] calls.
+    /// The request builder for [TranscoderService::list_jobs][crate::client::TranscoderService::list_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -268,7 +268,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::get_job][super::super::client::TranscoderService::get_job] calls.
+    /// The request builder for [TranscoderService::get_job][crate::client::TranscoderService::get_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -331,7 +331,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::delete_job][super::super::client::TranscoderService::delete_job] calls.
+    /// The request builder for [TranscoderService::delete_job][crate::client::TranscoderService::delete_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -400,7 +400,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::create_job_template][super::super::client::TranscoderService::create_job_template] calls.
+    /// The request builder for [TranscoderService::create_job_template][crate::client::TranscoderService::create_job_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -496,7 +496,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::list_job_templates][super::super::client::TranscoderService::list_job_templates] calls.
+    /// The request builder for [TranscoderService::list_job_templates][crate::client::TranscoderService::list_job_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -614,7 +614,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::get_job_template][super::super::client::TranscoderService::get_job_template] calls.
+    /// The request builder for [TranscoderService::get_job_template][crate::client::TranscoderService::get_job_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -677,7 +677,7 @@ pub mod transcoder_service {
         }
     }
 
-    /// The request builder for [TranscoderService::delete_job_template][super::super::client::TranscoderService::delete_job_template] calls.
+    /// The request builder for [TranscoderService::delete_job_template][crate::client::TranscoderService::delete_job_template] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/videointelligence/v1/src/builder.rs
+++ b/src/generated/cloud/videointelligence/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod video_intelligence_service {
     use crate::Result;
 
-    /// A builder for [VideoIntelligenceService][super::super::client::VideoIntelligenceService].
+    /// A builder for [VideoIntelligenceService][crate::client::VideoIntelligenceService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// Common implementation for [super::super::client::VideoIntelligenceService] request builders.
+    /// Common implementation for [crate::client::VideoIntelligenceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VideoIntelligenceService>,
@@ -68,7 +68,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for [VideoIntelligenceService::annotate_video][super::super::client::VideoIntelligenceService::annotate_video] calls.
+    /// The request builder for [VideoIntelligenceService::annotate_video][crate::client::VideoIntelligenceService::annotate_video] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod video_intelligence_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [annotate_video][super::super::client::VideoIntelligenceService::annotate_video].
+        /// on [annotate_video][crate::client::VideoIntelligenceService::annotate_video].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .annotate_video(self.0.request, self.0.options)
@@ -220,7 +220,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for [VideoIntelligenceService::list_operations][super::super::client::VideoIntelligenceService::list_operations] calls.
+    /// The request builder for [VideoIntelligenceService::list_operations][crate::client::VideoIntelligenceService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -332,7 +332,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for [VideoIntelligenceService::get_operation][super::super::client::VideoIntelligenceService::get_operation] calls.
+    /// The request builder for [VideoIntelligenceService::get_operation][crate::client::VideoIntelligenceService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -396,7 +396,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for [VideoIntelligenceService::delete_operation][super::super::client::VideoIntelligenceService::delete_operation] calls.
+    /// The request builder for [VideoIntelligenceService::delete_operation][crate::client::VideoIntelligenceService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -460,7 +460,7 @@ pub mod video_intelligence_service {
         }
     }
 
-    /// The request builder for [VideoIntelligenceService::cancel_operation][super::super::client::VideoIntelligenceService::cancel_operation] calls.
+    /// The request builder for [VideoIntelligenceService::cancel_operation][crate::client::VideoIntelligenceService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/vision/v1/src/builder.rs
+++ b/src/generated/cloud/vision/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod image_annotator {
     use crate::Result;
 
-    /// A builder for [ImageAnnotator][super::super::client::ImageAnnotator].
+    /// A builder for [ImageAnnotator][crate::client::ImageAnnotator].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod image_annotator {
         }
     }
 
-    /// Common implementation for [super::super::client::ImageAnnotator] request builders.
+    /// Common implementation for [crate::client::ImageAnnotator] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ImageAnnotator>,
@@ -68,7 +68,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for [ImageAnnotator::batch_annotate_images][super::super::client::ImageAnnotator::batch_annotate_images] calls.
+    /// The request builder for [ImageAnnotator::batch_annotate_images][crate::client::ImageAnnotator::batch_annotate_images] calls.
     ///
     /// # Example
     /// ```no_run
@@ -156,7 +156,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for [ImageAnnotator::batch_annotate_files][super::super::client::ImageAnnotator::batch_annotate_files] calls.
+    /// The request builder for [ImageAnnotator::batch_annotate_files][crate::client::ImageAnnotator::batch_annotate_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -244,7 +244,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for [ImageAnnotator::async_batch_annotate_images][super::super::client::ImageAnnotator::async_batch_annotate_images] calls.
+    /// The request builder for [ImageAnnotator::async_batch_annotate_images][crate::client::ImageAnnotator::async_batch_annotate_images] calls.
     ///
     /// # Example
     /// ```no_run
@@ -294,7 +294,7 @@ pub mod image_annotator {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [async_batch_annotate_images][super::super::client::ImageAnnotator::async_batch_annotate_images].
+        /// on [async_batch_annotate_images][crate::client::ImageAnnotator::async_batch_annotate_images].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .async_batch_annotate_images(self.0.request, self.0.options)
@@ -400,7 +400,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for [ImageAnnotator::async_batch_annotate_files][super::super::client::ImageAnnotator::async_batch_annotate_files] calls.
+    /// The request builder for [ImageAnnotator::async_batch_annotate_files][crate::client::ImageAnnotator::async_batch_annotate_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -450,7 +450,7 @@ pub mod image_annotator {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [async_batch_annotate_files][super::super::client::ImageAnnotator::async_batch_annotate_files].
+        /// on [async_batch_annotate_files][crate::client::ImageAnnotator::async_batch_annotate_files].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .async_batch_annotate_files(self.0.request, self.0.options)
@@ -534,7 +534,7 @@ pub mod image_annotator {
         }
     }
 
-    /// The request builder for [ImageAnnotator::get_operation][super::super::client::ImageAnnotator::get_operation] calls.
+    /// The request builder for [ImageAnnotator::get_operation][crate::client::ImageAnnotator::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -602,7 +602,7 @@ pub mod image_annotator {
 pub mod product_search {
     use crate::Result;
 
-    /// A builder for [ProductSearch][super::super::client::ProductSearch].
+    /// A builder for [ProductSearch][crate::client::ProductSearch].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -630,7 +630,7 @@ pub mod product_search {
         }
     }
 
-    /// Common implementation for [super::super::client::ProductSearch] request builders.
+    /// Common implementation for [crate::client::ProductSearch] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ProductSearch>,
@@ -653,7 +653,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::create_product_set][super::super::client::ProductSearch::create_product_set] calls.
+    /// The request builder for [ProductSearch::create_product_set][crate::client::ProductSearch::create_product_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -747,7 +747,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::list_product_sets][super::super::client::ProductSearch::list_product_sets] calls.
+    /// The request builder for [ProductSearch::list_product_sets][crate::client::ProductSearch::list_product_sets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -850,7 +850,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::get_product_set][super::super::client::ProductSearch::get_product_set] calls.
+    /// The request builder for [ProductSearch::get_product_set][crate::client::ProductSearch::get_product_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -913,7 +913,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::update_product_set][super::super::client::ProductSearch::update_product_set] calls.
+    /// The request builder for [ProductSearch::update_product_set][crate::client::ProductSearch::update_product_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1011,7 +1011,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::delete_product_set][super::super::client::ProductSearch::delete_product_set] calls.
+    /// The request builder for [ProductSearch::delete_product_set][crate::client::ProductSearch::delete_product_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1077,7 +1077,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::create_product][super::super::client::ProductSearch::create_product] calls.
+    /// The request builder for [ProductSearch::create_product][crate::client::ProductSearch::create_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1168,7 +1168,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::list_products][super::super::client::ProductSearch::list_products] calls.
+    /// The request builder for [ProductSearch::list_products][crate::client::ProductSearch::list_products] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1271,7 +1271,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::get_product][super::super::client::ProductSearch::get_product] calls.
+    /// The request builder for [ProductSearch::get_product][crate::client::ProductSearch::get_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1334,7 +1334,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::update_product][super::super::client::ProductSearch::update_product] calls.
+    /// The request builder for [ProductSearch::update_product][crate::client::ProductSearch::update_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1429,7 +1429,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::delete_product][super::super::client::ProductSearch::delete_product] calls.
+    /// The request builder for [ProductSearch::delete_product][crate::client::ProductSearch::delete_product] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1492,7 +1492,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::create_reference_image][super::super::client::ProductSearch::create_reference_image] calls.
+    /// The request builder for [ProductSearch::create_reference_image][crate::client::ProductSearch::create_reference_image] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1586,7 +1586,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::delete_reference_image][super::super::client::ProductSearch::delete_reference_image] calls.
+    /// The request builder for [ProductSearch::delete_reference_image][crate::client::ProductSearch::delete_reference_image] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1652,7 +1652,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::list_reference_images][super::super::client::ProductSearch::list_reference_images] calls.
+    /// The request builder for [ProductSearch::list_reference_images][crate::client::ProductSearch::list_reference_images] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1760,7 +1760,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::get_reference_image][super::super::client::ProductSearch::get_reference_image] calls.
+    /// The request builder for [ProductSearch::get_reference_image][crate::client::ProductSearch::get_reference_image] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1826,7 +1826,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::add_product_to_product_set][super::super::client::ProductSearch::add_product_to_product_set] calls.
+    /// The request builder for [ProductSearch::add_product_to_product_set][crate::client::ProductSearch::add_product_to_product_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1900,7 +1900,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::remove_product_from_product_set][super::super::client::ProductSearch::remove_product_from_product_set] calls.
+    /// The request builder for [ProductSearch::remove_product_from_product_set][crate::client::ProductSearch::remove_product_from_product_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1976,7 +1976,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::list_products_in_product_set][super::super::client::ProductSearch::list_products_in_product_set] calls.
+    /// The request builder for [ProductSearch::list_products_in_product_set][crate::client::ProductSearch::list_products_in_product_set] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2088,7 +2088,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::import_product_sets][super::super::client::ProductSearch::import_product_sets] calls.
+    /// The request builder for [ProductSearch::import_product_sets][crate::client::ProductSearch::import_product_sets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2136,7 +2136,7 @@ pub mod product_search {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_product_sets][super::super::client::ProductSearch::import_product_sets].
+        /// on [import_product_sets][crate::client::ProductSearch::import_product_sets].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_product_sets(self.0.request, self.0.options)
@@ -2220,7 +2220,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::purge_products][super::super::client::ProductSearch::purge_products] calls.
+    /// The request builder for [ProductSearch::purge_products][crate::client::ProductSearch::purge_products] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2265,7 +2265,7 @@ pub mod product_search {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [purge_products][super::super::client::ProductSearch::purge_products].
+        /// on [purge_products][crate::client::ProductSearch::purge_products].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .purge_products(self.0.request, self.0.options)
@@ -2368,7 +2368,7 @@ pub mod product_search {
         }
     }
 
-    /// The request builder for [ProductSearch::get_operation][super::super::client::ProductSearch::get_operation] calls.
+    /// The request builder for [ProductSearch::get_operation][crate::client::ProductSearch::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/vmmigration/v1/src/builder.rs
+++ b/src/generated/cloud/vmmigration/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod vm_migration {
     use crate::Result;
 
-    /// A builder for [VmMigration][super::super::client::VmMigration].
+    /// A builder for [VmMigration][crate::client::VmMigration].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod vm_migration {
         }
     }
 
-    /// Common implementation for [super::super::client::VmMigration] request builders.
+    /// Common implementation for [crate::client::VmMigration] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VmMigration>,
@@ -68,7 +68,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_sources][super::super::client::VmMigration::list_sources] calls.
+    /// The request builder for [VmMigration::list_sources][crate::client::VmMigration::list_sources] calls.
     ///
     /// # Example
     /// ```no_run
@@ -185,7 +185,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_source][super::super::client::VmMigration::get_source] calls.
+    /// The request builder for [VmMigration::get_source][crate::client::VmMigration::get_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -248,7 +248,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_source][super::super::client::VmMigration::create_source] calls.
+    /// The request builder for [VmMigration::create_source][crate::client::VmMigration::create_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -293,7 +293,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_source][super::super::client::VmMigration::create_source].
+        /// on [create_source][crate::client::VmMigration::create_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_source(self.0.request, self.0.options)
@@ -386,7 +386,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::update_source][super::super::client::VmMigration::update_source] calls.
+    /// The request builder for [VmMigration::update_source][crate::client::VmMigration::update_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -431,7 +431,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_source][super::super::client::VmMigration::update_source].
+        /// on [update_source][crate::client::VmMigration::update_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_source(self.0.request, self.0.options)
@@ -526,7 +526,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::delete_source][super::super::client::VmMigration::delete_source] calls.
+    /// The request builder for [VmMigration::delete_source][crate::client::VmMigration::delete_source] calls.
     ///
     /// # Example
     /// ```no_run
@@ -571,7 +571,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_source][super::super::client::VmMigration::delete_source].
+        /// on [delete_source][crate::client::VmMigration::delete_source].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_source(self.0.request, self.0.options)
@@ -636,7 +636,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::fetch_inventory][super::super::client::VmMigration::fetch_inventory] calls.
+    /// The request builder for [VmMigration::fetch_inventory][crate::client::VmMigration::fetch_inventory] calls.
     ///
     /// # Example
     /// ```no_run
@@ -705,7 +705,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_utilization_reports][super::super::client::VmMigration::list_utilization_reports] calls.
+    /// The request builder for [VmMigration::list_utilization_reports][crate::client::VmMigration::list_utilization_reports] calls.
     ///
     /// # Example
     /// ```no_run
@@ -835,7 +835,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_utilization_report][super::super::client::VmMigration::get_utilization_report] calls.
+    /// The request builder for [VmMigration::get_utilization_report][crate::client::VmMigration::get_utilization_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -907,7 +907,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_utilization_report][super::super::client::VmMigration::create_utilization_report] calls.
+    /// The request builder for [VmMigration::create_utilization_report][crate::client::VmMigration::create_utilization_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -957,7 +957,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_utilization_report][super::super::client::VmMigration::create_utilization_report].
+        /// on [create_utilization_report][crate::client::VmMigration::create_utilization_report].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_utilization_report(self.0.request, self.0.options)
@@ -1053,7 +1053,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::delete_utilization_report][super::super::client::VmMigration::delete_utilization_report] calls.
+    /// The request builder for [VmMigration::delete_utilization_report][crate::client::VmMigration::delete_utilization_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1103,7 +1103,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_utilization_report][super::super::client::VmMigration::delete_utilization_report].
+        /// on [delete_utilization_report][crate::client::VmMigration::delete_utilization_report].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_utilization_report(self.0.request, self.0.options)
@@ -1168,7 +1168,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_datacenter_connectors][super::super::client::VmMigration::list_datacenter_connectors] calls.
+    /// The request builder for [VmMigration::list_datacenter_connectors][crate::client::VmMigration::list_datacenter_connectors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1294,7 +1294,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_datacenter_connector][super::super::client::VmMigration::get_datacenter_connector] calls.
+    /// The request builder for [VmMigration::get_datacenter_connector][crate::client::VmMigration::get_datacenter_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1360,7 +1360,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_datacenter_connector][super::super::client::VmMigration::create_datacenter_connector] calls.
+    /// The request builder for [VmMigration::create_datacenter_connector][crate::client::VmMigration::create_datacenter_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1410,7 +1410,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_datacenter_connector][super::super::client::VmMigration::create_datacenter_connector].
+        /// on [create_datacenter_connector][crate::client::VmMigration::create_datacenter_connector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_datacenter_connector(self.0.request, self.0.options)
@@ -1506,7 +1506,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::delete_datacenter_connector][super::super::client::VmMigration::delete_datacenter_connector] calls.
+    /// The request builder for [VmMigration::delete_datacenter_connector][crate::client::VmMigration::delete_datacenter_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1556,7 +1556,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_datacenter_connector][super::super::client::VmMigration::delete_datacenter_connector].
+        /// on [delete_datacenter_connector][crate::client::VmMigration::delete_datacenter_connector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_datacenter_connector(self.0.request, self.0.options)
@@ -1621,7 +1621,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::upgrade_appliance][super::super::client::VmMigration::upgrade_appliance] calls.
+    /// The request builder for [VmMigration::upgrade_appliance][crate::client::VmMigration::upgrade_appliance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1669,7 +1669,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [upgrade_appliance][super::super::client::VmMigration::upgrade_appliance].
+        /// on [upgrade_appliance][crate::client::VmMigration::upgrade_appliance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .upgrade_appliance(self.0.request, self.0.options)
@@ -1735,7 +1735,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_migrating_vm][super::super::client::VmMigration::create_migrating_vm] calls.
+    /// The request builder for [VmMigration::create_migrating_vm][crate::client::VmMigration::create_migrating_vm] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1783,7 +1783,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_migrating_vm][super::super::client::VmMigration::create_migrating_vm].
+        /// on [create_migrating_vm][crate::client::VmMigration::create_migrating_vm].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_migrating_vm(self.0.request, self.0.options)
@@ -1878,7 +1878,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_migrating_vms][super::super::client::VmMigration::list_migrating_vms] calls.
+    /// The request builder for [VmMigration::list_migrating_vms][crate::client::VmMigration::list_migrating_vms] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2004,7 +2004,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_migrating_vm][super::super::client::VmMigration::get_migrating_vm] calls.
+    /// The request builder for [VmMigration::get_migrating_vm][crate::client::VmMigration::get_migrating_vm] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2073,7 +2073,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::update_migrating_vm][super::super::client::VmMigration::update_migrating_vm] calls.
+    /// The request builder for [VmMigration::update_migrating_vm][crate::client::VmMigration::update_migrating_vm] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2121,7 +2121,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_migrating_vm][super::super::client::VmMigration::update_migrating_vm].
+        /// on [update_migrating_vm][crate::client::VmMigration::update_migrating_vm].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_migrating_vm(self.0.request, self.0.options)
@@ -2218,7 +2218,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::delete_migrating_vm][super::super::client::VmMigration::delete_migrating_vm] calls.
+    /// The request builder for [VmMigration::delete_migrating_vm][crate::client::VmMigration::delete_migrating_vm] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2266,7 +2266,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_migrating_vm][super::super::client::VmMigration::delete_migrating_vm].
+        /// on [delete_migrating_vm][crate::client::VmMigration::delete_migrating_vm].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_migrating_vm(self.0.request, self.0.options)
@@ -2325,7 +2325,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::start_migration][super::super::client::VmMigration::start_migration] calls.
+    /// The request builder for [VmMigration::start_migration][crate::client::VmMigration::start_migration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2370,7 +2370,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_migration][super::super::client::VmMigration::start_migration].
+        /// on [start_migration][crate::client::VmMigration::start_migration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_migration(self.0.request, self.0.options)
@@ -2430,7 +2430,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::resume_migration][super::super::client::VmMigration::resume_migration] calls.
+    /// The request builder for [VmMigration::resume_migration][crate::client::VmMigration::resume_migration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2475,7 +2475,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [resume_migration][super::super::client::VmMigration::resume_migration].
+        /// on [resume_migration][crate::client::VmMigration::resume_migration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .resume_migration(self.0.request, self.0.options)
@@ -2535,7 +2535,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::pause_migration][super::super::client::VmMigration::pause_migration] calls.
+    /// The request builder for [VmMigration::pause_migration][crate::client::VmMigration::pause_migration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2580,7 +2580,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [pause_migration][super::super::client::VmMigration::pause_migration].
+        /// on [pause_migration][crate::client::VmMigration::pause_migration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .pause_migration(self.0.request, self.0.options)
@@ -2640,7 +2640,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::finalize_migration][super::super::client::VmMigration::finalize_migration] calls.
+    /// The request builder for [VmMigration::finalize_migration][crate::client::VmMigration::finalize_migration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2688,7 +2688,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [finalize_migration][super::super::client::VmMigration::finalize_migration].
+        /// on [finalize_migration][crate::client::VmMigration::finalize_migration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .finalize_migration(self.0.request, self.0.options)
@@ -2748,7 +2748,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_clone_job][super::super::client::VmMigration::create_clone_job] calls.
+    /// The request builder for [VmMigration::create_clone_job][crate::client::VmMigration::create_clone_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2793,7 +2793,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_clone_job][super::super::client::VmMigration::create_clone_job].
+        /// on [create_clone_job][crate::client::VmMigration::create_clone_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_clone_job(self.0.request, self.0.options)
@@ -2886,7 +2886,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::cancel_clone_job][super::super::client::VmMigration::cancel_clone_job] calls.
+    /// The request builder for [VmMigration::cancel_clone_job][crate::client::VmMigration::cancel_clone_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2931,7 +2931,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [cancel_clone_job][super::super::client::VmMigration::cancel_clone_job].
+        /// on [cancel_clone_job][crate::client::VmMigration::cancel_clone_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .cancel_clone_job(self.0.request, self.0.options)
@@ -2991,7 +2991,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_clone_jobs][super::super::client::VmMigration::list_clone_jobs] calls.
+    /// The request builder for [VmMigration::list_clone_jobs][crate::client::VmMigration::list_clone_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3108,7 +3108,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_clone_job][super::super::client::VmMigration::get_clone_job] calls.
+    /// The request builder for [VmMigration::get_clone_job][crate::client::VmMigration::get_clone_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3171,7 +3171,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_cutover_job][super::super::client::VmMigration::create_cutover_job] calls.
+    /// The request builder for [VmMigration::create_cutover_job][crate::client::VmMigration::create_cutover_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3219,7 +3219,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cutover_job][super::super::client::VmMigration::create_cutover_job].
+        /// on [create_cutover_job][crate::client::VmMigration::create_cutover_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cutover_job(self.0.request, self.0.options)
@@ -3312,7 +3312,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::cancel_cutover_job][super::super::client::VmMigration::cancel_cutover_job] calls.
+    /// The request builder for [VmMigration::cancel_cutover_job][crate::client::VmMigration::cancel_cutover_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3360,7 +3360,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [cancel_cutover_job][super::super::client::VmMigration::cancel_cutover_job].
+        /// on [cancel_cutover_job][crate::client::VmMigration::cancel_cutover_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .cancel_cutover_job(self.0.request, self.0.options)
@@ -3420,7 +3420,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_cutover_jobs][super::super::client::VmMigration::list_cutover_jobs] calls.
+    /// The request builder for [VmMigration::list_cutover_jobs][crate::client::VmMigration::list_cutover_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3537,7 +3537,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_cutover_job][super::super::client::VmMigration::get_cutover_job] calls.
+    /// The request builder for [VmMigration::get_cutover_job][crate::client::VmMigration::get_cutover_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3600,7 +3600,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_groups][super::super::client::VmMigration::list_groups] calls.
+    /// The request builder for [VmMigration::list_groups][crate::client::VmMigration::list_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3717,7 +3717,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_group][super::super::client::VmMigration::get_group] calls.
+    /// The request builder for [VmMigration::get_group][crate::client::VmMigration::get_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3780,7 +3780,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_group][super::super::client::VmMigration::create_group] calls.
+    /// The request builder for [VmMigration::create_group][crate::client::VmMigration::create_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3825,7 +3825,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_group][super::super::client::VmMigration::create_group].
+        /// on [create_group][crate::client::VmMigration::create_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_group(self.0.request, self.0.options)
@@ -3918,7 +3918,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::update_group][super::super::client::VmMigration::update_group] calls.
+    /// The request builder for [VmMigration::update_group][crate::client::VmMigration::update_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3963,7 +3963,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_group][super::super::client::VmMigration::update_group].
+        /// on [update_group][crate::client::VmMigration::update_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_group(self.0.request, self.0.options)
@@ -4058,7 +4058,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::delete_group][super::super::client::VmMigration::delete_group] calls.
+    /// The request builder for [VmMigration::delete_group][crate::client::VmMigration::delete_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4103,7 +4103,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_group][super::super::client::VmMigration::delete_group].
+        /// on [delete_group][crate::client::VmMigration::delete_group].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_group(self.0.request, self.0.options)
@@ -4168,7 +4168,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::add_group_migration][super::super::client::VmMigration::add_group_migration] calls.
+    /// The request builder for [VmMigration::add_group_migration][crate::client::VmMigration::add_group_migration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4216,7 +4216,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [add_group_migration][super::super::client::VmMigration::add_group_migration].
+        /// on [add_group_migration][crate::client::VmMigration::add_group_migration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .add_group_migration(self.0.request, self.0.options)
@@ -4282,7 +4282,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::remove_group_migration][super::super::client::VmMigration::remove_group_migration] calls.
+    /// The request builder for [VmMigration::remove_group_migration][crate::client::VmMigration::remove_group_migration] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4330,7 +4330,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [remove_group_migration][super::super::client::VmMigration::remove_group_migration].
+        /// on [remove_group_migration][crate::client::VmMigration::remove_group_migration].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .remove_group_migration(self.0.request, self.0.options)
@@ -4396,7 +4396,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_target_projects][super::super::client::VmMigration::list_target_projects] calls.
+    /// The request builder for [VmMigration::list_target_projects][crate::client::VmMigration::list_target_projects] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4518,7 +4518,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_target_project][super::super::client::VmMigration::get_target_project] calls.
+    /// The request builder for [VmMigration::get_target_project][crate::client::VmMigration::get_target_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4584,7 +4584,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::create_target_project][super::super::client::VmMigration::create_target_project] calls.
+    /// The request builder for [VmMigration::create_target_project][crate::client::VmMigration::create_target_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4632,7 +4632,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_target_project][super::super::client::VmMigration::create_target_project].
+        /// on [create_target_project][crate::client::VmMigration::create_target_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_target_project(self.0.request, self.0.options)
@@ -4728,7 +4728,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::update_target_project][super::super::client::VmMigration::update_target_project] calls.
+    /// The request builder for [VmMigration::update_target_project][crate::client::VmMigration::update_target_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4776,7 +4776,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_target_project][super::super::client::VmMigration::update_target_project].
+        /// on [update_target_project][crate::client::VmMigration::update_target_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_target_project(self.0.request, self.0.options)
@@ -4874,7 +4874,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::delete_target_project][super::super::client::VmMigration::delete_target_project] calls.
+    /// The request builder for [VmMigration::delete_target_project][crate::client::VmMigration::delete_target_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4922,7 +4922,7 @@ pub mod vm_migration {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_target_project][super::super::client::VmMigration::delete_target_project].
+        /// on [delete_target_project][crate::client::VmMigration::delete_target_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_target_project(self.0.request, self.0.options)
@@ -4987,7 +4987,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_replication_cycles][super::super::client::VmMigration::list_replication_cycles] calls.
+    /// The request builder for [VmMigration::list_replication_cycles][crate::client::VmMigration::list_replication_cycles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5109,7 +5109,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_replication_cycle][super::super::client::VmMigration::get_replication_cycle] calls.
+    /// The request builder for [VmMigration::get_replication_cycle][crate::client::VmMigration::get_replication_cycle] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5175,7 +5175,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_locations][super::super::client::VmMigration::list_locations] calls.
+    /// The request builder for [VmMigration::list_locations][crate::client::VmMigration::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5285,7 +5285,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_location][super::super::client::VmMigration::get_location] calls.
+    /// The request builder for [VmMigration::get_location][crate::client::VmMigration::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5346,7 +5346,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::list_operations][super::super::client::VmMigration::list_operations] calls.
+    /// The request builder for [VmMigration::list_operations][crate::client::VmMigration::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5458,7 +5458,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::get_operation][super::super::client::VmMigration::get_operation] calls.
+    /// The request builder for [VmMigration::get_operation][crate::client::VmMigration::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5522,7 +5522,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::delete_operation][super::super::client::VmMigration::delete_operation] calls.
+    /// The request builder for [VmMigration::delete_operation][crate::client::VmMigration::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5586,7 +5586,7 @@ pub mod vm_migration {
         }
     }
 
-    /// The request builder for [VmMigration::cancel_operation][super::super::client::VmMigration::cancel_operation] calls.
+    /// The request builder for [VmMigration::cancel_operation][crate::client::VmMigration::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/vmwareengine/v1/src/builder.rs
+++ b/src/generated/cloud/vmwareengine/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod vmware_engine {
     use crate::Result;
 
-    /// A builder for [VmwareEngine][super::super::client::VmwareEngine].
+    /// A builder for [VmwareEngine][crate::client::VmwareEngine].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// Common implementation for [super::super::client::VmwareEngine] request builders.
+    /// Common implementation for [crate::client::VmwareEngine] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VmwareEngine>,
@@ -68,7 +68,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_private_clouds][super::super::client::VmwareEngine::list_private_clouds] calls.
+    /// The request builder for [VmwareEngine::list_private_clouds][crate::client::VmwareEngine::list_private_clouds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_private_cloud][super::super::client::VmwareEngine::get_private_cloud] calls.
+    /// The request builder for [VmwareEngine::get_private_cloud][crate::client::VmwareEngine::get_private_cloud] calls.
     ///
     /// # Example
     /// ```no_run
@@ -249,7 +249,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_private_cloud][super::super::client::VmwareEngine::create_private_cloud] calls.
+    /// The request builder for [VmwareEngine::create_private_cloud][crate::client::VmwareEngine::create_private_cloud] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_private_cloud][super::super::client::VmwareEngine::create_private_cloud].
+        /// on [create_private_cloud][crate::client::VmwareEngine::create_private_cloud].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_private_cloud(self.0.request, self.0.options)
@@ -398,7 +398,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_private_cloud][super::super::client::VmwareEngine::update_private_cloud] calls.
+    /// The request builder for [VmwareEngine::update_private_cloud][crate::client::VmwareEngine::update_private_cloud] calls.
     ///
     /// # Example
     /// ```no_run
@@ -446,7 +446,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_private_cloud][super::super::client::VmwareEngine::update_private_cloud].
+        /// on [update_private_cloud][crate::client::VmwareEngine::update_private_cloud].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_private_cloud(self.0.request, self.0.options)
@@ -547,7 +547,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_private_cloud][super::super::client::VmwareEngine::delete_private_cloud] calls.
+    /// The request builder for [VmwareEngine::delete_private_cloud][crate::client::VmwareEngine::delete_private_cloud] calls.
     ///
     /// # Example
     /// ```no_run
@@ -595,7 +595,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_private_cloud][super::super::client::VmwareEngine::delete_private_cloud].
+        /// on [delete_private_cloud][crate::client::VmwareEngine::delete_private_cloud].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_private_cloud(self.0.request, self.0.options)
@@ -684,7 +684,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::undelete_private_cloud][super::super::client::VmwareEngine::undelete_private_cloud] calls.
+    /// The request builder for [VmwareEngine::undelete_private_cloud][crate::client::VmwareEngine::undelete_private_cloud] calls.
     ///
     /// # Example
     /// ```no_run
@@ -732,7 +732,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [undelete_private_cloud][super::super::client::VmwareEngine::undelete_private_cloud].
+        /// on [undelete_private_cloud][crate::client::VmwareEngine::undelete_private_cloud].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .undelete_private_cloud(self.0.request, self.0.options)
@@ -797,7 +797,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_clusters][super::super::client::VmwareEngine::list_clusters] calls.
+    /// The request builder for [VmwareEngine::list_clusters][crate::client::VmwareEngine::list_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -912,7 +912,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_cluster][super::super::client::VmwareEngine::get_cluster] calls.
+    /// The request builder for [VmwareEngine::get_cluster][crate::client::VmwareEngine::get_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -975,7 +975,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_cluster][super::super::client::VmwareEngine::create_cluster] calls.
+    /// The request builder for [VmwareEngine::create_cluster][crate::client::VmwareEngine::create_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1020,7 +1020,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_cluster][super::super::client::VmwareEngine::create_cluster].
+        /// on [create_cluster][crate::client::VmwareEngine::create_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_cluster(self.0.request, self.0.options)
@@ -1119,7 +1119,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_cluster][super::super::client::VmwareEngine::update_cluster] calls.
+    /// The request builder for [VmwareEngine::update_cluster][crate::client::VmwareEngine::update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1164,7 +1164,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_cluster][super::super::client::VmwareEngine::update_cluster].
+        /// on [update_cluster][crate::client::VmwareEngine::update_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_cluster(self.0.request, self.0.options)
@@ -1269,7 +1269,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_cluster][super::super::client::VmwareEngine::delete_cluster] calls.
+    /// The request builder for [VmwareEngine::delete_cluster][crate::client::VmwareEngine::delete_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1314,7 +1314,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_cluster][super::super::client::VmwareEngine::delete_cluster].
+        /// on [delete_cluster][crate::client::VmwareEngine::delete_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_cluster(self.0.request, self.0.options)
@@ -1379,7 +1379,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_nodes][super::super::client::VmwareEngine::list_nodes] calls.
+    /// The request builder for [VmwareEngine::list_nodes][crate::client::VmwareEngine::list_nodes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1482,7 +1482,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_node][super::super::client::VmwareEngine::get_node] calls.
+    /// The request builder for [VmwareEngine::get_node][crate::client::VmwareEngine::get_node] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1545,7 +1545,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_external_addresses][super::super::client::VmwareEngine::list_external_addresses] calls.
+    /// The request builder for [VmwareEngine::list_external_addresses][crate::client::VmwareEngine::list_external_addresses] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1665,7 +1665,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::fetch_network_policy_external_addresses][super::super::client::VmwareEngine::fetch_network_policy_external_addresses] calls.
+    /// The request builder for [VmwareEngine::fetch_network_policy_external_addresses][crate::client::VmwareEngine::fetch_network_policy_external_addresses] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1779,7 +1779,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_external_address][super::super::client::VmwareEngine::get_external_address] calls.
+    /// The request builder for [VmwareEngine::get_external_address][crate::client::VmwareEngine::get_external_address] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1845,7 +1845,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_external_address][super::super::client::VmwareEngine::create_external_address] calls.
+    /// The request builder for [VmwareEngine::create_external_address][crate::client::VmwareEngine::create_external_address] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1893,7 +1893,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_external_address][super::super::client::VmwareEngine::create_external_address].
+        /// on [create_external_address][crate::client::VmwareEngine::create_external_address].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_external_address(self.0.request, self.0.options)
@@ -1989,7 +1989,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_external_address][super::super::client::VmwareEngine::update_external_address] calls.
+    /// The request builder for [VmwareEngine::update_external_address][crate::client::VmwareEngine::update_external_address] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2037,7 +2037,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_external_address][super::super::client::VmwareEngine::update_external_address].
+        /// on [update_external_address][crate::client::VmwareEngine::update_external_address].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_external_address(self.0.request, self.0.options)
@@ -2139,7 +2139,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_external_address][super::super::client::VmwareEngine::delete_external_address] calls.
+    /// The request builder for [VmwareEngine::delete_external_address][crate::client::VmwareEngine::delete_external_address] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2187,7 +2187,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_external_address][super::super::client::VmwareEngine::delete_external_address].
+        /// on [delete_external_address][crate::client::VmwareEngine::delete_external_address].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_external_address(self.0.request, self.0.options)
@@ -2252,7 +2252,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_subnets][super::super::client::VmwareEngine::list_subnets] calls.
+    /// The request builder for [VmwareEngine::list_subnets][crate::client::VmwareEngine::list_subnets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2355,7 +2355,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_subnet][super::super::client::VmwareEngine::get_subnet] calls.
+    /// The request builder for [VmwareEngine::get_subnet][crate::client::VmwareEngine::get_subnet] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2418,7 +2418,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_subnet][super::super::client::VmwareEngine::update_subnet] calls.
+    /// The request builder for [VmwareEngine::update_subnet][crate::client::VmwareEngine::update_subnet] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2463,7 +2463,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_subnet][super::super::client::VmwareEngine::update_subnet].
+        /// on [update_subnet][crate::client::VmwareEngine::update_subnet].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_subnet(self.0.request, self.0.options)
@@ -2556,7 +2556,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_external_access_rules][super::super::client::VmwareEngine::list_external_access_rules] calls.
+    /// The request builder for [VmwareEngine::list_external_access_rules][crate::client::VmwareEngine::list_external_access_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2680,7 +2680,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_external_access_rule][super::super::client::VmwareEngine::get_external_access_rule] calls.
+    /// The request builder for [VmwareEngine::get_external_access_rule][crate::client::VmwareEngine::get_external_access_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2746,7 +2746,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_external_access_rule][super::super::client::VmwareEngine::create_external_access_rule] calls.
+    /// The request builder for [VmwareEngine::create_external_access_rule][crate::client::VmwareEngine::create_external_access_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2796,7 +2796,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_external_access_rule][super::super::client::VmwareEngine::create_external_access_rule].
+        /// on [create_external_access_rule][crate::client::VmwareEngine::create_external_access_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_external_access_rule(self.0.request, self.0.options)
@@ -2892,7 +2892,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_external_access_rule][super::super::client::VmwareEngine::update_external_access_rule] calls.
+    /// The request builder for [VmwareEngine::update_external_access_rule][crate::client::VmwareEngine::update_external_access_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2942,7 +2942,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_external_access_rule][super::super::client::VmwareEngine::update_external_access_rule].
+        /// on [update_external_access_rule][crate::client::VmwareEngine::update_external_access_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_external_access_rule(self.0.request, self.0.options)
@@ -3044,7 +3044,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_external_access_rule][super::super::client::VmwareEngine::delete_external_access_rule] calls.
+    /// The request builder for [VmwareEngine::delete_external_access_rule][crate::client::VmwareEngine::delete_external_access_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3094,7 +3094,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_external_access_rule][super::super::client::VmwareEngine::delete_external_access_rule].
+        /// on [delete_external_access_rule][crate::client::VmwareEngine::delete_external_access_rule].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_external_access_rule(self.0.request, self.0.options)
@@ -3159,7 +3159,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_logging_servers][super::super::client::VmwareEngine::list_logging_servers] calls.
+    /// The request builder for [VmwareEngine::list_logging_servers][crate::client::VmwareEngine::list_logging_servers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3279,7 +3279,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_logging_server][super::super::client::VmwareEngine::get_logging_server] calls.
+    /// The request builder for [VmwareEngine::get_logging_server][crate::client::VmwareEngine::get_logging_server] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3345,7 +3345,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_logging_server][super::super::client::VmwareEngine::create_logging_server] calls.
+    /// The request builder for [VmwareEngine::create_logging_server][crate::client::VmwareEngine::create_logging_server] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3393,7 +3393,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_logging_server][super::super::client::VmwareEngine::create_logging_server].
+        /// on [create_logging_server][crate::client::VmwareEngine::create_logging_server].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_logging_server(self.0.request, self.0.options)
@@ -3489,7 +3489,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_logging_server][super::super::client::VmwareEngine::update_logging_server] calls.
+    /// The request builder for [VmwareEngine::update_logging_server][crate::client::VmwareEngine::update_logging_server] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3537,7 +3537,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_logging_server][super::super::client::VmwareEngine::update_logging_server].
+        /// on [update_logging_server][crate::client::VmwareEngine::update_logging_server].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_logging_server(self.0.request, self.0.options)
@@ -3639,7 +3639,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_logging_server][super::super::client::VmwareEngine::delete_logging_server] calls.
+    /// The request builder for [VmwareEngine::delete_logging_server][crate::client::VmwareEngine::delete_logging_server] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3687,7 +3687,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_logging_server][super::super::client::VmwareEngine::delete_logging_server].
+        /// on [delete_logging_server][crate::client::VmwareEngine::delete_logging_server].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_logging_server(self.0.request, self.0.options)
@@ -3752,7 +3752,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_node_types][super::super::client::VmwareEngine::list_node_types] calls.
+    /// The request builder for [VmwareEngine::list_node_types][crate::client::VmwareEngine::list_node_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3861,7 +3861,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_node_type][super::super::client::VmwareEngine::get_node_type] calls.
+    /// The request builder for [VmwareEngine::get_node_type][crate::client::VmwareEngine::get_node_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3924,7 +3924,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::show_nsx_credentials][super::super::client::VmwareEngine::show_nsx_credentials] calls.
+    /// The request builder for [VmwareEngine::show_nsx_credentials][crate::client::VmwareEngine::show_nsx_credentials] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3990,7 +3990,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::show_vcenter_credentials][super::super::client::VmwareEngine::show_vcenter_credentials] calls.
+    /// The request builder for [VmwareEngine::show_vcenter_credentials][crate::client::VmwareEngine::show_vcenter_credentials] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4062,7 +4062,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::reset_nsx_credentials][super::super::client::VmwareEngine::reset_nsx_credentials] calls.
+    /// The request builder for [VmwareEngine::reset_nsx_credentials][crate::client::VmwareEngine::reset_nsx_credentials] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4110,7 +4110,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reset_nsx_credentials][super::super::client::VmwareEngine::reset_nsx_credentials].
+        /// on [reset_nsx_credentials][crate::client::VmwareEngine::reset_nsx_credentials].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reset_nsx_credentials(self.0.request, self.0.options)
@@ -4175,7 +4175,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::reset_vcenter_credentials][super::super::client::VmwareEngine::reset_vcenter_credentials] calls.
+    /// The request builder for [VmwareEngine::reset_vcenter_credentials][crate::client::VmwareEngine::reset_vcenter_credentials] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4225,7 +4225,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [reset_vcenter_credentials][super::super::client::VmwareEngine::reset_vcenter_credentials].
+        /// on [reset_vcenter_credentials][crate::client::VmwareEngine::reset_vcenter_credentials].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .reset_vcenter_credentials(self.0.request, self.0.options)
@@ -4296,7 +4296,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_dns_forwarding][super::super::client::VmwareEngine::get_dns_forwarding] calls.
+    /// The request builder for [VmwareEngine::get_dns_forwarding][crate::client::VmwareEngine::get_dns_forwarding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4362,7 +4362,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_dns_forwarding][super::super::client::VmwareEngine::update_dns_forwarding] calls.
+    /// The request builder for [VmwareEngine::update_dns_forwarding][crate::client::VmwareEngine::update_dns_forwarding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4410,7 +4410,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_dns_forwarding][super::super::client::VmwareEngine::update_dns_forwarding].
+        /// on [update_dns_forwarding][crate::client::VmwareEngine::update_dns_forwarding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_dns_forwarding(self.0.request, self.0.options)
@@ -4512,7 +4512,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_network_peering][super::super::client::VmwareEngine::get_network_peering] calls.
+    /// The request builder for [VmwareEngine::get_network_peering][crate::client::VmwareEngine::get_network_peering] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4578,7 +4578,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_network_peerings][super::super::client::VmwareEngine::list_network_peerings] calls.
+    /// The request builder for [VmwareEngine::list_network_peerings][crate::client::VmwareEngine::list_network_peerings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4698,7 +4698,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_network_peering][super::super::client::VmwareEngine::create_network_peering] calls.
+    /// The request builder for [VmwareEngine::create_network_peering][crate::client::VmwareEngine::create_network_peering] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4746,7 +4746,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_network_peering][super::super::client::VmwareEngine::create_network_peering].
+        /// on [create_network_peering][crate::client::VmwareEngine::create_network_peering].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_network_peering(self.0.request, self.0.options)
@@ -4842,7 +4842,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_network_peering][super::super::client::VmwareEngine::delete_network_peering] calls.
+    /// The request builder for [VmwareEngine::delete_network_peering][crate::client::VmwareEngine::delete_network_peering] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4890,7 +4890,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_network_peering][super::super::client::VmwareEngine::delete_network_peering].
+        /// on [delete_network_peering][crate::client::VmwareEngine::delete_network_peering].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_network_peering(self.0.request, self.0.options)
@@ -4955,7 +4955,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_network_peering][super::super::client::VmwareEngine::update_network_peering] calls.
+    /// The request builder for [VmwareEngine::update_network_peering][crate::client::VmwareEngine::update_network_peering] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5003,7 +5003,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_network_peering][super::super::client::VmwareEngine::update_network_peering].
+        /// on [update_network_peering][crate::client::VmwareEngine::update_network_peering].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_network_peering(self.0.request, self.0.options)
@@ -5105,7 +5105,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_peering_routes][super::super::client::VmwareEngine::list_peering_routes] calls.
+    /// The request builder for [VmwareEngine::list_peering_routes][crate::client::VmwareEngine::list_peering_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5217,7 +5217,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_hcx_activation_key][super::super::client::VmwareEngine::create_hcx_activation_key] calls.
+    /// The request builder for [VmwareEngine::create_hcx_activation_key][crate::client::VmwareEngine::create_hcx_activation_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5265,7 +5265,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_hcx_activation_key][super::super::client::VmwareEngine::create_hcx_activation_key].
+        /// on [create_hcx_activation_key][crate::client::VmwareEngine::create_hcx_activation_key].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_hcx_activation_key(self.0.request, self.0.options)
@@ -5361,7 +5361,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_hcx_activation_keys][super::super::client::VmwareEngine::list_hcx_activation_keys] calls.
+    /// The request builder for [VmwareEngine::list_hcx_activation_keys][crate::client::VmwareEngine::list_hcx_activation_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5469,7 +5469,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_hcx_activation_key][super::super::client::VmwareEngine::get_hcx_activation_key] calls.
+    /// The request builder for [VmwareEngine::get_hcx_activation_key][crate::client::VmwareEngine::get_hcx_activation_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5535,7 +5535,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_network_policy][super::super::client::VmwareEngine::get_network_policy] calls.
+    /// The request builder for [VmwareEngine::get_network_policy][crate::client::VmwareEngine::get_network_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5601,7 +5601,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_network_policies][super::super::client::VmwareEngine::list_network_policies] calls.
+    /// The request builder for [VmwareEngine::list_network_policies][crate::client::VmwareEngine::list_network_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5721,7 +5721,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_network_policy][super::super::client::VmwareEngine::create_network_policy] calls.
+    /// The request builder for [VmwareEngine::create_network_policy][crate::client::VmwareEngine::create_network_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5769,7 +5769,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_network_policy][super::super::client::VmwareEngine::create_network_policy].
+        /// on [create_network_policy][crate::client::VmwareEngine::create_network_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_network_policy(self.0.request, self.0.options)
@@ -5865,7 +5865,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_network_policy][super::super::client::VmwareEngine::update_network_policy] calls.
+    /// The request builder for [VmwareEngine::update_network_policy][crate::client::VmwareEngine::update_network_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5913,7 +5913,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_network_policy][super::super::client::VmwareEngine::update_network_policy].
+        /// on [update_network_policy][crate::client::VmwareEngine::update_network_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_network_policy(self.0.request, self.0.options)
@@ -6015,7 +6015,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_network_policy][super::super::client::VmwareEngine::delete_network_policy] calls.
+    /// The request builder for [VmwareEngine::delete_network_policy][crate::client::VmwareEngine::delete_network_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6063,7 +6063,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_network_policy][super::super::client::VmwareEngine::delete_network_policy].
+        /// on [delete_network_policy][crate::client::VmwareEngine::delete_network_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_network_policy(self.0.request, self.0.options)
@@ -6128,7 +6128,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_management_dns_zone_bindings][super::super::client::VmwareEngine::list_management_dns_zone_bindings] calls.
+    /// The request builder for [VmwareEngine::list_management_dns_zone_bindings][crate::client::VmwareEngine::list_management_dns_zone_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6252,7 +6252,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_management_dns_zone_binding][super::super::client::VmwareEngine::get_management_dns_zone_binding] calls.
+    /// The request builder for [VmwareEngine::get_management_dns_zone_binding][crate::client::VmwareEngine::get_management_dns_zone_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6320,7 +6320,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_management_dns_zone_binding][super::super::client::VmwareEngine::create_management_dns_zone_binding] calls.
+    /// The request builder for [VmwareEngine::create_management_dns_zone_binding][crate::client::VmwareEngine::create_management_dns_zone_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6370,7 +6370,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_management_dns_zone_binding][super::super::client::VmwareEngine::create_management_dns_zone_binding].
+        /// on [create_management_dns_zone_binding][crate::client::VmwareEngine::create_management_dns_zone_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_management_dns_zone_binding(self.0.request, self.0.options)
@@ -6472,7 +6472,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_management_dns_zone_binding][super::super::client::VmwareEngine::update_management_dns_zone_binding] calls.
+    /// The request builder for [VmwareEngine::update_management_dns_zone_binding][crate::client::VmwareEngine::update_management_dns_zone_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6522,7 +6522,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_management_dns_zone_binding][super::super::client::VmwareEngine::update_management_dns_zone_binding].
+        /// on [update_management_dns_zone_binding][crate::client::VmwareEngine::update_management_dns_zone_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_management_dns_zone_binding(self.0.request, self.0.options)
@@ -6627,7 +6627,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_management_dns_zone_binding][super::super::client::VmwareEngine::delete_management_dns_zone_binding] calls.
+    /// The request builder for [VmwareEngine::delete_management_dns_zone_binding][crate::client::VmwareEngine::delete_management_dns_zone_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6677,7 +6677,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_management_dns_zone_binding][super::super::client::VmwareEngine::delete_management_dns_zone_binding].
+        /// on [delete_management_dns_zone_binding][crate::client::VmwareEngine::delete_management_dns_zone_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_management_dns_zone_binding(self.0.request, self.0.options)
@@ -6742,7 +6742,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::repair_management_dns_zone_binding][super::super::client::VmwareEngine::repair_management_dns_zone_binding] calls.
+    /// The request builder for [VmwareEngine::repair_management_dns_zone_binding][crate::client::VmwareEngine::repair_management_dns_zone_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6792,7 +6792,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [repair_management_dns_zone_binding][super::super::client::VmwareEngine::repair_management_dns_zone_binding].
+        /// on [repair_management_dns_zone_binding][crate::client::VmwareEngine::repair_management_dns_zone_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .repair_management_dns_zone_binding(self.0.request, self.0.options)
@@ -6858,7 +6858,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_vmware_engine_network][super::super::client::VmwareEngine::create_vmware_engine_network] calls.
+    /// The request builder for [VmwareEngine::create_vmware_engine_network][crate::client::VmwareEngine::create_vmware_engine_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6908,7 +6908,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_vmware_engine_network][super::super::client::VmwareEngine::create_vmware_engine_network].
+        /// on [create_vmware_engine_network][crate::client::VmwareEngine::create_vmware_engine_network].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_vmware_engine_network(self.0.request, self.0.options)
@@ -7004,7 +7004,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_vmware_engine_network][super::super::client::VmwareEngine::update_vmware_engine_network] calls.
+    /// The request builder for [VmwareEngine::update_vmware_engine_network][crate::client::VmwareEngine::update_vmware_engine_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7054,7 +7054,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_vmware_engine_network][super::super::client::VmwareEngine::update_vmware_engine_network].
+        /// on [update_vmware_engine_network][crate::client::VmwareEngine::update_vmware_engine_network].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_vmware_engine_network(self.0.request, self.0.options)
@@ -7156,7 +7156,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_vmware_engine_network][super::super::client::VmwareEngine::delete_vmware_engine_network] calls.
+    /// The request builder for [VmwareEngine::delete_vmware_engine_network][crate::client::VmwareEngine::delete_vmware_engine_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7206,7 +7206,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_vmware_engine_network][super::super::client::VmwareEngine::delete_vmware_engine_network].
+        /// on [delete_vmware_engine_network][crate::client::VmwareEngine::delete_vmware_engine_network].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_vmware_engine_network(self.0.request, self.0.options)
@@ -7277,7 +7277,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_vmware_engine_network][super::super::client::VmwareEngine::get_vmware_engine_network] calls.
+    /// The request builder for [VmwareEngine::get_vmware_engine_network][crate::client::VmwareEngine::get_vmware_engine_network] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7343,7 +7343,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_vmware_engine_networks][super::super::client::VmwareEngine::list_vmware_engine_networks] calls.
+    /// The request builder for [VmwareEngine::list_vmware_engine_networks][crate::client::VmwareEngine::list_vmware_engine_networks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7467,7 +7467,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::create_private_connection][super::super::client::VmwareEngine::create_private_connection] calls.
+    /// The request builder for [VmwareEngine::create_private_connection][crate::client::VmwareEngine::create_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7517,7 +7517,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_private_connection][super::super::client::VmwareEngine::create_private_connection].
+        /// on [create_private_connection][crate::client::VmwareEngine::create_private_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_private_connection(self.0.request, self.0.options)
@@ -7613,7 +7613,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_private_connection][super::super::client::VmwareEngine::get_private_connection] calls.
+    /// The request builder for [VmwareEngine::get_private_connection][crate::client::VmwareEngine::get_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7679,7 +7679,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_private_connections][super::super::client::VmwareEngine::list_private_connections] calls.
+    /// The request builder for [VmwareEngine::list_private_connections][crate::client::VmwareEngine::list_private_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7801,7 +7801,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::update_private_connection][super::super::client::VmwareEngine::update_private_connection] calls.
+    /// The request builder for [VmwareEngine::update_private_connection][crate::client::VmwareEngine::update_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7851,7 +7851,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_private_connection][super::super::client::VmwareEngine::update_private_connection].
+        /// on [update_private_connection][crate::client::VmwareEngine::update_private_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_private_connection(self.0.request, self.0.options)
@@ -7953,7 +7953,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_private_connection][super::super::client::VmwareEngine::delete_private_connection] calls.
+    /// The request builder for [VmwareEngine::delete_private_connection][crate::client::VmwareEngine::delete_private_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8003,7 +8003,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_private_connection][super::super::client::VmwareEngine::delete_private_connection].
+        /// on [delete_private_connection][crate::client::VmwareEngine::delete_private_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_private_connection(self.0.request, self.0.options)
@@ -8068,7 +8068,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_private_connection_peering_routes][super::super::client::VmwareEngine::list_private_connection_peering_routes] calls.
+    /// The request builder for [VmwareEngine::list_private_connection_peering_routes][crate::client::VmwareEngine::list_private_connection_peering_routes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8182,7 +8182,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::grant_dns_bind_permission][super::super::client::VmwareEngine::grant_dns_bind_permission] calls.
+    /// The request builder for [VmwareEngine::grant_dns_bind_permission][crate::client::VmwareEngine::grant_dns_bind_permission] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8230,7 +8230,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [grant_dns_bind_permission][super::super::client::VmwareEngine::grant_dns_bind_permission].
+        /// on [grant_dns_bind_permission][crate::client::VmwareEngine::grant_dns_bind_permission].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .grant_dns_bind_permission(self.0.request, self.0.options)
@@ -8318,7 +8318,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_dns_bind_permission][super::super::client::VmwareEngine::get_dns_bind_permission] calls.
+    /// The request builder for [VmwareEngine::get_dns_bind_permission][crate::client::VmwareEngine::get_dns_bind_permission] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8384,7 +8384,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::revoke_dns_bind_permission][super::super::client::VmwareEngine::revoke_dns_bind_permission] calls.
+    /// The request builder for [VmwareEngine::revoke_dns_bind_permission][crate::client::VmwareEngine::revoke_dns_bind_permission] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8434,7 +8434,7 @@ pub mod vmware_engine {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [revoke_dns_bind_permission][super::super::client::VmwareEngine::revoke_dns_bind_permission].
+        /// on [revoke_dns_bind_permission][crate::client::VmwareEngine::revoke_dns_bind_permission].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .revoke_dns_bind_permission(self.0.request, self.0.options)
@@ -8522,7 +8522,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_locations][super::super::client::VmwareEngine::list_locations] calls.
+    /// The request builder for [VmwareEngine::list_locations][crate::client::VmwareEngine::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8632,7 +8632,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_location][super::super::client::VmwareEngine::get_location] calls.
+    /// The request builder for [VmwareEngine::get_location][crate::client::VmwareEngine::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8693,7 +8693,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::set_iam_policy][super::super::client::VmwareEngine::set_iam_policy] calls.
+    /// The request builder for [VmwareEngine::set_iam_policy][crate::client::VmwareEngine::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8796,7 +8796,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_iam_policy][super::super::client::VmwareEngine::get_iam_policy] calls.
+    /// The request builder for [VmwareEngine::get_iam_policy][crate::client::VmwareEngine::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8877,7 +8877,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::test_iam_permissions][super::super::client::VmwareEngine::test_iam_permissions] calls.
+    /// The request builder for [VmwareEngine::test_iam_permissions][crate::client::VmwareEngine::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8956,7 +8956,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::list_operations][super::super::client::VmwareEngine::list_operations] calls.
+    /// The request builder for [VmwareEngine::list_operations][crate::client::VmwareEngine::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9068,7 +9068,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::get_operation][super::super::client::VmwareEngine::get_operation] calls.
+    /// The request builder for [VmwareEngine::get_operation][crate::client::VmwareEngine::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9132,7 +9132,7 @@ pub mod vmware_engine {
         }
     }
 
-    /// The request builder for [VmwareEngine::delete_operation][super::super::client::VmwareEngine::delete_operation] calls.
+    /// The request builder for [VmwareEngine::delete_operation][crate::client::VmwareEngine::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/vpcaccess/v1/src/builder.rs
+++ b/src/generated/cloud/vpcaccess/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod vpc_access_service {
     use crate::Result;
 
-    /// A builder for [VpcAccessService][super::super::client::VpcAccessService].
+    /// A builder for [VpcAccessService][crate::client::VpcAccessService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// Common implementation for [super::super::client::VpcAccessService] request builders.
+    /// Common implementation for [crate::client::VpcAccessService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::VpcAccessService>,
@@ -68,7 +68,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for [VpcAccessService::create_connector][super::super::client::VpcAccessService::create_connector] calls.
+    /// The request builder for [VpcAccessService::create_connector][crate::client::VpcAccessService::create_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod vpc_access_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_connector][super::super::client::VpcAccessService::create_connector].
+        /// on [create_connector][crate::client::VpcAccessService::create_connector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_connector(self.0.request, self.0.options)
@@ -200,7 +200,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for [VpcAccessService::get_connector][super::super::client::VpcAccessService::get_connector] calls.
+    /// The request builder for [VpcAccessService::get_connector][crate::client::VpcAccessService::get_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -263,7 +263,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for [VpcAccessService::list_connectors][super::super::client::VpcAccessService::list_connectors] calls.
+    /// The request builder for [VpcAccessService::list_connectors][crate::client::VpcAccessService::list_connectors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -366,7 +366,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for [VpcAccessService::delete_connector][super::super::client::VpcAccessService::delete_connector] calls.
+    /// The request builder for [VpcAccessService::delete_connector][crate::client::VpcAccessService::delete_connector] calls.
     ///
     /// # Example
     /// ```no_run
@@ -411,7 +411,7 @@ pub mod vpc_access_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_connector][super::super::client::VpcAccessService::delete_connector].
+        /// on [delete_connector][crate::client::VpcAccessService::delete_connector].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_connector(self.0.request, self.0.options)
@@ -470,7 +470,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for [VpcAccessService::list_locations][super::super::client::VpcAccessService::list_locations] calls.
+    /// The request builder for [VpcAccessService::list_locations][crate::client::VpcAccessService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -580,7 +580,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for [VpcAccessService::list_operations][super::super::client::VpcAccessService::list_operations] calls.
+    /// The request builder for [VpcAccessService::list_operations][crate::client::VpcAccessService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -692,7 +692,7 @@ pub mod vpc_access_service {
         }
     }
 
-    /// The request builder for [VpcAccessService::get_operation][super::super::client::VpcAccessService::get_operation] calls.
+    /// The request builder for [VpcAccessService::get_operation][crate::client::VpcAccessService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/webrisk/v1/src/builder.rs
+++ b/src/generated/cloud/webrisk/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod web_risk_service {
     use crate::Result;
 
-    /// A builder for [WebRiskService][super::super::client::WebRiskService].
+    /// A builder for [WebRiskService][crate::client::WebRiskService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// Common implementation for [super::super::client::WebRiskService] request builders.
+    /// Common implementation for [crate::client::WebRiskService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::WebRiskService>,
@@ -68,7 +68,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::compute_threat_list_diff][super::super::client::WebRiskService::compute_threat_list_diff] calls.
+    /// The request builder for [WebRiskService::compute_threat_list_diff][crate::client::WebRiskService::compute_threat_list_diff] calls.
     ///
     /// # Example
     /// ```no_run
@@ -162,7 +162,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::search_uris][super::super::client::WebRiskService::search_uris] calls.
+    /// The request builder for [WebRiskService::search_uris][crate::client::WebRiskService::search_uris] calls.
     ///
     /// # Example
     /// ```no_run
@@ -238,7 +238,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::search_hashes][super::super::client::WebRiskService::search_hashes] calls.
+    /// The request builder for [WebRiskService::search_hashes][crate::client::WebRiskService::search_hashes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -312,7 +312,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::create_submission][super::super::client::WebRiskService::create_submission] calls.
+    /// The request builder for [WebRiskService::create_submission][crate::client::WebRiskService::create_submission] calls.
     ///
     /// # Example
     /// ```no_run
@@ -400,7 +400,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::submit_uri][super::super::client::WebRiskService::submit_uri] calls.
+    /// The request builder for [WebRiskService::submit_uri][crate::client::WebRiskService::submit_uri] calls.
     ///
     /// # Example
     /// ```no_run
@@ -445,7 +445,7 @@ pub mod web_risk_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [submit_uri][super::super::client::WebRiskService::submit_uri].
+        /// on [submit_uri][crate::client::WebRiskService::submit_uri].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .submit_uri(self.0.request, self.0.options)
@@ -560,7 +560,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::list_operations][super::super::client::WebRiskService::list_operations] calls.
+    /// The request builder for [WebRiskService::list_operations][crate::client::WebRiskService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -672,7 +672,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::get_operation][super::super::client::WebRiskService::get_operation] calls.
+    /// The request builder for [WebRiskService::get_operation][crate::client::WebRiskService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -736,7 +736,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::delete_operation][super::super::client::WebRiskService::delete_operation] calls.
+    /// The request builder for [WebRiskService::delete_operation][crate::client::WebRiskService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -800,7 +800,7 @@ pub mod web_risk_service {
         }
     }
 
-    /// The request builder for [WebRiskService::cancel_operation][super::super::client::WebRiskService::cancel_operation] calls.
+    /// The request builder for [WebRiskService::cancel_operation][crate::client::WebRiskService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/websecurityscanner/v1/src/builder.rs
+++ b/src/generated/cloud/websecurityscanner/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod web_security_scanner {
     use crate::Result;
 
-    /// A builder for [WebSecurityScanner][super::super::client::WebSecurityScanner].
+    /// A builder for [WebSecurityScanner][crate::client::WebSecurityScanner].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// Common implementation for [super::super::client::WebSecurityScanner] request builders.
+    /// Common implementation for [crate::client::WebSecurityScanner] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::WebSecurityScanner>,
@@ -68,7 +68,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::create_scan_config][super::super::client::WebSecurityScanner::create_scan_config] calls.
+    /// The request builder for [WebSecurityScanner::create_scan_config][crate::client::WebSecurityScanner::create_scan_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -150,7 +150,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::delete_scan_config][super::super::client::WebSecurityScanner::delete_scan_config] calls.
+    /// The request builder for [WebSecurityScanner::delete_scan_config][crate::client::WebSecurityScanner::delete_scan_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -214,7 +214,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::get_scan_config][super::super::client::WebSecurityScanner::get_scan_config] calls.
+    /// The request builder for [WebSecurityScanner::get_scan_config][crate::client::WebSecurityScanner::get_scan_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -275,7 +275,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::list_scan_configs][super::super::client::WebSecurityScanner::list_scan_configs] calls.
+    /// The request builder for [WebSecurityScanner::list_scan_configs][crate::client::WebSecurityScanner::list_scan_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -376,7 +376,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::update_scan_config][super::super::client::WebSecurityScanner::update_scan_config] calls.
+    /// The request builder for [WebSecurityScanner::update_scan_config][crate::client::WebSecurityScanner::update_scan_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -470,7 +470,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::start_scan_run][super::super::client::WebSecurityScanner::start_scan_run] calls.
+    /// The request builder for [WebSecurityScanner::start_scan_run][crate::client::WebSecurityScanner::start_scan_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -531,7 +531,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::get_scan_run][super::super::client::WebSecurityScanner::get_scan_run] calls.
+    /// The request builder for [WebSecurityScanner::get_scan_run][crate::client::WebSecurityScanner::get_scan_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -592,7 +592,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::list_scan_runs][super::super::client::WebSecurityScanner::list_scan_runs] calls.
+    /// The request builder for [WebSecurityScanner::list_scan_runs][crate::client::WebSecurityScanner::list_scan_runs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -693,7 +693,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::stop_scan_run][super::super::client::WebSecurityScanner::stop_scan_run] calls.
+    /// The request builder for [WebSecurityScanner::stop_scan_run][crate::client::WebSecurityScanner::stop_scan_run] calls.
     ///
     /// # Example
     /// ```no_run
@@ -754,7 +754,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::list_crawled_urls][super::super::client::WebSecurityScanner::list_crawled_urls] calls.
+    /// The request builder for [WebSecurityScanner::list_crawled_urls][crate::client::WebSecurityScanner::list_crawled_urls] calls.
     ///
     /// # Example
     /// ```no_run
@@ -855,7 +855,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::get_finding][super::super::client::WebSecurityScanner::get_finding] calls.
+    /// The request builder for [WebSecurityScanner::get_finding][crate::client::WebSecurityScanner::get_finding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -916,7 +916,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::list_findings][super::super::client::WebSecurityScanner::list_findings] calls.
+    /// The request builder for [WebSecurityScanner::list_findings][crate::client::WebSecurityScanner::list_findings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1023,7 +1023,7 @@ pub mod web_security_scanner {
         }
     }
 
-    /// The request builder for [WebSecurityScanner::list_finding_type_stats][super::super::client::WebSecurityScanner::list_finding_type_stats] calls.
+    /// The request builder for [WebSecurityScanner::list_finding_type_stats][crate::client::WebSecurityScanner::list_finding_type_stats] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/workflows/executions/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/executions/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod executions {
     use crate::Result;
 
-    /// A builder for [Executions][super::super::client::Executions].
+    /// A builder for [Executions][crate::client::Executions].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod executions {
         }
     }
 
-    /// Common implementation for [super::super::client::Executions] request builders.
+    /// Common implementation for [crate::client::Executions] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Executions>,
@@ -68,7 +68,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::list_executions][super::super::client::Executions::list_executions] calls.
+    /// The request builder for [Executions::list_executions][crate::client::Executions::list_executions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -189,7 +189,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::create_execution][super::super::client::Executions::create_execution] calls.
+    /// The request builder for [Executions::create_execution][crate::client::Executions::create_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -274,7 +274,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::get_execution][super::super::client::Executions::get_execution] calls.
+    /// The request builder for [Executions::get_execution][crate::client::Executions::get_execution] calls.
     ///
     /// # Example
     /// ```no_run
@@ -343,7 +343,7 @@ pub mod executions {
         }
     }
 
-    /// The request builder for [Executions::cancel_execution][super::super::client::Executions::cancel_execution] calls.
+    /// The request builder for [Executions::cancel_execution][crate::client::Executions::cancel_execution] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/workflows/v1/src/builder.rs
+++ b/src/generated/cloud/workflows/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod workflows {
     use crate::Result;
 
-    /// A builder for [Workflows][super::super::client::Workflows].
+    /// A builder for [Workflows][crate::client::Workflows].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod workflows {
         }
     }
 
-    /// Common implementation for [super::super::client::Workflows] request builders.
+    /// Common implementation for [crate::client::Workflows] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Workflows>,
@@ -68,7 +68,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::list_workflows][super::super::client::Workflows::list_workflows] calls.
+    /// The request builder for [Workflows::list_workflows][crate::client::Workflows::list_workflows] calls.
     ///
     /// # Example
     /// ```no_run
@@ -183,7 +183,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::get_workflow][super::super::client::Workflows::get_workflow] calls.
+    /// The request builder for [Workflows::get_workflow][crate::client::Workflows::get_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::create_workflow][super::super::client::Workflows::create_workflow] calls.
+    /// The request builder for [Workflows::create_workflow][crate::client::Workflows::create_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod workflows {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_workflow][super::super::client::Workflows::create_workflow].
+        /// on [create_workflow][crate::client::Workflows::create_workflow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_workflow(self.0.request, self.0.options)
@@ -384,7 +384,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::delete_workflow][super::super::client::Workflows::delete_workflow] calls.
+    /// The request builder for [Workflows::delete_workflow][crate::client::Workflows::delete_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod workflows {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_workflow][super::super::client::Workflows::delete_workflow].
+        /// on [delete_workflow][crate::client::Workflows::delete_workflow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_workflow(self.0.request, self.0.options)
@@ -488,7 +488,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::update_workflow][super::super::client::Workflows::update_workflow] calls.
+    /// The request builder for [Workflows::update_workflow][crate::client::Workflows::update_workflow] calls.
     ///
     /// # Example
     /// ```no_run
@@ -533,7 +533,7 @@ pub mod workflows {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_workflow][super::super::client::Workflows::update_workflow].
+        /// on [update_workflow][crate::client::Workflows::update_workflow].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_workflow(self.0.request, self.0.options)
@@ -622,7 +622,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::list_workflow_revisions][super::super::client::Workflows::list_workflow_revisions] calls.
+    /// The request builder for [Workflows::list_workflow_revisions][crate::client::Workflows::list_workflow_revisions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -730,7 +730,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::list_locations][super::super::client::Workflows::list_locations] calls.
+    /// The request builder for [Workflows::list_locations][crate::client::Workflows::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -840,7 +840,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::get_location][super::super::client::Workflows::get_location] calls.
+    /// The request builder for [Workflows::get_location][crate::client::Workflows::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -901,7 +901,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::list_operations][super::super::client::Workflows::list_operations] calls.
+    /// The request builder for [Workflows::list_operations][crate::client::Workflows::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1013,7 +1013,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::get_operation][super::super::client::Workflows::get_operation] calls.
+    /// The request builder for [Workflows::get_operation][crate::client::Workflows::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1077,7 +1077,7 @@ pub mod workflows {
         }
     }
 
-    /// The request builder for [Workflows::delete_operation][super::super::client::Workflows::delete_operation] calls.
+    /// The request builder for [Workflows::delete_operation][crate::client::Workflows::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/cloud/workstations/v1/src/builder.rs
+++ b/src/generated/cloud/workstations/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod workstations {
     use crate::Result;
 
-    /// A builder for [Workstations][super::super::client::Workstations].
+    /// A builder for [Workstations][crate::client::Workstations].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod workstations {
         }
     }
 
-    /// Common implementation for [super::super::client::Workstations] request builders.
+    /// Common implementation for [crate::client::Workstations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Workstations>,
@@ -68,7 +68,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::get_workstation_cluster][super::super::client::Workstations::get_workstation_cluster] calls.
+    /// The request builder for [Workstations::get_workstation_cluster][crate::client::Workstations::get_workstation_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -134,7 +134,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::list_workstation_clusters][super::super::client::Workstations::list_workstation_clusters] calls.
+    /// The request builder for [Workstations::list_workstation_clusters][crate::client::Workstations::list_workstation_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::create_workstation_cluster][super::super::client::Workstations::create_workstation_cluster] calls.
+    /// The request builder for [Workstations::create_workstation_cluster][crate::client::Workstations::create_workstation_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -296,7 +296,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_workstation_cluster][super::super::client::Workstations::create_workstation_cluster].
+        /// on [create_workstation_cluster][crate::client::Workstations::create_workstation_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_workstation_cluster(self.0.request, self.0.options)
@@ -392,7 +392,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::update_workstation_cluster][super::super::client::Workstations::update_workstation_cluster] calls.
+    /// The request builder for [Workstations::update_workstation_cluster][crate::client::Workstations::update_workstation_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -442,7 +442,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_workstation_cluster][super::super::client::Workstations::update_workstation_cluster].
+        /// on [update_workstation_cluster][crate::client::Workstations::update_workstation_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_workstation_cluster(self.0.request, self.0.options)
@@ -550,7 +550,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::delete_workstation_cluster][super::super::client::Workstations::delete_workstation_cluster] calls.
+    /// The request builder for [Workstations::delete_workstation_cluster][crate::client::Workstations::delete_workstation_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -600,7 +600,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_workstation_cluster][super::super::client::Workstations::delete_workstation_cluster].
+        /// on [delete_workstation_cluster][crate::client::Workstations::delete_workstation_cluster].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_workstation_cluster(self.0.request, self.0.options)
@@ -678,7 +678,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::get_workstation_config][super::super::client::Workstations::get_workstation_config] calls.
+    /// The request builder for [Workstations::get_workstation_config][crate::client::Workstations::get_workstation_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -744,7 +744,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::list_workstation_configs][super::super::client::Workstations::list_workstation_configs] calls.
+    /// The request builder for [Workstations::list_workstation_configs][crate::client::Workstations::list_workstation_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -854,7 +854,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::list_usable_workstation_configs][super::super::client::Workstations::list_usable_workstation_configs] calls.
+    /// The request builder for [Workstations::list_usable_workstation_configs][crate::client::Workstations::list_usable_workstation_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -966,7 +966,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::create_workstation_config][super::super::client::Workstations::create_workstation_config] calls.
+    /// The request builder for [Workstations::create_workstation_config][crate::client::Workstations::create_workstation_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1016,7 +1016,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_workstation_config][super::super::client::Workstations::create_workstation_config].
+        /// on [create_workstation_config][crate::client::Workstations::create_workstation_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_workstation_config(self.0.request, self.0.options)
@@ -1112,7 +1112,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::update_workstation_config][super::super::client::Workstations::update_workstation_config] calls.
+    /// The request builder for [Workstations::update_workstation_config][crate::client::Workstations::update_workstation_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1162,7 +1162,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_workstation_config][super::super::client::Workstations::update_workstation_config].
+        /// on [update_workstation_config][crate::client::Workstations::update_workstation_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_workstation_config(self.0.request, self.0.options)
@@ -1270,7 +1270,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::delete_workstation_config][super::super::client::Workstations::delete_workstation_config] calls.
+    /// The request builder for [Workstations::delete_workstation_config][crate::client::Workstations::delete_workstation_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1320,7 +1320,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_workstation_config][super::super::client::Workstations::delete_workstation_config].
+        /// on [delete_workstation_config][crate::client::Workstations::delete_workstation_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_workstation_config(self.0.request, self.0.options)
@@ -1398,7 +1398,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::get_workstation][super::super::client::Workstations::get_workstation] calls.
+    /// The request builder for [Workstations::get_workstation][crate::client::Workstations::get_workstation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1461,7 +1461,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::list_workstations][super::super::client::Workstations::list_workstations] calls.
+    /// The request builder for [Workstations::list_workstations][crate::client::Workstations::list_workstations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1567,7 +1567,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::list_usable_workstations][super::super::client::Workstations::list_usable_workstations] calls.
+    /// The request builder for [Workstations::list_usable_workstations][crate::client::Workstations::list_usable_workstations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1677,7 +1677,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::create_workstation][super::super::client::Workstations::create_workstation] calls.
+    /// The request builder for [Workstations::create_workstation][crate::client::Workstations::create_workstation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1725,7 +1725,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_workstation][super::super::client::Workstations::create_workstation].
+        /// on [create_workstation][crate::client::Workstations::create_workstation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_workstation(self.0.request, self.0.options)
@@ -1820,7 +1820,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::update_workstation][super::super::client::Workstations::update_workstation] calls.
+    /// The request builder for [Workstations::update_workstation][crate::client::Workstations::update_workstation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1868,7 +1868,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_workstation][super::super::client::Workstations::update_workstation].
+        /// on [update_workstation][crate::client::Workstations::update_workstation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_workstation(self.0.request, self.0.options)
@@ -1975,7 +1975,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::delete_workstation][super::super::client::Workstations::delete_workstation] calls.
+    /// The request builder for [Workstations::delete_workstation][crate::client::Workstations::delete_workstation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2023,7 +2023,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_workstation][super::super::client::Workstations::delete_workstation].
+        /// on [delete_workstation][crate::client::Workstations::delete_workstation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_workstation(self.0.request, self.0.options)
@@ -2094,7 +2094,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::start_workstation][super::super::client::Workstations::start_workstation] calls.
+    /// The request builder for [Workstations::start_workstation][crate::client::Workstations::start_workstation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2142,7 +2142,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [start_workstation][super::super::client::Workstations::start_workstation].
+        /// on [start_workstation][crate::client::Workstations::start_workstation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .start_workstation(self.0.request, self.0.options)
@@ -2213,7 +2213,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::stop_workstation][super::super::client::Workstations::stop_workstation] calls.
+    /// The request builder for [Workstations::stop_workstation][crate::client::Workstations::stop_workstation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2258,7 +2258,7 @@ pub mod workstations {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [stop_workstation][super::super::client::Workstations::stop_workstation].
+        /// on [stop_workstation][crate::client::Workstations::stop_workstation].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .stop_workstation(self.0.request, self.0.options)
@@ -2329,7 +2329,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::generate_access_token][super::super::client::Workstations::generate_access_token] calls.
+    /// The request builder for [Workstations::generate_access_token][crate::client::Workstations::generate_access_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2435,7 +2435,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::set_iam_policy][super::super::client::Workstations::set_iam_policy] calls.
+    /// The request builder for [Workstations::set_iam_policy][crate::client::Workstations::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2538,7 +2538,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::get_iam_policy][super::super::client::Workstations::get_iam_policy] calls.
+    /// The request builder for [Workstations::get_iam_policy][crate::client::Workstations::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2619,7 +2619,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::test_iam_permissions][super::super::client::Workstations::test_iam_permissions] calls.
+    /// The request builder for [Workstations::test_iam_permissions][crate::client::Workstations::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2698,7 +2698,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::list_operations][super::super::client::Workstations::list_operations] calls.
+    /// The request builder for [Workstations::list_operations][crate::client::Workstations::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2810,7 +2810,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::get_operation][super::super::client::Workstations::get_operation] calls.
+    /// The request builder for [Workstations::get_operation][crate::client::Workstations::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2874,7 +2874,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::delete_operation][super::super::client::Workstations::delete_operation] calls.
+    /// The request builder for [Workstations::delete_operation][crate::client::Workstations::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2938,7 +2938,7 @@ pub mod workstations {
         }
     }
 
-    /// The request builder for [Workstations::cancel_operation][super::super::client::Workstations::cancel_operation] calls.
+    /// The request builder for [Workstations::cancel_operation][crate::client::Workstations::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/container/v1/src/builder.rs
+++ b/src/generated/container/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cluster_manager {
     use crate::Result;
 
-    /// A builder for [ClusterManager][super::super::client::ClusterManager].
+    /// A builder for [ClusterManager][crate::client::ClusterManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::ClusterManager] request builders.
+    /// Common implementation for [crate::client::ClusterManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ClusterManager>,
@@ -68,7 +68,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::list_clusters][super::super::client::ClusterManager::list_clusters] calls.
+    /// The request builder for [ClusterManager::list_clusters][crate::client::ClusterManager::list_clusters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -143,7 +143,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::get_cluster][super::super::client::ClusterManager::get_cluster] calls.
+    /// The request builder for [ClusterManager::get_cluster][crate::client::ClusterManager::get_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -225,7 +225,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::create_cluster][super::super::client::ClusterManager::create_cluster] calls.
+    /// The request builder for [ClusterManager::create_cluster][crate::client::ClusterManager::create_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -322,7 +322,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::update_cluster][super::super::client::ClusterManager::update_cluster] calls.
+    /// The request builder for [ClusterManager::update_cluster][crate::client::ClusterManager::update_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -426,7 +426,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::update_node_pool][super::super::client::ClusterManager::update_node_pool] calls.
+    /// The request builder for [ClusterManager::update_node_pool][crate::client::ClusterManager::update_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -912,7 +912,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_node_pool_autoscaling][super::super::client::ClusterManager::set_node_pool_autoscaling] calls.
+    /// The request builder for [ClusterManager::set_node_pool_autoscaling][crate::client::ClusterManager::set_node_pool_autoscaling] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1026,7 +1026,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_logging_service][super::super::client::ClusterManager::set_logging_service] calls.
+    /// The request builder for [ClusterManager::set_logging_service][crate::client::ClusterManager::set_logging_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1119,7 +1119,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_monitoring_service][super::super::client::ClusterManager::set_monitoring_service] calls.
+    /// The request builder for [ClusterManager::set_monitoring_service][crate::client::ClusterManager::set_monitoring_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1212,7 +1212,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_addons_config][super::super::client::ClusterManager::set_addons_config] calls.
+    /// The request builder for [ClusterManager::set_addons_config][crate::client::ClusterManager::set_addons_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1316,7 +1316,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_locations][super::super::client::ClusterManager::set_locations] calls.
+    /// The request builder for [ClusterManager::set_locations][crate::client::ClusterManager::set_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1411,7 +1411,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::update_master][super::super::client::ClusterManager::update_master] calls.
+    /// The request builder for [ClusterManager::update_master][crate::client::ClusterManager::update_master] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1501,7 +1501,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_master_auth][super::super::client::ClusterManager::set_master_auth] calls.
+    /// The request builder for [ClusterManager::set_master_auth][crate::client::ClusterManager::set_master_auth] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1616,7 +1616,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::delete_cluster][super::super::client::ClusterManager::delete_cluster] calls.
+    /// The request builder for [ClusterManager::delete_cluster][crate::client::ClusterManager::delete_cluster] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1698,7 +1698,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::list_operations][super::super::client::ClusterManager::list_operations] calls.
+    /// The request builder for [ClusterManager::list_operations][crate::client::ClusterManager::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1773,7 +1773,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::get_operation][super::super::client::ClusterManager::get_operation] calls.
+    /// The request builder for [ClusterManager::get_operation][crate::client::ClusterManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1855,7 +1855,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::cancel_operation][super::super::client::ClusterManager::cancel_operation] calls.
+    /// The request builder for [ClusterManager::cancel_operation][crate::client::ClusterManager::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1937,7 +1937,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::get_server_config][super::super::client::ClusterManager::get_server_config] calls.
+    /// The request builder for [ClusterManager::get_server_config][crate::client::ClusterManager::get_server_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2012,7 +2012,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::get_json_web_keys][super::super::client::ClusterManager::get_json_web_keys] calls.
+    /// The request builder for [ClusterManager::get_json_web_keys][crate::client::ClusterManager::get_json_web_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2073,7 +2073,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::list_node_pools][super::super::client::ClusterManager::list_node_pools] calls.
+    /// The request builder for [ClusterManager::list_node_pools][crate::client::ClusterManager::list_node_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2155,7 +2155,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::get_node_pool][super::super::client::ClusterManager::get_node_pool] calls.
+    /// The request builder for [ClusterManager::get_node_pool][crate::client::ClusterManager::get_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2244,7 +2244,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::create_node_pool][super::super::client::ClusterManager::create_node_pool] calls.
+    /// The request builder for [ClusterManager::create_node_pool][crate::client::ClusterManager::create_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2348,7 +2348,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::delete_node_pool][super::super::client::ClusterManager::delete_node_pool] calls.
+    /// The request builder for [ClusterManager::delete_node_pool][crate::client::ClusterManager::delete_node_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2437,7 +2437,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::complete_node_pool_upgrade][super::super::client::ClusterManager::complete_node_pool_upgrade] calls.
+    /// The request builder for [ClusterManager::complete_node_pool_upgrade][crate::client::ClusterManager::complete_node_pool_upgrade] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2503,7 +2503,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::rollback_node_pool_upgrade][super::super::client::ClusterManager::rollback_node_pool_upgrade] calls.
+    /// The request builder for [ClusterManager::rollback_node_pool_upgrade][crate::client::ClusterManager::rollback_node_pool_upgrade] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2603,7 +2603,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_node_pool_management][super::super::client::ClusterManager::set_node_pool_management] calls.
+    /// The request builder for [ClusterManager::set_node_pool_management][crate::client::ClusterManager::set_node_pool_management] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2717,7 +2717,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_labels][super::super::client::ClusterManager::set_labels] calls.
+    /// The request builder for [ClusterManager::set_labels][crate::client::ClusterManager::set_labels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2821,7 +2821,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_legacy_abac][super::super::client::ClusterManager::set_legacy_abac] calls.
+    /// The request builder for [ClusterManager::set_legacy_abac][crate::client::ClusterManager::set_legacy_abac] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2911,7 +2911,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::start_ip_rotation][super::super::client::ClusterManager::start_ip_rotation] calls.
+    /// The request builder for [ClusterManager::start_ip_rotation][crate::client::ClusterManager::start_ip_rotation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2999,7 +2999,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::complete_ip_rotation][super::super::client::ClusterManager::complete_ip_rotation] calls.
+    /// The request builder for [ClusterManager::complete_ip_rotation][crate::client::ClusterManager::complete_ip_rotation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3084,7 +3084,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_node_pool_size][super::super::client::ClusterManager::set_node_pool_size] calls.
+    /// The request builder for [ClusterManager::set_node_pool_size][crate::client::ClusterManager::set_node_pool_size] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3181,7 +3181,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_network_policy][super::super::client::ClusterManager::set_network_policy] calls.
+    /// The request builder for [ClusterManager::set_network_policy][crate::client::ClusterManager::set_network_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3288,7 +3288,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::set_maintenance_policy][super::super::client::ClusterManager::set_maintenance_policy] calls.
+    /// The request builder for [ClusterManager::set_maintenance_policy][crate::client::ClusterManager::set_maintenance_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3398,7 +3398,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::list_usable_subnetworks][super::super::client::ClusterManager::list_usable_subnetworks] calls.
+    /// The request builder for [ClusterManager::list_usable_subnetworks][crate::client::ClusterManager::list_usable_subnetworks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3510,7 +3510,7 @@ pub mod cluster_manager {
         }
     }
 
-    /// The request builder for [ClusterManager::check_autopilot_compatibility][super::super::client::ClusterManager::check_autopilot_compatibility] calls.
+    /// The request builder for [ClusterManager::check_autopilot_compatibility][crate::client::ClusterManager::check_autopilot_compatibility] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/datastore/admin/v1/src/builder.rs
+++ b/src/generated/datastore/admin/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod datastore_admin {
     use crate::Result;
 
-    /// A builder for [DatastoreAdmin][super::super::client::DatastoreAdmin].
+    /// A builder for [DatastoreAdmin][crate::client::DatastoreAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::DatastoreAdmin] request builders.
+    /// Common implementation for [crate::client::DatastoreAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DatastoreAdmin>,
@@ -68,7 +68,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::export_entities][super::super::client::DatastoreAdmin::export_entities] calls.
+    /// The request builder for [DatastoreAdmin::export_entities][crate::client::DatastoreAdmin::export_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod datastore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_entities][super::super::client::DatastoreAdmin::export_entities].
+        /// on [export_entities][crate::client::DatastoreAdmin::export_entities].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_entities(self.0.request, self.0.options)
@@ -210,7 +210,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::import_entities][super::super::client::DatastoreAdmin::import_entities] calls.
+    /// The request builder for [DatastoreAdmin::import_entities][crate::client::DatastoreAdmin::import_entities] calls.
     ///
     /// # Example
     /// ```no_run
@@ -255,7 +255,7 @@ pub mod datastore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_entities][super::super::client::DatastoreAdmin::import_entities].
+        /// on [import_entities][crate::client::DatastoreAdmin::import_entities].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_entities(self.0.request, self.0.options)
@@ -352,7 +352,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::create_index][super::super::client::DatastoreAdmin::create_index] calls.
+    /// The request builder for [DatastoreAdmin::create_index][crate::client::DatastoreAdmin::create_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -397,7 +397,7 @@ pub mod datastore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_index][super::super::client::DatastoreAdmin::create_index].
+        /// on [create_index][crate::client::DatastoreAdmin::create_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_index(self.0.request, self.0.options)
@@ -470,7 +470,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::delete_index][super::super::client::DatastoreAdmin::delete_index] calls.
+    /// The request builder for [DatastoreAdmin::delete_index][crate::client::DatastoreAdmin::delete_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -515,7 +515,7 @@ pub mod datastore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_index][super::super::client::DatastoreAdmin::delete_index].
+        /// on [delete_index][crate::client::DatastoreAdmin::delete_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_index(self.0.request, self.0.options)
@@ -576,7 +576,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::get_index][super::super::client::DatastoreAdmin::get_index] calls.
+    /// The request builder for [DatastoreAdmin::get_index][crate::client::DatastoreAdmin::get_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -643,7 +643,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::list_indexes][super::super::client::DatastoreAdmin::list_indexes] calls.
+    /// The request builder for [DatastoreAdmin::list_indexes][crate::client::DatastoreAdmin::list_indexes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -750,7 +750,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::list_operations][super::super::client::DatastoreAdmin::list_operations] calls.
+    /// The request builder for [DatastoreAdmin::list_operations][crate::client::DatastoreAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -862,7 +862,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::get_operation][super::super::client::DatastoreAdmin::get_operation] calls.
+    /// The request builder for [DatastoreAdmin::get_operation][crate::client::DatastoreAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -926,7 +926,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::delete_operation][super::super::client::DatastoreAdmin::delete_operation] calls.
+    /// The request builder for [DatastoreAdmin::delete_operation][crate::client::DatastoreAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -990,7 +990,7 @@ pub mod datastore_admin {
         }
     }
 
-    /// The request builder for [DatastoreAdmin::cancel_operation][super::super::client::DatastoreAdmin::cancel_operation] calls.
+    /// The request builder for [DatastoreAdmin::cancel_operation][crate::client::DatastoreAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/devtools/artifactregistry/v1/src/builder.rs
+++ b/src/generated/devtools/artifactregistry/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod artifact_registry {
     use crate::Result;
 
-    /// A builder for [ArtifactRegistry][super::super::client::ArtifactRegistry].
+    /// A builder for [ArtifactRegistry][crate::client::ArtifactRegistry].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// Common implementation for [super::super::client::ArtifactRegistry] request builders.
+    /// Common implementation for [crate::client::ArtifactRegistry] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ArtifactRegistry>,
@@ -68,7 +68,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_docker_images][super::super::client::ArtifactRegistry::list_docker_images] calls.
+    /// The request builder for [ArtifactRegistry::list_docker_images][crate::client::ArtifactRegistry::list_docker_images] calls.
     ///
     /// # Example
     /// ```no_run
@@ -180,7 +180,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_docker_image][super::super::client::ArtifactRegistry::get_docker_image] calls.
+    /// The request builder for [ArtifactRegistry::get_docker_image][crate::client::ArtifactRegistry::get_docker_image] calls.
     ///
     /// # Example
     /// ```no_run
@@ -243,7 +243,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_maven_artifacts][super::super::client::ArtifactRegistry::list_maven_artifacts] calls.
+    /// The request builder for [ArtifactRegistry::list_maven_artifacts][crate::client::ArtifactRegistry::list_maven_artifacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -351,7 +351,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_maven_artifact][super::super::client::ArtifactRegistry::get_maven_artifact] calls.
+    /// The request builder for [ArtifactRegistry::get_maven_artifact][crate::client::ArtifactRegistry::get_maven_artifact] calls.
     ///
     /// # Example
     /// ```no_run
@@ -417,7 +417,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_npm_packages][super::super::client::ArtifactRegistry::list_npm_packages] calls.
+    /// The request builder for [ArtifactRegistry::list_npm_packages][crate::client::ArtifactRegistry::list_npm_packages] calls.
     ///
     /// # Example
     /// ```no_run
@@ -520,7 +520,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_npm_package][super::super::client::ArtifactRegistry::get_npm_package] calls.
+    /// The request builder for [ArtifactRegistry::get_npm_package][crate::client::ArtifactRegistry::get_npm_package] calls.
     ///
     /// # Example
     /// ```no_run
@@ -583,7 +583,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_python_packages][super::super::client::ArtifactRegistry::list_python_packages] calls.
+    /// The request builder for [ArtifactRegistry::list_python_packages][crate::client::ArtifactRegistry::list_python_packages] calls.
     ///
     /// # Example
     /// ```no_run
@@ -691,7 +691,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_python_package][super::super::client::ArtifactRegistry::get_python_package] calls.
+    /// The request builder for [ArtifactRegistry::get_python_package][crate::client::ArtifactRegistry::get_python_package] calls.
     ///
     /// # Example
     /// ```no_run
@@ -757,7 +757,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::import_apt_artifacts][super::super::client::ArtifactRegistry::import_apt_artifacts] calls.
+    /// The request builder for [ArtifactRegistry::import_apt_artifacts][crate::client::ArtifactRegistry::import_apt_artifacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -805,7 +805,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_apt_artifacts][super::super::client::ArtifactRegistry::import_apt_artifacts].
+        /// on [import_apt_artifacts][crate::client::ArtifactRegistry::import_apt_artifacts].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_apt_artifacts(self.0.request, self.0.options)
@@ -892,7 +892,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::import_yum_artifacts][super::super::client::ArtifactRegistry::import_yum_artifacts] calls.
+    /// The request builder for [ArtifactRegistry::import_yum_artifacts][crate::client::ArtifactRegistry::import_yum_artifacts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -940,7 +940,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_yum_artifacts][super::super::client::ArtifactRegistry::import_yum_artifacts].
+        /// on [import_yum_artifacts][crate::client::ArtifactRegistry::import_yum_artifacts].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_yum_artifacts(self.0.request, self.0.options)
@@ -1027,7 +1027,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_repositories][super::super::client::ArtifactRegistry::list_repositories] calls.
+    /// The request builder for [ArtifactRegistry::list_repositories][crate::client::ArtifactRegistry::list_repositories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1145,7 +1145,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_repository][super::super::client::ArtifactRegistry::get_repository] calls.
+    /// The request builder for [ArtifactRegistry::get_repository][crate::client::ArtifactRegistry::get_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1208,7 +1208,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::create_repository][super::super::client::ArtifactRegistry::create_repository] calls.
+    /// The request builder for [ArtifactRegistry::create_repository][crate::client::ArtifactRegistry::create_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1256,7 +1256,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_repository][super::super::client::ArtifactRegistry::create_repository].
+        /// on [create_repository][crate::client::ArtifactRegistry::create_repository].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_repository(self.0.request, self.0.options)
@@ -1343,7 +1343,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_repository][super::super::client::ArtifactRegistry::update_repository] calls.
+    /// The request builder for [ArtifactRegistry::update_repository][crate::client::ArtifactRegistry::update_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1437,7 +1437,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::delete_repository][super::super::client::ArtifactRegistry::delete_repository] calls.
+    /// The request builder for [ArtifactRegistry::delete_repository][crate::client::ArtifactRegistry::delete_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1485,7 +1485,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_repository][super::super::client::ArtifactRegistry::delete_repository].
+        /// on [delete_repository][crate::client::ArtifactRegistry::delete_repository].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_repository(self.0.request, self.0.options)
@@ -1544,7 +1544,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_packages][super::super::client::ArtifactRegistry::list_packages] calls.
+    /// The request builder for [ArtifactRegistry::list_packages][crate::client::ArtifactRegistry::list_packages] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1659,7 +1659,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_package][super::super::client::ArtifactRegistry::get_package] calls.
+    /// The request builder for [ArtifactRegistry::get_package][crate::client::ArtifactRegistry::get_package] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1722,7 +1722,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::delete_package][super::super::client::ArtifactRegistry::delete_package] calls.
+    /// The request builder for [ArtifactRegistry::delete_package][crate::client::ArtifactRegistry::delete_package] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1767,7 +1767,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_package][super::super::client::ArtifactRegistry::delete_package].
+        /// on [delete_package][crate::client::ArtifactRegistry::delete_package].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_package(self.0.request, self.0.options)
@@ -1826,7 +1826,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_versions][super::super::client::ArtifactRegistry::list_versions] calls.
+    /// The request builder for [ArtifactRegistry::list_versions][crate::client::ArtifactRegistry::list_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1945,7 +1945,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_version][super::super::client::ArtifactRegistry::get_version] calls.
+    /// The request builder for [ArtifactRegistry::get_version][crate::client::ArtifactRegistry::get_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2012,7 +2012,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::delete_version][super::super::client::ArtifactRegistry::delete_version] calls.
+    /// The request builder for [ArtifactRegistry::delete_version][crate::client::ArtifactRegistry::delete_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2057,7 +2057,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_version][super::super::client::ArtifactRegistry::delete_version].
+        /// on [delete_version][crate::client::ArtifactRegistry::delete_version].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_version(self.0.request, self.0.options)
@@ -2120,7 +2120,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::batch_delete_versions][super::super::client::ArtifactRegistry::batch_delete_versions] calls.
+    /// The request builder for [ArtifactRegistry::batch_delete_versions][crate::client::ArtifactRegistry::batch_delete_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2168,7 +2168,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_delete_versions][super::super::client::ArtifactRegistry::batch_delete_versions].
+        /// on [batch_delete_versions][crate::client::ArtifactRegistry::batch_delete_versions].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_delete_versions(self.0.request, self.0.options)
@@ -2245,7 +2245,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_version][super::super::client::ArtifactRegistry::update_version] calls.
+    /// The request builder for [ArtifactRegistry::update_version][crate::client::ArtifactRegistry::update_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2340,7 +2340,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_files][super::super::client::ArtifactRegistry::list_files] calls.
+    /// The request builder for [ArtifactRegistry::list_files][crate::client::ArtifactRegistry::list_files] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2455,7 +2455,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_file][super::super::client::ArtifactRegistry::get_file] calls.
+    /// The request builder for [ArtifactRegistry::get_file][crate::client::ArtifactRegistry::get_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2518,7 +2518,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::delete_file][super::super::client::ArtifactRegistry::delete_file] calls.
+    /// The request builder for [ArtifactRegistry::delete_file][crate::client::ArtifactRegistry::delete_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2563,7 +2563,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_file][super::super::client::ArtifactRegistry::delete_file].
+        /// on [delete_file][crate::client::ArtifactRegistry::delete_file].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_file(self.0.request, self.0.options)
@@ -2622,7 +2622,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_file][super::super::client::ArtifactRegistry::update_file] calls.
+    /// The request builder for [ArtifactRegistry::update_file][crate::client::ArtifactRegistry::update_file] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2721,7 +2721,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_tags][super::super::client::ArtifactRegistry::list_tags] calls.
+    /// The request builder for [ArtifactRegistry::list_tags][crate::client::ArtifactRegistry::list_tags] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2828,7 +2828,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_tag][super::super::client::ArtifactRegistry::get_tag] calls.
+    /// The request builder for [ArtifactRegistry::get_tag][crate::client::ArtifactRegistry::get_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2889,7 +2889,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::create_tag][super::super::client::ArtifactRegistry::create_tag] calls.
+    /// The request builder for [ArtifactRegistry::create_tag][crate::client::ArtifactRegistry::create_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2974,7 +2974,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_tag][super::super::client::ArtifactRegistry::update_tag] calls.
+    /// The request builder for [ArtifactRegistry::update_tag][crate::client::ArtifactRegistry::update_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3065,7 +3065,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::delete_tag][super::super::client::ArtifactRegistry::delete_tag] calls.
+    /// The request builder for [ArtifactRegistry::delete_tag][crate::client::ArtifactRegistry::delete_tag] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3126,7 +3126,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::create_rule][super::super::client::ArtifactRegistry::create_rule] calls.
+    /// The request builder for [ArtifactRegistry::create_rule][crate::client::ArtifactRegistry::create_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3213,7 +3213,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_rules][super::super::client::ArtifactRegistry::list_rules] calls.
+    /// The request builder for [ArtifactRegistry::list_rules][crate::client::ArtifactRegistry::list_rules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3316,7 +3316,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_rule][super::super::client::ArtifactRegistry::get_rule] calls.
+    /// The request builder for [ArtifactRegistry::get_rule][crate::client::ArtifactRegistry::get_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3379,7 +3379,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_rule][super::super::client::ArtifactRegistry::update_rule] calls.
+    /// The request builder for [ArtifactRegistry::update_rule][crate::client::ArtifactRegistry::update_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3470,7 +3470,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::delete_rule][super::super::client::ArtifactRegistry::delete_rule] calls.
+    /// The request builder for [ArtifactRegistry::delete_rule][crate::client::ArtifactRegistry::delete_rule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3533,7 +3533,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::set_iam_policy][super::super::client::ArtifactRegistry::set_iam_policy] calls.
+    /// The request builder for [ArtifactRegistry::set_iam_policy][crate::client::ArtifactRegistry::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3636,7 +3636,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_iam_policy][super::super::client::ArtifactRegistry::get_iam_policy] calls.
+    /// The request builder for [ArtifactRegistry::get_iam_policy][crate::client::ArtifactRegistry::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3717,7 +3717,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::test_iam_permissions][super::super::client::ArtifactRegistry::test_iam_permissions] calls.
+    /// The request builder for [ArtifactRegistry::test_iam_permissions][crate::client::ArtifactRegistry::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3796,7 +3796,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_project_settings][super::super::client::ArtifactRegistry::get_project_settings] calls.
+    /// The request builder for [ArtifactRegistry::get_project_settings][crate::client::ArtifactRegistry::get_project_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3862,7 +3862,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_project_settings][super::super::client::ArtifactRegistry::update_project_settings] calls.
+    /// The request builder for [ArtifactRegistry::update_project_settings][crate::client::ArtifactRegistry::update_project_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3956,7 +3956,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_vpcsc_config][super::super::client::ArtifactRegistry::get_vpcsc_config] calls.
+    /// The request builder for [ArtifactRegistry::get_vpcsc_config][crate::client::ArtifactRegistry::get_vpcsc_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4019,7 +4019,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_vpcsc_config][super::super::client::ArtifactRegistry::update_vpcsc_config] calls.
+    /// The request builder for [ArtifactRegistry::update_vpcsc_config][crate::client::ArtifactRegistry::update_vpcsc_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4113,7 +4113,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::update_package][super::super::client::ArtifactRegistry::update_package] calls.
+    /// The request builder for [ArtifactRegistry::update_package][crate::client::ArtifactRegistry::update_package] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4204,7 +4204,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_attachments][super::super::client::ArtifactRegistry::list_attachments] calls.
+    /// The request builder for [ArtifactRegistry::list_attachments][crate::client::ArtifactRegistry::list_attachments] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4313,7 +4313,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_attachment][super::super::client::ArtifactRegistry::get_attachment] calls.
+    /// The request builder for [ArtifactRegistry::get_attachment][crate::client::ArtifactRegistry::get_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4376,7 +4376,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::create_attachment][super::super::client::ArtifactRegistry::create_attachment] calls.
+    /// The request builder for [ArtifactRegistry::create_attachment][crate::client::ArtifactRegistry::create_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4424,7 +4424,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_attachment][super::super::client::ArtifactRegistry::create_attachment].
+        /// on [create_attachment][crate::client::ArtifactRegistry::create_attachment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_attachment(self.0.request, self.0.options)
@@ -4511,7 +4511,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::delete_attachment][super::super::client::ArtifactRegistry::delete_attachment] calls.
+    /// The request builder for [ArtifactRegistry::delete_attachment][crate::client::ArtifactRegistry::delete_attachment] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4559,7 +4559,7 @@ pub mod artifact_registry {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_attachment][super::super::client::ArtifactRegistry::delete_attachment].
+        /// on [delete_attachment][crate::client::ArtifactRegistry::delete_attachment].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_attachment(self.0.request, self.0.options)
@@ -4618,7 +4618,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::list_locations][super::super::client::ArtifactRegistry::list_locations] calls.
+    /// The request builder for [ArtifactRegistry::list_locations][crate::client::ArtifactRegistry::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4728,7 +4728,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_location][super::super::client::ArtifactRegistry::get_location] calls.
+    /// The request builder for [ArtifactRegistry::get_location][crate::client::ArtifactRegistry::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4789,7 +4789,7 @@ pub mod artifact_registry {
         }
     }
 
-    /// The request builder for [ArtifactRegistry::get_operation][super::super::client::ArtifactRegistry::get_operation] calls.
+    /// The request builder for [ArtifactRegistry::get_operation][crate::client::ArtifactRegistry::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/devtools/cloudbuild/v1/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod cloud_build {
     use crate::Result;
 
-    /// A builder for [CloudBuild][super::super::client::CloudBuild].
+    /// A builder for [CloudBuild][crate::client::CloudBuild].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod cloud_build {
         }
     }
 
-    /// Common implementation for [super::super::client::CloudBuild] request builders.
+    /// Common implementation for [crate::client::CloudBuild] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::CloudBuild>,
@@ -68,7 +68,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::create_build][super::super::client::CloudBuild::create_build] calls.
+    /// The request builder for [CloudBuild::create_build][crate::client::CloudBuild::create_build] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod cloud_build {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_build][super::super::client::CloudBuild::create_build].
+        /// on [create_build][crate::client::CloudBuild::create_build].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_build(self.0.request, self.0.options)
@@ -198,7 +198,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::get_build][super::super::client::CloudBuild::get_build] calls.
+    /// The request builder for [CloudBuild::get_build][crate::client::CloudBuild::get_build] calls.
     ///
     /// # Example
     /// ```no_run
@@ -275,7 +275,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::list_builds][super::super::client::CloudBuild::list_builds] calls.
+    /// The request builder for [CloudBuild::list_builds][crate::client::CloudBuild::list_builds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -390,7 +390,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::cancel_build][super::super::client::CloudBuild::cancel_build] calls.
+    /// The request builder for [CloudBuild::cancel_build][crate::client::CloudBuild::cancel_build] calls.
     ///
     /// # Example
     /// ```no_run
@@ -467,7 +467,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::retry_build][super::super::client::CloudBuild::retry_build] calls.
+    /// The request builder for [CloudBuild::retry_build][crate::client::CloudBuild::retry_build] calls.
     ///
     /// # Example
     /// ```no_run
@@ -512,7 +512,7 @@ pub mod cloud_build {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [retry_build][super::super::client::CloudBuild::retry_build].
+        /// on [retry_build][crate::client::CloudBuild::retry_build].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .retry_build(self.0.request, self.0.options)
@@ -583,7 +583,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::approve_build][super::super::client::CloudBuild::approve_build] calls.
+    /// The request builder for [CloudBuild::approve_build][crate::client::CloudBuild::approve_build] calls.
     ///
     /// # Example
     /// ```no_run
@@ -628,7 +628,7 @@ pub mod cloud_build {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [approve_build][super::super::client::CloudBuild::approve_build].
+        /// on [approve_build][crate::client::CloudBuild::approve_build].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .approve_build(self.0.request, self.0.options)
@@ -703,7 +703,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::create_build_trigger][super::super::client::CloudBuild::create_build_trigger] calls.
+    /// The request builder for [CloudBuild::create_build_trigger][crate::client::CloudBuild::create_build_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -797,7 +797,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::get_build_trigger][super::super::client::CloudBuild::get_build_trigger] calls.
+    /// The request builder for [CloudBuild::get_build_trigger][crate::client::CloudBuild::get_build_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -874,7 +874,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::list_build_triggers][super::super::client::CloudBuild::list_build_triggers] calls.
+    /// The request builder for [CloudBuild::list_build_triggers][crate::client::CloudBuild::list_build_triggers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -986,7 +986,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::delete_build_trigger][super::super::client::CloudBuild::delete_build_trigger] calls.
+    /// The request builder for [CloudBuild::delete_build_trigger][crate::client::CloudBuild::delete_build_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1066,7 +1066,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::update_build_trigger][super::super::client::CloudBuild::update_build_trigger] calls.
+    /// The request builder for [CloudBuild::update_build_trigger][crate::client::CloudBuild::update_build_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1180,7 +1180,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::run_build_trigger][super::super::client::CloudBuild::run_build_trigger] calls.
+    /// The request builder for [CloudBuild::run_build_trigger][crate::client::CloudBuild::run_build_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1225,7 +1225,7 @@ pub mod cloud_build {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [run_build_trigger][super::super::client::CloudBuild::run_build_trigger].
+        /// on [run_build_trigger][crate::client::CloudBuild::run_build_trigger].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .run_build_trigger(self.0.request, self.0.options)
@@ -1314,7 +1314,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::receive_trigger_webhook][super::super::client::CloudBuild::receive_trigger_webhook] calls.
+    /// The request builder for [CloudBuild::receive_trigger_webhook][crate::client::CloudBuild::receive_trigger_webhook] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1414,7 +1414,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::create_worker_pool][super::super::client::CloudBuild::create_worker_pool] calls.
+    /// The request builder for [CloudBuild::create_worker_pool][crate::client::CloudBuild::create_worker_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1462,7 +1462,7 @@ pub mod cloud_build {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_worker_pool][super::super::client::CloudBuild::create_worker_pool].
+        /// on [create_worker_pool][crate::client::CloudBuild::create_worker_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_worker_pool(self.0.request, self.0.options)
@@ -1558,7 +1558,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::get_worker_pool][super::super::client::CloudBuild::get_worker_pool] calls.
+    /// The request builder for [CloudBuild::get_worker_pool][crate::client::CloudBuild::get_worker_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1621,7 +1621,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::delete_worker_pool][super::super::client::CloudBuild::delete_worker_pool] calls.
+    /// The request builder for [CloudBuild::delete_worker_pool][crate::client::CloudBuild::delete_worker_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1669,7 +1669,7 @@ pub mod cloud_build {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_worker_pool][super::super::client::CloudBuild::delete_worker_pool].
+        /// on [delete_worker_pool][crate::client::CloudBuild::delete_worker_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_worker_pool(self.0.request, self.0.options)
@@ -1751,7 +1751,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::update_worker_pool][super::super::client::CloudBuild::update_worker_pool] calls.
+    /// The request builder for [CloudBuild::update_worker_pool][crate::client::CloudBuild::update_worker_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1799,7 +1799,7 @@ pub mod cloud_build {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_worker_pool][super::super::client::CloudBuild::update_worker_pool].
+        /// on [update_worker_pool][crate::client::CloudBuild::update_worker_pool].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_worker_pool(self.0.request, self.0.options)
@@ -1897,7 +1897,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::list_worker_pools][super::super::client::CloudBuild::list_worker_pools] calls.
+    /// The request builder for [CloudBuild::list_worker_pools][crate::client::CloudBuild::list_worker_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2000,7 +2000,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::get_operation][super::super::client::CloudBuild::get_operation] calls.
+    /// The request builder for [CloudBuild::get_operation][crate::client::CloudBuild::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2064,7 +2064,7 @@ pub mod cloud_build {
         }
     }
 
-    /// The request builder for [CloudBuild::cancel_operation][super::super::client::CloudBuild::cancel_operation] calls.
+    /// The request builder for [CloudBuild::cancel_operation][crate::client::CloudBuild::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/devtools/cloudbuild/v2/src/builder.rs
+++ b/src/generated/devtools/cloudbuild/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod repository_manager {
     use crate::Result;
 
-    /// A builder for [RepositoryManager][super::super::client::RepositoryManager].
+    /// A builder for [RepositoryManager][crate::client::RepositoryManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod repository_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::RepositoryManager] request builders.
+    /// Common implementation for [crate::client::RepositoryManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::RepositoryManager>,
@@ -68,7 +68,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::create_connection][super::super::client::RepositoryManager::create_connection] calls.
+    /// The request builder for [RepositoryManager::create_connection][crate::client::RepositoryManager::create_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -116,7 +116,7 @@ pub mod repository_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_connection][super::super::client::RepositoryManager::create_connection].
+        /// on [create_connection][crate::client::RepositoryManager::create_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_connection(self.0.request, self.0.options)
@@ -203,7 +203,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::get_connection][super::super::client::RepositoryManager::get_connection] calls.
+    /// The request builder for [RepositoryManager::get_connection][crate::client::RepositoryManager::get_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -266,7 +266,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::list_connections][super::super::client::RepositoryManager::list_connections] calls.
+    /// The request builder for [RepositoryManager::list_connections][crate::client::RepositoryManager::list_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -369,7 +369,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::update_connection][super::super::client::RepositoryManager::update_connection] calls.
+    /// The request builder for [RepositoryManager::update_connection][crate::client::RepositoryManager::update_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -417,7 +417,7 @@ pub mod repository_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_connection][super::super::client::RepositoryManager::update_connection].
+        /// on [update_connection][crate::client::RepositoryManager::update_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_connection(self.0.request, self.0.options)
@@ -518,7 +518,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::delete_connection][super::super::client::RepositoryManager::delete_connection] calls.
+    /// The request builder for [RepositoryManager::delete_connection][crate::client::RepositoryManager::delete_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -566,7 +566,7 @@ pub mod repository_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_connection][super::super::client::RepositoryManager::delete_connection].
+        /// on [delete_connection][crate::client::RepositoryManager::delete_connection].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_connection(self.0.request, self.0.options)
@@ -637,7 +637,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::create_repository][super::super::client::RepositoryManager::create_repository] calls.
+    /// The request builder for [RepositoryManager::create_repository][crate::client::RepositoryManager::create_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -685,7 +685,7 @@ pub mod repository_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_repository][super::super::client::RepositoryManager::create_repository].
+        /// on [create_repository][crate::client::RepositoryManager::create_repository].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_repository(self.0.request, self.0.options)
@@ -772,7 +772,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::batch_create_repositories][super::super::client::RepositoryManager::batch_create_repositories] calls.
+    /// The request builder for [RepositoryManager::batch_create_repositories][crate::client::RepositoryManager::batch_create_repositories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -822,7 +822,7 @@ pub mod repository_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [batch_create_repositories][super::super::client::RepositoryManager::batch_create_repositories].
+        /// on [batch_create_repositories][crate::client::RepositoryManager::batch_create_repositories].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .batch_create_repositories(self.0.request, self.0.options)
@@ -897,7 +897,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::get_repository][super::super::client::RepositoryManager::get_repository] calls.
+    /// The request builder for [RepositoryManager::get_repository][crate::client::RepositoryManager::get_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -960,7 +960,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::list_repositories][super::super::client::RepositoryManager::list_repositories] calls.
+    /// The request builder for [RepositoryManager::list_repositories][crate::client::RepositoryManager::list_repositories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1072,7 +1072,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::delete_repository][super::super::client::RepositoryManager::delete_repository] calls.
+    /// The request builder for [RepositoryManager::delete_repository][crate::client::RepositoryManager::delete_repository] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1120,7 +1120,7 @@ pub mod repository_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_repository][super::super::client::RepositoryManager::delete_repository].
+        /// on [delete_repository][crate::client::RepositoryManager::delete_repository].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_repository(self.0.request, self.0.options)
@@ -1191,7 +1191,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::fetch_read_write_token][super::super::client::RepositoryManager::fetch_read_write_token] calls.
+    /// The request builder for [RepositoryManager::fetch_read_write_token][crate::client::RepositoryManager::fetch_read_write_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1257,7 +1257,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::fetch_read_token][super::super::client::RepositoryManager::fetch_read_token] calls.
+    /// The request builder for [RepositoryManager::fetch_read_token][crate::client::RepositoryManager::fetch_read_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1320,7 +1320,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::fetch_linkable_repositories][super::super::client::RepositoryManager::fetch_linkable_repositories] calls.
+    /// The request builder for [RepositoryManager::fetch_linkable_repositories][crate::client::RepositoryManager::fetch_linkable_repositories] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1432,7 +1432,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::fetch_git_refs][super::super::client::RepositoryManager::fetch_git_refs] calls.
+    /// The request builder for [RepositoryManager::fetch_git_refs][crate::client::RepositoryManager::fetch_git_refs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1504,7 +1504,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::set_iam_policy][super::super::client::RepositoryManager::set_iam_policy] calls.
+    /// The request builder for [RepositoryManager::set_iam_policy][crate::client::RepositoryManager::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1607,7 +1607,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::get_iam_policy][super::super::client::RepositoryManager::get_iam_policy] calls.
+    /// The request builder for [RepositoryManager::get_iam_policy][crate::client::RepositoryManager::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1688,7 +1688,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::test_iam_permissions][super::super::client::RepositoryManager::test_iam_permissions] calls.
+    /// The request builder for [RepositoryManager::test_iam_permissions][crate::client::RepositoryManager::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1767,7 +1767,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::get_operation][super::super::client::RepositoryManager::get_operation] calls.
+    /// The request builder for [RepositoryManager::get_operation][crate::client::RepositoryManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1831,7 +1831,7 @@ pub mod repository_manager {
         }
     }
 
-    /// The request builder for [RepositoryManager::cancel_operation][super::super::client::RepositoryManager::cancel_operation] calls.
+    /// The request builder for [RepositoryManager::cancel_operation][crate::client::RepositoryManager::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/devtools/cloudprofiler/v2/src/builder.rs
+++ b/src/generated/devtools/cloudprofiler/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod profiler_service {
     use crate::Result;
 
-    /// A builder for [ProfilerService][super::super::client::ProfilerService].
+    /// A builder for [ProfilerService][crate::client::ProfilerService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod profiler_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ProfilerService] request builders.
+    /// Common implementation for [crate::client::ProfilerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ProfilerService>,
@@ -68,7 +68,7 @@ pub mod profiler_service {
         }
     }
 
-    /// The request builder for [ProfilerService::create_profile][super::super::client::ProfilerService::create_profile] calls.
+    /// The request builder for [ProfilerService::create_profile][crate::client::ProfilerService::create_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -158,7 +158,7 @@ pub mod profiler_service {
         }
     }
 
-    /// The request builder for [ProfilerService::create_offline_profile][super::super::client::ProfilerService::create_offline_profile] calls.
+    /// The request builder for [ProfilerService::create_offline_profile][crate::client::ProfilerService::create_offline_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -240,7 +240,7 @@ pub mod profiler_service {
         }
     }
 
-    /// The request builder for [ProfilerService::update_profile][super::super::client::ProfilerService::update_profile] calls.
+    /// The request builder for [ProfilerService::update_profile][crate::client::ProfilerService::update_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -335,7 +335,7 @@ pub mod profiler_service {
 pub mod export_service {
     use crate::Result;
 
-    /// A builder for [ExportService][super::super::client::ExportService].
+    /// A builder for [ExportService][crate::client::ExportService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -363,7 +363,7 @@ pub mod export_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ExportService] request builders.
+    /// Common implementation for [crate::client::ExportService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ExportService>,
@@ -386,7 +386,7 @@ pub mod export_service {
         }
     }
 
-    /// The request builder for [ExportService::list_profiles][super::super::client::ExportService::list_profiles] calls.
+    /// The request builder for [ExportService::list_profiles][crate::client::ExportService::list_profiles] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/devtools/cloudtrace/v2/src/builder.rs
+++ b/src/generated/devtools/cloudtrace/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod trace_service {
     use crate::Result;
 
-    /// A builder for [TraceService][super::super::client::TraceService].
+    /// A builder for [TraceService][crate::client::TraceService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod trace_service {
         }
     }
 
-    /// Common implementation for [super::super::client::TraceService] request builders.
+    /// Common implementation for [crate::client::TraceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::TraceService>,
@@ -68,7 +68,7 @@ pub mod trace_service {
         }
     }
 
-    /// The request builder for [TraceService::batch_write_spans][super::super::client::TraceService::batch_write_spans] calls.
+    /// The request builder for [TraceService::batch_write_spans][crate::client::TraceService::batch_write_spans] calls.
     ///
     /// # Example
     /// ```no_run
@@ -144,7 +144,7 @@ pub mod trace_service {
         }
     }
 
-    /// The request builder for [TraceService::create_span][super::super::client::TraceService::create_span] calls.
+    /// The request builder for [TraceService::create_span][crate::client::TraceService::create_span] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/devtools/containeranalysis/v1/src/builder.rs
+++ b/src/generated/devtools/containeranalysis/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod container_analysis {
     use crate::Result;
 
-    /// A builder for [ContainerAnalysis][super::super::client::ContainerAnalysis].
+    /// A builder for [ContainerAnalysis][crate::client::ContainerAnalysis].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod container_analysis {
         }
     }
 
-    /// Common implementation for [super::super::client::ContainerAnalysis] request builders.
+    /// Common implementation for [crate::client::ContainerAnalysis] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ContainerAnalysis>,
@@ -68,7 +68,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for [ContainerAnalysis::set_iam_policy][super::super::client::ContainerAnalysis::set_iam_policy] calls.
+    /// The request builder for [ContainerAnalysis::set_iam_policy][crate::client::ContainerAnalysis::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for [ContainerAnalysis::get_iam_policy][super::super::client::ContainerAnalysis::get_iam_policy] calls.
+    /// The request builder for [ContainerAnalysis::get_iam_policy][crate::client::ContainerAnalysis::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for [ContainerAnalysis::test_iam_permissions][super::super::client::ContainerAnalysis::test_iam_permissions] calls.
+    /// The request builder for [ContainerAnalysis::test_iam_permissions][crate::client::ContainerAnalysis::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -331,7 +331,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for [ContainerAnalysis::get_vulnerability_occurrences_summary][super::super::client::ContainerAnalysis::get_vulnerability_occurrences_summary] calls.
+    /// The request builder for [ContainerAnalysis::get_vulnerability_occurrences_summary][crate::client::ContainerAnalysis::get_vulnerability_occurrences_summary] calls.
     ///
     /// # Example
     /// ```no_run
@@ -405,7 +405,7 @@ pub mod container_analysis {
         }
     }
 
-    /// The request builder for [ContainerAnalysis::export_sbom][super::super::client::ContainerAnalysis::export_sbom] calls.
+    /// The request builder for [ContainerAnalysis::export_sbom][crate::client::ContainerAnalysis::export_sbom] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/firestore/admin/v1/src/builder.rs
+++ b/src/generated/firestore/admin/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod firestore_admin {
     use crate::Result;
 
-    /// A builder for [FirestoreAdmin][super::super::client::FirestoreAdmin].
+    /// A builder for [FirestoreAdmin][crate::client::FirestoreAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::FirestoreAdmin] request builders.
+    /// Common implementation for [crate::client::FirestoreAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::FirestoreAdmin>,
@@ -68,7 +68,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::create_index][super::super::client::FirestoreAdmin::create_index] calls.
+    /// The request builder for [FirestoreAdmin::create_index][crate::client::FirestoreAdmin::create_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -113,7 +113,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_index][super::super::client::FirestoreAdmin::create_index].
+        /// on [create_index][crate::client::FirestoreAdmin::create_index].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_index(self.0.request, self.0.options)
@@ -192,7 +192,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::list_indexes][super::super::client::FirestoreAdmin::list_indexes] calls.
+    /// The request builder for [FirestoreAdmin::list_indexes][crate::client::FirestoreAdmin::list_indexes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -301,7 +301,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::get_index][super::super::client::FirestoreAdmin::get_index] calls.
+    /// The request builder for [FirestoreAdmin::get_index][crate::client::FirestoreAdmin::get_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -364,7 +364,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::delete_index][super::super::client::FirestoreAdmin::delete_index] calls.
+    /// The request builder for [FirestoreAdmin::delete_index][crate::client::FirestoreAdmin::delete_index] calls.
     ///
     /// # Example
     /// ```no_run
@@ -427,7 +427,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::get_field][super::super::client::FirestoreAdmin::get_field] calls.
+    /// The request builder for [FirestoreAdmin::get_field][crate::client::FirestoreAdmin::get_field] calls.
     ///
     /// # Example
     /// ```no_run
@@ -490,7 +490,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::update_field][super::super::client::FirestoreAdmin::update_field] calls.
+    /// The request builder for [FirestoreAdmin::update_field][crate::client::FirestoreAdmin::update_field] calls.
     ///
     /// # Example
     /// ```no_run
@@ -535,7 +535,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_field][super::super::client::FirestoreAdmin::update_field].
+        /// on [update_field][crate::client::FirestoreAdmin::update_field].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_field(self.0.request, self.0.options)
@@ -624,7 +624,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::list_fields][super::super::client::FirestoreAdmin::list_fields] calls.
+    /// The request builder for [FirestoreAdmin::list_fields][crate::client::FirestoreAdmin::list_fields] calls.
     ///
     /// # Example
     /// ```no_run
@@ -733,7 +733,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::export_documents][super::super::client::FirestoreAdmin::export_documents] calls.
+    /// The request builder for [FirestoreAdmin::export_documents][crate::client::FirestoreAdmin::export_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -778,7 +778,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [export_documents][super::super::client::FirestoreAdmin::export_documents].
+        /// on [export_documents][crate::client::FirestoreAdmin::export_documents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .export_documents(self.0.request, self.0.options)
@@ -884,7 +884,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::import_documents][super::super::client::FirestoreAdmin::import_documents] calls.
+    /// The request builder for [FirestoreAdmin::import_documents][crate::client::FirestoreAdmin::import_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -929,7 +929,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [import_documents][super::super::client::FirestoreAdmin::import_documents].
+        /// on [import_documents][crate::client::FirestoreAdmin::import_documents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .import_documents(self.0.request, self.0.options)
@@ -1017,7 +1017,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::bulk_delete_documents][super::super::client::FirestoreAdmin::bulk_delete_documents] calls.
+    /// The request builder for [FirestoreAdmin::bulk_delete_documents][crate::client::FirestoreAdmin::bulk_delete_documents] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1065,7 +1065,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [bulk_delete_documents][super::super::client::FirestoreAdmin::bulk_delete_documents].
+        /// on [bulk_delete_documents][crate::client::FirestoreAdmin::bulk_delete_documents].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .bulk_delete_documents(self.0.request, self.0.options)
@@ -1149,7 +1149,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::create_database][super::super::client::FirestoreAdmin::create_database] calls.
+    /// The request builder for [FirestoreAdmin::create_database][crate::client::FirestoreAdmin::create_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1194,7 +1194,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_database][super::super::client::FirestoreAdmin::create_database].
+        /// on [create_database][crate::client::FirestoreAdmin::create_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_database(self.0.request, self.0.options)
@@ -1284,7 +1284,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::get_database][super::super::client::FirestoreAdmin::get_database] calls.
+    /// The request builder for [FirestoreAdmin::get_database][crate::client::FirestoreAdmin::get_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1347,7 +1347,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::list_databases][super::super::client::FirestoreAdmin::list_databases] calls.
+    /// The request builder for [FirestoreAdmin::list_databases][crate::client::FirestoreAdmin::list_databases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1416,7 +1416,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::update_database][super::super::client::FirestoreAdmin::update_database] calls.
+    /// The request builder for [FirestoreAdmin::update_database][crate::client::FirestoreAdmin::update_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1461,7 +1461,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_database][super::super::client::FirestoreAdmin::update_database].
+        /// on [update_database][crate::client::FirestoreAdmin::update_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_database(self.0.request, self.0.options)
@@ -1553,7 +1553,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::delete_database][super::super::client::FirestoreAdmin::delete_database] calls.
+    /// The request builder for [FirestoreAdmin::delete_database][crate::client::FirestoreAdmin::delete_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1598,7 +1598,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_database][super::super::client::FirestoreAdmin::delete_database].
+        /// on [delete_database][crate::client::FirestoreAdmin::delete_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_database(self.0.request, self.0.options)
@@ -1664,7 +1664,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::create_user_creds][super::super::client::FirestoreAdmin::create_user_creds] calls.
+    /// The request builder for [FirestoreAdmin::create_user_creds][crate::client::FirestoreAdmin::create_user_creds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1757,7 +1757,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::get_user_creds][super::super::client::FirestoreAdmin::get_user_creds] calls.
+    /// The request builder for [FirestoreAdmin::get_user_creds][crate::client::FirestoreAdmin::get_user_creds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1820,7 +1820,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::list_user_creds][super::super::client::FirestoreAdmin::list_user_creds] calls.
+    /// The request builder for [FirestoreAdmin::list_user_creds][crate::client::FirestoreAdmin::list_user_creds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1883,7 +1883,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::enable_user_creds][super::super::client::FirestoreAdmin::enable_user_creds] calls.
+    /// The request builder for [FirestoreAdmin::enable_user_creds][crate::client::FirestoreAdmin::enable_user_creds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1946,7 +1946,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::disable_user_creds][super::super::client::FirestoreAdmin::disable_user_creds] calls.
+    /// The request builder for [FirestoreAdmin::disable_user_creds][crate::client::FirestoreAdmin::disable_user_creds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2012,7 +2012,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::reset_user_password][super::super::client::FirestoreAdmin::reset_user_password] calls.
+    /// The request builder for [FirestoreAdmin::reset_user_password][crate::client::FirestoreAdmin::reset_user_password] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2078,7 +2078,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::delete_user_creds][super::super::client::FirestoreAdmin::delete_user_creds] calls.
+    /// The request builder for [FirestoreAdmin::delete_user_creds][crate::client::FirestoreAdmin::delete_user_creds] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2141,7 +2141,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::get_backup][super::super::client::FirestoreAdmin::get_backup] calls.
+    /// The request builder for [FirestoreAdmin::get_backup][crate::client::FirestoreAdmin::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2204,7 +2204,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::list_backups][super::super::client::FirestoreAdmin::list_backups] calls.
+    /// The request builder for [FirestoreAdmin::list_backups][crate::client::FirestoreAdmin::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2273,7 +2273,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::delete_backup][super::super::client::FirestoreAdmin::delete_backup] calls.
+    /// The request builder for [FirestoreAdmin::delete_backup][crate::client::FirestoreAdmin::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2336,7 +2336,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::restore_database][super::super::client::FirestoreAdmin::restore_database] calls.
+    /// The request builder for [FirestoreAdmin::restore_database][crate::client::FirestoreAdmin::restore_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2381,7 +2381,7 @@ pub mod firestore_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_database][super::super::client::FirestoreAdmin::restore_database].
+        /// on [restore_database][crate::client::FirestoreAdmin::restore_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_database(self.0.request, self.0.options)
@@ -2475,7 +2475,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::create_backup_schedule][super::super::client::FirestoreAdmin::create_backup_schedule] calls.
+    /// The request builder for [FirestoreAdmin::create_backup_schedule][crate::client::FirestoreAdmin::create_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2563,7 +2563,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::get_backup_schedule][super::super::client::FirestoreAdmin::get_backup_schedule] calls.
+    /// The request builder for [FirestoreAdmin::get_backup_schedule][crate::client::FirestoreAdmin::get_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2629,7 +2629,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::list_backup_schedules][super::super::client::FirestoreAdmin::list_backup_schedules] calls.
+    /// The request builder for [FirestoreAdmin::list_backup_schedules][crate::client::FirestoreAdmin::list_backup_schedules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2695,7 +2695,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::update_backup_schedule][super::super::client::FirestoreAdmin::update_backup_schedule] calls.
+    /// The request builder for [FirestoreAdmin::update_backup_schedule][crate::client::FirestoreAdmin::update_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2793,7 +2793,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::delete_backup_schedule][super::super::client::FirestoreAdmin::delete_backup_schedule] calls.
+    /// The request builder for [FirestoreAdmin::delete_backup_schedule][crate::client::FirestoreAdmin::delete_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2859,7 +2859,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::list_operations][super::super::client::FirestoreAdmin::list_operations] calls.
+    /// The request builder for [FirestoreAdmin::list_operations][crate::client::FirestoreAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2971,7 +2971,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::get_operation][super::super::client::FirestoreAdmin::get_operation] calls.
+    /// The request builder for [FirestoreAdmin::get_operation][crate::client::FirestoreAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3035,7 +3035,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::delete_operation][super::super::client::FirestoreAdmin::delete_operation] calls.
+    /// The request builder for [FirestoreAdmin::delete_operation][crate::client::FirestoreAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3099,7 +3099,7 @@ pub mod firestore_admin {
         }
     }
 
-    /// The request builder for [FirestoreAdmin::cancel_operation][super::super::client::FirestoreAdmin::cancel_operation] calls.
+    /// The request builder for [FirestoreAdmin::cancel_operation][crate::client::FirestoreAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/grafeas/v1/src/builder.rs
+++ b/src/generated/grafeas/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod grafeas {
     use crate::Result;
 
-    /// A builder for [Grafeas][super::super::client::Grafeas].
+    /// A builder for [Grafeas][crate::client::Grafeas].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod grafeas {
         }
     }
 
-    /// Common implementation for [super::super::client::Grafeas] request builders.
+    /// Common implementation for [crate::client::Grafeas] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Grafeas>,
@@ -66,7 +66,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::get_occurrence][super::super::client::Grafeas::get_occurrence] calls.
+    /// The request builder for [Grafeas::get_occurrence][crate::client::Grafeas::get_occurrence] calls.
     ///
     /// # Example
     /// ```no_run
@@ -127,7 +127,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::list_occurrences][super::super::client::Grafeas::list_occurrences] calls.
+    /// The request builder for [Grafeas::list_occurrences][crate::client::Grafeas::list_occurrences] calls.
     ///
     /// # Example
     /// ```no_run
@@ -234,7 +234,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::delete_occurrence][super::super::client::Grafeas::delete_occurrence] calls.
+    /// The request builder for [Grafeas::delete_occurrence][crate::client::Grafeas::delete_occurrence] calls.
     ///
     /// # Example
     /// ```no_run
@@ -298,7 +298,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::create_occurrence][super::super::client::Grafeas::create_occurrence] calls.
+    /// The request builder for [Grafeas::create_occurrence][crate::client::Grafeas::create_occurrence] calls.
     ///
     /// # Example
     /// ```no_run
@@ -384,7 +384,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::batch_create_occurrences][super::super::client::Grafeas::batch_create_occurrences] calls.
+    /// The request builder for [Grafeas::batch_create_occurrences][crate::client::Grafeas::batch_create_occurrences] calls.
     ///
     /// # Example
     /// ```no_run
@@ -461,7 +461,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::update_occurrence][super::super::client::Grafeas::update_occurrence] calls.
+    /// The request builder for [Grafeas::update_occurrence][crate::client::Grafeas::update_occurrence] calls.
     ///
     /// # Example
     /// ```no_run
@@ -565,7 +565,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::get_occurrence_note][super::super::client::Grafeas::get_occurrence_note] calls.
+    /// The request builder for [Grafeas::get_occurrence_note][crate::client::Grafeas::get_occurrence_note] calls.
     ///
     /// # Example
     /// ```no_run
@@ -629,7 +629,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::get_note][super::super::client::Grafeas::get_note] calls.
+    /// The request builder for [Grafeas::get_note][crate::client::Grafeas::get_note] calls.
     ///
     /// # Example
     /// ```no_run
@@ -690,7 +690,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::list_notes][super::super::client::Grafeas::list_notes] calls.
+    /// The request builder for [Grafeas::list_notes][crate::client::Grafeas::list_notes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -797,7 +797,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::delete_note][super::super::client::Grafeas::delete_note] calls.
+    /// The request builder for [Grafeas::delete_note][crate::client::Grafeas::delete_note] calls.
     ///
     /// # Example
     /// ```no_run
@@ -858,7 +858,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::create_note][super::super::client::Grafeas::create_note] calls.
+    /// The request builder for [Grafeas::create_note][crate::client::Grafeas::create_note] calls.
     ///
     /// # Example
     /// ```no_run
@@ -949,7 +949,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::batch_create_notes][super::super::client::Grafeas::batch_create_notes] calls.
+    /// The request builder for [Grafeas::batch_create_notes][crate::client::Grafeas::batch_create_notes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1026,7 +1026,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::update_note][super::super::client::Grafeas::update_note] calls.
+    /// The request builder for [Grafeas::update_note][crate::client::Grafeas::update_note] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1127,7 +1127,7 @@ pub mod grafeas {
         }
     }
 
-    /// The request builder for [Grafeas::list_note_occurrences][super::super::client::Grafeas::list_note_occurrences] calls.
+    /// The request builder for [Grafeas::list_note_occurrences][crate::client::Grafeas::list_note_occurrences] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/iam/admin/v1/src/builder.rs
+++ b/src/generated/iam/admin/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod iam {
     use crate::Result;
 
-    /// A builder for [Iam][super::super::client::Iam].
+    /// A builder for [Iam][crate::client::Iam].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod iam {
         }
     }
 
-    /// Common implementation for [super::super::client::Iam] request builders.
+    /// Common implementation for [crate::client::Iam] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Iam>,
@@ -66,7 +66,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::list_service_accounts][super::super::client::Iam::list_service_accounts] calls.
+    /// The request builder for [Iam::list_service_accounts][crate::client::Iam::list_service_accounts] calls.
     ///
     /// # Example
     /// ```no_run
@@ -172,7 +172,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::get_service_account][super::super::client::Iam::get_service_account] calls.
+    /// The request builder for [Iam::get_service_account][crate::client::Iam::get_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -236,7 +236,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::create_service_account][super::super::client::Iam::create_service_account] calls.
+    /// The request builder for [Iam::create_service_account][crate::client::Iam::create_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -326,7 +326,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::update_service_account][super::super::client::Iam::update_service_account] calls.
+    /// The request builder for [Iam::update_service_account][crate::client::Iam::update_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -434,7 +434,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::patch_service_account][super::super::client::Iam::patch_service_account] calls.
+    /// The request builder for [Iam::patch_service_account][crate::client::Iam::patch_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -526,7 +526,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::delete_service_account][super::super::client::Iam::delete_service_account] calls.
+    /// The request builder for [Iam::delete_service_account][crate::client::Iam::delete_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -590,7 +590,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::undelete_service_account][super::super::client::Iam::undelete_service_account] calls.
+    /// The request builder for [Iam::undelete_service_account][crate::client::Iam::undelete_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -652,7 +652,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::enable_service_account][super::super::client::Iam::enable_service_account] calls.
+    /// The request builder for [Iam::enable_service_account][crate::client::Iam::enable_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -714,7 +714,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::disable_service_account][super::super::client::Iam::disable_service_account] calls.
+    /// The request builder for [Iam::disable_service_account][crate::client::Iam::disable_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -776,7 +776,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::list_service_account_keys][super::super::client::Iam::list_service_account_keys] calls.
+    /// The request builder for [Iam::list_service_account_keys][crate::client::Iam::list_service_account_keys] calls.
     ///
     /// # Example
     /// ```no_run
@@ -851,7 +851,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::get_service_account_key][super::super::client::Iam::get_service_account_key] calls.
+    /// The request builder for [Iam::get_service_account_key][crate::client::Iam::get_service_account_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -924,7 +924,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::create_service_account_key][super::super::client::Iam::create_service_account_key] calls.
+    /// The request builder for [Iam::create_service_account_key][crate::client::Iam::create_service_account_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1008,7 +1008,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::upload_service_account_key][super::super::client::Iam::upload_service_account_key] calls.
+    /// The request builder for [Iam::upload_service_account_key][crate::client::Iam::upload_service_account_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1078,7 +1078,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::delete_service_account_key][super::super::client::Iam::delete_service_account_key] calls.
+    /// The request builder for [Iam::delete_service_account_key][crate::client::Iam::delete_service_account_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1144,7 +1144,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::disable_service_account_key][super::super::client::Iam::disable_service_account_key] calls.
+    /// The request builder for [Iam::disable_service_account_key][crate::client::Iam::disable_service_account_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1210,7 +1210,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::enable_service_account_key][super::super::client::Iam::enable_service_account_key] calls.
+    /// The request builder for [Iam::enable_service_account_key][crate::client::Iam::enable_service_account_key] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1276,7 +1276,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::sign_blob][super::super::client::Iam::sign_blob] calls.
+    /// The request builder for [Iam::sign_blob][crate::client::Iam::sign_blob] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1347,7 +1347,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::sign_jwt][super::super::client::Iam::sign_jwt] calls.
+    /// The request builder for [Iam::sign_jwt][crate::client::Iam::sign_jwt] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1418,7 +1418,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::get_iam_policy][super::super::client::Iam::get_iam_policy] calls.
+    /// The request builder for [Iam::get_iam_policy][crate::client::Iam::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1497,7 +1497,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::set_iam_policy][super::super::client::Iam::set_iam_policy] calls.
+    /// The request builder for [Iam::set_iam_policy][crate::client::Iam::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1598,7 +1598,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::test_iam_permissions][super::super::client::Iam::test_iam_permissions] calls.
+    /// The request builder for [Iam::test_iam_permissions][crate::client::Iam::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1675,7 +1675,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::query_grantable_roles][super::super::client::Iam::query_grantable_roles] calls.
+    /// The request builder for [Iam::query_grantable_roles][crate::client::Iam::query_grantable_roles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1787,7 +1787,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::list_roles][super::super::client::Iam::list_roles] calls.
+    /// The request builder for [Iam::list_roles][crate::client::Iam::list_roles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1898,7 +1898,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::get_role][super::super::client::Iam::get_role] calls.
+    /// The request builder for [Iam::get_role][crate::client::Iam::get_role] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1957,7 +1957,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::create_role][super::super::client::Iam::create_role] calls.
+    /// The request builder for [Iam::create_role][crate::client::Iam::create_role] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2040,7 +2040,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::update_role][super::super::client::Iam::update_role] calls.
+    /// The request builder for [Iam::update_role][crate::client::Iam::update_role] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2135,7 +2135,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::delete_role][super::super::client::Iam::delete_role] calls.
+    /// The request builder for [Iam::delete_role][crate::client::Iam::delete_role] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2200,7 +2200,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::undelete_role][super::super::client::Iam::undelete_role] calls.
+    /// The request builder for [Iam::undelete_role][crate::client::Iam::undelete_role] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2265,7 +2265,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::query_testable_permissions][super::super::client::Iam::query_testable_permissions] calls.
+    /// The request builder for [Iam::query_testable_permissions][crate::client::Iam::query_testable_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2373,7 +2373,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::query_auditable_services][super::super::client::Iam::query_auditable_services] calls.
+    /// The request builder for [Iam::query_auditable_services][crate::client::Iam::query_auditable_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2435,7 +2435,7 @@ pub mod iam {
         }
     }
 
-    /// The request builder for [Iam::lint_policy][super::super::client::Iam::lint_policy] calls.
+    /// The request builder for [Iam::lint_policy][crate::client::Iam::lint_policy] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/iam/credentials/v1/src/builder.rs
+++ b/src/generated/iam/credentials/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod iam_credentials {
     use crate::Result;
 
-    /// A builder for [IAMCredentials][super::super::client::IAMCredentials].
+    /// A builder for [IAMCredentials][crate::client::IAMCredentials].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// Common implementation for [super::super::client::IAMCredentials] request builders.
+    /// Common implementation for [crate::client::IAMCredentials] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::IAMCredentials>,
@@ -68,7 +68,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for [IAMCredentials::generate_access_token][super::super::client::IAMCredentials::generate_access_token] calls.
+    /// The request builder for [IAMCredentials::generate_access_token][crate::client::IAMCredentials::generate_access_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -176,7 +176,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for [IAMCredentials::generate_id_token][super::super::client::IAMCredentials::generate_id_token] calls.
+    /// The request builder for [IAMCredentials::generate_id_token][crate::client::IAMCredentials::generate_id_token] calls.
     ///
     /// # Example
     /// ```no_run
@@ -264,7 +264,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for [IAMCredentials::sign_blob][super::super::client::IAMCredentials::sign_blob] calls.
+    /// The request builder for [IAMCredentials::sign_blob][crate::client::IAMCredentials::sign_blob] calls.
     ///
     /// # Example
     /// ```no_run
@@ -346,7 +346,7 @@ pub mod iam_credentials {
         }
     }
 
-    /// The request builder for [IAMCredentials::sign_jwt][super::super::client::IAMCredentials::sign_jwt] calls.
+    /// The request builder for [IAMCredentials::sign_jwt][crate::client::IAMCredentials::sign_jwt] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/iam/v1/src/builder.rs
+++ b/src/generated/iam/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod iam_policy {
     use crate::Result;
 
-    /// A builder for [IAMPolicy][super::super::client::IAMPolicy].
+    /// A builder for [IAMPolicy][crate::client::IAMPolicy].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod iam_policy {
         }
     }
 
-    /// Common implementation for [super::super::client::IAMPolicy] request builders.
+    /// Common implementation for [crate::client::IAMPolicy] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::IAMPolicy>,
@@ -68,7 +68,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for [IAMPolicy::set_iam_policy][super::super::client::IAMPolicy::set_iam_policy] calls.
+    /// The request builder for [IAMPolicy::set_iam_policy][crate::client::IAMPolicy::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for [IAMPolicy::get_iam_policy][super::super::client::IAMPolicy::get_iam_policy] calls.
+    /// The request builder for [IAMPolicy::get_iam_policy][crate::client::IAMPolicy::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod iam_policy {
         }
     }
 
-    /// The request builder for [IAMPolicy::test_iam_permissions][super::super::client::IAMPolicy::test_iam_permissions] calls.
+    /// The request builder for [IAMPolicy::test_iam_permissions][crate::client::IAMPolicy::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/iam/v2/src/builder.rs
+++ b/src/generated/iam/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod policies {
     use crate::Result;
 
-    /// A builder for [Policies][super::super::client::Policies].
+    /// A builder for [Policies][crate::client::Policies].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod policies {
         }
     }
 
-    /// Common implementation for [super::super::client::Policies] request builders.
+    /// Common implementation for [crate::client::Policies] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Policies>,
@@ -66,7 +66,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for [Policies::list_policies][super::super::client::Policies::list_policies] calls.
+    /// The request builder for [Policies::list_policies][crate::client::Policies::list_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -167,7 +167,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for [Policies::get_policy][super::super::client::Policies::get_policy] calls.
+    /// The request builder for [Policies::get_policy][crate::client::Policies::get_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -228,7 +228,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for [Policies::create_policy][super::super::client::Policies::create_policy] calls.
+    /// The request builder for [Policies::create_policy][crate::client::Policies::create_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -271,7 +271,7 @@ pub mod policies {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_policy][super::super::client::Policies::create_policy].
+        /// on [create_policy][crate::client::Policies::create_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_policy(self.0.request, self.0.options)
@@ -358,7 +358,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for [Policies::update_policy][super::super::client::Policies::update_policy] calls.
+    /// The request builder for [Policies::update_policy][crate::client::Policies::update_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -401,7 +401,7 @@ pub mod policies {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_policy][super::super::client::Policies::update_policy].
+        /// on [update_policy][crate::client::Policies::update_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_policy(self.0.request, self.0.options)
@@ -474,7 +474,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for [Policies::delete_policy][super::super::client::Policies::delete_policy] calls.
+    /// The request builder for [Policies::delete_policy][crate::client::Policies::delete_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -517,7 +517,7 @@ pub mod policies {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_policy][super::super::client::Policies::delete_policy].
+        /// on [delete_policy][crate::client::Policies::delete_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_policy(self.0.request, self.0.options)
@@ -582,7 +582,7 @@ pub mod policies {
         }
     }
 
-    /// The request builder for [Policies::get_operation][super::super::client::Policies::get_operation] calls.
+    /// The request builder for [Policies::get_operation][crate::client::Policies::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/iam/v3/src/builder.rs
+++ b/src/generated/iam/v3/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod policy_bindings {
     use crate::Result;
 
-    /// A builder for [PolicyBindings][super::super::client::PolicyBindings].
+    /// A builder for [PolicyBindings][crate::client::PolicyBindings].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// Common implementation for [super::super::client::PolicyBindings] request builders.
+    /// Common implementation for [crate::client::PolicyBindings] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PolicyBindings>,
@@ -68,7 +68,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for [PolicyBindings::create_policy_binding][super::super::client::PolicyBindings::create_policy_binding] calls.
+    /// The request builder for [PolicyBindings::create_policy_binding][crate::client::PolicyBindings::create_policy_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -116,7 +116,7 @@ pub mod policy_bindings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_policy_binding][super::super::client::PolicyBindings::create_policy_binding].
+        /// on [create_policy_binding][crate::client::PolicyBindings::create_policy_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_policy_binding(self.0.request, self.0.options)
@@ -212,7 +212,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for [PolicyBindings::get_policy_binding][super::super::client::PolicyBindings::get_policy_binding] calls.
+    /// The request builder for [PolicyBindings::get_policy_binding][crate::client::PolicyBindings::get_policy_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -278,7 +278,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for [PolicyBindings::update_policy_binding][super::super::client::PolicyBindings::update_policy_binding] calls.
+    /// The request builder for [PolicyBindings::update_policy_binding][crate::client::PolicyBindings::update_policy_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -326,7 +326,7 @@ pub mod policy_bindings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_policy_binding][super::super::client::PolicyBindings::update_policy_binding].
+        /// on [update_policy_binding][crate::client::PolicyBindings::update_policy_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_policy_binding(self.0.request, self.0.options)
@@ -424,7 +424,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for [PolicyBindings::delete_policy_binding][super::super::client::PolicyBindings::delete_policy_binding] calls.
+    /// The request builder for [PolicyBindings::delete_policy_binding][crate::client::PolicyBindings::delete_policy_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -472,7 +472,7 @@ pub mod policy_bindings {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_policy_binding][super::super::client::PolicyBindings::delete_policy_binding].
+        /// on [delete_policy_binding][crate::client::PolicyBindings::delete_policy_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_policy_binding(self.0.request, self.0.options)
@@ -543,7 +543,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for [PolicyBindings::list_policy_bindings][super::super::client::PolicyBindings::list_policy_bindings] calls.
+    /// The request builder for [PolicyBindings::list_policy_bindings][crate::client::PolicyBindings::list_policy_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -657,7 +657,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for [PolicyBindings::search_target_policy_bindings][super::super::client::PolicyBindings::search_target_policy_bindings] calls.
+    /// The request builder for [PolicyBindings::search_target_policy_bindings][crate::client::PolicyBindings::search_target_policy_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -777,7 +777,7 @@ pub mod policy_bindings {
         }
     }
 
-    /// The request builder for [PolicyBindings::get_operation][super::super::client::PolicyBindings::get_operation] calls.
+    /// The request builder for [PolicyBindings::get_operation][crate::client::PolicyBindings::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -845,7 +845,7 @@ pub mod policy_bindings {
 pub mod principal_access_boundary_policies {
     use crate::Result;
 
-    /// A builder for [PrincipalAccessBoundaryPolicies][super::super::client::PrincipalAccessBoundaryPolicies].
+    /// A builder for [PrincipalAccessBoundaryPolicies][crate::client::PrincipalAccessBoundaryPolicies].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -873,7 +873,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// Common implementation for [super::super::client::PrincipalAccessBoundaryPolicies] request builders.
+    /// Common implementation for [crate::client::PrincipalAccessBoundaryPolicies] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::PrincipalAccessBoundaryPolicies>,
@@ -896,7 +896,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for [PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy] calls.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy][crate::client::PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -946,7 +946,7 @@ pub mod principal_access_boundary_policies {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy].
+        /// on [create_principal_access_boundary_policy][crate::client::PrincipalAccessBoundaryPolicies::create_principal_access_boundary_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_principal_access_boundary_policy(self.0.request, self.0.options)
@@ -1048,7 +1048,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for [PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy] calls.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy][crate::client::PrincipalAccessBoundaryPolicies::get_principal_access_boundary_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1116,7 +1116,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for [PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy] calls.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy][crate::client::PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1166,7 +1166,7 @@ pub mod principal_access_boundary_policies {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy].
+        /// on [update_principal_access_boundary_policy][crate::client::PrincipalAccessBoundaryPolicies::update_principal_access_boundary_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_principal_access_boundary_policy(self.0.request, self.0.options)
@@ -1267,7 +1267,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for [PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy] calls.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy][crate::client::PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1317,7 +1317,7 @@ pub mod principal_access_boundary_policies {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_principal_access_boundary_policy][super::super::client::PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy].
+        /// on [delete_principal_access_boundary_policy][crate::client::PrincipalAccessBoundaryPolicies::delete_principal_access_boundary_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_principal_access_boundary_policy(self.0.request, self.0.options)
@@ -1394,7 +1394,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for [PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies][super::super::client::PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies] calls.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies][crate::client::PrincipalAccessBoundaryPolicies::list_principal_access_boundary_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1508,7 +1508,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for [PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings][super::super::client::PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings] calls.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings][crate::client::PrincipalAccessBoundaryPolicies::search_principal_access_boundary_policy_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1624,7 +1624,7 @@ pub mod principal_access_boundary_policies {
         }
     }
 
-    /// The request builder for [PrincipalAccessBoundaryPolicies::get_operation][super::super::client::PrincipalAccessBoundaryPolicies::get_operation] calls.
+    /// The request builder for [PrincipalAccessBoundaryPolicies::get_operation][crate::client::PrincipalAccessBoundaryPolicies::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/identity/accesscontextmanager/v1/src/builder.rs
+++ b/src/generated/identity/accesscontextmanager/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod access_context_manager {
     use crate::Result;
 
-    /// A builder for [AccessContextManager][super::super::client::AccessContextManager].
+    /// A builder for [AccessContextManager][crate::client::AccessContextManager].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// Common implementation for [super::super::client::AccessContextManager] request builders.
+    /// Common implementation for [crate::client::AccessContextManager] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AccessContextManager>,
@@ -68,7 +68,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::list_access_policies][super::super::client::AccessContextManager::list_access_policies] calls.
+    /// The request builder for [AccessContextManager::list_access_policies][crate::client::AccessContextManager::list_access_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -176,7 +176,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::get_access_policy][super::super::client::AccessContextManager::get_access_policy] calls.
+    /// The request builder for [AccessContextManager::get_access_policy][crate::client::AccessContextManager::get_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -239,7 +239,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::create_access_policy][super::super::client::AccessContextManager::create_access_policy] calls.
+    /// The request builder for [AccessContextManager::create_access_policy][crate::client::AccessContextManager::create_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -284,7 +284,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_access_policy][super::super::client::AccessContextManager::create_access_policy].
+        /// on [create_access_policy][crate::client::AccessContextManager::create_access_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_access_policy(self.0.request, self.0.options)
@@ -409,7 +409,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::update_access_policy][super::super::client::AccessContextManager::update_access_policy] calls.
+    /// The request builder for [AccessContextManager::update_access_policy][crate::client::AccessContextManager::update_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -457,7 +457,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_access_policy][super::super::client::AccessContextManager::update_access_policy].
+        /// on [update_access_policy][crate::client::AccessContextManager::update_access_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_access_policy(self.0.request, self.0.options)
@@ -555,7 +555,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::delete_access_policy][super::super::client::AccessContextManager::delete_access_policy] calls.
+    /// The request builder for [AccessContextManager::delete_access_policy][crate::client::AccessContextManager::delete_access_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -603,7 +603,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_access_policy][super::super::client::AccessContextManager::delete_access_policy].
+        /// on [delete_access_policy][crate::client::AccessContextManager::delete_access_policy].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_access_policy(self.0.request, self.0.options)
@@ -667,7 +667,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::list_access_levels][super::super::client::AccessContextManager::list_access_levels] calls.
+    /// The request builder for [AccessContextManager::list_access_levels][crate::client::AccessContextManager::list_access_levels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -779,7 +779,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::get_access_level][super::super::client::AccessContextManager::get_access_level] calls.
+    /// The request builder for [AccessContextManager::get_access_level][crate::client::AccessContextManager::get_access_level] calls.
     ///
     /// # Example
     /// ```no_run
@@ -848,7 +848,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::create_access_level][super::super::client::AccessContextManager::create_access_level] calls.
+    /// The request builder for [AccessContextManager::create_access_level][crate::client::AccessContextManager::create_access_level] calls.
     ///
     /// # Example
     /// ```no_run
@@ -896,7 +896,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_access_level][super::super::client::AccessContextManager::create_access_level].
+        /// on [create_access_level][crate::client::AccessContextManager::create_access_level].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_access_level(self.0.request, self.0.options)
@@ -980,7 +980,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::update_access_level][super::super::client::AccessContextManager::update_access_level] calls.
+    /// The request builder for [AccessContextManager::update_access_level][crate::client::AccessContextManager::update_access_level] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1028,7 +1028,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_access_level][super::super::client::AccessContextManager::update_access_level].
+        /// on [update_access_level][crate::client::AccessContextManager::update_access_level].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_access_level(self.0.request, self.0.options)
@@ -1126,7 +1126,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::delete_access_level][super::super::client::AccessContextManager::delete_access_level] calls.
+    /// The request builder for [AccessContextManager::delete_access_level][crate::client::AccessContextManager::delete_access_level] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1174,7 +1174,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_access_level][super::super::client::AccessContextManager::delete_access_level].
+        /// on [delete_access_level][crate::client::AccessContextManager::delete_access_level].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_access_level(self.0.request, self.0.options)
@@ -1238,7 +1238,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::replace_access_levels][super::super::client::AccessContextManager::replace_access_levels] calls.
+    /// The request builder for [AccessContextManager::replace_access_levels][crate::client::AccessContextManager::replace_access_levels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1286,7 +1286,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [replace_access_levels][super::super::client::AccessContextManager::replace_access_levels].
+        /// on [replace_access_levels][crate::client::AccessContextManager::replace_access_levels].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .replace_access_levels(self.0.request, self.0.options)
@@ -1367,7 +1367,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::list_service_perimeters][super::super::client::AccessContextManager::list_service_perimeters] calls.
+    /// The request builder for [AccessContextManager::list_service_perimeters][crate::client::AccessContextManager::list_service_perimeters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1475,7 +1475,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::get_service_perimeter][super::super::client::AccessContextManager::get_service_perimeter] calls.
+    /// The request builder for [AccessContextManager::get_service_perimeter][crate::client::AccessContextManager::get_service_perimeter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1541,7 +1541,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::create_service_perimeter][super::super::client::AccessContextManager::create_service_perimeter] calls.
+    /// The request builder for [AccessContextManager::create_service_perimeter][crate::client::AccessContextManager::create_service_perimeter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1589,7 +1589,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_service_perimeter][super::super::client::AccessContextManager::create_service_perimeter].
+        /// on [create_service_perimeter][crate::client::AccessContextManager::create_service_perimeter].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_service_perimeter(self.0.request, self.0.options)
@@ -1673,7 +1673,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::update_service_perimeter][super::super::client::AccessContextManager::update_service_perimeter] calls.
+    /// The request builder for [AccessContextManager::update_service_perimeter][crate::client::AccessContextManager::update_service_perimeter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1721,7 +1721,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_service_perimeter][super::super::client::AccessContextManager::update_service_perimeter].
+        /// on [update_service_perimeter][crate::client::AccessContextManager::update_service_perimeter].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_service_perimeter(self.0.request, self.0.options)
@@ -1819,7 +1819,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::delete_service_perimeter][super::super::client::AccessContextManager::delete_service_perimeter] calls.
+    /// The request builder for [AccessContextManager::delete_service_perimeter][crate::client::AccessContextManager::delete_service_perimeter] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1867,7 +1867,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_service_perimeter][super::super::client::AccessContextManager::delete_service_perimeter].
+        /// on [delete_service_perimeter][crate::client::AccessContextManager::delete_service_perimeter].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_service_perimeter(self.0.request, self.0.options)
@@ -1931,7 +1931,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::replace_service_perimeters][super::super::client::AccessContextManager::replace_service_perimeters] calls.
+    /// The request builder for [AccessContextManager::replace_service_perimeters][crate::client::AccessContextManager::replace_service_perimeters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1981,7 +1981,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [replace_service_perimeters][super::super::client::AccessContextManager::replace_service_perimeters].
+        /// on [replace_service_perimeters][crate::client::AccessContextManager::replace_service_perimeters].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .replace_service_perimeters(self.0.request, self.0.options)
@@ -2062,7 +2062,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::commit_service_perimeters][super::super::client::AccessContextManager::commit_service_perimeters] calls.
+    /// The request builder for [AccessContextManager::commit_service_perimeters][crate::client::AccessContextManager::commit_service_perimeters] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2112,7 +2112,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [commit_service_perimeters][super::super::client::AccessContextManager::commit_service_perimeters].
+        /// on [commit_service_perimeters][crate::client::AccessContextManager::commit_service_perimeters].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .commit_service_perimeters(self.0.request, self.0.options)
@@ -2180,7 +2180,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::list_gcp_user_access_bindings][super::super::client::AccessContextManager::list_gcp_user_access_bindings] calls.
+    /// The request builder for [AccessContextManager::list_gcp_user_access_bindings][crate::client::AccessContextManager::list_gcp_user_access_bindings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2292,7 +2292,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::get_gcp_user_access_binding][super::super::client::AccessContextManager::get_gcp_user_access_binding] calls.
+    /// The request builder for [AccessContextManager::get_gcp_user_access_binding][crate::client::AccessContextManager::get_gcp_user_access_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2360,7 +2360,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::create_gcp_user_access_binding][super::super::client::AccessContextManager::create_gcp_user_access_binding] calls.
+    /// The request builder for [AccessContextManager::create_gcp_user_access_binding][crate::client::AccessContextManager::create_gcp_user_access_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2410,7 +2410,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_gcp_user_access_binding][super::super::client::AccessContextManager::create_gcp_user_access_binding].
+        /// on [create_gcp_user_access_binding][crate::client::AccessContextManager::create_gcp_user_access_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_gcp_user_access_binding(self.0.request, self.0.options)
@@ -2494,7 +2494,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::update_gcp_user_access_binding][super::super::client::AccessContextManager::update_gcp_user_access_binding] calls.
+    /// The request builder for [AccessContextManager::update_gcp_user_access_binding][crate::client::AccessContextManager::update_gcp_user_access_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2544,7 +2544,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_gcp_user_access_binding][super::super::client::AccessContextManager::update_gcp_user_access_binding].
+        /// on [update_gcp_user_access_binding][crate::client::AccessContextManager::update_gcp_user_access_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_gcp_user_access_binding(self.0.request, self.0.options)
@@ -2642,7 +2642,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::delete_gcp_user_access_binding][super::super::client::AccessContextManager::delete_gcp_user_access_binding] calls.
+    /// The request builder for [AccessContextManager::delete_gcp_user_access_binding][crate::client::AccessContextManager::delete_gcp_user_access_binding] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2692,7 +2692,7 @@ pub mod access_context_manager {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_gcp_user_access_binding][super::super::client::AccessContextManager::delete_gcp_user_access_binding].
+        /// on [delete_gcp_user_access_binding][crate::client::AccessContextManager::delete_gcp_user_access_binding].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_gcp_user_access_binding(self.0.request, self.0.options)
@@ -2756,7 +2756,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::set_iam_policy][super::super::client::AccessContextManager::set_iam_policy] calls.
+    /// The request builder for [AccessContextManager::set_iam_policy][crate::client::AccessContextManager::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2859,7 +2859,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::get_iam_policy][super::super::client::AccessContextManager::get_iam_policy] calls.
+    /// The request builder for [AccessContextManager::get_iam_policy][crate::client::AccessContextManager::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2940,7 +2940,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::test_iam_permissions][super::super::client::AccessContextManager::test_iam_permissions] calls.
+    /// The request builder for [AccessContextManager::test_iam_permissions][crate::client::AccessContextManager::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3019,7 +3019,7 @@ pub mod access_context_manager {
         }
     }
 
-    /// The request builder for [AccessContextManager::get_operation][super::super::client::AccessContextManager::get_operation] calls.
+    /// The request builder for [AccessContextManager::get_operation][crate::client::AccessContextManager::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/logging/v2/src/builder.rs
+++ b/src/generated/logging/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod logging_service_v_2 {
     use crate::Result;
 
-    /// A builder for [LoggingServiceV2][super::super::client::LoggingServiceV2].
+    /// A builder for [LoggingServiceV2][crate::client::LoggingServiceV2].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// Common implementation for [super::super::client::LoggingServiceV2] request builders.
+    /// Common implementation for [crate::client::LoggingServiceV2] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::LoggingServiceV2>,
@@ -68,7 +68,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::delete_log][super::super::client::LoggingServiceV2::delete_log] calls.
+    /// The request builder for [LoggingServiceV2::delete_log][crate::client::LoggingServiceV2::delete_log] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::write_log_entries][super::super::client::LoggingServiceV2::write_log_entries] calls.
+    /// The request builder for [LoggingServiceV2::write_log_entries][crate::client::LoggingServiceV2::write_log_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -246,7 +246,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::list_log_entries][super::super::client::LoggingServiceV2::list_log_entries] calls.
+    /// The request builder for [LoggingServiceV2::list_log_entries][crate::client::LoggingServiceV2::list_log_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -366,7 +366,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::list_monitored_resource_descriptors][super::super::client::LoggingServiceV2::list_monitored_resource_descriptors] calls.
+    /// The request builder for [LoggingServiceV2::list_monitored_resource_descriptors][crate::client::LoggingServiceV2::list_monitored_resource_descriptors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -470,7 +470,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::list_logs][super::super::client::LoggingServiceV2::list_logs] calls.
+    /// The request builder for [LoggingServiceV2::list_logs][crate::client::LoggingServiceV2::list_logs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -556,7 +556,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::list_operations][super::super::client::LoggingServiceV2::list_operations] calls.
+    /// The request builder for [LoggingServiceV2::list_operations][crate::client::LoggingServiceV2::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -668,7 +668,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::get_operation][super::super::client::LoggingServiceV2::get_operation] calls.
+    /// The request builder for [LoggingServiceV2::get_operation][crate::client::LoggingServiceV2::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -732,7 +732,7 @@ pub mod logging_service_v_2 {
         }
     }
 
-    /// The request builder for [LoggingServiceV2::cancel_operation][super::super::client::LoggingServiceV2::cancel_operation] calls.
+    /// The request builder for [LoggingServiceV2::cancel_operation][crate::client::LoggingServiceV2::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -800,7 +800,7 @@ pub mod logging_service_v_2 {
 pub mod config_service_v_2 {
     use crate::Result;
 
-    /// A builder for [ConfigServiceV2][super::super::client::ConfigServiceV2].
+    /// A builder for [ConfigServiceV2][crate::client::ConfigServiceV2].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -828,7 +828,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// Common implementation for [super::super::client::ConfigServiceV2] request builders.
+    /// Common implementation for [crate::client::ConfigServiceV2] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ConfigServiceV2>,
@@ -851,7 +851,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::list_buckets][super::super::client::ConfigServiceV2::list_buckets] calls.
+    /// The request builder for [ConfigServiceV2::list_buckets][crate::client::ConfigServiceV2::list_buckets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -954,7 +954,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_bucket][super::super::client::ConfigServiceV2::get_bucket] calls.
+    /// The request builder for [ConfigServiceV2::get_bucket][crate::client::ConfigServiceV2::get_bucket] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1017,7 +1017,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::create_bucket_async][super::super::client::ConfigServiceV2::create_bucket_async] calls.
+    /// The request builder for [ConfigServiceV2::create_bucket_async][crate::client::ConfigServiceV2::create_bucket_async] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1062,7 +1062,7 @@ pub mod config_service_v_2 {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_bucket_async][super::super::client::ConfigServiceV2::create_bucket_async].
+        /// on [create_bucket_async][crate::client::ConfigServiceV2::create_bucket_async].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_bucket_async(self.0.request, self.0.options)
@@ -1149,7 +1149,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::update_bucket_async][super::super::client::ConfigServiceV2::update_bucket_async] calls.
+    /// The request builder for [ConfigServiceV2::update_bucket_async][crate::client::ConfigServiceV2::update_bucket_async] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1194,7 +1194,7 @@ pub mod config_service_v_2 {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_bucket_async][super::super::client::ConfigServiceV2::update_bucket_async].
+        /// on [update_bucket_async][crate::client::ConfigServiceV2::update_bucket_async].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_bucket_async(self.0.request, self.0.options)
@@ -1295,7 +1295,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::create_bucket][super::super::client::ConfigServiceV2::create_bucket] calls.
+    /// The request builder for [ConfigServiceV2::create_bucket][crate::client::ConfigServiceV2::create_bucket] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1388,7 +1388,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::update_bucket][super::super::client::ConfigServiceV2::update_bucket] calls.
+    /// The request builder for [ConfigServiceV2::update_bucket][crate::client::ConfigServiceV2::update_bucket] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1495,7 +1495,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::delete_bucket][super::super::client::ConfigServiceV2::delete_bucket] calls.
+    /// The request builder for [ConfigServiceV2::delete_bucket][crate::client::ConfigServiceV2::delete_bucket] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1558,7 +1558,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::undelete_bucket][super::super::client::ConfigServiceV2::undelete_bucket] calls.
+    /// The request builder for [ConfigServiceV2::undelete_bucket][crate::client::ConfigServiceV2::undelete_bucket] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1621,7 +1621,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::list_views][super::super::client::ConfigServiceV2::list_views] calls.
+    /// The request builder for [ConfigServiceV2::list_views][crate::client::ConfigServiceV2::list_views] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1724,7 +1724,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_view][super::super::client::ConfigServiceV2::get_view] calls.
+    /// The request builder for [ConfigServiceV2::get_view][crate::client::ConfigServiceV2::get_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1787,7 +1787,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::create_view][super::super::client::ConfigServiceV2::create_view] calls.
+    /// The request builder for [ConfigServiceV2::create_view][crate::client::ConfigServiceV2::create_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1880,7 +1880,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::update_view][super::super::client::ConfigServiceV2::update_view] calls.
+    /// The request builder for [ConfigServiceV2::update_view][crate::client::ConfigServiceV2::update_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1983,7 +1983,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::delete_view][super::super::client::ConfigServiceV2::delete_view] calls.
+    /// The request builder for [ConfigServiceV2::delete_view][crate::client::ConfigServiceV2::delete_view] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2046,7 +2046,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::list_sinks][super::super::client::ConfigServiceV2::list_sinks] calls.
+    /// The request builder for [ConfigServiceV2::list_sinks][crate::client::ConfigServiceV2::list_sinks] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2149,7 +2149,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_sink][super::super::client::ConfigServiceV2::get_sink] calls.
+    /// The request builder for [ConfigServiceV2::get_sink][crate::client::ConfigServiceV2::get_sink] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2212,7 +2212,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::create_sink][super::super::client::ConfigServiceV2::create_sink] calls.
+    /// The request builder for [ConfigServiceV2::create_sink][crate::client::ConfigServiceV2::create_sink] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2303,7 +2303,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::update_sink][super::super::client::ConfigServiceV2::update_sink] calls.
+    /// The request builder for [ConfigServiceV2::update_sink][crate::client::ConfigServiceV2::update_sink] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2412,7 +2412,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::delete_sink][super::super::client::ConfigServiceV2::delete_sink] calls.
+    /// The request builder for [ConfigServiceV2::delete_sink][crate::client::ConfigServiceV2::delete_sink] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2475,7 +2475,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::create_link][super::super::client::ConfigServiceV2::create_link] calls.
+    /// The request builder for [ConfigServiceV2::create_link][crate::client::ConfigServiceV2::create_link] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2520,7 +2520,7 @@ pub mod config_service_v_2 {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_link][super::super::client::ConfigServiceV2::create_link].
+        /// on [create_link][crate::client::ConfigServiceV2::create_link].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_link(self.0.request, self.0.options)
@@ -2605,7 +2605,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::delete_link][super::super::client::ConfigServiceV2::delete_link] calls.
+    /// The request builder for [ConfigServiceV2::delete_link][crate::client::ConfigServiceV2::delete_link] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2650,7 +2650,7 @@ pub mod config_service_v_2 {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_link][super::super::client::ConfigServiceV2::delete_link].
+        /// on [delete_link][crate::client::ConfigServiceV2::delete_link].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_link(self.0.request, self.0.options)
@@ -2709,7 +2709,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::list_links][super::super::client::ConfigServiceV2::list_links] calls.
+    /// The request builder for [ConfigServiceV2::list_links][crate::client::ConfigServiceV2::list_links] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2812,7 +2812,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_link][super::super::client::ConfigServiceV2::get_link] calls.
+    /// The request builder for [ConfigServiceV2::get_link][crate::client::ConfigServiceV2::get_link] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2875,7 +2875,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::list_exclusions][super::super::client::ConfigServiceV2::list_exclusions] calls.
+    /// The request builder for [ConfigServiceV2::list_exclusions][crate::client::ConfigServiceV2::list_exclusions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2978,7 +2978,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_exclusion][super::super::client::ConfigServiceV2::get_exclusion] calls.
+    /// The request builder for [ConfigServiceV2::get_exclusion][crate::client::ConfigServiceV2::get_exclusion] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3041,7 +3041,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::create_exclusion][super::super::client::ConfigServiceV2::create_exclusion] calls.
+    /// The request builder for [ConfigServiceV2::create_exclusion][crate::client::ConfigServiceV2::create_exclusion] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3126,7 +3126,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::update_exclusion][super::super::client::ConfigServiceV2::update_exclusion] calls.
+    /// The request builder for [ConfigServiceV2::update_exclusion][crate::client::ConfigServiceV2::update_exclusion] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3233,7 +3233,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::delete_exclusion][super::super::client::ConfigServiceV2::delete_exclusion] calls.
+    /// The request builder for [ConfigServiceV2::delete_exclusion][crate::client::ConfigServiceV2::delete_exclusion] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3296,7 +3296,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_cmek_settings][super::super::client::ConfigServiceV2::get_cmek_settings] calls.
+    /// The request builder for [ConfigServiceV2::get_cmek_settings][crate::client::ConfigServiceV2::get_cmek_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3359,7 +3359,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::update_cmek_settings][super::super::client::ConfigServiceV2::update_cmek_settings] calls.
+    /// The request builder for [ConfigServiceV2::update_cmek_settings][crate::client::ConfigServiceV2::update_cmek_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3465,7 +3465,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_settings][super::super::client::ConfigServiceV2::get_settings] calls.
+    /// The request builder for [ConfigServiceV2::get_settings][crate::client::ConfigServiceV2::get_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3528,7 +3528,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::update_settings][super::super::client::ConfigServiceV2::update_settings] calls.
+    /// The request builder for [ConfigServiceV2::update_settings][crate::client::ConfigServiceV2::update_settings] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3631,7 +3631,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::copy_log_entries][super::super::client::ConfigServiceV2::copy_log_entries] calls.
+    /// The request builder for [ConfigServiceV2::copy_log_entries][crate::client::ConfigServiceV2::copy_log_entries] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3676,7 +3676,7 @@ pub mod config_service_v_2 {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [copy_log_entries][super::super::client::ConfigServiceV2::copy_log_entries].
+        /// on [copy_log_entries][crate::client::ConfigServiceV2::copy_log_entries].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .copy_log_entries(self.0.request, self.0.options)
@@ -3750,7 +3750,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::list_operations][super::super::client::ConfigServiceV2::list_operations] calls.
+    /// The request builder for [ConfigServiceV2::list_operations][crate::client::ConfigServiceV2::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3862,7 +3862,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::get_operation][super::super::client::ConfigServiceV2::get_operation] calls.
+    /// The request builder for [ConfigServiceV2::get_operation][crate::client::ConfigServiceV2::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3926,7 +3926,7 @@ pub mod config_service_v_2 {
         }
     }
 
-    /// The request builder for [ConfigServiceV2::cancel_operation][super::super::client::ConfigServiceV2::cancel_operation] calls.
+    /// The request builder for [ConfigServiceV2::cancel_operation][crate::client::ConfigServiceV2::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3994,7 +3994,7 @@ pub mod config_service_v_2 {
 pub mod metrics_service_v_2 {
     use crate::Result;
 
-    /// A builder for [MetricsServiceV2][super::super::client::MetricsServiceV2].
+    /// A builder for [MetricsServiceV2][crate::client::MetricsServiceV2].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4022,7 +4022,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// Common implementation for [super::super::client::MetricsServiceV2] request builders.
+    /// Common implementation for [crate::client::MetricsServiceV2] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MetricsServiceV2>,
@@ -4045,7 +4045,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::list_log_metrics][super::super::client::MetricsServiceV2::list_log_metrics] calls.
+    /// The request builder for [MetricsServiceV2::list_log_metrics][crate::client::MetricsServiceV2::list_log_metrics] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4148,7 +4148,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::get_log_metric][super::super::client::MetricsServiceV2::get_log_metric] calls.
+    /// The request builder for [MetricsServiceV2::get_log_metric][crate::client::MetricsServiceV2::get_log_metric] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4211,7 +4211,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::create_log_metric][super::super::client::MetricsServiceV2::create_log_metric] calls.
+    /// The request builder for [MetricsServiceV2::create_log_metric][crate::client::MetricsServiceV2::create_log_metric] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4296,7 +4296,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::update_log_metric][super::super::client::MetricsServiceV2::update_log_metric] calls.
+    /// The request builder for [MetricsServiceV2::update_log_metric][crate::client::MetricsServiceV2::update_log_metric] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4381,7 +4381,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::delete_log_metric][super::super::client::MetricsServiceV2::delete_log_metric] calls.
+    /// The request builder for [MetricsServiceV2::delete_log_metric][crate::client::MetricsServiceV2::delete_log_metric] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4444,7 +4444,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::list_operations][super::super::client::MetricsServiceV2::list_operations] calls.
+    /// The request builder for [MetricsServiceV2::list_operations][crate::client::MetricsServiceV2::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4556,7 +4556,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::get_operation][super::super::client::MetricsServiceV2::get_operation] calls.
+    /// The request builder for [MetricsServiceV2::get_operation][crate::client::MetricsServiceV2::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4620,7 +4620,7 @@ pub mod metrics_service_v_2 {
         }
     }
 
-    /// The request builder for [MetricsServiceV2::cancel_operation][super::super::client::MetricsServiceV2::cancel_operation] calls.
+    /// The request builder for [MetricsServiceV2::cancel_operation][crate::client::MetricsServiceV2::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/longrunning/src/builder.rs
+++ b/src/generated/longrunning/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod operations {
     use crate::Result;
 
-    /// A builder for [Operations][super::super::client::Operations].
+    /// A builder for [Operations][crate::client::Operations].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod operations {
         }
     }
 
-    /// Common implementation for [super::super::client::Operations] request builders.
+    /// Common implementation for [crate::client::Operations] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Operations>,
@@ -68,7 +68,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for [Operations::list_operations][super::super::client::Operations::list_operations] calls.
+    /// The request builder for [Operations::list_operations][crate::client::Operations::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -175,7 +175,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for [Operations::get_operation][super::super::client::Operations::get_operation] calls.
+    /// The request builder for [Operations::get_operation][crate::client::Operations::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -236,7 +236,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for [Operations::delete_operation][super::super::client::Operations::delete_operation] calls.
+    /// The request builder for [Operations::delete_operation][crate::client::Operations::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod operations {
         }
     }
 
-    /// The request builder for [Operations::cancel_operation][super::super::client::Operations::cancel_operation] calls.
+    /// The request builder for [Operations::cancel_operation][crate::client::Operations::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/monitoring/dashboard/v1/src/builder.rs
+++ b/src/generated/monitoring/dashboard/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod dashboards_service {
     use crate::Result;
 
-    /// A builder for [DashboardsService][super::super::client::DashboardsService].
+    /// A builder for [DashboardsService][crate::client::DashboardsService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DashboardsService] request builders.
+    /// Common implementation for [crate::client::DashboardsService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DashboardsService>,
@@ -68,7 +68,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for [DashboardsService::create_dashboard][super::super::client::DashboardsService::create_dashboard] calls.
+    /// The request builder for [DashboardsService::create_dashboard][crate::client::DashboardsService::create_dashboard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -159,7 +159,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for [DashboardsService::list_dashboards][super::super::client::DashboardsService::list_dashboards] calls.
+    /// The request builder for [DashboardsService::list_dashboards][crate::client::DashboardsService::list_dashboards] calls.
     ///
     /// # Example
     /// ```no_run
@@ -262,7 +262,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for [DashboardsService::get_dashboard][super::super::client::DashboardsService::get_dashboard] calls.
+    /// The request builder for [DashboardsService::get_dashboard][crate::client::DashboardsService::get_dashboard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -325,7 +325,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for [DashboardsService::delete_dashboard][super::super::client::DashboardsService::delete_dashboard] calls.
+    /// The request builder for [DashboardsService::delete_dashboard][crate::client::DashboardsService::delete_dashboard] calls.
     ///
     /// # Example
     /// ```no_run
@@ -388,7 +388,7 @@ pub mod dashboards_service {
         }
     }
 
-    /// The request builder for [DashboardsService::update_dashboard][super::super::client::DashboardsService::update_dashboard] calls.
+    /// The request builder for [DashboardsService::update_dashboard][crate::client::DashboardsService::update_dashboard] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/monitoring/metricsscope/v1/src/builder.rs
+++ b/src/generated/monitoring/metricsscope/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod metrics_scopes {
     use crate::Result;
 
-    /// A builder for [MetricsScopes][super::super::client::MetricsScopes].
+    /// A builder for [MetricsScopes][crate::client::MetricsScopes].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// Common implementation for [super::super::client::MetricsScopes] request builders.
+    /// Common implementation for [crate::client::MetricsScopes] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MetricsScopes>,
@@ -68,7 +68,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for [MetricsScopes::get_metrics_scope][super::super::client::MetricsScopes::get_metrics_scope] calls.
+    /// The request builder for [MetricsScopes::get_metrics_scope][crate::client::MetricsScopes::get_metrics_scope] calls.
     ///
     /// # Example
     /// ```no_run
@@ -131,7 +131,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for [MetricsScopes::list_metrics_scopes_by_monitored_project][super::super::client::MetricsScopes::list_metrics_scopes_by_monitored_project] calls.
+    /// The request builder for [MetricsScopes::list_metrics_scopes_by_monitored_project][crate::client::MetricsScopes::list_metrics_scopes_by_monitored_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -204,7 +204,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for [MetricsScopes::create_monitored_project][super::super::client::MetricsScopes::create_monitored_project] calls.
+    /// The request builder for [MetricsScopes::create_monitored_project][crate::client::MetricsScopes::create_monitored_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -252,7 +252,7 @@ pub mod metrics_scopes {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_monitored_project][super::super::client::MetricsScopes::create_monitored_project].
+        /// on [create_monitored_project][crate::client::MetricsScopes::create_monitored_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_monitored_project(self.0.request, self.0.options)
@@ -334,7 +334,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for [MetricsScopes::delete_monitored_project][super::super::client::MetricsScopes::delete_monitored_project] calls.
+    /// The request builder for [MetricsScopes::delete_monitored_project][crate::client::MetricsScopes::delete_monitored_project] calls.
     ///
     /// # Example
     /// ```no_run
@@ -382,7 +382,7 @@ pub mod metrics_scopes {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [delete_monitored_project][super::super::client::MetricsScopes::delete_monitored_project].
+        /// on [delete_monitored_project][crate::client::MetricsScopes::delete_monitored_project].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .delete_monitored_project(self.0.request, self.0.options)
@@ -441,7 +441,7 @@ pub mod metrics_scopes {
         }
     }
 
-    /// The request builder for [MetricsScopes::get_operation][super::super::client::MetricsScopes::get_operation] calls.
+    /// The request builder for [MetricsScopes::get_operation][crate::client::MetricsScopes::get_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/monitoring/v3/src/builder.rs
+++ b/src/generated/monitoring/v3/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod alert_policy_service {
     use crate::Result;
 
-    /// A builder for [AlertPolicyService][super::super::client::AlertPolicyService].
+    /// A builder for [AlertPolicyService][crate::client::AlertPolicyService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// Common implementation for [super::super::client::AlertPolicyService] request builders.
+    /// Common implementation for [crate::client::AlertPolicyService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::AlertPolicyService>,
@@ -68,7 +68,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for [AlertPolicyService::list_alert_policies][super::super::client::AlertPolicyService::list_alert_policies] calls.
+    /// The request builder for [AlertPolicyService::list_alert_policies][crate::client::AlertPolicyService::list_alert_policies] calls.
     ///
     /// # Example
     /// ```no_run
@@ -186,7 +186,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for [AlertPolicyService::get_alert_policy][super::super::client::AlertPolicyService::get_alert_policy] calls.
+    /// The request builder for [AlertPolicyService::get_alert_policy][crate::client::AlertPolicyService::get_alert_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -249,7 +249,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for [AlertPolicyService::create_alert_policy][super::super::client::AlertPolicyService::create_alert_policy] calls.
+    /// The request builder for [AlertPolicyService::create_alert_policy][crate::client::AlertPolicyService::create_alert_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -337,7 +337,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for [AlertPolicyService::delete_alert_policy][super::super::client::AlertPolicyService::delete_alert_policy] calls.
+    /// The request builder for [AlertPolicyService::delete_alert_policy][crate::client::AlertPolicyService::delete_alert_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -403,7 +403,7 @@ pub mod alert_policy_service {
         }
     }
 
-    /// The request builder for [AlertPolicyService::update_alert_policy][super::super::client::AlertPolicyService::update_alert_policy] calls.
+    /// The request builder for [AlertPolicyService::update_alert_policy][crate::client::AlertPolicyService::update_alert_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -505,7 +505,7 @@ pub mod alert_policy_service {
 pub mod group_service {
     use crate::Result;
 
-    /// A builder for [GroupService][super::super::client::GroupService].
+    /// A builder for [GroupService][crate::client::GroupService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -533,7 +533,7 @@ pub mod group_service {
         }
     }
 
-    /// Common implementation for [super::super::client::GroupService] request builders.
+    /// Common implementation for [crate::client::GroupService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::GroupService>,
@@ -556,7 +556,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for [GroupService::list_groups][super::super::client::GroupService::list_groups] calls.
+    /// The request builder for [GroupService::list_groups][crate::client::GroupService::list_groups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -710,7 +710,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for [GroupService::get_group][super::super::client::GroupService::get_group] calls.
+    /// The request builder for [GroupService::get_group][crate::client::GroupService::get_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -773,7 +773,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for [GroupService::create_group][super::super::client::GroupService::create_group] calls.
+    /// The request builder for [GroupService::create_group][crate::client::GroupService::create_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -864,7 +864,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for [GroupService::update_group][super::super::client::GroupService::update_group] calls.
+    /// The request builder for [GroupService::update_group][crate::client::GroupService::update_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -947,7 +947,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for [GroupService::delete_group][super::super::client::GroupService::delete_group] calls.
+    /// The request builder for [GroupService::delete_group][crate::client::GroupService::delete_group] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1016,7 +1016,7 @@ pub mod group_service {
         }
     }
 
-    /// The request builder for [GroupService::list_group_members][super::super::client::GroupService::list_group_members] calls.
+    /// The request builder for [GroupService::list_group_members][crate::client::GroupService::list_group_members] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1150,7 +1150,7 @@ pub mod group_service {
 pub mod metric_service {
     use crate::Result;
 
-    /// A builder for [MetricService][super::super::client::MetricService].
+    /// A builder for [MetricService][crate::client::MetricService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -1178,7 +1178,7 @@ pub mod metric_service {
         }
     }
 
-    /// Common implementation for [super::super::client::MetricService] request builders.
+    /// Common implementation for [crate::client::MetricService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::MetricService>,
@@ -1201,7 +1201,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::list_monitored_resource_descriptors][super::super::client::MetricService::list_monitored_resource_descriptors] calls.
+    /// The request builder for [MetricService::list_monitored_resource_descriptors][crate::client::MetricService::list_monitored_resource_descriptors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1319,7 +1319,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::get_monitored_resource_descriptor][super::super::client::MetricService::get_monitored_resource_descriptor] calls.
+    /// The request builder for [MetricService::get_monitored_resource_descriptor][crate::client::MetricService::get_monitored_resource_descriptor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1387,7 +1387,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::list_metric_descriptors][super::super::client::MetricService::list_metric_descriptors] calls.
+    /// The request builder for [MetricService::list_metric_descriptors][crate::client::MetricService::list_metric_descriptors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1507,7 +1507,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::get_metric_descriptor][super::super::client::MetricService::get_metric_descriptor] calls.
+    /// The request builder for [MetricService::get_metric_descriptor][crate::client::MetricService::get_metric_descriptor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1573,7 +1573,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::create_metric_descriptor][super::super::client::MetricService::create_metric_descriptor] calls.
+    /// The request builder for [MetricService::create_metric_descriptor][crate::client::MetricService::create_metric_descriptor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1661,7 +1661,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::delete_metric_descriptor][super::super::client::MetricService::delete_metric_descriptor] calls.
+    /// The request builder for [MetricService::delete_metric_descriptor][crate::client::MetricService::delete_metric_descriptor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1727,7 +1727,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::list_time_series][super::super::client::MetricService::list_time_series] calls.
+    /// The request builder for [MetricService::list_time_series][crate::client::MetricService::list_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1913,7 +1913,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::create_time_series][super::super::client::MetricService::create_time_series] calls.
+    /// The request builder for [MetricService::create_time_series][crate::client::MetricService::create_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1992,7 +1992,7 @@ pub mod metric_service {
         }
     }
 
-    /// The request builder for [MetricService::create_service_time_series][super::super::client::MetricService::create_service_time_series] calls.
+    /// The request builder for [MetricService::create_service_time_series][crate::client::MetricService::create_service_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2075,7 +2075,7 @@ pub mod metric_service {
 pub mod notification_channel_service {
     use crate::Result;
 
-    /// A builder for [NotificationChannelService][super::super::client::NotificationChannelService].
+    /// A builder for [NotificationChannelService][crate::client::NotificationChannelService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2103,7 +2103,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// Common implementation for [super::super::client::NotificationChannelService] request builders.
+    /// Common implementation for [crate::client::NotificationChannelService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::NotificationChannelService>,
@@ -2126,7 +2126,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::list_notification_channel_descriptors][super::super::client::NotificationChannelService::list_notification_channel_descriptors] calls.
+    /// The request builder for [NotificationChannelService::list_notification_channel_descriptors][crate::client::NotificationChannelService::list_notification_channel_descriptors] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2240,7 +2240,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::get_notification_channel_descriptor][super::super::client::NotificationChannelService::get_notification_channel_descriptor] calls.
+    /// The request builder for [NotificationChannelService::get_notification_channel_descriptor][crate::client::NotificationChannelService::get_notification_channel_descriptor] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2308,7 +2308,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::list_notification_channels][super::super::client::NotificationChannelService::list_notification_channels] calls.
+    /// The request builder for [NotificationChannelService::list_notification_channels][crate::client::NotificationChannelService::list_notification_channels] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2432,7 +2432,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::get_notification_channel][super::super::client::NotificationChannelService::get_notification_channel] calls.
+    /// The request builder for [NotificationChannelService::get_notification_channel][crate::client::NotificationChannelService::get_notification_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2498,7 +2498,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::create_notification_channel][super::super::client::NotificationChannelService::create_notification_channel] calls.
+    /// The request builder for [NotificationChannelService::create_notification_channel][crate::client::NotificationChannelService::create_notification_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2588,7 +2588,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::update_notification_channel][super::super::client::NotificationChannelService::update_notification_channel] calls.
+    /// The request builder for [NotificationChannelService::update_notification_channel][crate::client::NotificationChannelService::update_notification_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2688,7 +2688,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::delete_notification_channel][super::super::client::NotificationChannelService::delete_notification_channel] calls.
+    /// The request builder for [NotificationChannelService::delete_notification_channel][crate::client::NotificationChannelService::delete_notification_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2762,7 +2762,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::send_notification_channel_verification_code][super::super::client::NotificationChannelService::send_notification_channel_verification_code] calls.
+    /// The request builder for [NotificationChannelService::send_notification_channel_verification_code][crate::client::NotificationChannelService::send_notification_channel_verification_code] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2832,7 +2832,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::get_notification_channel_verification_code][super::super::client::NotificationChannelService::get_notification_channel_verification_code] calls.
+    /// The request builder for [NotificationChannelService::get_notification_channel_verification_code][crate::client::NotificationChannelService::get_notification_channel_verification_code] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2922,7 +2922,7 @@ pub mod notification_channel_service {
         }
     }
 
-    /// The request builder for [NotificationChannelService::verify_notification_channel][super::super::client::NotificationChannelService::verify_notification_channel] calls.
+    /// The request builder for [NotificationChannelService::verify_notification_channel][crate::client::NotificationChannelService::verify_notification_channel] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3002,7 +3002,7 @@ pub mod notification_channel_service {
 pub mod query_service {
     use crate::Result;
 
-    /// A builder for [QueryService][super::super::client::QueryService].
+    /// A builder for [QueryService][crate::client::QueryService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3030,7 +3030,7 @@ pub mod query_service {
         }
     }
 
-    /// Common implementation for [super::super::client::QueryService] request builders.
+    /// Common implementation for [crate::client::QueryService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::QueryService>,
@@ -3053,7 +3053,7 @@ pub mod query_service {
         }
     }
 
-    /// The request builder for [QueryService::query_time_series][super::super::client::QueryService::query_time_series] calls.
+    /// The request builder for [QueryService::query_time_series][crate::client::QueryService::query_time_series] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3168,7 +3168,7 @@ pub mod query_service {
 pub mod service_monitoring_service {
     use crate::Result;
 
-    /// A builder for [ServiceMonitoringService][super::super::client::ServiceMonitoringService].
+    /// A builder for [ServiceMonitoringService][crate::client::ServiceMonitoringService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3196,7 +3196,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// Common implementation for [super::super::client::ServiceMonitoringService] request builders.
+    /// Common implementation for [crate::client::ServiceMonitoringService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::ServiceMonitoringService>,
@@ -3219,7 +3219,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::create_service][super::super::client::ServiceMonitoringService::create_service] calls.
+    /// The request builder for [ServiceMonitoringService::create_service][crate::client::ServiceMonitoringService::create_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3310,7 +3310,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::get_service][super::super::client::ServiceMonitoringService::get_service] calls.
+    /// The request builder for [ServiceMonitoringService::get_service][crate::client::ServiceMonitoringService::get_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3373,7 +3373,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::list_services][super::super::client::ServiceMonitoringService::list_services] calls.
+    /// The request builder for [ServiceMonitoringService::list_services][crate::client::ServiceMonitoringService::list_services] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3482,7 +3482,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::update_service][super::super::client::ServiceMonitoringService::update_service] calls.
+    /// The request builder for [ServiceMonitoringService::update_service][crate::client::ServiceMonitoringService::update_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3577,7 +3577,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::delete_service][super::super::client::ServiceMonitoringService::delete_service] calls.
+    /// The request builder for [ServiceMonitoringService::delete_service][crate::client::ServiceMonitoringService::delete_service] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3640,7 +3640,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::create_service_level_objective][super::super::client::ServiceMonitoringService::create_service_level_objective] calls.
+    /// The request builder for [ServiceMonitoringService::create_service_level_objective][crate::client::ServiceMonitoringService::create_service_level_objective] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3739,7 +3739,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::get_service_level_objective][super::super::client::ServiceMonitoringService::get_service_level_objective] calls.
+    /// The request builder for [ServiceMonitoringService::get_service_level_objective][crate::client::ServiceMonitoringService::get_service_level_objective] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3816,7 +3816,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::list_service_level_objectives][super::super::client::ServiceMonitoringService::list_service_level_objectives] calls.
+    /// The request builder for [ServiceMonitoringService::list_service_level_objectives][crate::client::ServiceMonitoringService::list_service_level_objectives] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3943,7 +3943,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::update_service_level_objective][super::super::client::ServiceMonitoringService::update_service_level_objective] calls.
+    /// The request builder for [ServiceMonitoringService::update_service_level_objective][crate::client::ServiceMonitoringService::update_service_level_objective] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4043,7 +4043,7 @@ pub mod service_monitoring_service {
         }
     }
 
-    /// The request builder for [ServiceMonitoringService::delete_service_level_objective][super::super::client::ServiceMonitoringService::delete_service_level_objective] calls.
+    /// The request builder for [ServiceMonitoringService::delete_service_level_objective][crate::client::ServiceMonitoringService::delete_service_level_objective] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4115,7 +4115,7 @@ pub mod service_monitoring_service {
 pub mod snooze_service {
     use crate::Result;
 
-    /// A builder for [SnoozeService][super::super::client::SnoozeService].
+    /// A builder for [SnoozeService][crate::client::SnoozeService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4143,7 +4143,7 @@ pub mod snooze_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SnoozeService] request builders.
+    /// Common implementation for [crate::client::SnoozeService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SnoozeService>,
@@ -4166,7 +4166,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for [SnoozeService::create_snooze][super::super::client::SnoozeService::create_snooze] calls.
+    /// The request builder for [SnoozeService::create_snooze][crate::client::SnoozeService::create_snooze] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4251,7 +4251,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for [SnoozeService::list_snoozes][super::super::client::SnoozeService::list_snoozes] calls.
+    /// The request builder for [SnoozeService::list_snoozes][crate::client::SnoozeService::list_snoozes] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4360,7 +4360,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for [SnoozeService::get_snooze][super::super::client::SnoozeService::get_snooze] calls.
+    /// The request builder for [SnoozeService::get_snooze][crate::client::SnoozeService::get_snooze] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4423,7 +4423,7 @@ pub mod snooze_service {
         }
     }
 
-    /// The request builder for [SnoozeService::update_snooze][super::super::client::SnoozeService::update_snooze] calls.
+    /// The request builder for [SnoozeService::update_snooze][crate::client::SnoozeService::update_snooze] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4526,7 +4526,7 @@ pub mod snooze_service {
 pub mod uptime_check_service {
     use crate::Result;
 
-    /// A builder for [UptimeCheckService][super::super::client::UptimeCheckService].
+    /// A builder for [UptimeCheckService][crate::client::UptimeCheckService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -4554,7 +4554,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// Common implementation for [super::super::client::UptimeCheckService] request builders.
+    /// Common implementation for [crate::client::UptimeCheckService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::UptimeCheckService>,
@@ -4577,7 +4577,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for [UptimeCheckService::list_uptime_check_configs][super::super::client::UptimeCheckService::list_uptime_check_configs] calls.
+    /// The request builder for [UptimeCheckService::list_uptime_check_configs][crate::client::UptimeCheckService::list_uptime_check_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4693,7 +4693,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for [UptimeCheckService::get_uptime_check_config][super::super::client::UptimeCheckService::get_uptime_check_config] calls.
+    /// The request builder for [UptimeCheckService::get_uptime_check_config][crate::client::UptimeCheckService::get_uptime_check_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4759,7 +4759,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for [UptimeCheckService::create_uptime_check_config][super::super::client::UptimeCheckService::create_uptime_check_config] calls.
+    /// The request builder for [UptimeCheckService::create_uptime_check_config][crate::client::UptimeCheckService::create_uptime_check_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4849,7 +4849,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for [UptimeCheckService::update_uptime_check_config][super::super::client::UptimeCheckService::update_uptime_check_config] calls.
+    /// The request builder for [UptimeCheckService::update_uptime_check_config][crate::client::UptimeCheckService::update_uptime_check_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4949,7 +4949,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for [UptimeCheckService::delete_uptime_check_config][super::super::client::UptimeCheckService::delete_uptime_check_config] calls.
+    /// The request builder for [UptimeCheckService::delete_uptime_check_config][crate::client::UptimeCheckService::delete_uptime_check_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5017,7 +5017,7 @@ pub mod uptime_check_service {
         }
     }
 
-    /// The request builder for [UptimeCheckService::list_uptime_check_ips][super::super::client::UptimeCheckService::list_uptime_check_ips] calls.
+    /// The request builder for [UptimeCheckService::list_uptime_check_ips][crate::client::UptimeCheckService::list_uptime_check_ips] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/openapi-validation/src/builder.rs
+++ b/src/generated/openapi-validation/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod secret_manager_service {
     use crate::Result;
 
-    /// A builder for [SecretManagerService][super::super::client::SecretManagerService].
+    /// A builder for [SecretManagerService][crate::client::SecretManagerService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SecretManagerService] request builders.
+    /// Common implementation for [crate::client::SecretManagerService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SecretManagerService>,
@@ -68,7 +68,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_locations][super::super::client::SecretManagerService::list_locations] calls.
+    /// The request builder for [SecretManagerService::list_locations][crate::client::SecretManagerService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -213,7 +213,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_location][super::super::client::SecretManagerService::get_location] calls.
+    /// The request builder for [SecretManagerService::get_location][crate::client::SecretManagerService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -284,7 +284,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secrets][super::super::client::SecretManagerService::list_secrets] calls.
+    /// The request builder for [SecretManagerService::list_secrets][crate::client::SecretManagerService::list_secrets] calls.
     ///
     /// # Example
     /// ```no_run
@@ -429,7 +429,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::create_secret][super::super::client::SecretManagerService::create_secret] calls.
+    /// The request builder for [SecretManagerService::create_secret][crate::client::SecretManagerService::create_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -518,7 +518,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secrets_by_project_and_location][super::super::client::SecretManagerService::list_secrets_by_project_and_location] calls.
+    /// The request builder for [SecretManagerService::list_secrets_by_project_and_location][crate::client::SecretManagerService::list_secrets_by_project_and_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -676,7 +676,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::create_secret_by_project_and_location][super::super::client::SecretManagerService::create_secret_by_project_and_location] calls.
+    /// The request builder for [SecretManagerService::create_secret_by_project_and_location][crate::client::SecretManagerService::create_secret_by_project_and_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -778,7 +778,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::add_secret_version][super::super::client::SecretManagerService::add_secret_version] calls.
+    /// The request builder for [SecretManagerService::add_secret_version][crate::client::SecretManagerService::add_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -878,7 +878,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::add_secret_version_by_project_and_location_and_secret][super::super::client::SecretManagerService::add_secret_version_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::add_secret_version_by_project_and_location_and_secret][crate::client::SecretManagerService::add_secret_version_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -983,7 +983,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret][super::super::client::SecretManagerService::get_secret] calls.
+    /// The request builder for [SecretManagerService::get_secret][crate::client::SecretManagerService::get_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1054,7 +1054,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::delete_secret][super::super::client::SecretManagerService::delete_secret] calls.
+    /// The request builder for [SecretManagerService::delete_secret][crate::client::SecretManagerService::delete_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1143,7 +1143,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::update_secret][super::super::client::SecretManagerService::update_secret] calls.
+    /// The request builder for [SecretManagerService::update_secret][crate::client::SecretManagerService::update_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1240,7 +1240,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_secret_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::get_secret_by_project_and_location_and_secret][crate::client::SecretManagerService::get_secret_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1326,7 +1326,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::delete_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::delete_secret_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::delete_secret_by_project_and_location_and_secret][crate::client::SecretManagerService::delete_secret_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1430,7 +1430,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::update_secret_by_project_and_location_and_secret][super::super::client::SecretManagerService::update_secret_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::update_secret_by_project_and_location_and_secret][crate::client::SecretManagerService::update_secret_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1542,7 +1542,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secret_versions][super::super::client::SecretManagerService::list_secret_versions] calls.
+    /// The request builder for [SecretManagerService::list_secret_versions][crate::client::SecretManagerService::list_secret_versions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1700,7 +1700,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::list_secret_versions_by_project_and_location_and_secret][super::super::client::SecretManagerService::list_secret_versions_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::list_secret_versions_by_project_and_location_and_secret][crate::client::SecretManagerService::list_secret_versions_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1873,7 +1873,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_version][super::super::client::SecretManagerService::get_secret_version] calls.
+    /// The request builder for [SecretManagerService::get_secret_version][crate::client::SecretManagerService::get_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1955,7 +1955,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version] calls.
+    /// The request builder for [SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version][crate::client::SecretManagerService::get_secret_version_by_project_and_location_and_secret_and_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2056,7 +2056,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::access_secret_version][super::super::client::SecretManagerService::access_secret_version] calls.
+    /// The request builder for [SecretManagerService::access_secret_version][crate::client::SecretManagerService::access_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2138,7 +2138,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version] calls.
+    /// The request builder for [SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version][crate::client::SecretManagerService::access_secret_version_by_project_and_location_and_secret_and_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2239,7 +2239,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::disable_secret_version][super::super::client::SecretManagerService::disable_secret_version] calls.
+    /// The request builder for [SecretManagerService::disable_secret_version][crate::client::SecretManagerService::disable_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2347,7 +2347,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version] calls.
+    /// The request builder for [SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version][crate::client::SecretManagerService::disable_secret_version_by_project_and_location_and_secret_and_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2462,7 +2462,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::enable_secret_version][super::super::client::SecretManagerService::enable_secret_version] calls.
+    /// The request builder for [SecretManagerService::enable_secret_version][crate::client::SecretManagerService::enable_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2570,7 +2570,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version] calls.
+    /// The request builder for [SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version][crate::client::SecretManagerService::enable_secret_version_by_project_and_location_and_secret_and_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2685,7 +2685,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::destroy_secret_version][super::super::client::SecretManagerService::destroy_secret_version] calls.
+    /// The request builder for [SecretManagerService::destroy_secret_version][crate::client::SecretManagerService::destroy_secret_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2793,7 +2793,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version][super::super::client::SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version] calls.
+    /// The request builder for [SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version][crate::client::SecretManagerService::destroy_secret_version_by_project_and_location_and_secret_and_version] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2908,7 +2908,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::set_iam_policy][super::super::client::SecretManagerService::set_iam_policy] calls.
+    /// The request builder for [SecretManagerService::set_iam_policy][crate::client::SecretManagerService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3023,7 +3023,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::set_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::set_iam_policy_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::set_iam_policy_by_project_and_location_and_secret][crate::client::SecretManagerService::set_iam_policy_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3140,7 +3140,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_iam_policy][super::super::client::SecretManagerService::get_iam_policy] calls.
+    /// The request builder for [SecretManagerService::get_iam_policy][crate::client::SecretManagerService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3232,7 +3232,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::get_iam_policy_by_project_and_location_and_secret][super::super::client::SecretManagerService::get_iam_policy_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::get_iam_policy_by_project_and_location_and_secret][crate::client::SecretManagerService::get_iam_policy_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3339,7 +3339,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::test_iam_permissions][super::super::client::SecretManagerService::test_iam_permissions] calls.
+    /// The request builder for [SecretManagerService::test_iam_permissions][crate::client::SecretManagerService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3432,7 +3432,7 @@ pub mod secret_manager_service {
         }
     }
 
-    /// The request builder for [SecretManagerService::test_iam_permissions_by_project_and_location_and_secret][super::super::client::SecretManagerService::test_iam_permissions_by_project_and_location_and_secret] calls.
+    /// The request builder for [SecretManagerService::test_iam_permissions_by_project_and_location_and_secret][crate::client::SecretManagerService::test_iam_permissions_by_project_and_location_and_secret] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/privacy/dlp/v2/src/builder.rs
+++ b/src/generated/privacy/dlp/v2/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod dlp_service {
     use crate::Result;
 
-    /// A builder for [DlpService][super::super::client::DlpService].
+    /// A builder for [DlpService][crate::client::DlpService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod dlp_service {
         }
     }
 
-    /// Common implementation for [super::super::client::DlpService] request builders.
+    /// Common implementation for [crate::client::DlpService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DlpService>,
@@ -68,7 +68,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::inspect_content][super::super::client::DlpService::inspect_content] calls.
+    /// The request builder for [DlpService::inspect_content][crate::client::DlpService::inspect_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -177,7 +177,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::redact_image][super::super::client::DlpService::redact_image] calls.
+    /// The request builder for [DlpService::redact_image][crate::client::DlpService::redact_image] calls.
     ///
     /// # Example
     /// ```no_run
@@ -297,7 +297,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::deidentify_content][super::super::client::DlpService::deidentify_content] calls.
+    /// The request builder for [DlpService::deidentify_content][crate::client::DlpService::deidentify_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -433,7 +433,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::reidentify_content][super::super::client::DlpService::reidentify_content] calls.
+    /// The request builder for [DlpService::reidentify_content][crate::client::DlpService::reidentify_content] calls.
     ///
     /// # Example
     /// ```no_run
@@ -571,7 +571,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_info_types][super::super::client::DlpService::list_info_types] calls.
+    /// The request builder for [DlpService::list_info_types][crate::client::DlpService::list_info_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -650,7 +650,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::create_inspect_template][super::super::client::DlpService::create_inspect_template] calls.
+    /// The request builder for [DlpService::create_inspect_template][crate::client::DlpService::create_inspect_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -750,7 +750,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::update_inspect_template][super::super::client::DlpService::update_inspect_template] calls.
+    /// The request builder for [DlpService::update_inspect_template][crate::client::DlpService::update_inspect_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -852,7 +852,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_inspect_template][super::super::client::DlpService::get_inspect_template] calls.
+    /// The request builder for [DlpService::get_inspect_template][crate::client::DlpService::get_inspect_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -918,7 +918,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_inspect_templates][super::super::client::DlpService::list_inspect_templates] calls.
+    /// The request builder for [DlpService::list_inspect_templates][crate::client::DlpService::list_inspect_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1038,7 +1038,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_inspect_template][super::super::client::DlpService::delete_inspect_template] calls.
+    /// The request builder for [DlpService::delete_inspect_template][crate::client::DlpService::delete_inspect_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1104,7 +1104,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::create_deidentify_template][super::super::client::DlpService::create_deidentify_template] calls.
+    /// The request builder for [DlpService::create_deidentify_template][crate::client::DlpService::create_deidentify_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1206,7 +1206,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::update_deidentify_template][super::super::client::DlpService::update_deidentify_template] calls.
+    /// The request builder for [DlpService::update_deidentify_template][crate::client::DlpService::update_deidentify_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1310,7 +1310,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_deidentify_template][super::super::client::DlpService::get_deidentify_template] calls.
+    /// The request builder for [DlpService::get_deidentify_template][crate::client::DlpService::get_deidentify_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1376,7 +1376,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_deidentify_templates][super::super::client::DlpService::list_deidentify_templates] calls.
+    /// The request builder for [DlpService::list_deidentify_templates][crate::client::DlpService::list_deidentify_templates] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1500,7 +1500,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_deidentify_template][super::super::client::DlpService::delete_deidentify_template] calls.
+    /// The request builder for [DlpService::delete_deidentify_template][crate::client::DlpService::delete_deidentify_template] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1568,7 +1568,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::create_job_trigger][super::super::client::DlpService::create_job_trigger] calls.
+    /// The request builder for [DlpService::create_job_trigger][crate::client::DlpService::create_job_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1668,7 +1668,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::update_job_trigger][super::super::client::DlpService::update_job_trigger] calls.
+    /// The request builder for [DlpService::update_job_trigger][crate::client::DlpService::update_job_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1770,7 +1770,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::hybrid_inspect_job_trigger][super::super::client::DlpService::hybrid_inspect_job_trigger] calls.
+    /// The request builder for [DlpService::hybrid_inspect_job_trigger][crate::client::DlpService::hybrid_inspect_job_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1856,7 +1856,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_job_trigger][super::super::client::DlpService::get_job_trigger] calls.
+    /// The request builder for [DlpService::get_job_trigger][crate::client::DlpService::get_job_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1919,7 +1919,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_job_triggers][super::super::client::DlpService::list_job_triggers] calls.
+    /// The request builder for [DlpService::list_job_triggers][crate::client::DlpService::list_job_triggers] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2046,7 +2046,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_job_trigger][super::super::client::DlpService::delete_job_trigger] calls.
+    /// The request builder for [DlpService::delete_job_trigger][crate::client::DlpService::delete_job_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2112,7 +2112,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::activate_job_trigger][super::super::client::DlpService::activate_job_trigger] calls.
+    /// The request builder for [DlpService::activate_job_trigger][crate::client::DlpService::activate_job_trigger] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2178,7 +2178,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::create_discovery_config][super::super::client::DlpService::create_discovery_config] calls.
+    /// The request builder for [DlpService::create_discovery_config][crate::client::DlpService::create_discovery_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2272,7 +2272,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::update_discovery_config][super::super::client::DlpService::update_discovery_config] calls.
+    /// The request builder for [DlpService::update_discovery_config][crate::client::DlpService::update_discovery_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2378,7 +2378,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_discovery_config][super::super::client::DlpService::get_discovery_config] calls.
+    /// The request builder for [DlpService::get_discovery_config][crate::client::DlpService::get_discovery_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2444,7 +2444,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_discovery_configs][super::super::client::DlpService::list_discovery_configs] calls.
+    /// The request builder for [DlpService::list_discovery_configs][crate::client::DlpService::list_discovery_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2558,7 +2558,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_discovery_config][super::super::client::DlpService::delete_discovery_config] calls.
+    /// The request builder for [DlpService::delete_discovery_config][crate::client::DlpService::delete_discovery_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2624,7 +2624,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::create_dlp_job][super::super::client::DlpService::create_dlp_job] calls.
+    /// The request builder for [DlpService::create_dlp_job][crate::client::DlpService::create_dlp_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2741,7 +2741,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_dlp_jobs][super::super::client::DlpService::list_dlp_jobs] calls.
+    /// The request builder for [DlpService::list_dlp_jobs][crate::client::DlpService::list_dlp_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2868,7 +2868,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_dlp_job][super::super::client::DlpService::get_dlp_job] calls.
+    /// The request builder for [DlpService::get_dlp_job][crate::client::DlpService::get_dlp_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2931,7 +2931,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_dlp_job][super::super::client::DlpService::delete_dlp_job] calls.
+    /// The request builder for [DlpService::delete_dlp_job][crate::client::DlpService::delete_dlp_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2994,7 +2994,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::cancel_dlp_job][super::super::client::DlpService::cancel_dlp_job] calls.
+    /// The request builder for [DlpService::cancel_dlp_job][crate::client::DlpService::cancel_dlp_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3057,7 +3057,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::create_stored_info_type][super::super::client::DlpService::create_stored_info_type] calls.
+    /// The request builder for [DlpService::create_stored_info_type][crate::client::DlpService::create_stored_info_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3157,7 +3157,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::update_stored_info_type][super::super::client::DlpService::update_stored_info_type] calls.
+    /// The request builder for [DlpService::update_stored_info_type][crate::client::DlpService::update_stored_info_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3259,7 +3259,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_stored_info_type][super::super::client::DlpService::get_stored_info_type] calls.
+    /// The request builder for [DlpService::get_stored_info_type][crate::client::DlpService::get_stored_info_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3325,7 +3325,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_stored_info_types][super::super::client::DlpService::list_stored_info_types] calls.
+    /// The request builder for [DlpService::list_stored_info_types][crate::client::DlpService::list_stored_info_types] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3445,7 +3445,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_stored_info_type][super::super::client::DlpService::delete_stored_info_type] calls.
+    /// The request builder for [DlpService::delete_stored_info_type][crate::client::DlpService::delete_stored_info_type] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3511,7 +3511,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_project_data_profiles][super::super::client::DlpService::list_project_data_profiles] calls.
+    /// The request builder for [DlpService::list_project_data_profiles][crate::client::DlpService::list_project_data_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3635,7 +3635,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_table_data_profiles][super::super::client::DlpService::list_table_data_profiles] calls.
+    /// The request builder for [DlpService::list_table_data_profiles][crate::client::DlpService::list_table_data_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3755,7 +3755,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_column_data_profiles][super::super::client::DlpService::list_column_data_profiles] calls.
+    /// The request builder for [DlpService::list_column_data_profiles][crate::client::DlpService::list_column_data_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3877,7 +3877,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_project_data_profile][super::super::client::DlpService::get_project_data_profile] calls.
+    /// The request builder for [DlpService::get_project_data_profile][crate::client::DlpService::get_project_data_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3943,7 +3943,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_file_store_data_profiles][super::super::client::DlpService::list_file_store_data_profiles] calls.
+    /// The request builder for [DlpService::list_file_store_data_profiles][crate::client::DlpService::list_file_store_data_profiles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4067,7 +4067,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_file_store_data_profile][super::super::client::DlpService::get_file_store_data_profile] calls.
+    /// The request builder for [DlpService::get_file_store_data_profile][crate::client::DlpService::get_file_store_data_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4135,7 +4135,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_file_store_data_profile][super::super::client::DlpService::delete_file_store_data_profile] calls.
+    /// The request builder for [DlpService::delete_file_store_data_profile][crate::client::DlpService::delete_file_store_data_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4203,7 +4203,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_table_data_profile][super::super::client::DlpService::get_table_data_profile] calls.
+    /// The request builder for [DlpService::get_table_data_profile][crate::client::DlpService::get_table_data_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4269,7 +4269,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_column_data_profile][super::super::client::DlpService::get_column_data_profile] calls.
+    /// The request builder for [DlpService::get_column_data_profile][crate::client::DlpService::get_column_data_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4335,7 +4335,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_table_data_profile][super::super::client::DlpService::delete_table_data_profile] calls.
+    /// The request builder for [DlpService::delete_table_data_profile][crate::client::DlpService::delete_table_data_profile] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4401,7 +4401,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::hybrid_inspect_dlp_job][super::super::client::DlpService::hybrid_inspect_dlp_job] calls.
+    /// The request builder for [DlpService::hybrid_inspect_dlp_job][crate::client::DlpService::hybrid_inspect_dlp_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4485,7 +4485,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::finish_dlp_job][super::super::client::DlpService::finish_dlp_job] calls.
+    /// The request builder for [DlpService::finish_dlp_job][crate::client::DlpService::finish_dlp_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4548,7 +4548,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::create_connection][super::super::client::DlpService::create_connection] calls.
+    /// The request builder for [DlpService::create_connection][crate::client::DlpService::create_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4636,7 +4636,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::get_connection][super::super::client::DlpService::get_connection] calls.
+    /// The request builder for [DlpService::get_connection][crate::client::DlpService::get_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4699,7 +4699,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::list_connections][super::super::client::DlpService::list_connections] calls.
+    /// The request builder for [DlpService::list_connections][crate::client::DlpService::list_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4808,7 +4808,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::search_connections][super::super::client::DlpService::search_connections] calls.
+    /// The request builder for [DlpService::search_connections][crate::client::DlpService::search_connections] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4920,7 +4920,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::delete_connection][super::super::client::DlpService::delete_connection] calls.
+    /// The request builder for [DlpService::delete_connection][crate::client::DlpService::delete_connection] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4986,7 +4986,7 @@ pub mod dlp_service {
         }
     }
 
-    /// The request builder for [DlpService::update_connection][super::super::client::DlpService::update_connection] calls.
+    /// The request builder for [DlpService::update_connection][crate::client::DlpService::update_connection] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/showcase/src/builder.rs
+++ b/src/generated/showcase/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod compliance {
     use crate::Result;
 
-    /// A builder for [Compliance][super::super::client::Compliance].
+    /// A builder for [Compliance][crate::client::Compliance].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod compliance {
         }
     }
 
-    /// Common implementation for [super::super::client::Compliance] request builders.
+    /// Common implementation for [crate::client::Compliance] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Compliance>,
@@ -68,7 +68,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_body][super::super::client::Compliance::repeat_data_body] calls.
+    /// The request builder for [Compliance::repeat_data_body][crate::client::Compliance::repeat_data_body] calls.
     ///
     /// # Example
     /// ```no_run
@@ -243,7 +243,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_body_info][super::super::client::Compliance::repeat_data_body_info] calls.
+    /// The request builder for [Compliance::repeat_data_body_info][crate::client::Compliance::repeat_data_body_info] calls.
     ///
     /// # Example
     /// ```no_run
@@ -418,7 +418,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_query][super::super::client::Compliance::repeat_data_query] calls.
+    /// The request builder for [Compliance::repeat_data_query][crate::client::Compliance::repeat_data_query] calls.
     ///
     /// # Example
     /// ```no_run
@@ -593,7 +593,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_simple_path][super::super::client::Compliance::repeat_data_simple_path] calls.
+    /// The request builder for [Compliance::repeat_data_simple_path][crate::client::Compliance::repeat_data_simple_path] calls.
     ///
     /// # Example
     /// ```no_run
@@ -768,7 +768,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_path_resource][super::super::client::Compliance::repeat_data_path_resource] calls.
+    /// The request builder for [Compliance::repeat_data_path_resource][crate::client::Compliance::repeat_data_path_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -943,7 +943,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_path_trailing_resource][super::super::client::Compliance::repeat_data_path_trailing_resource] calls.
+    /// The request builder for [Compliance::repeat_data_path_trailing_resource][crate::client::Compliance::repeat_data_path_trailing_resource] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1118,7 +1118,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_body_put][super::super::client::Compliance::repeat_data_body_put] calls.
+    /// The request builder for [Compliance::repeat_data_body_put][crate::client::Compliance::repeat_data_body_put] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1293,7 +1293,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::repeat_data_body_patch][super::super::client::Compliance::repeat_data_body_patch] calls.
+    /// The request builder for [Compliance::repeat_data_body_patch][crate::client::Compliance::repeat_data_body_patch] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1468,7 +1468,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::get_enum][super::super::client::Compliance::get_enum] calls.
+    /// The request builder for [Compliance::get_enum][crate::client::Compliance::get_enum] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1529,7 +1529,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::verify_enum][super::super::client::Compliance::verify_enum] calls.
+    /// The request builder for [Compliance::verify_enum][crate::client::Compliance::verify_enum] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1608,7 +1608,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::list_locations][super::super::client::Compliance::list_locations] calls.
+    /// The request builder for [Compliance::list_locations][crate::client::Compliance::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1718,7 +1718,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::get_location][super::super::client::Compliance::get_location] calls.
+    /// The request builder for [Compliance::get_location][crate::client::Compliance::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1779,7 +1779,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::set_iam_policy][super::super::client::Compliance::set_iam_policy] calls.
+    /// The request builder for [Compliance::set_iam_policy][crate::client::Compliance::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1882,7 +1882,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::get_iam_policy][super::super::client::Compliance::get_iam_policy] calls.
+    /// The request builder for [Compliance::get_iam_policy][crate::client::Compliance::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1963,7 +1963,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::test_iam_permissions][super::super::client::Compliance::test_iam_permissions] calls.
+    /// The request builder for [Compliance::test_iam_permissions][crate::client::Compliance::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2042,7 +2042,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::list_operations][super::super::client::Compliance::list_operations] calls.
+    /// The request builder for [Compliance::list_operations][crate::client::Compliance::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2154,7 +2154,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::get_operation][super::super::client::Compliance::get_operation] calls.
+    /// The request builder for [Compliance::get_operation][crate::client::Compliance::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2218,7 +2218,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::delete_operation][super::super::client::Compliance::delete_operation] calls.
+    /// The request builder for [Compliance::delete_operation][crate::client::Compliance::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2282,7 +2282,7 @@ pub mod compliance {
         }
     }
 
-    /// The request builder for [Compliance::cancel_operation][super::super::client::Compliance::cancel_operation] calls.
+    /// The request builder for [Compliance::cancel_operation][crate::client::Compliance::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2350,7 +2350,7 @@ pub mod compliance {
 pub mod echo {
     use crate::Result;
 
-    /// A builder for [Echo][super::super::client::Echo].
+    /// A builder for [Echo][crate::client::Echo].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -2378,7 +2378,7 @@ pub mod echo {
         }
     }
 
-    /// Common implementation for [super::super::client::Echo] request builders.
+    /// Common implementation for [crate::client::Echo] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Echo>,
@@ -2399,7 +2399,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::echo][super::super::client::Echo::echo] calls.
+    /// The request builder for [Echo::echo][crate::client::Echo::echo] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2529,7 +2529,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::echo_error_details][super::super::client::Echo::echo_error_details] calls.
+    /// The request builder for [Echo::echo_error_details][crate::client::Echo::echo_error_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2602,7 +2602,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::fail_echo_with_details][super::super::client::Echo::fail_echo_with_details] calls.
+    /// The request builder for [Echo::fail_echo_with_details][crate::client::Echo::fail_echo_with_details] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2664,7 +2664,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::paged_expand][super::super::client::Echo::paged_expand] calls.
+    /// The request builder for [Echo::paged_expand][crate::client::Echo::paged_expand] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2765,7 +2765,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::paged_expand_legacy][super::super::client::Echo::paged_expand_legacy] calls.
+    /// The request builder for [Echo::paged_expand_legacy][crate::client::Echo::paged_expand_legacy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2869,7 +2869,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::paged_expand_legacy_mapped][super::super::client::Echo::paged_expand_legacy_mapped] calls.
+    /// The request builder for [Echo::paged_expand_legacy_mapped][crate::client::Echo::paged_expand_legacy_mapped] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2942,7 +2942,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::wait][super::super::client::Echo::wait] calls.
+    /// The request builder for [Echo::wait][crate::client::Echo::wait] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2985,7 +2985,7 @@ pub mod echo {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [wait][super::super::client::Echo::wait].
+        /// on [wait][crate::client::Echo::wait].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .wait(self.0.request, self.0.options)
@@ -3107,7 +3107,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::block][super::super::client::Echo::block] calls.
+    /// The request builder for [Echo::block][crate::client::Echo::block] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3216,7 +3216,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::list_locations][super::super::client::Echo::list_locations] calls.
+    /// The request builder for [Echo::list_locations][crate::client::Echo::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3324,7 +3324,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::get_location][super::super::client::Echo::get_location] calls.
+    /// The request builder for [Echo::get_location][crate::client::Echo::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3383,7 +3383,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::set_iam_policy][super::super::client::Echo::set_iam_policy] calls.
+    /// The request builder for [Echo::set_iam_policy][crate::client::Echo::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3484,7 +3484,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::get_iam_policy][super::super::client::Echo::get_iam_policy] calls.
+    /// The request builder for [Echo::get_iam_policy][crate::client::Echo::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3563,7 +3563,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::test_iam_permissions][super::super::client::Echo::test_iam_permissions] calls.
+    /// The request builder for [Echo::test_iam_permissions][crate::client::Echo::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3640,7 +3640,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::list_operations][super::super::client::Echo::list_operations] calls.
+    /// The request builder for [Echo::list_operations][crate::client::Echo::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3750,7 +3750,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::get_operation][super::super::client::Echo::get_operation] calls.
+    /// The request builder for [Echo::get_operation][crate::client::Echo::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3812,7 +3812,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::delete_operation][super::super::client::Echo::delete_operation] calls.
+    /// The request builder for [Echo::delete_operation][crate::client::Echo::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3874,7 +3874,7 @@ pub mod echo {
         }
     }
 
-    /// The request builder for [Echo::cancel_operation][super::super::client::Echo::cancel_operation] calls.
+    /// The request builder for [Echo::cancel_operation][crate::client::Echo::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -3940,7 +3940,7 @@ pub mod echo {
 pub mod identity {
     use crate::Result;
 
-    /// A builder for [Identity][super::super::client::Identity].
+    /// A builder for [Identity][crate::client::Identity].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -3968,7 +3968,7 @@ pub mod identity {
         }
     }
 
-    /// Common implementation for [super::super::client::Identity] request builders.
+    /// Common implementation for [crate::client::Identity] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Identity>,
@@ -3989,7 +3989,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::create_user][super::super::client::Identity::create_user] calls.
+    /// The request builder for [Identity::create_user][crate::client::Identity::create_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4060,7 +4060,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::get_user][super::super::client::Identity::get_user] calls.
+    /// The request builder for [Identity::get_user][crate::client::Identity::get_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4121,7 +4121,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::update_user][super::super::client::Identity::update_user] calls.
+    /// The request builder for [Identity::update_user][crate::client::Identity::update_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4210,7 +4210,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::delete_user][super::super::client::Identity::delete_user] calls.
+    /// The request builder for [Identity::delete_user][crate::client::Identity::delete_user] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4271,7 +4271,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::list_users][super::super::client::Identity::list_users] calls.
+    /// The request builder for [Identity::list_users][crate::client::Identity::list_users] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4364,7 +4364,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::list_locations][super::super::client::Identity::list_locations] calls.
+    /// The request builder for [Identity::list_locations][crate::client::Identity::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4472,7 +4472,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::get_location][super::super::client::Identity::get_location] calls.
+    /// The request builder for [Identity::get_location][crate::client::Identity::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4531,7 +4531,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::set_iam_policy][super::super::client::Identity::set_iam_policy] calls.
+    /// The request builder for [Identity::set_iam_policy][crate::client::Identity::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4632,7 +4632,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::get_iam_policy][super::super::client::Identity::get_iam_policy] calls.
+    /// The request builder for [Identity::get_iam_policy][crate::client::Identity::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4711,7 +4711,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::test_iam_permissions][super::super::client::Identity::test_iam_permissions] calls.
+    /// The request builder for [Identity::test_iam_permissions][crate::client::Identity::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4788,7 +4788,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::list_operations][super::super::client::Identity::list_operations] calls.
+    /// The request builder for [Identity::list_operations][crate::client::Identity::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4898,7 +4898,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::get_operation][super::super::client::Identity::get_operation] calls.
+    /// The request builder for [Identity::get_operation][crate::client::Identity::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -4960,7 +4960,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::delete_operation][super::super::client::Identity::delete_operation] calls.
+    /// The request builder for [Identity::delete_operation][crate::client::Identity::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5022,7 +5022,7 @@ pub mod identity {
         }
     }
 
-    /// The request builder for [Identity::cancel_operation][super::super::client::Identity::cancel_operation] calls.
+    /// The request builder for [Identity::cancel_operation][crate::client::Identity::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5088,7 +5088,7 @@ pub mod identity {
 pub mod messaging {
     use crate::Result;
 
-    /// A builder for [Messaging][super::super::client::Messaging].
+    /// A builder for [Messaging][crate::client::Messaging].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -5116,7 +5116,7 @@ pub mod messaging {
         }
     }
 
-    /// Common implementation for [super::super::client::Messaging] request builders.
+    /// Common implementation for [crate::client::Messaging] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Messaging>,
@@ -5139,7 +5139,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::create_room][super::super::client::Messaging::create_room] calls.
+    /// The request builder for [Messaging::create_room][crate::client::Messaging::create_room] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5212,7 +5212,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::get_room][super::super::client::Messaging::get_room] calls.
+    /// The request builder for [Messaging::get_room][crate::client::Messaging::get_room] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5275,7 +5275,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::update_room][super::super::client::Messaging::update_room] calls.
+    /// The request builder for [Messaging::update_room][crate::client::Messaging::update_room] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5366,7 +5366,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::delete_room][super::super::client::Messaging::delete_room] calls.
+    /// The request builder for [Messaging::delete_room][crate::client::Messaging::delete_room] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5429,7 +5429,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::list_rooms][super::super::client::Messaging::list_rooms] calls.
+    /// The request builder for [Messaging::list_rooms][crate::client::Messaging::list_rooms] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5524,7 +5524,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::create_blurb][super::super::client::Messaging::create_blurb] calls.
+    /// The request builder for [Messaging::create_blurb][crate::client::Messaging::create_blurb] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5605,7 +5605,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::get_blurb][super::super::client::Messaging::get_blurb] calls.
+    /// The request builder for [Messaging::get_blurb][crate::client::Messaging::get_blurb] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5668,7 +5668,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::update_blurb][super::super::client::Messaging::update_blurb] calls.
+    /// The request builder for [Messaging::update_blurb][crate::client::Messaging::update_blurb] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5759,7 +5759,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::delete_blurb][super::super::client::Messaging::delete_blurb] calls.
+    /// The request builder for [Messaging::delete_blurb][crate::client::Messaging::delete_blurb] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5822,7 +5822,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::list_blurbs][super::super::client::Messaging::list_blurbs] calls.
+    /// The request builder for [Messaging::list_blurbs][crate::client::Messaging::list_blurbs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5925,7 +5925,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::search_blurbs][super::super::client::Messaging::search_blurbs] calls.
+    /// The request builder for [Messaging::search_blurbs][crate::client::Messaging::search_blurbs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -5970,7 +5970,7 @@ pub mod messaging {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [search_blurbs][super::super::client::Messaging::search_blurbs].
+        /// on [search_blurbs][crate::client::Messaging::search_blurbs].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .search_blurbs(self.0.request, self.0.options)
@@ -6048,7 +6048,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::list_locations][super::super::client::Messaging::list_locations] calls.
+    /// The request builder for [Messaging::list_locations][crate::client::Messaging::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6158,7 +6158,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::get_location][super::super::client::Messaging::get_location] calls.
+    /// The request builder for [Messaging::get_location][crate::client::Messaging::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6219,7 +6219,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::set_iam_policy][super::super::client::Messaging::set_iam_policy] calls.
+    /// The request builder for [Messaging::set_iam_policy][crate::client::Messaging::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6322,7 +6322,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::get_iam_policy][super::super::client::Messaging::get_iam_policy] calls.
+    /// The request builder for [Messaging::get_iam_policy][crate::client::Messaging::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6403,7 +6403,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::test_iam_permissions][super::super::client::Messaging::test_iam_permissions] calls.
+    /// The request builder for [Messaging::test_iam_permissions][crate::client::Messaging::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6482,7 +6482,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::list_operations][super::super::client::Messaging::list_operations] calls.
+    /// The request builder for [Messaging::list_operations][crate::client::Messaging::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6594,7 +6594,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::get_operation][super::super::client::Messaging::get_operation] calls.
+    /// The request builder for [Messaging::get_operation][crate::client::Messaging::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6658,7 +6658,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::delete_operation][super::super::client::Messaging::delete_operation] calls.
+    /// The request builder for [Messaging::delete_operation][crate::client::Messaging::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6722,7 +6722,7 @@ pub mod messaging {
         }
     }
 
-    /// The request builder for [Messaging::cancel_operation][super::super::client::Messaging::cancel_operation] calls.
+    /// The request builder for [Messaging::cancel_operation][crate::client::Messaging::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6790,7 +6790,7 @@ pub mod messaging {
 pub mod sequence_service {
     use crate::Result;
 
-    /// A builder for [SequenceService][super::super::client::SequenceService].
+    /// A builder for [SequenceService][crate::client::SequenceService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -6818,7 +6818,7 @@ pub mod sequence_service {
         }
     }
 
-    /// Common implementation for [super::super::client::SequenceService] request builders.
+    /// Common implementation for [crate::client::SequenceService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::SequenceService>,
@@ -6841,7 +6841,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::create_sequence][super::super::client::SequenceService::create_sequence] calls.
+    /// The request builder for [SequenceService::create_sequence][crate::client::SequenceService::create_sequence] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6914,7 +6914,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::create_streaming_sequence][super::super::client::SequenceService::create_streaming_sequence] calls.
+    /// The request builder for [SequenceService::create_streaming_sequence][crate::client::SequenceService::create_streaming_sequence] calls.
     ///
     /// # Example
     /// ```no_run
@@ -6992,7 +6992,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::get_sequence_report][super::super::client::SequenceService::get_sequence_report] calls.
+    /// The request builder for [SequenceService::get_sequence_report][crate::client::SequenceService::get_sequence_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7058,7 +7058,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::get_streaming_sequence_report][super::super::client::SequenceService::get_streaming_sequence_report] calls.
+    /// The request builder for [SequenceService::get_streaming_sequence_report][crate::client::SequenceService::get_streaming_sequence_report] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7126,7 +7126,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::attempt_sequence][super::super::client::SequenceService::attempt_sequence] calls.
+    /// The request builder for [SequenceService::attempt_sequence][crate::client::SequenceService::attempt_sequence] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7189,7 +7189,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::list_locations][super::super::client::SequenceService::list_locations] calls.
+    /// The request builder for [SequenceService::list_locations][crate::client::SequenceService::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7299,7 +7299,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::get_location][super::super::client::SequenceService::get_location] calls.
+    /// The request builder for [SequenceService::get_location][crate::client::SequenceService::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7360,7 +7360,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::set_iam_policy][super::super::client::SequenceService::set_iam_policy] calls.
+    /// The request builder for [SequenceService::set_iam_policy][crate::client::SequenceService::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7463,7 +7463,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::get_iam_policy][super::super::client::SequenceService::get_iam_policy] calls.
+    /// The request builder for [SequenceService::get_iam_policy][crate::client::SequenceService::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7544,7 +7544,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::test_iam_permissions][super::super::client::SequenceService::test_iam_permissions] calls.
+    /// The request builder for [SequenceService::test_iam_permissions][crate::client::SequenceService::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7623,7 +7623,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::list_operations][super::super::client::SequenceService::list_operations] calls.
+    /// The request builder for [SequenceService::list_operations][crate::client::SequenceService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7735,7 +7735,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::get_operation][super::super::client::SequenceService::get_operation] calls.
+    /// The request builder for [SequenceService::get_operation][crate::client::SequenceService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7799,7 +7799,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::delete_operation][super::super::client::SequenceService::delete_operation] calls.
+    /// The request builder for [SequenceService::delete_operation][crate::client::SequenceService::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7863,7 +7863,7 @@ pub mod sequence_service {
         }
     }
 
-    /// The request builder for [SequenceService::cancel_operation][super::super::client::SequenceService::cancel_operation] calls.
+    /// The request builder for [SequenceService::cancel_operation][crate::client::SequenceService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -7931,7 +7931,7 @@ pub mod sequence_service {
 pub mod testing {
     use crate::Result;
 
-    /// A builder for [Testing][super::super::client::Testing].
+    /// A builder for [Testing][crate::client::Testing].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -7959,7 +7959,7 @@ pub mod testing {
         }
     }
 
-    /// Common implementation for [super::super::client::Testing] request builders.
+    /// Common implementation for [crate::client::Testing] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Testing>,
@@ -7980,7 +7980,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::create_session][super::super::client::Testing::create_session] calls.
+    /// The request builder for [Testing::create_session][crate::client::Testing::create_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8051,7 +8051,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::get_session][super::super::client::Testing::get_session] calls.
+    /// The request builder for [Testing::get_session][crate::client::Testing::get_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8110,7 +8110,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::list_sessions][super::super::client::Testing::list_sessions] calls.
+    /// The request builder for [Testing::list_sessions][crate::client::Testing::list_sessions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8203,7 +8203,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::delete_session][super::super::client::Testing::delete_session] calls.
+    /// The request builder for [Testing::delete_session][crate::client::Testing::delete_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8262,7 +8262,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::report_session][super::super::client::Testing::report_session] calls.
+    /// The request builder for [Testing::report_session][crate::client::Testing::report_session] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8321,7 +8321,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::list_tests][super::super::client::Testing::list_tests] calls.
+    /// The request builder for [Testing::list_tests][crate::client::Testing::list_tests] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8420,7 +8420,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::delete_test][super::super::client::Testing::delete_test] calls.
+    /// The request builder for [Testing::delete_test][crate::client::Testing::delete_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8479,7 +8479,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::verify_test][super::super::client::Testing::verify_test] calls.
+    /// The request builder for [Testing::verify_test][crate::client::Testing::verify_test] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8555,7 +8555,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::list_locations][super::super::client::Testing::list_locations] calls.
+    /// The request builder for [Testing::list_locations][crate::client::Testing::list_locations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8663,7 +8663,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::get_location][super::super::client::Testing::get_location] calls.
+    /// The request builder for [Testing::get_location][crate::client::Testing::get_location] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8722,7 +8722,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::set_iam_policy][super::super::client::Testing::set_iam_policy] calls.
+    /// The request builder for [Testing::set_iam_policy][crate::client::Testing::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8823,7 +8823,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::get_iam_policy][super::super::client::Testing::get_iam_policy] calls.
+    /// The request builder for [Testing::get_iam_policy][crate::client::Testing::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8902,7 +8902,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::test_iam_permissions][super::super::client::Testing::test_iam_permissions] calls.
+    /// The request builder for [Testing::test_iam_permissions][crate::client::Testing::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -8979,7 +8979,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::list_operations][super::super::client::Testing::list_operations] calls.
+    /// The request builder for [Testing::list_operations][crate::client::Testing::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9089,7 +9089,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::get_operation][super::super::client::Testing::get_operation] calls.
+    /// The request builder for [Testing::get_operation][crate::client::Testing::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9151,7 +9151,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::delete_operation][super::super::client::Testing::delete_operation] calls.
+    /// The request builder for [Testing::delete_operation][crate::client::Testing::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -9213,7 +9213,7 @@ pub mod testing {
         }
     }
 
-    /// The request builder for [Testing::cancel_operation][super::super::client::Testing::cancel_operation] calls.
+    /// The request builder for [Testing::cancel_operation][crate::client::Testing::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/spanner/admin/database/v1/src/builder.rs
+++ b/src/generated/spanner/admin/database/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod database_admin {
     use crate::Result;
 
-    /// A builder for [DatabaseAdmin][super::super::client::DatabaseAdmin].
+    /// A builder for [DatabaseAdmin][crate::client::DatabaseAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod database_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::DatabaseAdmin] request builders.
+    /// Common implementation for [crate::client::DatabaseAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::DatabaseAdmin>,
@@ -68,7 +68,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::list_databases][super::super::client::DatabaseAdmin::list_databases] calls.
+    /// The request builder for [DatabaseAdmin::list_databases][crate::client::DatabaseAdmin::list_databases] calls.
     ///
     /// # Example
     /// ```no_run
@@ -171,7 +171,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::create_database][super::super::client::DatabaseAdmin::create_database] calls.
+    /// The request builder for [DatabaseAdmin::create_database][crate::client::DatabaseAdmin::create_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -216,7 +216,7 @@ pub mod database_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_database][super::super::client::DatabaseAdmin::create_database].
+        /// on [create_database][crate::client::DatabaseAdmin::create_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_database(self.0.request, self.0.options)
@@ -328,7 +328,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::get_database][super::super::client::DatabaseAdmin::get_database] calls.
+    /// The request builder for [DatabaseAdmin::get_database][crate::client::DatabaseAdmin::get_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -391,7 +391,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::update_database][super::super::client::DatabaseAdmin::update_database] calls.
+    /// The request builder for [DatabaseAdmin::update_database][crate::client::DatabaseAdmin::update_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -436,7 +436,7 @@ pub mod database_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_database][super::super::client::DatabaseAdmin::update_database].
+        /// on [update_database][crate::client::DatabaseAdmin::update_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_database(self.0.request, self.0.options)
@@ -532,7 +532,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::update_database_ddl][super::super::client::DatabaseAdmin::update_database_ddl] calls.
+    /// The request builder for [DatabaseAdmin::update_database_ddl][crate::client::DatabaseAdmin::update_database_ddl] calls.
     ///
     /// # Example
     /// ```no_run
@@ -580,7 +580,7 @@ pub mod database_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_database_ddl][super::super::client::DatabaseAdmin::update_database_ddl].
+        /// on [update_database_ddl][crate::client::DatabaseAdmin::update_database_ddl].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_database_ddl(self.0.request, self.0.options)
@@ -665,7 +665,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::drop_database][super::super::client::DatabaseAdmin::drop_database] calls.
+    /// The request builder for [DatabaseAdmin::drop_database][crate::client::DatabaseAdmin::drop_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -728,7 +728,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::get_database_ddl][super::super::client::DatabaseAdmin::get_database_ddl] calls.
+    /// The request builder for [DatabaseAdmin::get_database_ddl][crate::client::DatabaseAdmin::get_database_ddl] calls.
     ///
     /// # Example
     /// ```no_run
@@ -791,7 +791,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::set_iam_policy][super::super::client::DatabaseAdmin::set_iam_policy] calls.
+    /// The request builder for [DatabaseAdmin::set_iam_policy][crate::client::DatabaseAdmin::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -894,7 +894,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::get_iam_policy][super::super::client::DatabaseAdmin::get_iam_policy] calls.
+    /// The request builder for [DatabaseAdmin::get_iam_policy][crate::client::DatabaseAdmin::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -975,7 +975,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::test_iam_permissions][super::super::client::DatabaseAdmin::test_iam_permissions] calls.
+    /// The request builder for [DatabaseAdmin::test_iam_permissions][crate::client::DatabaseAdmin::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1054,7 +1054,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::create_backup][super::super::client::DatabaseAdmin::create_backup] calls.
+    /// The request builder for [DatabaseAdmin::create_backup][crate::client::DatabaseAdmin::create_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1099,7 +1099,7 @@ pub mod database_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_backup][super::super::client::DatabaseAdmin::create_backup].
+        /// on [create_backup][crate::client::DatabaseAdmin::create_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_backup(self.0.request, self.0.options)
@@ -1204,7 +1204,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::copy_backup][super::super::client::DatabaseAdmin::copy_backup] calls.
+    /// The request builder for [DatabaseAdmin::copy_backup][crate::client::DatabaseAdmin::copy_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1249,7 +1249,7 @@ pub mod database_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [copy_backup][super::super::client::DatabaseAdmin::copy_backup].
+        /// on [copy_backup][crate::client::DatabaseAdmin::copy_backup].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .copy_backup(self.0.request, self.0.options)
@@ -1362,7 +1362,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::get_backup][super::super::client::DatabaseAdmin::get_backup] calls.
+    /// The request builder for [DatabaseAdmin::get_backup][crate::client::DatabaseAdmin::get_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1425,7 +1425,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::update_backup][super::super::client::DatabaseAdmin::update_backup] calls.
+    /// The request builder for [DatabaseAdmin::update_backup][crate::client::DatabaseAdmin::update_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1524,7 +1524,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::delete_backup][super::super::client::DatabaseAdmin::delete_backup] calls.
+    /// The request builder for [DatabaseAdmin::delete_backup][crate::client::DatabaseAdmin::delete_backup] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1587,7 +1587,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::list_backups][super::super::client::DatabaseAdmin::list_backups] calls.
+    /// The request builder for [DatabaseAdmin::list_backups][crate::client::DatabaseAdmin::list_backups] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1696,7 +1696,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::restore_database][super::super::client::DatabaseAdmin::restore_database] calls.
+    /// The request builder for [DatabaseAdmin::restore_database][crate::client::DatabaseAdmin::restore_database] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1741,7 +1741,7 @@ pub mod database_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [restore_database][super::super::client::DatabaseAdmin::restore_database].
+        /// on [restore_database][crate::client::DatabaseAdmin::restore_database].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .restore_database(self.0.request, self.0.options)
@@ -1849,7 +1849,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::list_database_operations][super::super::client::DatabaseAdmin::list_database_operations] calls.
+    /// The request builder for [DatabaseAdmin::list_database_operations][crate::client::DatabaseAdmin::list_database_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1965,7 +1965,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::list_backup_operations][super::super::client::DatabaseAdmin::list_backup_operations] calls.
+    /// The request builder for [DatabaseAdmin::list_backup_operations][crate::client::DatabaseAdmin::list_backup_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2079,7 +2079,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::list_database_roles][super::super::client::DatabaseAdmin::list_database_roles] calls.
+    /// The request builder for [DatabaseAdmin::list_database_roles][crate::client::DatabaseAdmin::list_database_roles] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2185,7 +2185,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::add_split_points][super::super::client::DatabaseAdmin::add_split_points] calls.
+    /// The request builder for [DatabaseAdmin::add_split_points][crate::client::DatabaseAdmin::add_split_points] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2267,7 +2267,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::create_backup_schedule][super::super::client::DatabaseAdmin::create_backup_schedule] calls.
+    /// The request builder for [DatabaseAdmin::create_backup_schedule][crate::client::DatabaseAdmin::create_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2363,7 +2363,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::get_backup_schedule][super::super::client::DatabaseAdmin::get_backup_schedule] calls.
+    /// The request builder for [DatabaseAdmin::get_backup_schedule][crate::client::DatabaseAdmin::get_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2429,7 +2429,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::update_backup_schedule][super::super::client::DatabaseAdmin::update_backup_schedule] calls.
+    /// The request builder for [DatabaseAdmin::update_backup_schedule][crate::client::DatabaseAdmin::update_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2531,7 +2531,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::delete_backup_schedule][super::super::client::DatabaseAdmin::delete_backup_schedule] calls.
+    /// The request builder for [DatabaseAdmin::delete_backup_schedule][crate::client::DatabaseAdmin::delete_backup_schedule] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2597,7 +2597,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::list_backup_schedules][super::super::client::DatabaseAdmin::list_backup_schedules] calls.
+    /// The request builder for [DatabaseAdmin::list_backup_schedules][crate::client::DatabaseAdmin::list_backup_schedules] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2705,7 +2705,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::list_operations][super::super::client::DatabaseAdmin::list_operations] calls.
+    /// The request builder for [DatabaseAdmin::list_operations][crate::client::DatabaseAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2817,7 +2817,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::get_operation][super::super::client::DatabaseAdmin::get_operation] calls.
+    /// The request builder for [DatabaseAdmin::get_operation][crate::client::DatabaseAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2881,7 +2881,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::delete_operation][super::super::client::DatabaseAdmin::delete_operation] calls.
+    /// The request builder for [DatabaseAdmin::delete_operation][crate::client::DatabaseAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2945,7 +2945,7 @@ pub mod database_admin {
         }
     }
 
-    /// The request builder for [DatabaseAdmin::cancel_operation][super::super::client::DatabaseAdmin::cancel_operation] calls.
+    /// The request builder for [DatabaseAdmin::cancel_operation][crate::client::DatabaseAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/spanner/admin/instance/v1/src/builder.rs
+++ b/src/generated/spanner/admin/instance/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod instance_admin {
     use crate::Result;
 
-    /// A builder for [InstanceAdmin][super::super::client::InstanceAdmin].
+    /// A builder for [InstanceAdmin][crate::client::InstanceAdmin].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod instance_admin {
         }
     }
 
-    /// Common implementation for [super::super::client::InstanceAdmin] request builders.
+    /// Common implementation for [crate::client::InstanceAdmin] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::InstanceAdmin>,
@@ -68,7 +68,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::list_instance_configs][super::super::client::InstanceAdmin::list_instance_configs] calls.
+    /// The request builder for [InstanceAdmin::list_instance_configs][crate::client::InstanceAdmin::list_instance_configs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -176,7 +176,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::get_instance_config][super::super::client::InstanceAdmin::get_instance_config] calls.
+    /// The request builder for [InstanceAdmin::get_instance_config][crate::client::InstanceAdmin::get_instance_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -242,7 +242,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::create_instance_config][super::super::client::InstanceAdmin::create_instance_config] calls.
+    /// The request builder for [InstanceAdmin::create_instance_config][crate::client::InstanceAdmin::create_instance_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -290,7 +290,7 @@ pub mod instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance_config][super::super::client::InstanceAdmin::create_instance_config].
+        /// on [create_instance_config][crate::client::InstanceAdmin::create_instance_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance_config(self.0.request, self.0.options)
@@ -386,7 +386,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::update_instance_config][super::super::client::InstanceAdmin::update_instance_config] calls.
+    /// The request builder for [InstanceAdmin::update_instance_config][crate::client::InstanceAdmin::update_instance_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -434,7 +434,7 @@ pub mod instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance_config][super::super::client::InstanceAdmin::update_instance_config].
+        /// on [update_instance_config][crate::client::InstanceAdmin::update_instance_config].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance_config(self.0.request, self.0.options)
@@ -536,7 +536,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::delete_instance_config][super::super::client::InstanceAdmin::delete_instance_config] calls.
+    /// The request builder for [InstanceAdmin::delete_instance_config][crate::client::InstanceAdmin::delete_instance_config] calls.
     ///
     /// # Example
     /// ```no_run
@@ -614,7 +614,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::list_instance_config_operations][super::super::client::InstanceAdmin::list_instance_config_operations] calls.
+    /// The request builder for [InstanceAdmin::list_instance_config_operations][crate::client::InstanceAdmin::list_instance_config_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -732,7 +732,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::list_instances][super::super::client::InstanceAdmin::list_instances] calls.
+    /// The request builder for [InstanceAdmin::list_instances][crate::client::InstanceAdmin::list_instances] calls.
     ///
     /// # Example
     /// ```no_run
@@ -859,7 +859,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::list_instance_partitions][super::super::client::InstanceAdmin::list_instance_partitions] calls.
+    /// The request builder for [InstanceAdmin::list_instance_partitions][crate::client::InstanceAdmin::list_instance_partitions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -990,7 +990,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::get_instance][super::super::client::InstanceAdmin::get_instance] calls.
+    /// The request builder for [InstanceAdmin::get_instance][crate::client::InstanceAdmin::get_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1071,7 +1071,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::create_instance][super::super::client::InstanceAdmin::create_instance] calls.
+    /// The request builder for [InstanceAdmin::create_instance][crate::client::InstanceAdmin::create_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1116,7 +1116,7 @@ pub mod instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance][super::super::client::InstanceAdmin::create_instance].
+        /// on [create_instance][crate::client::InstanceAdmin::create_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance(self.0.request, self.0.options)
@@ -1206,7 +1206,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::update_instance][super::super::client::InstanceAdmin::update_instance] calls.
+    /// The request builder for [InstanceAdmin::update_instance][crate::client::InstanceAdmin::update_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1251,7 +1251,7 @@ pub mod instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance][super::super::client::InstanceAdmin::update_instance].
+        /// on [update_instance][crate::client::InstanceAdmin::update_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance(self.0.request, self.0.options)
@@ -1347,7 +1347,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::delete_instance][super::super::client::InstanceAdmin::delete_instance] calls.
+    /// The request builder for [InstanceAdmin::delete_instance][crate::client::InstanceAdmin::delete_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1410,7 +1410,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::set_iam_policy][super::super::client::InstanceAdmin::set_iam_policy] calls.
+    /// The request builder for [InstanceAdmin::set_iam_policy][crate::client::InstanceAdmin::set_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1513,7 +1513,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::get_iam_policy][super::super::client::InstanceAdmin::get_iam_policy] calls.
+    /// The request builder for [InstanceAdmin::get_iam_policy][crate::client::InstanceAdmin::get_iam_policy] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1594,7 +1594,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::test_iam_permissions][super::super::client::InstanceAdmin::test_iam_permissions] calls.
+    /// The request builder for [InstanceAdmin::test_iam_permissions][crate::client::InstanceAdmin::test_iam_permissions] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1673,7 +1673,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::get_instance_partition][super::super::client::InstanceAdmin::get_instance_partition] calls.
+    /// The request builder for [InstanceAdmin::get_instance_partition][crate::client::InstanceAdmin::get_instance_partition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1739,7 +1739,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::create_instance_partition][super::super::client::InstanceAdmin::create_instance_partition] calls.
+    /// The request builder for [InstanceAdmin::create_instance_partition][crate::client::InstanceAdmin::create_instance_partition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1789,7 +1789,7 @@ pub mod instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [create_instance_partition][super::super::client::InstanceAdmin::create_instance_partition].
+        /// on [create_instance_partition][crate::client::InstanceAdmin::create_instance_partition].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .create_instance_partition(self.0.request, self.0.options)
@@ -1881,7 +1881,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::delete_instance_partition][super::super::client::InstanceAdmin::delete_instance_partition] calls.
+    /// The request builder for [InstanceAdmin::delete_instance_partition][crate::client::InstanceAdmin::delete_instance_partition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1955,7 +1955,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::update_instance_partition][super::super::client::InstanceAdmin::update_instance_partition] calls.
+    /// The request builder for [InstanceAdmin::update_instance_partition][crate::client::InstanceAdmin::update_instance_partition] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2005,7 +2005,7 @@ pub mod instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [update_instance_partition][super::super::client::InstanceAdmin::update_instance_partition].
+        /// on [update_instance_partition][crate::client::InstanceAdmin::update_instance_partition].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .update_instance_partition(self.0.request, self.0.options)
@@ -2103,7 +2103,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::list_instance_partition_operations][super::super::client::InstanceAdmin::list_instance_partition_operations] calls.
+    /// The request builder for [InstanceAdmin::list_instance_partition_operations][crate::client::InstanceAdmin::list_instance_partition_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2242,7 +2242,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::move_instance][super::super::client::InstanceAdmin::move_instance] calls.
+    /// The request builder for [InstanceAdmin::move_instance][crate::client::InstanceAdmin::move_instance] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2287,7 +2287,7 @@ pub mod instance_admin {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [move_instance][super::super::client::InstanceAdmin::move_instance].
+        /// on [move_instance][crate::client::InstanceAdmin::move_instance].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .move_instance(self.0.request, self.0.options)
@@ -2355,7 +2355,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::list_operations][super::super::client::InstanceAdmin::list_operations] calls.
+    /// The request builder for [InstanceAdmin::list_operations][crate::client::InstanceAdmin::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2467,7 +2467,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::get_operation][super::super::client::InstanceAdmin::get_operation] calls.
+    /// The request builder for [InstanceAdmin::get_operation][crate::client::InstanceAdmin::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2531,7 +2531,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::delete_operation][super::super::client::InstanceAdmin::delete_operation] calls.
+    /// The request builder for [InstanceAdmin::delete_operation][crate::client::InstanceAdmin::delete_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -2595,7 +2595,7 @@ pub mod instance_admin {
         }
     }
 
-    /// The request builder for [InstanceAdmin::cancel_operation][super::super::client::InstanceAdmin::cancel_operation] calls.
+    /// The request builder for [InstanceAdmin::cancel_operation][crate::client::InstanceAdmin::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/generated/storagetransfer/v1/src/builder.rs
+++ b/src/generated/storagetransfer/v1/src/builder.rs
@@ -17,7 +17,7 @@
 pub mod storage_transfer_service {
     use crate::Result;
 
-    /// A builder for [StorageTransferService][super::super::client::StorageTransferService].
+    /// A builder for [StorageTransferService][crate::client::StorageTransferService].
     ///
     /// ```
     /// # tokio_test::block_on(async {
@@ -45,7 +45,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// Common implementation for [super::super::client::StorageTransferService] request builders.
+    /// Common implementation for [crate::client::StorageTransferService] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::StorageTransferService>,
@@ -68,7 +68,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::get_google_service_account][super::super::client::StorageTransferService::get_google_service_account] calls.
+    /// The request builder for [StorageTransferService::get_google_service_account][crate::client::StorageTransferService::get_google_service_account] calls.
     ///
     /// # Example
     /// ```no_run
@@ -136,7 +136,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::create_transfer_job][super::super::client::StorageTransferService::create_transfer_job] calls.
+    /// The request builder for [StorageTransferService::create_transfer_job][crate::client::StorageTransferService::create_transfer_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -216,7 +216,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::update_transfer_job][super::super::client::StorageTransferService::update_transfer_job] calls.
+    /// The request builder for [StorageTransferService::update_transfer_job][crate::client::StorageTransferService::update_transfer_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -333,7 +333,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::get_transfer_job][super::super::client::StorageTransferService::get_transfer_job] calls.
+    /// The request builder for [StorageTransferService::get_transfer_job][crate::client::StorageTransferService::get_transfer_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -404,7 +404,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::list_transfer_jobs][super::super::client::StorageTransferService::list_transfer_jobs] calls.
+    /// The request builder for [StorageTransferService::list_transfer_jobs][crate::client::StorageTransferService::list_transfer_jobs] calls.
     ///
     /// # Example
     /// ```no_run
@@ -510,7 +510,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::pause_transfer_operation][super::super::client::StorageTransferService::pause_transfer_operation] calls.
+    /// The request builder for [StorageTransferService::pause_transfer_operation][crate::client::StorageTransferService::pause_transfer_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -576,7 +576,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::resume_transfer_operation][super::super::client::StorageTransferService::resume_transfer_operation] calls.
+    /// The request builder for [StorageTransferService::resume_transfer_operation][crate::client::StorageTransferService::resume_transfer_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -644,7 +644,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::run_transfer_job][super::super::client::StorageTransferService::run_transfer_job] calls.
+    /// The request builder for [StorageTransferService::run_transfer_job][crate::client::StorageTransferService::run_transfer_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -689,7 +689,7 @@ pub mod storage_transfer_service {
         /// # Long running operations
         ///
         /// This starts, but does not poll, a longrunning operation. More information
-        /// on [run_transfer_job][super::super::client::StorageTransferService::run_transfer_job].
+        /// on [run_transfer_job][crate::client::StorageTransferService::run_transfer_job].
         pub async fn send(self) -> Result<longrunning::model::Operation> {
             (*self.0.stub)
                 .run_transfer_job(self.0.request, self.0.options)
@@ -756,7 +756,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::delete_transfer_job][super::super::client::StorageTransferService::delete_transfer_job] calls.
+    /// The request builder for [StorageTransferService::delete_transfer_job][crate::client::StorageTransferService::delete_transfer_job] calls.
     ///
     /// # Example
     /// ```no_run
@@ -830,7 +830,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::create_agent_pool][super::super::client::StorageTransferService::create_agent_pool] calls.
+    /// The request builder for [StorageTransferService::create_agent_pool][crate::client::StorageTransferService::create_agent_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -923,7 +923,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::update_agent_pool][super::super::client::StorageTransferService::update_agent_pool] calls.
+    /// The request builder for [StorageTransferService::update_agent_pool][crate::client::StorageTransferService::update_agent_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1018,7 +1018,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::get_agent_pool][super::super::client::StorageTransferService::get_agent_pool] calls.
+    /// The request builder for [StorageTransferService::get_agent_pool][crate::client::StorageTransferService::get_agent_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1081,7 +1081,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::list_agent_pools][super::super::client::StorageTransferService::list_agent_pools] calls.
+    /// The request builder for [StorageTransferService::list_agent_pools][crate::client::StorageTransferService::list_agent_pools] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1190,7 +1190,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::delete_agent_pool][super::super::client::StorageTransferService::delete_agent_pool] calls.
+    /// The request builder for [StorageTransferService::delete_agent_pool][crate::client::StorageTransferService::delete_agent_pool] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1253,7 +1253,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::list_operations][super::super::client::StorageTransferService::list_operations] calls.
+    /// The request builder for [StorageTransferService::list_operations][crate::client::StorageTransferService::list_operations] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1365,7 +1365,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::get_operation][super::super::client::StorageTransferService::get_operation] calls.
+    /// The request builder for [StorageTransferService::get_operation][crate::client::StorageTransferService::get_operation] calls.
     ///
     /// # Example
     /// ```no_run
@@ -1429,7 +1429,7 @@ pub mod storage_transfer_service {
         }
     }
 
-    /// The request builder for [StorageTransferService::cancel_operation][super::super::client::StorageTransferService::cancel_operation] calls.
+    /// The request builder for [StorageTransferService::cancel_operation][crate::client::StorageTransferService::cancel_operation] calls.
     ///
     /// # Example
     /// ```no_run

--- a/src/storage-control/src/generated/gapic/builder.rs
+++ b/src/storage-control/src/generated/gapic/builder.rs
@@ -17,7 +17,7 @@
 pub mod storage {
     use crate::Result;
 
-    /// Common implementation for [super::super::client::Storage] request builders.
+    /// Common implementation for [crate::client::Storage] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::Storage>,

--- a/src/storage-control/src/generated/gapic_control/builder.rs
+++ b/src/storage-control/src/generated/gapic_control/builder.rs
@@ -17,7 +17,7 @@
 pub mod storage_control {
     use crate::Result;
 
-    /// Common implementation for [super::super::client::StorageControl] request builders.
+    /// Common implementation for [crate::client::StorageControl] request builders.
     #[derive(Clone, Debug)]
     pub(crate) struct RequestBuilder<R: std::default::Default> {
         stub: std::sync::Arc<dyn super::super::stub::dynamic::StorageControl>,


### PR DESCRIPTION
Part of the work for #1813, #2232 

Use absolute links to a client instead of relative links from the request builder.

This is enough to unblock the builder docs for storage control, without too much special handling.

I suspect more complicated veneers will have handwritten builders that are not exposed in the client surface. We will cross that bridge when we get to it.