### PR TITLE
cleanup(auth): hide `token` module

### DIFF
--- a/src/auth/src/credentials.rs
+++ b/src/auth/src/credentials.rs
@@ -30,11 +30,15 @@ pub mod user_account;
 pub(crate) const QUOTA_PROJECT_KEY: &str = "x-goog-user-project";
 pub(crate) const DEFAULT_UNIVERSE_DOMAIN: &str = "googleapis.com";
 
-/// Represents an Entity Tag (ETag) for a cacheable resource.
+/// Represents an Entity Tag for a [CacheableResource].
 ///
 /// An `EntityTag` is an opaque token that can be used to determine if a
-/// cached resource has changed. The specific format of the ETag is
-/// determined by its generator.
+/// cached resource has changed. The specific format of this tag is an
+/// implementation detail.
+///
+/// As the name indicates, these are inspired by the ETags prevalent in HTTP
+/// caching protocols. Their implementation is very different, and are only
+/// intended for use within a single program.
 #[derive(Clone, Debug, PartialEq, Default)]
 pub struct EntityTag(u64);
 
@@ -50,7 +54,7 @@ impl EntityTag {
 ///
 /// This enum is used to provide cacheable data to the consumers of the credential provider.
 /// It allows a data provider to return either new data (with an [EntityTag]) or
-/// indicate that the client's cached version (identified by a previously provided [EntityTag])
+/// indicate that the caller's cached version (identified by a previously provided [EntityTag])
 /// is still valid.
 #[derive(Clone, PartialEq, Debug)]
 pub enum CacheableResource<T> {

--- a/src/auth/src/credentials/api_key_credentials.rs
+++ b/src/auth/src/credentials/api_key_credentials.rs
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! [API Key] Credentials type.
+//!
+//! An API key is a simple encrypted string that you can use when calling
+//! Google Cloud APIs. When you use API keys in your applications, ensure that
+//! they are kept secure during both storage and transmission.
+//!
+//! [API Key]: https://cloud.google.com/api-keys/docs/overview
+
 use crate::credentials::dynamic::CredentialsProvider;
 use crate::credentials::{CacheableResource, Credentials, Result};
 use crate::headers_util::build_cacheable_api_key_headers;

--- a/src/auth/src/lib.rs
+++ b/src/auth/src/lib.rs
@@ -45,10 +45,7 @@ pub(crate) type BuildResult<T> = std::result::Result<T, build_errors::Error>;
 /// [Credentials]: https://cloud.google.com/docs/authentication#credentials
 pub mod credentials;
 
-/// Types and functions to work with auth [Tokens].
-///
-/// [Tokens]: https://cloud.google.com/docs/authentication#token
-pub mod token;
+pub(crate) mod token;
 
 /// The token cache
 pub(crate) mod token_cache;

--- a/src/auth/src/token.rs
+++ b/src/auth/src/token.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Types and functions to work with auth [Tokens].
+//!
+//! [Tokens]: https://cloud.google.com/docs/authentication#token
+
 use crate::Result;
 use crate::credentials::CacheableResource;
 use http::Extensions;
@@ -20,7 +24,7 @@ use tokio::time::Instant;
 
 /// Represents an auth token.
 #[derive(Clone, PartialEq)]
-pub(crate) struct Token {
+pub struct Token {
     /// The actual token string.
     ///
     /// This is the value used in `Authorization:` header.


### PR DESCRIPTION
The module had no public APIs, there is no sense in documenting and making it
part of the public API.

I also fixed some documentation nits along the way.