### PR TITLE
feat(gax): introduce `client_builder::Error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,6 +2367,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "test-case",
+ "thiserror",
  "tokio",
  "tokio-test",
 ]

--- a/src/gax/Cargo.toml
+++ b/src/gax/Cargo.toml
@@ -38,6 +38,7 @@ pin-project.workspace = true
 rand                  = { workspace = true, features = ["thread_rng"] }
 serde.workspace       = true
 serde_json.workspace  = true
+thiserror.workspace   = true
 tokio                 = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 # Local crates
 rpc.workspace = true


### PR DESCRIPTION
Introduce a new type to represent errors in `ClientBuilder`.

Part of the work for #2221
