### PR TITLE
fix(gax): handle unknown error details

### DIFF
--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -450,6 +450,7 @@ impl From<wkt::Any> for StatusDetails {
 #[cfg(test)]
 mod test {
     use super::*;
+    use anyhow::Result;
     use rpc::model::BadRequest;
     use rpc::model::DebugInfo;
     use rpc::model::ErrorInfo;
@@ -462,7 +463,6 @@ mod test {
     use rpc::model::RetryInfo;
     use serde_json::json;
     use test_case::test_case;
-    type Result = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[test]
     fn status_basic_setters() {
@@ -488,7 +488,7 @@ mod test {
     }
 
     #[test]
-    fn status_detail_setter() -> Result {
+    fn status_detail_setter() -> Result<()> {
         let d0 = StatusDetails::ErrorInfo(rpc::model::ErrorInfo::new().set_reason("test-reason"));
         let d1 = StatusDetails::Help(
             rpc::model::Help::new().set_links([rpc::model::help::Link::new().set_url("test-url")]),
@@ -679,18 +679,16 @@ mod test {
     }
 
     #[test]
-    fn serialization_other() {
+    fn serialization_other() -> Result<()> {
         const TIME: &str = "2025-05-27T10:00:00Z";
-        let timestamp =
-            wkt::Timestamp::try_from(TIME).expect("hardcoded value is expected to convert");
-        let any =
-            wkt::Any::from_msg(&timestamp).expect("good timestamp value should encode into Any");
+        let timestamp = wkt::Timestamp::try_from(TIME)?;
+        let any = wkt::Any::from_msg(&timestamp)?;
         let input = Status {
             code: Code::Unknown,
             message: "test".to_string(),
             details: vec![StatusDetails::Other(any)],
         };
-        let got = serde_json::to_value(&input).expect("serialization succeeds");
+        let got = serde_json::to_value(&input)?;
         let want = json!({
             "code": Code::Unknown as i32,
             "message": "test",
@@ -699,10 +697,11 @@ mod test {
             ]
         });
         assert_eq!(got, want);
+        Ok(())
     }
 
     #[test]
-    fn deserialization_other() {
+    fn deserialization_other() -> Result<()> {
         const TIME: &str = "2025-05-27T10:00:00Z";
         let json = json!({
             "code": Code::Unknown as i32,
@@ -711,17 +710,16 @@ mod test {
                 {"@type": "type.googleapis.com/google.protobuf.Timestamp", "value": TIME},
             ]
         });
-        let timestamp =
-            wkt::Timestamp::try_from(TIME).expect("hardcoded value is expected to convert");
-        let any =
-            wkt::Any::from_msg(&timestamp).expect("good timestamp value should encode into Any");
-        let got: Status = serde_json::from_value(json).unwrap();
+        let timestamp = wkt::Timestamp::try_from(TIME)?;
+        let any = wkt::Any::from_msg(&timestamp)?;
+        let got: Status = serde_json::from_value(json)?;
         let want = Status {
             code: Code::Unknown,
             message: "test".to_string(),
             details: vec![StatusDetails::Other(any)],
         };
         assert_eq!(got, want);
+        Ok(())
     }
 
     #[test]
@@ -827,7 +825,7 @@ mod test {
     }
 
     #[test]
-    fn try_from_bytes() -> Result {
+    fn try_from_bytes() -> Result<()> {
         let got = Status::try_from(&bytes::Bytes::from_static(SAMPLE_PAYLOAD))?;
         let want = sample_status();
         assert_eq!(got, want);
@@ -871,8 +869,8 @@ mod test {
     #[test_case("UNAVAILABLE")]
     #[test_case("DATA_LOSS")]
     #[test_case("UNAUTHENTICATED")]
-    fn code_roundtrip(input: &str) -> Result {
-        let code = Code::try_from(input)?;
+    fn code_roundtrip(input: &str) -> Result<()> {
+        let code = Code::try_from(input).unwrap();
         let output = String::from(code);
         assert_eq!(output.as_str(), input.to_string());
         assert_eq!(&format!("{code}"), input);
@@ -897,7 +895,7 @@ mod test {
     #[test_case("UNAVAILABLE")]
     #[test_case("DATA_LOSS")]
     #[test_case("UNAUTHENTICATED")]
-    fn code_serialize_roundtrip(input: &str) -> Result {
+    fn code_serialize_roundtrip(input: &str) -> Result<()> {
         let want = Code::try_from(input).unwrap();
         let serialized = serde_json::to_value(want)?;
         let got = serde_json::from_value::<Code>(serialized)?;
@@ -922,7 +920,7 @@ mod test {
     }
 
     #[test]
-    fn code_deserialize_unknown() -> Result {
+    fn code_deserialize_unknown() -> Result<()> {
         let input = json!(-17);
         let code = serde_json::from_value::<Code>(input)?;
         assert_eq!(code, Code::Unknown);


### PR DESCRIPTION
We were supposed to put those in the `Other` variant, but it simply
failing to deserialize.

Found while implementing #2202
