### PR TITLE
impl(gax): introduce `client_builder::Error`

### DIFF
--- a/src/gax/src/client_builder.rs
+++ b/src/gax/src/client_builder.rs
@@ -78,7 +78,7 @@ pub type Result<T> = std::result::Result<T, crate::error::Error>;
 ///         return Err(e);
 ///     }
 /// };
-/// 
+///
 /// fn placeholder() -> std::result::Result<Client, Error> {
 ///   # panic!();
 /// }


### PR DESCRIPTION
This is an specific error type for client builders. It provides more
specific reasons than `gax::error::Error`. It is designed to grow
without breaking changes.

Part of the work for #2285
