### PR TITLE
fix(gax): no sleeps past overall timeout

### DIFF
--- a/src/gax/src/retry_loop_internal.rs
+++ b/src/gax/src/retry_loop_internal.rs
@@ -14,10 +14,27 @@
 
 use super::Result;
 use super::backoff_policy::BackoffPolicy;
+use super::error::Error;
 use super::loop_state::LoopState;
 use super::retry_policy::RetryPolicy;
 use super::retry_throttler::RetryThrottler;
 use std::sync::{Arc, Mutex};
+
+enum RetryLoopAttempt {
+    // The first attempt
+    Initial,
+    // (Attempt count, previous error)
+    Retry(u32, Error),
+}
+
+impl RetryLoopAttempt {
+    fn count(&self) -> u32 {
+        match self {
+            RetryLoopAttempt::Initial => 0,
+            RetryLoopAttempt::Retry(count, _) => *count,
+        }
+    }
+}
 
 /// Runs the retry loop for a given function.
 ///
@@ -40,25 +57,29 @@ where
     S: AsyncFn(std::time::Duration) -> () + Send,
 {
     let loop_start = tokio::time::Instant::now().into_std();
-    let mut attempt_count = 0;
+    let mut attempt = RetryLoopAttempt::Initial;
     loop {
+        let mut attempt_count = attempt.count();
         let remaining_time = retry_policy.remaining_time(loop_start, attempt_count);
-        let throttle = if attempt_count == 0 {
-            false
-        } else {
-            let t = retry_throttler
+
+        if let RetryLoopAttempt::Retry(attempt_count, prev_error) = attempt {
+            if retry_throttler
                 .lock()
-                .expect("retry throttler lock is poisoned");
-            t.throttle_retry_attempt()
-        };
-        if throttle {
-            // This counts as an error for the purposes of the retry policy.
-            if let Some(error) = retry_policy.on_throttle(loop_start, attempt_count) {
-                return Err(error);
+                .expect("retry throttler lock is poisoned")
+                .throttle_retry_attempt()
+            {
+                // This counts as an error for the purposes of the retry policy.
+                if let Some(error) = retry_policy.on_throttle(loop_start, attempt_count) {
+                    return Err(error);
+                }
+                let delay = backoff_policy.on_failure(loop_start, attempt_count);
+                if remaining_time.is_some_and(|remaining| remaining < delay) {
+                    return Err(Error::timeout(prev_error));
+                }
+                attempt = RetryLoopAttempt::Retry(attempt_count, prev_error);
+                sleep(delay).await;
+                continue;
             }
-            let delay = backoff_policy.on_failure(loop_start, attempt_count);
-            sleep(delay).await;
-            continue;
         }
         attempt_count += 1;
         match inner(remaining_time).await {
@@ -76,26 +97,20 @@ where
                     .lock()
                     .expect("retry throttler lock is poisoned")
                     .on_retry_failure(&flow);
-                on_error(&sleep, flow, delay).await?;
+                match flow {
+                    LoopState::Permanent(e) | LoopState::Exhausted(e) => return Err(e),
+                    LoopState::Continue(e) => {
+                        let remaining_time = retry_policy.remaining_time(loop_start, attempt_count);
+                        if remaining_time.is_some_and(|remaining| remaining < delay) {
+                            return Err(Error::timeout(e));
+                        }
+                        attempt = RetryLoopAttempt::Retry(attempt_count, e);
+                        sleep(delay).await;
+                        continue;
+                    }
+                }
             }
         };
-    }
-}
-
-async fn on_error<B>(
-    backoff: &B,
-    retry_flow: LoopState,
-    backoff_delay: std::time::Duration,
-) -> Result<()>
-where
-    B: AsyncFn(std::time::Duration) -> (),
-{
-    match retry_flow {
-        LoopState::Permanent(e) | LoopState::Exhausted(e) => Err(e),
-        LoopState::Continue(_e) => {
-            backoff(backoff_delay).await;
-            Ok(())
-        }
     }
 }
 
@@ -117,6 +132,7 @@ pub fn effective_timeout(
 mod test {
     use super::*;
     use crate::error::{Error, rpc::Code, rpc::Status};
+    use std::error::Error as _;
     use std::time::Duration;
     use test_case::test_case;
 
@@ -637,15 +653,217 @@ mod test {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn no_sleep_past_overall_timeout() -> anyhow::Result<()> {
+        // This test simulates a server responding with a transient error. The
+        // backoff policy wants to sleep for longer than the overall timeout. No
+        // sleeps should be performed. The loop should terminate with a
+        // `timeout` error.
+        let mut seq = mockall::Sequence::new();
+        let mut call = MockCall::new();
+        let mut throttler = MockRetryThrottler::new();
+        let mut retry_policy = MockRetryPolicy::new();
+        let mut backoff_policy = MockBackoffPolicy::new();
+        let sleep = MockSleep::new();
+
+        // Calculate the attempt deadline
+        retry_policy
+            .expect_remaining_time()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::from_millis(100));
+
+        // Simulate a call to the server, responding with a transient error.
+        call.expect_call()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_| transient());
+
+        // The retry policy says we should retry this error.
+        retry_policy
+            .expect_on_error()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, e| LoopState::Continue(e));
+
+        // The backoff policy wants to sleep for longer than the overall timeout.
+        backoff_policy
+            .expect_on_failure()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::from_secs(10));
+
+        // The throttler processes the result of the attempt.
+        throttler
+            .expect_on_retry_failure()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(());
+
+        // We recalculate how much time is left in the operation. This is
+        // compared against the delay returned by the backoff policy.
+        retry_policy
+            .expect_remaining_time()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::from_millis(100));
+
+        // There is not enough time left to sleep, and make another attempt, so
+        // the retry loop is terminated.
+
+        let inner = async move |d| call.call(d);
+        let backoff = async move |d| sleep.sleep(d).await;
+        let response = retry_loop(
+            inner,
+            backoff,
+            true,
+            to_retry_throttler(throttler),
+            to_retry_policy(retry_policy),
+            to_backoff_policy(backoff_policy),
+        )
+        .await;
+        let err = response.expect_err("retry loop should terminate");
+        assert!(err.is_timeout(), "{err:?}");
+        // Confirm that we expose the last seen status from the operation
+        let got = err
+            .source()
+            .and_then(|e| e.downcast_ref::<Error>())
+            .and_then(|e| e.status());
+        assert_eq!(got, Some(&transient_status()), "{err}");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn no_sleep_past_overall_timeout_after_throttle() -> anyhow::Result<()> {
+        // This test simulates a server responding with a transient error. There
+        // is no immediate backoff. The retry throttler then decides we should
+        // backoff again before making another request. This time, the backoff
+        // policy wants to sleep for longer than the overall timeout. No sleeps
+        // should be performed. The loop should terminate with a `timeout`
+        // error.
+        let mut seq = mockall::Sequence::new();
+        let mut call = MockCall::new();
+        let mut throttler = MockRetryThrottler::new();
+        let mut retry_policy = MockRetryPolicy::new();
+        let mut backoff_policy = MockBackoffPolicy::new();
+        let mut sleep = MockSleep::new();
+
+        // Calculate the attempt deadline
+        retry_policy
+            .expect_remaining_time()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::from_millis(100));
+
+        // Simulate a call to the server, responding with a transient error.
+        call.expect_call()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_| transient());
+
+        // The retry policy says we should retry this error.
+        retry_policy
+            .expect_on_error()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _, _, e| LoopState::Continue(e));
+
+        // The backoff policy returns an instantaneous sleep.
+        backoff_policy
+            .expect_on_failure()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::ZERO);
+
+        // The throttler processes the result of the attempt.
+        throttler
+            .expect_on_retry_failure()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(());
+
+        // We recalculate how much time is left in the operation. This is
+        // compared against the delay returned by the backoff policy.
+        retry_policy
+            .expect_remaining_time()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::from_millis(100));
+
+        // There is enough time, so we perform the (instantaneous) sleep
+        sleep
+            .expect_sleep()
+            .once()
+            .in_sequence(&mut seq)
+            .withf(move |got| got == &Duration::ZERO)
+            .returning(|_| Box::pin(async {}));
+
+        // We recalculate how much time is left in the operation.
+        retry_policy
+            .expect_remaining_time()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::from_millis(100));
+
+        // In the second attempt, the throttler kicks in. It tells us to backoff
+        // before sending this request out.
+        throttler
+            .expect_throttle_retry_attempt()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(true);
+
+        // The retry policy decides to continue the retry loop.
+        retry_policy
+            .expect_on_throttle()
+            .once()
+            .in_sequence(&mut seq)
+            .returning(|_, _| None);
+
+        // The backoff policy wants to sleep for longer than the overall timeout.
+        backoff_policy
+            .expect_on_failure()
+            .once()
+            .in_sequence(&mut seq)
+            .return_const(Duration::from_secs(10));
+
+        // There is not enough time left to sleep, and make another attempt, so
+        // the retry loop is terminated.
+
+        let inner = async move |d| call.call(d);
+        let backoff = async move |d| sleep.sleep(d).await;
+        let response = retry_loop(
+            inner,
+            backoff,
+            true,
+            to_retry_throttler(throttler),
+            to_retry_policy(retry_policy),
+            to_backoff_policy(backoff_policy),
+        )
+        .await;
+        let err = response.expect_err("retry loop should terminate");
+        assert!(err.is_timeout(), "{err:?}");
+        // Confirm that we expose the last seen status from the operation
+        let got = err
+            .source()
+            .and_then(|e| e.downcast_ref::<Error>())
+            .and_then(|e| e.status());
+        assert_eq!(got, Some(&transient_status()), "{err}");
+        Ok(())
+    }
+
     fn success() -> Result<String> {
         Ok("success".into())
     }
 
-    fn transient() -> Result<String> {
-        let status = Status::default()
+    fn transient_status() -> Status {
+        Status::default()
             .set_code(Code::Unavailable)
-            .set_message("try-again");
-        Err(Error::service(status))
+            .set_message("try-again")
+    }
+
+    fn transient() -> Result<String> {
+        Err(Error::service(transient_status()))
     }
 
     fn permanent() -> Result<String> {


### PR DESCRIPTION
Fixes #2307 

Compare how long we are going to sleep against the remaining time. If there is not enough time left, terminate the retry loop with a `timeout` error. The source of this timeout error holds the error from the previous attempt.

We refactor the implementation (with `RetryLoopAttempt`) to make it clear via code that either (1) we are on the initial attempt or (2) we have a previous error we can return.

For the tests, I preferred to use a single `mockall::Sequence` for all operations, instead of using one per mock (and only where necessary). I think one `Sequence` makes the flow easier to follow, and makes it more obvious where the expectations come from.