### PR TITLE
cleanup(gax)!: hide `CredentialsError` details

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -26,7 +26,6 @@ pub(crate) mod internal;
 pub mod mds;
 pub mod service_account;
 pub mod user_account;
-
 pub(crate) const QUOTA_PROJECT_KEY: &str = "x-goog-user-project";
 pub(crate) const DEFAULT_UNIVERSE_DOMAIN: &str = "googleapis.com";
 
@@ -646,7 +645,7 @@ pub mod testing {
     #[async_trait::async_trait]
     impl CredentialsProvider for ErrorCredentials {
         async fn headers(&self, _extensions: Extensions) -> Result<CacheableResource<HeaderMap>> {
-            Err(super::CredentialsError::from_str(self.0, "test-only"))
+            Err(super::CredentialsError::from_msg(self.0, "test-only"))
         }
 
         async fn universe_domain(&self) -> Option<String> {
@@ -674,7 +673,7 @@ mod test {
     ) -> Result<HeaderMap> {
         match headers {
             CacheableResource::New { data, .. } => Ok(data),
-            CacheableResource::NotModified => Err(CredentialsError::from_str(
+            CacheableResource::NotModified => Err(CredentialsError::from_msg(
                 false,
                 "Expecting headers to be present",
             )),
@@ -863,9 +862,9 @@ mod test {
             "{credentials:?}"
         );
         let err = credentials.headers(Extensions::new()).await.err().unwrap();
-        assert_eq!(err.is_retryable(), retryable, "{err:?}");
+        assert_eq!(err.is_transient(), retryable, "{err:?}");
         let err = credentials.headers(Extensions::new()).await.err().unwrap();
-        assert_eq!(err.is_retryable(), retryable, "{err:?}");
+        assert_eq!(err.is_transient(), retryable, "{err:?}");
     }
 
     #[tokio::test]

--- a/src/auth/src/credentials/internal/sts_exchange.rs
+++ b/src/auth/src/credentials/internal/sts_exchange.rs
@@ -86,12 +86,12 @@ impl STSHandler {
             .send()
             .await
             .map_err(|err| {
-                CredentialsError::from_str(false, format!("failed to request token: {}", err))
+                CredentialsError::from_msg(false, format!("failed to request token: {}", err))
             })?;
 
         let status = res.status();
         if !status.is_success() {
-            return Err(CredentialsError::from_str(
+            return Err(CredentialsError::from_msg(
                 false,
                 format!("error exchanging token, failed with status {status}"),
             ));
@@ -99,7 +99,7 @@ impl STSHandler {
         let token_res = res
             .json::<TokenResponse>()
             .await
-            .map_err(|err| CredentialsError::new(false, err))?;
+            .map_err(|err| CredentialsError::from_source(false, err))?;
         Ok(token_res)
     }
 }
@@ -319,7 +319,7 @@ mod test {
         };
         let err = assert_err!(STSHandler::exchange_token(token_req).await);
 
-        let expected_err = crate::errors::CredentialsError::from_str(
+        let expected_err = crate::errors::CredentialsError::from_msg(
             false,
             "error exchanging token, failed with status 400 Bad Request",
         );

--- a/src/auth/src/credentials/internal/sts_exchange.rs
+++ b/src/auth/src/credentials/internal/sts_exchange.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::credentials::errors::CredentialsError;
+use crate::credentials::errors::{self, CredentialsError};
 use base64::Engine;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -85,16 +85,12 @@ impl STSHandler {
             .headers(headers)
             .send()
             .await
-            .map_err(|err| {
-                CredentialsError::from_msg(false, format!("failed to request token: {}", err))
-            })?;
+            .map_err(|e| errors::from_http_error(e, MSG))?;
 
         let status = res.status();
         if !status.is_success() {
-            return Err(CredentialsError::from_msg(
-                false,
-                format!("error exchanging token, failed with status {status}"),
-            ));
+            let err = errors::from_http_response(res, MSG).await;
+            return Err(err);
         }
         let token_res = res
             .json::<TokenResponse>()
@@ -103,6 +99,8 @@ impl STSHandler {
         Ok(token_res)
     }
 }
+
+const MSG: &str = "failed to exchange token";
 
 /// TokenResponse is used to decode the remote server response during
 /// an oauth2 token exchange.
@@ -171,9 +169,11 @@ pub struct RefreshAccessTokenRequest {
 #[cfg(test)]
 mod test {
     use super::*;
+    use http::StatusCode;
     use httptest::{Expectation, Server, matchers::*, responders::*};
     use serde_json::json;
-    use tokio_test::assert_err;
+    use std::error::Error as _;
+
     type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
 
     #[tokio::test]
@@ -317,13 +317,20 @@ mod test {
             subject_token_type: JWT_TOKEN_TYPE.to_string(),
             ..ExchangeTokenRequest::default()
         };
-        let err = assert_err!(STSHandler::exchange_token(token_req).await);
-
-        let expected_err = crate::errors::CredentialsError::from_msg(
-            false,
-            "error exchanging token, failed with status 400 Bad Request",
+        let err = STSHandler::exchange_token(token_req).await.unwrap_err();
+        assert!(!err.is_transient(), "{err:?}");
+        assert!(err.to_string().contains(MSG), "{err}, debug={err:?}");
+        assert!(
+            err.to_string().contains("bad request"),
+            "{err}, debug={err:?}"
         );
-        assert_eq!(err.to_string(), expected_err.to_string());
+        let source = err
+            .source()
+            .and_then(|e| e.downcast_ref::<reqwest::Error>());
+        assert!(
+            matches!(source, Some(e) if e.status() == Some(StatusCode::BAD_REQUEST)),
+            "{err:?}"
+        );
 
         Ok(())
     }

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -461,9 +461,6 @@ mod test {
         let not_want = MDS_NOT_FOUND_ERROR;
         let got = provider.error_message();
         assert!(!got.contains(not_want), "{got}, {provider:?}");
-
-        let got = provider.error_message();
-        assert!(!got.contains(not_want), "{got}, {provider:?}");
     }
 
     #[tokio::test]

--- a/src/auth/src/credentials/mds.rs
+++ b/src/auth/src/credentials/mds.rs
@@ -451,11 +451,11 @@ mod test {
     #[test_case(false, false)]
     #[test_case(false, true)]
     #[test_case(true, true)]
-    fn error_message_without_adc(adc: bool, overriden: bool) {
+    fn error_message_without_adc(adc: bool, overridden: bool) {
         let provider = MDSAccessTokenProvider::builder()
             .endpoint("http://127.0.0.1")
             .created_by_adc(adc)
-            .endpoint_overridden(overriden)
+            .endpoint_overridden(overridden)
             .build();
 
         let not_want = MDS_NOT_FOUND_ERROR;

--- a/src/auth/src/credentials/user_account.rs
+++ b/src/auth/src/credentials/user_account.rs
@@ -69,7 +69,7 @@
 use crate::build_errors::Error as BuilderError;
 use crate::credentials::dynamic::CredentialsProvider;
 use crate::credentials::{CacheableResource, Credentials};
-use crate::errors::{self, CredentialsError, is_retryable};
+use crate::errors::{self, CredentialsError};
 use crate::headers_util::build_cacheable_headers;
 use crate::token::{CachedTokenProvider, Token, TokenProvider};
 use crate::token_cache::TokenCache;
@@ -270,19 +270,12 @@ impl TokenProvider for UserTokenProvider {
 
         // Process the response
         if !resp.status().is_success() {
-            let status = resp.status();
-            let body = resp
-                .text()
-                .await
-                .map_err(|e| CredentialsError::new(is_retryable(status), e))?;
-            return Err(CredentialsError::from_str(
-                is_retryable(status),
-                format!("Failed to fetch token. {body}"),
-            ));
+            let err = errors::from_http_error(resp).await;
+            return Err(err);
         }
         let response = resp.json::<Oauth2RefreshResponse>().await.map_err(|e| {
             let retryable = !e.is_decode();
-            CredentialsError::new(retryable, e)
+            CredentialsError::from_source(retryable, e)
         })?;
         let token = Token {
             token: response.access_token,
@@ -921,9 +914,16 @@ mod test {
             "token_uri": endpoint});
 
         let uc = Builder::new(authorized_user).build()?;
-        let e = uc.headers(Extensions::new()).await.err().unwrap();
-        assert!(e.is_retryable(), "{e}");
-        assert!(e.source().unwrap().to_string().contains("try again"), "{e}");
+        let err = uc.headers(Extensions::new()).await.unwrap_err();
+        assert!(err.is_transient(), "{err}");
+        assert!(err.to_string().contains("try again"), "{err:?}");
+        let source = err
+            .source()
+            .and_then(|e| e.downcast_ref::<reqwest::Error>());
+        assert!(
+            matches!(source, Some(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE)),
+            "{err:?}"
+        );
 
         Ok(())
     }
@@ -946,9 +946,16 @@ mod test {
             "token_uri": endpoint});
 
         let uc = Builder::new(authorized_user).build()?;
-        let e = uc.headers(Extensions::new()).await.err().unwrap();
-        assert!(!e.is_retryable(), "{e}");
-        assert!(e.source().unwrap().to_string().contains("epic fail"), "{e}");
+        let err = uc.headers(Extensions::new()).await.unwrap_err();
+        assert!(!err.is_transient(), "{err:?}");
+        assert!(err.to_string().contains("epic fail"), "{err:?}");
+        let source = err
+            .source()
+            .and_then(|e| e.downcast_ref::<reqwest::Error>());
+        assert!(
+            matches!(source, Some(e) if e.status() == Some(StatusCode::UNAUTHORIZED)),
+            "{err:?}"
+        );
 
         Ok(())
     }
@@ -968,11 +975,12 @@ mod test {
             "client_secret": "test-client-secret",
             "refresh_token": "test-refresh-token",
             "type": "authorized_user",
-            "token_uri": endpoint});
+            "token_uri": endpoint
+        });
 
         let uc = Builder::new(authorized_user).build()?;
         let e = uc.headers(Extensions::new()).await.err().unwrap();
-        assert!(!e.is_retryable(), "{e}");
+        assert!(!e.is_transient(), "{e}");
 
         Ok(())
     }
@@ -980,9 +988,9 @@ mod test {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn builder_malformed_authorized_json_nonretryable() -> TestResult {
         let authorized_user = serde_json::json!({
-        "client_secret": "test-client-secret",
-        "refresh_token": "test-refresh-token",
-        "type": "authorized_user",
+            "client_secret": "test-client-secret",
+            "refresh_token": "test-refresh-token",
+            "type": "authorized_user",
         });
 
         let e = Builder::new(authorized_user).build().unwrap_err();

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -17,25 +17,38 @@
 use http::StatusCode;
 use std::error::Error;
 
-pub use gax::error::CredentialsError;
+pub use gax::error::{BuildCredentialsError, CredentialsError};
+
+/// A helper to create an error from a failed HTTP request.
+pub(crate) async fn from_http_error(response: reqwest::Response) -> CredentialsError {
+    let transient = is_retryable(response.status());
+    let err = response.error_for_status_ref().unwrap_err();
+    let body = response.text().await;
+    match body {
+        Err(e) => CredentialsError::from_source(transient, e),
+        Ok(b) => {
+            CredentialsError::new(transient, format!("Failed to fetch token, body=<{b}>"), err)
+        }
+    }
+}
 
 /// A helper to create a retryable error.
 pub(crate) fn retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialsError {
-    CredentialsError::new(true, source)
+    CredentialsError::from_source(true, source)
 }
 
 #[allow(dead_code)]
 pub(crate) fn retryable_from_str<T: Into<String>>(message: T) -> CredentialsError {
-    CredentialsError::from_str(true, message)
+    CredentialsError::from_msg(true, message)
 }
 
 /// A helper to create a non-retryable error.
 pub(crate) fn non_retryable<T: Error + Send + Sync + 'static>(source: T) -> CredentialsError {
-    CredentialsError::new(false, source)
+    CredentialsError::from_source(false, source)
 }
 
 pub(crate) fn non_retryable_from_str<T: Into<String>>(message: T) -> CredentialsError {
-    CredentialsError::from_str(false, message)
+    CredentialsError::from_msg(false, message)
 }
 
 pub(crate) fn is_retryable(c: StatusCode) -> bool {
@@ -53,6 +66,7 @@ pub(crate) fn is_retryable(c: StatusCode) -> bool {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::num::ParseIntError;
     use test_case::test_case;
 
     #[test_case(StatusCode::INTERNAL_SERVER_ERROR)]
@@ -75,25 +89,25 @@ mod test {
     #[test]
     fn helpers() {
         let e = super::retryable_from_str("test-only-err-123");
-        assert!(e.is_retryable(), "{e}");
-        assert!(e.source().unwrap().source().is_none());
+        assert!(e.is_transient(), "{e}");
+        assert!(e.source().is_none());
         let got = format!("{e}");
         assert!(got.contains("test-only-err-123"), "{got}");
 
         let input = "NaN".parse::<u32>().unwrap_err();
         let e = super::retryable(input.clone());
-        assert!(e.is_retryable(), "{e}");
-        let got = format!("{e}");
-        assert!(got.contains(&format!("{input}")), "{got}");
+        assert!(e.is_transient(), "{e:?}");
+        let source = e.source().and_then(|e| e.downcast_ref::<ParseIntError>());
+        assert!(matches!(source, Some(ParseIntError { .. })), "{e:?}");
 
         let e = super::non_retryable_from_str("test-only-err-123");
-        assert!(!e.is_retryable(), "{e}");
+        assert!(!e.is_transient(), "{e}");
         let got = format!("{e}");
         assert!(got.contains("test-only-err-123"), "{got}");
 
         let e = super::non_retryable(input.clone());
-        assert!(!e.is_retryable(), "{e}");
-        let got = format!("{e}");
-        assert!(got.contains(&format!("{input}")), "{got}");
+        assert!(!e.is_transient(), "{e:?}");
+        let source = e.source().and_then(|e| e.downcast_ref::<ParseIntError>());
+        assert!(matches!(source, Some(ParseIntError { .. })), "{e:?}");
     }
 }

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -22,7 +22,9 @@ pub use gax::error::{BuildCredentialsError, CredentialsError};
 /// A helper to create an error from a failed HTTP request.
 pub(crate) async fn from_http_error(response: reqwest::Response) -> CredentialsError {
     let transient = is_retryable(response.status());
-    let err = response.error_for_status_ref().unwrap_err();
+    let err = response
+        .error_for_status_ref()
+        .expect_err("this function is only called on errors");
     let body = response.text().await;
     match body {
         Err(e) => CredentialsError::from_source(transient, e),

--- a/src/auth/src/errors.rs
+++ b/src/auth/src/errors.rs
@@ -17,7 +17,7 @@
 use http::StatusCode;
 use std::error::Error;
 
-pub use gax::error::{BuildCredentialsError, CredentialsError};
+pub use gax::error::CredentialsError;
 
 pub(crate) fn from_http_error(err: reqwest::Error, msg: &str) -> CredentialsError {
     let transient = self::is_retryable(&err);

--- a/src/auth/src/headers_util.rs
+++ b/src/auth/src/headers_util.rs
@@ -106,6 +106,7 @@ fn build_headers(
 mod test {
     use super::*;
     use crate::{credentials::EntityTag, token::Token};
+    use std::error::Error as _;
 
     // Helper to create test tokens
     fn create_test_token(token: &str, token_type: &str) -> Token {
@@ -215,7 +216,14 @@ mod test {
 
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("fail"));
+        assert!(!error.is_transient(), "{error:?}");
+        let source = error
+            .source()
+            .and_then(|e| e.downcast_ref::<http::header::InvalidHeaderValue>());
+        assert!(
+            matches!(source, Some(http::header::InvalidHeaderValue { .. })),
+            "{error:?}"
+        );
     }
 
     #[test]
@@ -294,12 +302,16 @@ mod test {
     #[test]
     fn build_api_key_headers_invalid_token() {
         let token = create_test_token("api_key with \n invalid chars", "Bearer");
-
         let result = build_api_key_headers(&token, &None);
-
-        assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("fail"));
+        assert!(!error.is_transient(), "{error:?}");
+        let source = error
+            .source()
+            .and_then(|e| e.downcast_ref::<http::header::InvalidHeaderValue>());
+        assert!(
+            matches!(source, Some(http::header::InvalidHeaderValue { .. })),
+            "{error:?}"
+        );
     }
 
     #[test]
@@ -311,6 +323,13 @@ mod test {
 
         assert!(result.is_err());
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("fail"));
+        assert!(!error.is_transient(), "{error:?}");
+        let source = error
+            .source()
+            .and_then(|e| e.downcast_ref::<http::header::InvalidHeaderValue>());
+        assert!(
+            matches!(source, Some(http::header::InvalidHeaderValue { .. })),
+            "{error:?}"
+        );
     }
 }

--- a/src/auth/src/token_cache.rs
+++ b/src/auth/src/token_cache.rs
@@ -157,7 +157,7 @@ mod test {
     fn get_cached_token(cache: CacheableResource<Token>) -> Result<Token> {
         match cache {
             CacheableResource::New { data, .. } => Ok(data),
-            CacheableResource::NotModified => Err(CredentialsError::from_str(
+            CacheableResource::NotModified => Err(CredentialsError::from_msg(
                 false,
                 "Expecting token to be present.",
             )),

--- a/src/gax-internal/tests/grpc_auth.rs
+++ b/src/gax-internal/tests/grpc_auth.rs
@@ -86,7 +86,7 @@ mod test {
         let mut mock = MockCredentials::new();
         mock.expect_headers()
             .times(retry_count..)
-            .returning(|_extensions| Err(CredentialsError::from_str(true, "mock retryable error")));
+            .returning(|_extensions| Err(CredentialsError::from_msg(true, "mock retryable error")));
 
         let retry_policy = Aip194Strict.with_attempt_limit(retry_count as u32);
         let client = builder(endpoint)
@@ -102,7 +102,7 @@ mod test {
         if let Err(e) = result {
             if let Some(cred_err) = e.as_inner::<CredentialsError>() {
                 assert!(
-                    cred_err.is_retryable(),
+                    cred_err.is_transient(),
                     "Expected a retryable CredentialsError, but got non-retryable"
                 );
             } else {
@@ -114,7 +114,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[test_case::test_case(Err(CredentialsError::from_str(
+    #[test_case::test_case(Err(CredentialsError::from_msg(
         false,
         "mock non-retryable error",
     )); "on_error_response")]
@@ -139,7 +139,7 @@ mod test {
         if let Err(e) = result {
             if let Some(cred_err) = e.as_inner::<CredentialsError>() {
                 assert!(
-                    !cred_err.is_retryable(),
+                    !cred_err.is_transient(),
                     "Expected a non-retryable CredentialsError, but got retryable"
                 );
             } else {

--- a/src/gax-internal/tests/http_auth.rs
+++ b/src/gax-internal/tests/http_auth.rs
@@ -89,7 +89,7 @@ mod test {
         let mut mock = MockCredentials::new();
         mock.expect_headers()
             .times(retry_count..)
-            .returning(|_extensions| Err(CredentialsError::from_str(true, "mock retryable error")));
+            .returning(|_extensions| Err(CredentialsError::from_msg(true, "mock retryable error")));
 
         let retry_policy = Aip194Strict.with_attempt_limit(retry_count as u32);
         let client = echo_server::builder(endpoint)
@@ -111,7 +111,7 @@ mod test {
         if let Err(e) = result {
             if let Some(cred_err) = e.as_inner::<CredentialsError>() {
                 assert!(
-                    cred_err.is_retryable(),
+                    cred_err.is_transient(),
                     "Expected a retryable CredentialsError, but got non-retryable"
                 );
             } else {
@@ -123,7 +123,7 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[test_case::test_case(Err(CredentialsError::from_str(
+    #[test_case::test_case(Err(CredentialsError::from_msg(
         false,
         "mock non-retryable error",
     )); "on_error_response")]
@@ -157,7 +157,7 @@ mod test {
         if let Err(e) = result {
             if let Some(cred_err) = e.as_inner::<CredentialsError>() {
                 assert!(
-                    !cred_err.is_retryable(),
+                    !cred_err.is_transient(),
                     "Expected a non-retryable CredentialsError, but got retryable"
                 );
             } else {

--- a/src/gax/src/error.rs
+++ b/src/gax/src/error.rs
@@ -15,7 +15,6 @@
 mod core_error;
 pub use core_error::*;
 mod credentials;
-pub use credentials::BuildCredentialsError;
 pub use credentials::CredentialsError;
 mod http_error;
 pub use http_error::*;

--- a/src/gax/src/error.rs
+++ b/src/gax/src/error.rs
@@ -15,6 +15,7 @@
 mod core_error;
 pub use core_error::*;
 mod credentials;
+pub use credentials::BuildCredentialsError;
 pub use credentials::CredentialsError;
 mod http_error;
 pub use http_error::*;

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -16,14 +16,34 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::sync::Arc;
 
-/// Represents an error creating or using a [Credentials].
+type BoxError = std::boxed::Box<dyn Error + Send + Sync>;
+type ArcError = Arc<dyn Error + Send + Sync>;
+
+/// Represents an error creating [Credentials].
 ///
-/// The Google Cloud client libraries may experience problems creating
-/// credentials and/or using them. An example of problems creating credentials
-/// may be a badly formatted or missing key file. An example of problems using
-/// credentials may be a temporary failure to retrieve or create
-/// [access tokens]. Note that the latter kind of errors may happen even after
-/// the credentials files are successfully loaded and parsed.
+/// Applications rarely need to create instances of this error type. The
+/// exception might be when testing application code, where the application is
+/// mocking a client library behavior. Such tests are extremely rare, most
+/// applications should only work with the [Error][crate::error::Error] type.
+///
+/// [Credentials]: https://docs.rs/google-cloud-auth/latest/google_cloud_auth/credentials/struct.Credential.html
+#[derive(thiserror::Error, Debug)]
+#[non_exhaustive]
+pub enum BuildCredentialsError {
+    #[error("could not find or open the credentials file {0}")]
+    Loading(#[source] BoxError),
+    #[error("cannot parse the credentials file {0}")]
+    Parsing(#[source] BoxError),
+    #[error("unknown or invalid credentials type {0}")]
+    UnknownType(#[source] BoxError),
+}
+
+/// Represents an error using [Credentials].
+///
+/// The Google Cloud client libraries may experience problems using credentials
+/// to create the necessary authentication headers. For example, a temporary
+/// failure to retrieve or create [access tokens]. Note that these failures may
+/// happen even after the credentials files are successfully loaded and parsed.
 ///
 /// Applications rarely need to create instances of this error type. The
 /// exception might be when testing application code, where the application is
@@ -32,33 +52,26 @@ use std::sync::Arc;
 ///
 /// # Example
 /// ```
-/// # use google_cloud_gax::error::CredentialsError;
-/// let err = CredentialsError::from_str(
-///     true, "simulated retryable error while trying to create credentials");
-/// assert!(err.is_retryable());
-/// assert!(format!("{err}").contains("simulated retryable error"));
+/// use google_cloud_gax::error::CredentialsError;
+/// let mut headers = fetch_headers();
+/// while let Err(e) = &headers {
+///     if e.is_transient() {
+///         headers = fetch_headers();
+///     }
+/// }
+///
+/// fn fetch_headers() -> Result<http::HeaderMap, CredentialsError> {
+///   # Ok(http::HeaderMap::new())
+/// }
 /// ```
 ///
 /// [access tokens]: https://cloud.google.com/docs/authentication/token-types
 /// [Credentials]: https://docs.rs/google-cloud-auth/latest/google_cloud_auth/credentials/struct.Credential.html
 #[derive(Clone, Debug)]
 pub struct CredentialsError {
-    /// A boolean value indicating whether the error is retryable.
-    ///
-    /// If `true`, the operation that resulted in this error might succeed upon
-    /// retry.
-    is_retryable: bool,
-
-    /// The underlying source of the error.
-    ///
-    /// This provides more specific information about the cause of the failure.
-    source: CredentialsErrorImpl,
-}
-
-#[derive(Clone, Debug)]
-enum CredentialsErrorImpl {
-    SimpleMessage(String),
-    Source(Arc<dyn Error + Send + Sync>),
+    is_transient: bool,
+    message: Option<String>,
+    source: Option<ArcError>,
 }
 
 impl CredentialsError {
@@ -71,20 +84,28 @@ impl CredentialsError {
     ///
     /// # Example
     /// ```
-    /// # use google_cloud_gax::error::CredentialsError;
-    /// # use google_cloud_gax::error::Error;
-    /// let source = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "cannot connect");
-    /// let err = CredentialsError::new(true, source);
-    /// assert!(err.is_retryable());
-    /// assert!(format!("{err}").contains("cannot connect"));
+    /// use google_cloud_gax::error::CredentialsError;
+    /// let mut headers = fetch_headers();
+    /// while let Err(e) = &headers {
+    ///     if e.is_transient() {
+    ///         headers = fetch_headers();
+    ///     }
+    /// }
+    ///
+    /// fn fetch_headers() -> Result<http::HeaderMap, CredentialsError> {
+    ///   # Ok(http::HeaderMap::new())
+    /// }
     /// ```
+    ///
     /// # Parameters
-    /// * `is_retryable` - A boolean indicating whether the error is retryable.
+    /// * `is_transient` - if true, the operation may succeed in future attempts.
     /// * `source` - The underlying error that caused the auth failure.
-    pub fn new<T: Error + Send + Sync + 'static>(is_retryable: bool, source: T) -> Self {
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+    pub fn from_source<T: Error + Send + Sync + 'static>(is_transient: bool, source: T) -> Self {
         CredentialsError {
-            is_retryable,
-            source: CredentialsErrorImpl::Source(Arc::new(source)),
+            is_transient,
+            source: Some(Arc::new(source)),
+            message: None,
         }
     }
 
@@ -98,68 +119,103 @@ impl CredentialsError {
     /// # Example
     /// ```
     /// # use google_cloud_gax::error::CredentialsError;
-    /// let err = CredentialsError::from_str(
+    /// let err = CredentialsError::from_msg(
     ///     true, "simulated retryable error while trying to create credentials");
-    /// assert!(err.is_retryable());
+    /// assert!(err.is_transient());
     /// assert!(format!("{err}").contains("simulated retryable error"));
     /// ```
     ///
     /// # Parameters
-    /// * `is_retryable` - A boolean indicating whether the error is retryable.
+    /// * `is_transient` - if true, the operation may succeed in future attempts.
     /// * `message` - The underlying error that caused the auth failure.
-    pub fn from_str<T: Into<String>>(is_retryable: bool, message: T) -> Self {
-        CredentialsError::new(
-            is_retryable,
-            CredentialsErrorImpl::SimpleMessage(message.into()),
-        )
-    }
-
-    /// Returns `true` if the error is retryable; otherwise returns `false`.
-    pub fn is_retryable(&self) -> bool {
-        self.is_retryable
-    }
-}
-
-impl std::error::Error for CredentialsErrorImpl {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self {
-            CredentialsErrorImpl::SimpleMessage(_) => None,
-            CredentialsErrorImpl::Source(arc) => Some(arc.as_ref()),
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+    pub fn from_msg<T: Into<String>>(is_transient: bool, message: T) -> Self {
+        CredentialsError {
+            is_transient,
+            message: Some(message.into()),
+            source: None,
         }
     }
-}
 
-impl Display for CredentialsErrorImpl {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        match &self {
-            CredentialsErrorImpl::SimpleMessage(message) => write!(f, "{}", message),
-            CredentialsErrorImpl::Source(source) => write!(f, "{}", source),
+    /// Creates a new `CredentialsError`.
+    ///
+    /// This function is only intended for use in the client libraries
+    /// implementation. Application may use this in mocks, though we do not
+    /// recommend that you write tests for specific error cases. Most tests
+    /// should use the generic [Error][crate::error::Error] type.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::error::CredentialsError;
+    /// let source = std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "cannot connect");
+    /// let err = CredentialsError::new(
+    ///     true,
+    ///     "simulated retryable error while trying to create credentials",
+    ///     source);
+    /// assert!(err.is_transient());
+    /// assert!(format!("{err}").contains("simulated retryable error"));
+    /// ```
+    ///
+    /// # Parameters
+    /// * `is_transient` - if true, the operation may succeed in future attempts.
+    /// * `message` - The underlying error that caused the auth failure.
+    #[cfg_attr(not(feature = "_internal-semver"), doc(hidden))]
+    pub fn new<M, S>(is_transient: bool, message: M, source: S) -> Self
+    where
+        M: Into<String>,
+        S: std::error::Error + Send + Sync + 'static,
+    {
+        CredentialsError {
+            is_transient,
+            message: Some(message.into()),
+            source: Some(Arc::new(source)),
         }
+    }
+
+    /// Returns true if the error is transient and may succeed in future attempts.
+    ///
+    /// # Example
+    /// ```
+    /// # use google_cloud_gax::error::CredentialsError;
+    /// let mut headers = fetch_headers();
+    /// while let Err(e) = &headers {
+    ///     if e.is_transient() {
+    ///         headers = fetch_headers();
+    ///     }
+    /// }
+    ///
+    /// fn fetch_headers() -> Result<http::HeaderMap, CredentialsError> {
+    ///   # Ok(http::HeaderMap::new())
+    /// }
+    /// ```
+    pub fn is_transient(&self) -> bool {
+        self.is_transient
     }
 }
 
 impl std::error::Error for CredentialsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.source.source()
+        self.source
+            .as_ref()
+            .map(|arc| arc.as_ref() as &(dyn std::error::Error + 'static))
     }
 }
 
-const RETRYABLE_MSG: &str = "but future attempts may succeed";
-const NON_RETRYABLE_MSG: &str = "and future attempts will not succeed";
+const TRANSIENT_MSG: &str = "but future attempts may succeed";
+const PERMANENT_MSG: &str = "and future attempts will not succeed";
 
 impl Display for CredentialsError {
     /// Formats the error message to include retryability and source.
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let msg = if self.is_retryable {
-            RETRYABLE_MSG
+        let msg = if self.is_transient {
+            TRANSIENT_MSG
         } else {
-            NON_RETRYABLE_MSG
+            PERMANENT_MSG
         };
-        write!(
-            f,
-            "cannot create access token, {}, source:{}",
-            msg, self.source
-        )
+        match &self.message {
+            None => write!(f, "cannot create auth headers {msg}"),
+            Some(m) => write!(f, "{m} {msg}"),
+        }
     }
 }
 
@@ -170,46 +226,59 @@ mod test {
 
     #[test_case(true)]
     #[test_case(false)]
-    fn new(retryable: bool) {
+    fn from_source(transient: bool) {
         let source = wkt::TimestampError::OutOfRange;
-        let got = CredentialsError::new(retryable, source);
-        assert_eq!(got.is_retryable(), retryable, "{got}");
-        assert!(got.source().is_some(), "{got}");
+        let got = CredentialsError::from_source(transient, source);
+        assert_eq!(got.is_transient(), transient, "{got:?}");
         assert!(
             got.source()
                 .and_then(|e| e.downcast_ref::<wkt::TimestampError>())
                 .is_some(),
-            "{got}"
+            "{got:?}"
+        );
+        assert!(
+            got.to_string().contains("cannot create auth headers"),
+            "{got:?}"
         );
     }
 
     #[test_case(true)]
     #[test_case(false)]
-    fn from_str(retryable: bool) {
-        let got = CredentialsError::from_str(retryable, "test-only");
-        assert_eq!(got.is_retryable(), retryable, "{got}");
-        assert!(got.source().is_some(), "{got}");
-        assert!(format!("{got}").contains("test-only"), "{got}");
+    fn from_str(transient: bool) {
+        let got = CredentialsError::from_msg(transient, "test-only");
+        assert_eq!(got.is_transient(), transient, "{got:?}");
+        assert!(got.source().is_none(), "{got:?}");
+        assert!(got.to_string().contains("test-only"), "{got}");
+    }
+
+    #[test_case(true)]
+    #[test_case(false)]
+    fn new(transient: bool) {
+        let source = wkt::TimestampError::OutOfRange;
+        let got = CredentialsError::new(transient, "additional information", source);
+        assert_eq!(got.is_transient(), transient, "{got:?}");
+        assert!(
+            got.source()
+                .and_then(|e| e.downcast_ref::<wkt::TimestampError>())
+                .is_some(),
+            "{got:?}"
+        );
+        assert!(
+            got.to_string().contains("additional information"),
+            "{got:?}"
+        );
     }
 
     #[test]
     fn fmt() {
-        let e = CredentialsError::from_str(true, "test-only-err-123");
+        let e = CredentialsError::from_msg(true, "test-only-err-123");
         let got = format!("{e}");
         assert!(got.contains("test-only-err-123"), "{got}");
-        assert!(got.contains(RETRYABLE_MSG), "{got}");
+        assert!(got.contains(TRANSIENT_MSG), "{got}");
 
-        let e = CredentialsError::from_str(false, "test-only-err-123");
+        let e = CredentialsError::from_msg(false, "test-only-err-123");
         let got = format!("{e}");
         assert!(got.contains("test-only-err-123"), "{got}");
-        assert!(got.contains(NON_RETRYABLE_MSG), "{got}");
-    }
-
-    #[test]
-    fn source() {
-        let got = CredentialsErrorImpl::SimpleMessage("test-only".into());
-        assert!(got.source().is_none(), "{got}");
-        let got = CredentialsErrorImpl::Source(Arc::new(crate::error::Error::other("test-only")));
-        assert!(got.source().is_some(), "{got}");
+        assert!(got.contains(PERMANENT_MSG), "{got}");
     }
 }

--- a/src/gax/src/error/credentials.rs
+++ b/src/gax/src/error/credentials.rs
@@ -16,27 +16,7 @@ use std::error::Error;
 use std::fmt::{Debug, Display, Formatter, Result};
 use std::sync::Arc;
 
-type BoxError = std::boxed::Box<dyn Error + Send + Sync>;
 type ArcError = Arc<dyn Error + Send + Sync>;
-
-/// Represents an error creating [Credentials].
-///
-/// Applications rarely need to create instances of this error type. The
-/// exception might be when testing application code, where the application is
-/// mocking a client library behavior. Such tests are extremely rare, most
-/// applications should only work with the [Error][crate::error::Error] type.
-///
-/// [Credentials]: https://docs.rs/google-cloud-auth/latest/google_cloud_auth/credentials/struct.Credential.html
-#[derive(thiserror::Error, Debug)]
-#[non_exhaustive]
-pub enum BuildCredentialsError {
-    #[error("could not find or open the credentials file {0}")]
-    Loading(#[source] BoxError),
-    #[error("cannot parse the credentials file {0}")]
-    Parsing(#[source] BoxError),
-    #[error("unknown or invalid credentials type {0}")]
-    UnknownType(#[source] BoxError),
-}
 
 /// Represents an error using [Credentials].
 ///

--- a/src/gax/src/retry_policy.rs
+++ b/src/gax/src/retry_policy.rs
@@ -259,7 +259,7 @@ impl RetryPolicy for Aip194Strict {
             }
             ErrorKind::Authentication => {
                 if let Some(cred_err) = error.as_inner::<CredentialsError>() {
-                    if cred_err.is_retryable() {
+                    if cred_err.is_transient() {
                         LoopState::Continue(error)
                     } else {
                         LoopState::Permanent(error)


### PR DESCRIPTION
Used this opportunity to rename `is_retryable()` to `is_transient()`.
Whether the error is retryable depends on what you are trying to do with
the result.

Support having a message with a source error, this is useful in the MDS
case where we get an error and we want to add some troubleshooting
information.

Preserve the error source from HTTP operations and rustls crypto
operations.

Fixes #2287