### PR TITLE
cleanup(gax)!: split policy error types

### DIFF
--- a/src/gax/src/backoff_policy.rs
+++ b/src/gax/src/backoff_policy.rs
@@ -38,9 +38,8 @@
 //!
 //! # Example
 //! ```
-//! # use google_cloud_gax::*;
-//! # use google_cloud_gax::backoff_policy::*;
-//! use exponential_backoff::ExponentialBackoffBuilder;
+//! # use google_cloud_gax::exponential_backoff::Error;
+//! # use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
 //! use std::time::Duration;
 //!
 //! let policy = ExponentialBackoffBuilder::new()
@@ -48,7 +47,7 @@
 //!     .with_maximum_delay(Duration::from_secs(5))
 //!     .with_scaling(4.0)
 //!     .build()?;
-//! # Ok::<(), error::Error>(())
+//! # Ok::<(), Error>(())
 //! ```
 //!
 //! [RetryThrottler]: crate::retry_throttler::RetryThrottler

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -282,6 +282,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// ```
     /// # use google_cloud_gax::client_builder::examples;
     /// # use google_cloud_gax as gax;
+    /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
     /// use gax::exponential_backoff::ExponentialBackoffBuilder;
@@ -294,7 +295,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// let client = Client::builder()
     ///     .with_backoff_policy(policy)
     ///     .build().await?;
-    /// # Ok::<(), anyhow::Error>(()) });
+    /// # Result::<()>::Ok(()) });
     /// ```
     pub fn with_backoff_policy<V: Into<BackoffPolicyArg>>(mut self, v: V) -> Self {
         self.config.backoff_policy = Some(v.into().0);
@@ -370,6 +371,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// ```
     /// # use google_cloud_gax::client_builder::examples;
     /// # use google_cloud_gax as gax;
+    /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
     /// use gax::exponential_backoff::ExponentialBackoffBuilder;
@@ -382,7 +384,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// let client = Client::builder()
     ///     .with_polling_backoff_policy(policy)
     ///     .build().await?;
-    /// # Ok::<(), anyhow::Error>(()) });
+    /// # Result::<()>::Ok(()) });
     /// ```
     pub fn with_polling_backoff_policy<V: Into<PollingBackoffPolicyArg>>(mut self, v: V) -> Self {
         self.config.polling_backoff_policy = Some(v.into().0);

--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -282,7 +282,6 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// ```
     /// # use google_cloud_gax::client_builder::examples;
     /// # use google_cloud_gax as gax;
-    /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
     /// use gax::exponential_backoff::ExponentialBackoffBuilder;
@@ -295,7 +294,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// let client = Client::builder()
     ///     .with_backoff_policy(policy)
     ///     .build().await?;
-    /// # Result::<()>::Ok(()) });
+    /// # Ok::<(), anyhow::Error>(()) });
     /// ```
     pub fn with_backoff_policy<V: Into<BackoffPolicyArg>>(mut self, v: V) -> Self {
         self.config.backoff_policy = Some(v.into().0);
@@ -371,7 +370,6 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// ```
     /// # use google_cloud_gax::client_builder::examples;
     /// # use google_cloud_gax as gax;
-    /// # use google_cloud_gax::client_builder::Result;
     /// # tokio_test::block_on(async {
     /// use examples::Client; // Placeholder for examples
     /// use gax::exponential_backoff::ExponentialBackoffBuilder;
@@ -384,7 +382,7 @@ impl<F, Cr> ClientBuilder<F, Cr> {
     /// let client = Client::builder()
     ///     .with_polling_backoff_policy(policy)
     ///     .build().await?;
-    /// # Result::<()>::Ok(()) });
+    /// # Ok::<(), anyhow::Error>(()) });
     /// ```
     pub fn with_polling_backoff_policy<V: Into<PollingBackoffPolicyArg>>(mut self, v: V) -> Self {
         self.config.polling_backoff_policy = Some(v.into().0);

--- a/src/gax/src/polling_backoff_policy.rs
+++ b/src/gax/src/polling_backoff_policy.rs
@@ -37,9 +37,8 @@
 //!
 //! # Example
 //! ```
-//! # use google_cloud_gax::*;
-//! # use polling_backoff_policy::*;
-//! use exponential_backoff::ExponentialBackoffBuilder;
+//! # use google_cloud_gax::exponential_backoff::Error;
+//! # use google_cloud_gax::exponential_backoff::ExponentialBackoffBuilder;
 //! use std::time::Duration;
 //!
 //! let policy = ExponentialBackoffBuilder::new()
@@ -48,7 +47,7 @@
 //!     .with_scaling(4.0)
 //!     .build()?;
 //! // `policy` implements the `PollingBackoffPolicy` trait.
-//! # Ok::<(), error::Error>(())
+//! # Ok::<(), Error>(())
 //! ```
 //!
 //! [Exponential backoff]: https://en.wikipedia.org/wiki/Exponential_backoff

--- a/src/gax/src/retry_throttler.rs
+++ b/src/gax/src/retry_throttler.rs
@@ -69,8 +69,8 @@ use std::sync::{Arc, Mutex};
 #[derive(thiserror::Error, Debug)]
 #[non_exhaustive]
 pub enum Error {
-    #[error("the scaling factor ({value}) must be greater or equal than 0.0")]
-    ScalingOutOfRange { value: f64 },
+    #[error("the scaling factor ({0}) must be greater or equal than 0.0")]
+    ScalingOutOfRange(f64),
     #[error(
         "the minimum tokens ({min}) must be less than or equal to the initial token ({initial}) count"
     )]
@@ -190,7 +190,7 @@ impl AdaptiveThrottler {
     /// ```
     pub fn new(factor: f64) -> Result<Self, Error> {
         if factor < 0.0 {
-            return Err(Error::ScalingOutOfRange { value: factor });
+            return Err(Error::ScalingOutOfRange(factor));
         }
         let factor = if factor < 0.0 { 0.0 } else { factor };
         Ok(Self::clamp(factor))

--- a/src/integration-tests/src/storage.rs
+++ b/src/integration-tests/src/storage.rs
@@ -85,7 +85,8 @@ pub async fn create_test_bucket() -> Result<(StorageControl, Bucket)> {
             gax::exponential_backoff::ExponentialBackoffBuilder::new()
                 .with_initial_delay(Duration::from_secs(2))
                 .with_maximum_delay(Duration::from_secs(8))
-                .build()?,
+                .build()
+                .unwrap(),
         )
         .with_retry_policy(
             gax::retry_policy::AlwaysRetry

--- a/src/integration-tests/src/workflows.rs
+++ b/src/integration-tests/src/workflows.rs
@@ -61,7 +61,7 @@ main:
                 .set_service_account(&workflows_runner)
                 .set_source_code(source_code),
         )
-        .with_polling_backoff_policy(test_backoff()?)
+        .with_polling_backoff_policy(test_backoff())
         .poller()
         .until_done()
         .await?;
@@ -178,12 +178,12 @@ main:
     Ok(())
 }
 
-fn test_backoff() -> Result<ExponentialBackoff> {
-    let policy = ExponentialBackoffBuilder::new()
+fn test_backoff() -> ExponentialBackoff {
+    ExponentialBackoffBuilder::new()
         .with_initial_delay(Duration::from_millis(100))
         .with_maximum_delay(Duration::from_secs(1))
-        .build()?;
-    Ok(policy)
+        .build()
+        .expect("test policy values should succeed")
 }
 
 async fn cleanup_stale_workflows(


### PR DESCRIPTION
We should use different error types for policy creation problems vs.
RPC problems.

Fixes #2283 