### PR TITLE
cleanup(storage-control): remove TODOs

### DIFF
--- a/src/storage-control/src/convert.rs
+++ b/src/storage-control/src/convert.rs
@@ -57,7 +57,6 @@ impl FromProto<rpc::model::Status> for google::rpc::Status {
     }
 }
 
-// TODO(#2037) - The generator should control this code.
 impl ToProto<google::longrunning::Operation> for longrunning::model::Operation {
     type Output = google::longrunning::Operation;
     fn to_proto(
@@ -85,7 +84,6 @@ impl ToProto<google::longrunning::Operation> for longrunning::model::Operation {
     }
 }
 
-// TODO(#2037) - The generator should control this code.
 impl FromProto<longrunning::model::Operation> for google::longrunning::Operation {
     fn cnv(self) -> std::result::Result<longrunning::model::Operation, ConvertError> {
         use crate::google::longrunning::operation::Result as P;


### PR DESCRIPTION
Fixes #2037 

In the fullness of time, the generator should probably own these `{To, From}Proto` conversions for LROs (and also the ones for `rpc::Status`).

But the important thing is that we don't have to do any work to update the conversions if/when a new LRO is added to Storage Control.

So I am removing the TODOs and close out the bug.