### PR TITLE
cleanup(storage-control): rename client

### DIFF
--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -19,6 +19,7 @@ use gax::paginator::ItemPaginator as _;
 use gax::retry_policy::RetryPolicyExt;
 use lro::Poller;
 use std::time::Duration;
+use storage_control::client::StorageControl;
 use storage_control::model::Bucket;
 use storage_control::model::bucket::iam_config::UniformBucketLevelAccess;
 use storage_control::model::bucket::{HierarchicalNamespace, IamConfig};
@@ -71,9 +72,9 @@ pub async fn objects(builder: storage::client::ClientBuilder) -> Result<()> {
     Ok(())
 }
 
-pub async fn create_test_bucket() -> gax::Result<(storage_control::client::Storage, Bucket)> {
+pub async fn create_test_bucket() -> gax::Result<(StorageControl, Bucket)> {
     let project_id = crate::project_id()?;
-    let client = storage_control::client::Storage::builder()
+    let client = StorageControl::builder()
         .with_tracing()
         .with_backoff_policy(
             gax::exponential_backoff::ExponentialBackoffBuilder::new()
@@ -185,7 +186,7 @@ pub async fn buckets(builder: storage_control::client::ClientBuilder) -> Result<
     Ok(())
 }
 
-async fn buckets_iam(client: &storage_control::client::Storage, bucket_name: &str) -> Result<()> {
+async fn buckets_iam(client: &StorageControl, bucket_name: &str) -> Result<()> {
     let service_account = crate::service_account_for_iam_tests()?;
 
     println!("\nTesting get_iam_policy()");
@@ -224,7 +225,7 @@ async fn buckets_iam(client: &storage_control::client::Storage, bucket_name: &st
     Ok(())
 }
 
-async fn folders(client: &storage_control::client::Storage, bucket_name: &str) -> Result<()> {
+async fn folders(client: &StorageControl, bucket_name: &str) -> Result<()> {
     let folder_name = format!("{bucket_name}/folders/test-folder/");
     let folder_rename = format!("{bucket_name}/folders/renamed-test-folder/");
 
@@ -277,10 +278,7 @@ async fn folders(client: &storage_control::client::Storage, bucket_name: &str) -
     Ok(())
 }
 
-async fn cleanup_stale_buckets(
-    client: &storage_control::client::Storage,
-    project_id: &str,
-) -> Result<()> {
+async fn cleanup_stale_buckets(client: &StorageControl, project_id: &str) -> Result<()> {
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
     let stale_deadline = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -320,7 +318,7 @@ async fn cleanup_stale_buckets(
     Ok(())
 }
 
-async fn cleanup_bucket(client: storage_control::client::Storage, name: String) -> Result<()> {
+async fn cleanup_bucket(client: StorageControl, name: String) -> Result<()> {
     let mut objects = client
         .list_objects()
         .set_parent(&name)

--- a/src/integration-tests/tests/driver.rs
+++ b/src/integration-tests/tests/driver.rs
@@ -14,6 +14,8 @@
 
 #[cfg(all(test, feature = "run-integration-tests"))]
 mod driver {
+    use storage::client::Storage;
+    use storage_control::client::StorageControl;
     use test_case::test_case;
 
     fn retry_policy() -> impl gax::retry_policy::RetryPolicy {
@@ -102,8 +104,8 @@ mod driver {
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(storage_control::client::Storage::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
-    #[test_case(storage_control::client::Storage::builder().with_retry_policy(retry_policy()); "with retry enabled")]
+    #[test_case(StorageControl::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
+    #[test_case(StorageControl::builder().with_retry_policy(retry_policy()); "with retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_control_buckets(
         builder: storage_control::client::ClientBuilder,
@@ -113,7 +115,7 @@ mod driver {
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(storage::client::Storage::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
+    #[test_case(Storage::builder().with_tracing().with_retry_policy(retry_policy()); "with tracing and retry enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_storage_objects(
         builder: storage::client::ClientBuilder,
@@ -143,7 +145,7 @@ mod driver {
             .map_err(integration_tests::report_error)
     }
 
-    #[test_case(storage_control::client::Storage::builder().with_tracing(); "with tracing enabled")]
+    #[test_case(StorageControl::builder().with_tracing(); "with tracing enabled")]
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_check_code_for_grpc(
         builder: storage_control::client::ClientBuilder,

--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -12,23 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Contains the Storage client and related types.
+//! Contains the StorageControl client and related types.
 
 /// Implements a client for the Cloud Storage API.
 ///
 /// # Example
 /// ```
 /// # tokio_test::block_on(async {
-/// # use google_cloud_storage_control::client::Storage;
-/// let client = Storage::builder().build().await?;
+/// # use google_cloud_storage_control::client::StorageControl;
+/// let client = StorageControl::builder().build().await?;
 /// // use `client` to make requests to Cloud Storage.
 /// # gax::Result::<()>::Ok(()) });
 /// ```
 ///
 /// # Configuration
 ///
-/// To configure `Storage` use the `with_*` methods in the type returned
-/// by [builder()][Storage::builder]. The default configuration should
+/// To configure `StorageControl` use the `with_*` methods in the type returned
+/// by [builder()][StorageControl::builder]. The default configuration should
 /// work for most applications. Common configuration changes include
 ///
 /// * [with_endpoint()]: by default this client uses the global default endpoint
@@ -42,8 +42,8 @@
 ///
 /// # Pooling and Cloning
 ///
-/// `Storage` holds a connection pool internally, it is advised to
-/// create one and the reuse it.  You do not need to wrap `Storage` in
+/// `StorageControl` holds a connection pool internally, it is advised to
+/// create one and the reuse it.  You do not need to wrap `StorageControl` in
 /// an [Rc](std::rc::Rc) or [Arc](std::sync::Arc) to reuse it, because it
 /// already uses an `Arc` internally.
 ///
@@ -80,18 +80,18 @@
 /// [Private Google Access with VPC Service Controls]: https://cloud.google.com/vpc-service-controls/docs/private-connectivity
 /// [Application Default Credentials]: https://cloud.google.com/docs/authentication#adc
 #[derive(Clone, Debug)]
-pub struct Storage {
+pub struct StorageControl {
     storage: super::generated::gapic::client::Storage,
     control: super::generated::gapic_control::client::StorageControl,
 }
 
-impl Storage {
-    /// Returns a builder for [Storage].
+impl StorageControl {
+    /// Returns a builder for [StorageControl].
     ///
     /// ```no_run
     /// # tokio_test::block_on(async {
-    /// # use google_cloud_storage_control::client::Storage;
-    /// let client = Storage::builder().build().await?;
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// let client = StorageControl::builder().build().await?;
     /// # gax::Result::<()>::Ok(()) });
     /// ```
     pub fn builder() -> ClientBuilder {
@@ -106,8 +106,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     client.delete_bucket()
     ///         .set_name("projects/_/buckets/my-bucket")
     ///         .send()
@@ -123,8 +123,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     let bucket = client.get_bucket()
     ///         .set_name("projects/_/buckets/my-bucket")
     ///         .send()
@@ -142,8 +142,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     let bucket = client.create_bucket()
     ///         .set_parent("projects/my-project")
     ///         .set_bucket_id("my-bucket")
@@ -162,8 +162,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     use gax::paginator::{ItemPaginator, Paginator};
     ///     let mut items = client.list_buckets()
     ///         .set_parent("projects/my-project")
@@ -183,8 +183,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     client.delete_object()
     ///         .set_bucket("projects/_/buckets/my-bucket")
     ///         .set_object("my-object")
@@ -217,8 +217,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     use gax::paginator::{ItemPaginator, Paginator};
     ///     let mut items = client.list_objects()
     ///         .set_parent("projects/_/buckets/my-bucket")
@@ -238,8 +238,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     let policy = client.get_iam_policy()
     ///         .set_resource("projects/_/buckets/my-bucket")
     ///         .send()
@@ -262,9 +262,9 @@ impl Storage {
     /// # Example
     ///
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
+    /// # use google_cloud_storage_control::client::StorageControl;
     /// # use iam_v1::model::Policy;
-    /// async fn example(client: &Storage, updated_policy: Policy) -> gax::Result<()> {
+    /// async fn example(client: &StorageControl, updated_policy: Policy) -> gax::Result<()> {
     ///     let policy = client.set_iam_policy()
     ///         .set_resource("projects/_/buckets/my-bucket")
     ///         .set_update_mask(wkt::FieldMask::default().set_paths(["bindings"]))
@@ -284,8 +284,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     let response = client.test_iam_permissions()
     ///         .set_resource("projects/_/buckets/my-bucket")
     ///         .set_permissions(["storage.buckets.get"])
@@ -306,8 +306,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     let folder = client.create_folder()
     ///         .set_parent("projects/my-project/buckets/my-bucket")
     ///         .set_folder_id("my-folder/my-subfolder/")
@@ -328,8 +328,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     let folder = client.get_folder()
     ///         .set_name("projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/")
     ///         .send()
@@ -349,8 +349,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     client.delete_folder()
     ///         .set_name("projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/")
     ///         .send()
@@ -369,8 +369,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     use gax::paginator::ItemPaginator as _;
     ///     let mut folders = client.list_folders()
     ///         .set_parent("projects/_/buckets/my-bucket")
@@ -396,8 +396,8 @@ impl Storage {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_storage_control::client::Storage;
-    /// async fn example(client: &Storage) -> gax::Result<()> {
+    /// # use google_cloud_storage_control::client::StorageControl;
+    /// async fn example(client: &StorageControl) -> gax::Result<()> {
     ///     use lro::Poller as _;
     ///     let folder = client.rename_folder()
     ///         .set_name("projects/_/buckets/my-bucket/folders/my-folder/my-subfolder/")
@@ -429,7 +429,7 @@ impl Storage {
     /// client's behavior.
     pub fn from_stub<T>(stub: T) -> Self
     where
-        T: super::stub::Storage + 'static,
+        T: super::stub::StorageControl + 'static,
     {
         let stub = std::sync::Arc::new(stub);
         Self {
@@ -445,14 +445,14 @@ impl Storage {
     }
 }
 
-/// A builder for [Storage].
+/// A builder for [StorageControl].
 ///
 /// ```
 /// # tokio_test::block_on(async {
 /// # use google_cloud_storage_control::*;
 /// # use client::ClientBuilder;
-/// # use client::Storage;
-/// let builder : ClientBuilder = Storage::builder();
+/// # use client::StorageControl;
+/// let builder : ClientBuilder = StorageControl::builder();
 /// let client = builder
 ///     .with_endpoint("https://storage.googleapis.com")
 ///     .build().await?;
@@ -462,10 +462,10 @@ pub type ClientBuilder =
     gax::client_builder::ClientBuilder<client_builder::Factory, gaxi::options::Credentials>;
 
 pub(crate) mod client_builder {
-    use super::Storage;
+    use super::StorageControl;
     pub struct Factory;
     impl gax::client_builder::internal::ClientFactory for Factory {
-        type Client = Storage;
+        type Client = StorageControl;
         type Credentials = gaxi::options::Credentials;
         async fn build(self, config: gaxi::options::ClientConfig) -> gax::Result<Self::Client> {
             Self::Client::new(config).await

--- a/src/storage-control/src/stub.rs
+++ b/src/storage-control/src/stub.rs
@@ -24,19 +24,19 @@
 
 use gax::error::Error;
 
-/// Defines the trait used to implement [super::client::Storage].
+/// Defines the trait used to implement [super::client::StorageControl].
 ///
 /// Application developers may need to implement this trait to mock
-/// `client::Storage`. In other use-cases, application developers only
-/// use `client::Storage` and need not be concerned with this trait or
+/// `client::StorageControl`. In other use-cases, application developers only
+/// use `client::StorageControl` and need not be concerned with this trait or
 /// its implementations.
 ///
 /// Services gain new RPCs routinely. Consequently, this trait gains new methods
 /// too. To avoid breaking applications the trait provides a default
 /// implementation of each method. Most of these implementations just return an
 /// error.
-pub trait Storage: std::fmt::Debug + Send + Sync {
-    /// Implements [super::client::Storage::delete_bucket].
+pub trait StorageControl: std::fmt::Debug + Send + Sync {
+    /// Implements [super::client::StorageControl::delete_bucket].
     fn delete_bucket(
         &self,
         _req: crate::model::DeleteBucketRequest,
@@ -47,7 +47,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )))
     }
 
-    /// Implements [super::client::Storage::get_bucket].
+    /// Implements [super::client::StorageControl::get_bucket].
     fn get_bucket(
         &self,
         _req: crate::model::GetBucketRequest,
@@ -60,7 +60,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::create_bucket].
+    /// Implements [super::client::StorageControl::create_bucket].
     fn create_bucket(
         &self,
         _req: crate::model::CreateBucketRequest,
@@ -73,7 +73,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::list_buckets].
+    /// Implements [super::client::StorageControl::list_buckets].
     fn list_buckets(
         &self,
         _req: crate::model::ListBucketsRequest,
@@ -86,7 +86,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         >(Err(Error::other("unimplemented")))
     }
 
-    /// Implements [super::client::Storage::lock_bucket_retention_policy].
+    /// Implements [super::client::StorageControl::lock_bucket_retention_policy].
     fn lock_bucket_retention_policy(
         &self,
         _req: crate::model::LockBucketRetentionPolicyRequest,
@@ -99,7 +99,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::get_iam_policy].
+    /// Implements [super::client::StorageControl::get_iam_policy].
     fn get_iam_policy(
         &self,
         _req: iam_v1::model::GetIamPolicyRequest,
@@ -112,7 +112,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::set_iam_policy].
+    /// Implements [super::client::StorageControl::set_iam_policy].
     fn set_iam_policy(
         &self,
         _req: iam_v1::model::SetIamPolicyRequest,
@@ -125,7 +125,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::test_iam_permissions].
+    /// Implements [super::client::StorageControl::test_iam_permissions].
     fn test_iam_permissions(
         &self,
         _req: iam_v1::model::TestIamPermissionsRequest,
@@ -138,7 +138,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         >(Err(Error::other("unimplemented")))
     }
 
-    /// Implements [super::client::Storage::update_bucket].
+    /// Implements [super::client::StorageControl::update_bucket].
     fn update_bucket(
         &self,
         _req: crate::model::UpdateBucketRequest,
@@ -151,7 +151,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::compose_object].
+    /// Implements [super::client::StorageControl::compose_object].
     fn compose_object(
         &self,
         _req: crate::model::ComposeObjectRequest,
@@ -164,7 +164,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::delete_object].
+    /// Implements [super::client::StorageControl::delete_object].
     fn delete_object(
         &self,
         _req: crate::model::DeleteObjectRequest,
@@ -175,7 +175,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )))
     }
 
-    /// Implements [super::client::Storage::restore_object].
+    /// Implements [super::client::StorageControl::restore_object].
     fn restore_object(
         &self,
         _req: crate::model::RestoreObjectRequest,
@@ -188,7 +188,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::get_object].
+    /// Implements [super::client::StorageControl::get_object].
     fn get_object(
         &self,
         _req: crate::model::GetObjectRequest,
@@ -201,7 +201,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::update_object].
+    /// Implements [super::client::StorageControl::update_object].
     fn update_object(
         &self,
         _req: crate::model::UpdateObjectRequest,
@@ -214,7 +214,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::list_objects].
+    /// Implements [super::client::StorageControl::list_objects].
     fn list_objects(
         &self,
         _req: crate::model::ListObjectsRequest,
@@ -227,7 +227,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         >(Err(Error::other("unimplemented")))
     }
 
-    /// Implements [super::client::Storage::rewrite_object].
+    /// Implements [super::client::StorageControl::rewrite_object].
     fn rewrite_object(
         &self,
         _req: crate::model::RewriteObjectRequest,
@@ -240,7 +240,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::move_object].
+    /// Implements [super::client::StorageControl::move_object].
     fn move_object(
         &self,
         _req: crate::model::MoveObjectRequest,
@@ -252,7 +252,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
             Error::other("unimplemented"),
         ))
     }
-    /// Implements [super::client::Storage::create_folder].
+    /// Implements [super::client::StorageControl::create_folder].
     fn create_folder(
         &self,
         _req: crate::model::CreateFolderRequest,
@@ -265,7 +265,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::delete_folder].
+    /// Implements [super::client::StorageControl::delete_folder].
     fn delete_folder(
         &self,
         _req: crate::model::DeleteFolderRequest,
@@ -276,7 +276,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )))
     }
 
-    /// Implements [super::client::Storage::get_folder].
+    /// Implements [super::client::StorageControl::get_folder].
     fn get_folder(
         &self,
         _req: crate::model::GetFolderRequest,
@@ -289,7 +289,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         ))
     }
 
-    /// Implements [super::client::Storage::list_folders].
+    /// Implements [super::client::StorageControl::list_folders].
     fn list_folders(
         &self,
         _req: crate::model::ListFoldersRequest,
@@ -302,7 +302,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         >(Err(Error::other("unimplemented")))
     }
 
-    /// Implements [super::client::Storage::rename_folder].
+    /// Implements [super::client::StorageControl::rename_folder].
     fn rename_folder(
         &self,
         _req: crate::model::RenameFolderRequest,
@@ -315,7 +315,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::get_storage_layout].
+    /// Implements [super::client::StorageControl::get_storage_layout].
     fn get_storage_layout(
         &self,
         _req: crate::model::GetStorageLayoutRequest,
@@ -328,7 +328,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::create_managed_folder].
+    /// Implements [super::client::StorageControl::create_managed_folder].
     fn create_managed_folder(
         &self,
         _req: crate::model::CreateManagedFolderRequest,
@@ -341,7 +341,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::delete_managed_folder].
+    /// Implements [super::client::StorageControl::delete_managed_folder].
     fn delete_managed_folder(
         &self,
         _req: crate::model::DeleteManagedFolderRequest,
@@ -352,7 +352,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )))
     }
 
-    /// Implements [super::client::Storage::get_managed_folder].
+    /// Implements [super::client::StorageControl::get_managed_folder].
     fn get_managed_folder(
         &self,
         _req: crate::model::GetManagedFolderRequest,
@@ -365,7 +365,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::list_managed_folders].
+    /// Implements [super::client::StorageControl::list_managed_folders].
     fn list_managed_folders(
         &self,
         _req: crate::model::ListManagedFoldersRequest,
@@ -378,7 +378,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         >(Err(Error::other("unimplemented")))
     }
 
-    /// Implements [super::client::Storage::create_anywhere_cache].
+    /// Implements [super::client::StorageControl::create_anywhere_cache].
     fn create_anywhere_cache(
         &self,
         _req: crate::model::CreateAnywhereCacheRequest,
@@ -391,7 +391,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::update_anywhere_cache].
+    /// Implements [super::client::StorageControl::update_anywhere_cache].
     fn update_anywhere_cache(
         &self,
         _req: crate::model::UpdateAnywhereCacheRequest,
@@ -404,7 +404,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::disable_anywhere_cache].
+    /// Implements [super::client::StorageControl::disable_anywhere_cache].
     fn disable_anywhere_cache(
         &self,
         _req: crate::model::DisableAnywhereCacheRequest,
@@ -417,7 +417,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::pause_anywhere_cache].
+    /// Implements [super::client::StorageControl::pause_anywhere_cache].
     fn pause_anywhere_cache(
         &self,
         _req: crate::model::PauseAnywhereCacheRequest,
@@ -430,7 +430,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::resume_anywhere_cache].
+    /// Implements [super::client::StorageControl::resume_anywhere_cache].
     fn resume_anywhere_cache(
         &self,
         _req: crate::model::ResumeAnywhereCacheRequest,
@@ -443,7 +443,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::get_anywhere_cache].
+    /// Implements [super::client::StorageControl::get_anywhere_cache].
     fn get_anywhere_cache(
         &self,
         _req: crate::model::GetAnywhereCacheRequest,
@@ -456,7 +456,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         )
     }
 
-    /// Implements [super::client::Storage::list_anywhere_caches].
+    /// Implements [super::client::StorageControl::list_anywhere_caches].
     fn list_anywhere_caches(
         &self,
         _req: crate::model::ListAnywhereCachesRequest,
@@ -469,7 +469,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
         >(Err(Error::other("unimplemented")))
     }
 
-    /// Implements [super::client::Storage::get_operation].
+    /// Implements [super::client::StorageControl::get_operation].
     fn get_operation(
         &self,
         _req: longrunning::model::GetOperationRequest,
@@ -485,7 +485,7 @@ pub trait Storage: std::fmt::Debug + Send + Sync {
 
 impl<T> crate::generated::gapic::stub::Storage for std::sync::Arc<T>
 where
-    T: Storage,
+    T: StorageControl,
 {
     fn delete_bucket(
         &self,
@@ -645,7 +645,7 @@ where
 
 impl<T> crate::generated::gapic_control::stub::StorageControl for std::sync::Arc<T>
 where
-    T: Storage,
+    T: StorageControl,
 {
     fn create_folder(
         &self,

--- a/src/storage-control/tests/mocking.rs
+++ b/src/storage-control/tests/mocking.rs
@@ -19,8 +19,8 @@ mod mocking {
 
     mockall::mock! {
         #[derive(Debug)]
-        Storage {}
-        impl gcs::stub::Storage for Storage {
+        StorageControl {}
+        impl gcs::stub::StorageControl for StorageControl {
             async fn get_bucket(&self, req: gcs::model::GetBucketRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::Bucket>>;
             async fn get_folder(&self, req: gcs::model::GetFolderRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::Folder>>;
         }
@@ -28,13 +28,13 @@ mod mocking {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_mocks() -> Result<()> {
-        let mut mock = MockStorage::new();
+        let mut mock = MockStorageControl::new();
         mock.expect_get_bucket()
             .return_once(|_, _| Err(gax::error::Error::other("simulated failure")));
         mock.expect_get_folder()
             .return_once(|_, _| Err(gax::error::Error::other("simulated failure")));
 
-        let client = gcs::client::Storage::from_stub(mock);
+        let client = gcs::client::StorageControl::from_stub(mock);
 
         let response = client.get_bucket().send().await;
         assert!(response.is_err());


### PR DESCRIPTION
Part of the work for #1813 

Rename the client to be consistent with code generated off of `storage/control/v2`.