### PR TITLE
test(lro): fix error simulation

### DIFF
--- a/src/lro/tests/fake/responses.rs
+++ b/src/lro/tests/fake/responses.rs
@@ -50,8 +50,7 @@ pub fn operation_error(name: impl Into<String>) -> Result<(StatusCode, String)> 
     let error = rpc::model::Status::default()
         .set_code(gax::error::rpc::Code::AlreadyExists as i32)
         .set_message("The resource  already exists");
-    let result =
-        longrunning::model::operation::Result::Response(wkt::Any::from_msg(&error)?.into());
+    let result = longrunning::model::operation::Result::Error(Box::new(error));
     let operation = longrunning::model::Operation::default()
         .set_name(name)
         .set_done(true)


### PR DESCRIPTION
The test were simulating errors incorrectly. Instead of returning a
`google.rpc.Status` in the right message field, it was always failing
to decode an any and returning the decoding error. The new tests are
more specific and verify the status is received.

Motivated by #2221
