### PR TITLE
docs(gax)!: hide policy functions

### DIFF
--- a/src/gax/src/backoff_policy.rs
+++ b/src/gax/src/backoff_policy.rs
@@ -65,6 +65,7 @@ pub trait BackoffPolicy: Send + Sync + std::fmt::Debug {
     /// * `loop_start` - when the retry loop started.
     /// * `attempt_count` - the number of attempts. This method is always called
     ///   after the first attempt.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn on_failure(&self, loop_start: std::time::Instant, attempt_count: u32)
     -> std::time::Duration;
 }

--- a/src/gax/src/polling_backoff_policy.rs
+++ b/src/gax/src/polling_backoff_policy.rs
@@ -63,6 +63,7 @@ pub trait PollingBackoffPolicy: Send + Sync + std::fmt::Debug {
     /// * `loop_start` - when the polling loop started.
     /// * `attempt_count` - the number of poll queries. This method is always
     ///   called after the first attempt.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn wait_period(
         &self,
         loop_start: std::time::Instant,

--- a/src/gax/src/polling_error_policy.rs
+++ b/src/gax/src/polling_error_policy.rs
@@ -59,6 +59,7 @@ pub trait PollingErrorPolicy: Send + Sync + std::fmt::Debug {
     ///   attempt. This method called after LRO successfully starts, it is
     ///   always non-zero.
     /// * `error` - the last error when attempting the request.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn on_error(
         &self,
         loop_start: std::time::Instant,
@@ -68,6 +69,7 @@ pub trait PollingErrorPolicy: Send + Sync + std::fmt::Debug {
 
     /// Called when the LRO is successfully polled, but the LRO is still in
     /// progress.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn on_in_progress(
         &self,
         _loop_start: std::time::Instant,

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -72,6 +72,7 @@ pub trait RetryPolicy: Send + Sync + std::fmt::Debug {
     /// * `idempotent` - if `true` assume the operation is idempotent. Many more
     ///   errors are retryable on idempotent operations.
     /// * `error` - the last error when attempting the request.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn on_error(
         &self,
         loop_start: std::time::Instant,
@@ -90,6 +91,7 @@ pub trait RetryPolicy: Send + Sync + std::fmt::Debug {
     /// * `loop_start` - when the retry loop started.
     /// * `attempt_count` - the number of attempts. This method is never called
     ///   before the first attempt.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn on_throttle(&self, _loop_start: std::time::Instant, _attempt_count: u32) -> Option<Error> {
         None
     }
@@ -104,6 +106,7 @@ pub trait RetryPolicy: Send + Sync + std::fmt::Debug {
     /// * `loop_start` - when the retry loop started.
     /// * `attempt_count` - the number of attempts. This method is called before
     ///   the first attempt, so the first value is zero.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn remaining_time(
         &self,
         _loop_start: std::time::Instant,

--- a/src/gax/src/retry_throttler.rs
+++ b/src/gax/src/retry_throttler.rs
@@ -87,12 +87,15 @@ pub trait RetryThrottler: Send + Sync + std::fmt::Debug {
     /// `false`. Note that the retry loop may stop if too many attempts are
     /// throttled: they are treated as transient errors and may exhaust the
     /// retry policy.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn throttle_retry_attempt(&self) -> bool;
 
     /// Called by the retry loop after a retry failure.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn on_retry_failure(&mut self, flow: &LoopState);
 
     /// Called by the retry loop when a RPC succeeds.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
     fn on_success(&mut self);
 }
 


### PR DESCRIPTION
Temporarily we are excluding the retry policy, backoff policy, polling
error policy, and polling backoff policy functions from the public
APIs. That will make it easier to evolve these APIs as we finalize the
design for the client libraries.

Part of the work for #2237
