### PR TITLE
ci: more, simpler, faster code coverage

### DIFF
--- a/.github/workflows/sdk.yaml
+++ b/.github/workflows/sdk.yaml
@@ -159,13 +159,7 @@ jobs:
         run: cargo version
       - name: Display rustc version
         run: rustup show active-toolchain -v
-      - run: |
-          cargo tarpaulin --out xml --all-features \
-            --package google-cloud-auth \
-            --package google-cloud-gax \
-            --package google-cloud-gax-internal \
-            --package google-cloud-lro \
-            --package google-cloud-wkt
+      - run: cargo tarpaulin --out xml
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v5
         with:

--- a/.tarpaulin.toml
+++ b/.tarpaulin.toml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Disable commit statuses
-coverage:
-  range: 80..100
-  status:
-    project: off
-    patch: off
-ignore:
+[coverage]
+all-features = true
+packages = [
+  "google-cloud-auth",
+  "google-cloud-gax",
+  "google-cloud-gax-internal",
+  "google-cloud-lro",
+  "google-cloud-storage",
+  "google-cloud-storage-control",
+  "google-cloud-wkt",
+]
+exclude-files = [
   # Ignore generated code.
-  - "**/generated/**"
-  # Ignore tools and test helpers.
-  - "src/gax-internal/echo-server"
-  - "src/gax-internal/grpc-server"
-  - "tools/check-copyright"
-  # Ignore libraries which go unused in the coverage build.
-  - "guide/samples"
-  - "src/integration-tests"
-  - "src/auth/integration-tests"
+  "**/generated/**",
+]

--- a/doc/contributor/howto-guide-set-up-development-environment.md
+++ b/doc/contributor/howto-guide-set-up-development-environment.md
@@ -126,15 +126,8 @@ cargo install cargo-tarpaulin --features vendored-openssl
 cargo tarpaulin --out xml
 ```
 
-If you prefer to exclude generated code:
-
-```bash
-cargo tarpaulin --out xml \
-  --exclude-files 'generator/**' \
-  --exclude-files 'src/generated/**' \
-  --exclude-files 'src/integration-tests/**' \
-  --exclude-files 'src/wkt/src/generated/**'
-```
+Generated code and test helpers are excluded by default. The configuration is in
+the top level `.tarpaulin.toml`.
 
 ## Integration tests
 


### PR DESCRIPTION
Introduce a `.tarpaulin.toml` config file, as it is sufficiently complicated. https://github.com/xd009642/tarpaulin?tab=readme-ov-file#config-file

Exclude generated files from the coverage generation step, instead of the report step. This seems to save some time.

Start reporting coverage for `storage`, `storage-control`.

From running locally, `cargo tarpaulin` still seemed to pick up packages like `integration-tests`, so I will continue to ignore these manually in the reporting step (`.codecov.yml`).