### PR TITLE
feat: new error kind for deserialization

### DIFF
--- a/generator/internal/rust/templates/grpc-client/transport.rs.mustache
+++ b/generator/internal/rust/templates/grpc-client/transport.rs.mustache
@@ -141,7 +141,7 @@ impl super::stub::{{Codec.Name}} for {{Codec.Name}} {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,

--- a/src/firestore/src/generated/gapic/transport.rs
+++ b/src/firestore/src/generated/gapic/transport.rs
@@ -83,7 +83,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -121,7 +121,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -162,7 +162,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -197,7 +197,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -232,7 +232,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -266,7 +266,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -300,7 +300,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -335,7 +335,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -371,7 +371,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -406,7 +406,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -444,7 +444,7 @@ impl super::stub::Firestore for Firestore {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,

--- a/src/gax-internal/src/grpc.rs
+++ b/src/gax-internal/src/grpc.rs
@@ -265,6 +265,6 @@ where
     let (metadata, body, _extensions) = response.into_parts();
     Ok(gax::response::Response::from_parts(
         gax::response::Parts::new().set_headers(metadata.into_headers()),
-        body.cnv().map_err(Error::serde)?,
+        body.cnv().map_err(Error::deser)?,
     ))
 }

--- a/src/gax-internal/src/http.rs
+++ b/src/gax-internal/src/http.rs
@@ -258,7 +258,7 @@ async fn to_http_response<O: serde::de::DeserializeOwned + Default>(
 
     let response = match body.to_bytes() {
         content if (content.is_empty() && no_content_status) => O::default(),
-        content => serde_json::from_slice::<O>(&content).map_err(Error::serde)?,
+        content => serde_json::from_slice::<O>(&content).map_err(Error::deser)?,
     };
 
     Ok(Response::from_parts(

--- a/src/gax/src/error/core_error.rs
+++ b/src/gax/src/error/core_error.rs
@@ -171,7 +171,7 @@ impl Error {
     /// prefer not to use, GitHub to discuss this problem, then contact
     /// [Google Cloud support].
     ///
-    /// [open an issue]: https://github.com/googleapis/google-cloud-rust/issues
+    /// [open an issue]: https://github.com/googleapis/google-cloud-rust/issues/new/choose
     /// [Google Cloud support]: https://cloud.google.com/support
     pub fn is_deserialization(&self) -> bool {
         matches!(self.kind, ErrorKind::Deserialization)

--- a/src/gax/src/error/core_error.rs
+++ b/src/gax/src/error/core_error.rs
@@ -125,9 +125,8 @@ impl Error {
     ///
     /// Applications should have no need to use this function. The exception
     /// could be mocks, but this error is too rare to merit mocks. If you are
-    /// writing a mock that extracts values from [wkt::Any], consider using a
+    /// writing a mock that extracts values from [wkt::Any], consider using
     /// `.expect()` calls instead.
-    ///
     ///
     /// # Example
     /// ```
@@ -145,7 +144,7 @@ impl Error {
         }
     }
 
-    /// The request could not be completed before its deadline.
+    /// The response could not be deserialized.
     ///
     /// This is always a client-side generated error. Note that the request may
     /// or may not have started, and it may or may not complete in the service.
@@ -704,7 +703,6 @@ mod test {
         let source = wkt::TimestampError::OutOfRange;
         let error = Error::deser(source);
         assert!(error.is_deserialization(), "{error:?}");
-        assert!(error.source().is_some(), "{error:?}");
         let got = error
             .source()
             .and_then(|e| e.downcast_ref::<wkt::TimestampError>());

--- a/src/gax/src/error/rpc.rs
+++ b/src/gax/src/error/rpc.rs
@@ -362,7 +362,7 @@ impl TryFrom<&bytes::Bytes> for Status {
     fn try_from(value: &bytes::Bytes) -> Result<Self, Self::Error> {
         let wrapper = serde_json::from_slice::<ErrorWrapper>(value)
             .map(|w| w.error)
-            .map_err(Error::serde)?;
+            .map_err(Error::deser)?;
         let code = match wrapper.status.as_deref().map(Code::try_from) {
             Some(Ok(code)) => code,
             Some(Err(_)) | None => Code::Unknown,
@@ -832,11 +832,11 @@ mod test {
 
         let got = Status::try_from(&bytes::Bytes::from_static(b"\"error\": 1234"));
         let err = got.unwrap_err();
-        assert!(err.is_serde(), "{err:?}");
+        assert!(err.is_deserialization(), "{err:?}");
 
         let got = Status::try_from(&bytes::Bytes::from_static(b"\"missing-error\": 1234"));
         let err = got.unwrap_err();
-        assert!(err.is_serde(), "{err:?}");
+        assert!(err.is_deserialization(), "{err:?}");
 
         let got = Status::try_from(&bytes::Bytes::from_static(INVALID_CODE_PAYLOAD))?;
         assert_eq!(got.code, Code::Unknown);

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -154,7 +154,7 @@ where
     if let Some(e) = op.error() {
         return Err(Error::service(gax::error::rpc::Status::from(e.clone())));
     }
-    Err(Error::deser("missing result in completed operation"))
+    Err(Error::other("missing result in completed operation"))
 }
 
 fn as_metadata<R, M>(op: Operation<R, M>) -> Option<M>
@@ -529,7 +529,8 @@ mod test {
         let op = longrunning::model::Operation::default();
         let op = O::new(op);
         let err = as_result(op).err().unwrap();
-        assert!(err.is_deserialization(), "{err:?}");
+        // TODO(#2312) - use a real `is_*()` predicate.
+        assert!(format!("{err:?}").contains("Other"), "{err:?}");
         assert!(format!("{err}").contains("missing result"), "{err}");
 
         Ok(())

--- a/src/lro/src/details.rs
+++ b/src/lro/src/details.rs
@@ -149,12 +149,12 @@ where
     R: wkt::message::Message + serde::ser::Serialize + serde::de::DeserializeOwned,
 {
     if let Some(any) = op.response() {
-        return any.to_msg::<R>().map_err(Error::serde);
+        return any.to_msg::<R>().map_err(Error::deser);
     }
     if let Some(e) = op.error() {
         return Err(Error::service(gax::error::rpc::Status::from(e.clone())));
     }
-    Err(Error::serde("missing result in completed operation"))
+    Err(Error::deser("missing result in completed operation"))
 }
 
 fn as_metadata<R, M>(op: Operation<R, M>) -> Option<M>
@@ -509,7 +509,7 @@ mod test {
         ));
         let op = O::new(op);
         let err = as_result(op).unwrap_err();
-        assert!(err.is_serde(), "{err:?}");
+        assert!(err.is_deserialization(), "{err:?}");
         assert!(
             matches!(
                 err.source().and_then(|e| e.downcast_ref::<wkt::AnyError>()),
@@ -529,7 +529,7 @@ mod test {
         let op = longrunning::model::Operation::default();
         let op = O::new(op);
         let err = as_result(op).err().unwrap();
-        assert!(err.is_serde(), "{err:?}");
+        assert!(err.is_deserialization(), "{err:?}");
         assert!(format!("{err}").contains("missing result"), "{err}");
 
         Ok(())

--- a/src/storage-control/src/generated/gapic/transport.rs
+++ b/src/storage-control/src/generated/gapic/transport.rs
@@ -89,7 +89,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -130,7 +130,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -181,7 +181,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -222,7 +222,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -265,7 +265,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -322,7 +322,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -379,7 +379,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -456,7 +456,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -499,7 +499,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -542,7 +542,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -583,7 +583,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -624,7 +624,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -665,7 +665,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -708,7 +708,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -749,7 +749,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -799,7 +799,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -840,7 +840,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,

--- a/src/storage-control/src/generated/gapic_control/transport.rs
+++ b/src/storage-control/src/generated/gapic_control/transport.rs
@@ -91,7 +91,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -142,7 +142,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -193,7 +193,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -236,7 +236,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -287,7 +287,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -338,7 +338,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -381,7 +381,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -432,7 +432,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -483,7 +483,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -526,7 +526,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -569,7 +569,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -622,7 +622,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -673,7 +673,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -724,7 +724,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -775,7 +775,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -826,7 +826,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -869,7 +869,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -905,7 +905,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -947,7 +947,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -983,7 +983,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -1025,7 +1025,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -1061,7 +1061,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -1103,7 +1103,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,
@@ -1139,7 +1139,7 @@ impl super::stub::StorageControl for StorageControl {
             .execute(
                 extensions,
                 path,
-                req.to_proto().map_err(Error::other)?,
+                req.to_proto().map_err(Error::deser)?,
                 options,
                 &info::X_GOOG_API_CLIENT_HEADER,
                 &x_goog_request_params,


### PR DESCRIPTION
I think we want to distinguish between serialization problems (as these
are most likely caused by the application), and deserialization problems
(as these are most likely problems with the client libraries). They also
have different semantics: the former cannot result in outgoing RPCs,
the latter only happen after an RPC completed.

part of the work for #2312 
