### PR TITLE
impl(generator/rust): support `bool` keys in maps

### DIFF
--- a/generator/internal/rust/codec.go
+++ b/generator/internal/rust/codec.go
@@ -422,6 +422,13 @@ func fieldFormatter(typez api.Typez) string {
 	}
 }
 
+func keyFieldFormatter(typez api.Typez) string {
+	if typez == api.BOOL_TYPE {
+		return "serde_with::DisplayFromStr"
+	}
+	return fieldFormatter(typez)
+}
+
 func fieldSkipAttributes(f *api.Field) []string {
 	// oneofs have explicit presence, and default values should be serialized:
 	// https://protobuf.dev/programming-guides/field_presence/.
@@ -573,7 +580,7 @@ func fieldAttributes(f *api.Field, state *api.APIState) []string {
 				slog.Error("missing key or value in map field")
 				return attributes
 			}
-			keyFormat := fieldFormatter(key.Typez)
+			keyFormat := keyFieldFormatter(key.Typez)
 			valFormat := fieldFormatter(value.Typez)
 			if keyFormat == "_" && valFormat == "_" {
 				return attributes

--- a/generator/internal/rust/codec_test.go
+++ b/generator/internal/rust/codec_test.go
@@ -560,6 +560,21 @@ func TestMapFieldAttributes(t *testing.T) {
 			},
 		},
 	}
+	map5 := &api.Message{
+		Name:  "$map<bool, string>",
+		ID:    "$map<bool, string>",
+		IsMap: true,
+		Fields: []*api.Field{
+			{
+				Name:  "key",
+				Typez: api.BOOL_TYPE,
+			},
+			{
+				Name:  "value",
+				Typez: api.STRING_TYPE,
+			},
+		},
+	}
 	message := &api.Message{
 		Name: "Fake",
 		ID:   "..Fake",
@@ -596,9 +611,15 @@ func TestMapFieldAttributes(t *testing.T) {
 				Typez:    api.MESSAGE_TYPE,
 				TypezID:  map4.ID,
 			},
+			{
+				Name:     "map_bool",
+				JSONName: "mapBool",
+				Typez:    api.MESSAGE_TYPE,
+				TypezID:  map5.ID,
+			},
 		},
 	}
-	model := api.NewTestAPI([]*api.Message{target, map1, map2, map3, map4, message}, []*api.Enum{}, []*api.Service{})
+	model := api.NewTestAPI([]*api.Message{target, map1, map2, map3, map4, map5, message}, []*api.Enum{}, []*api.Service{})
 
 	expectedAttributes := map[string]string{
 		"target":      `#[serde(skip_serializing_if = "std::option::Option::is_none")]`,
@@ -606,6 +627,7 @@ func TestMapFieldAttributes(t *testing.T) {
 		"map_i64":     `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<_, serde_with::DisplayFromStr>")]`,
 		"map_i64_key": `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]`,
 		"map_bytes":   `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<_, serde_with::base64::Base64>")]`,
+		"map_bool":    `#[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]` + "\n" + `#[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]`,
 	}
 	loadWellKnownTypes(model.State)
 	for _, field := range message.Fields {

--- a/src/protojson-conformance/src/generated/test_protos/mod.rs
+++ b/src/protojson-conformance/src/generated/test_protos/mod.rs
@@ -339,6 +339,7 @@ pub struct TestAllTypesProto3 {
     pub map_int32_double: std::collections::HashMap<i32, f64>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]
+    #[serde_as(as = "std::collections::HashMap<serde_with::DisplayFromStr, _>")]
     pub map_bool_bool: std::collections::HashMap<bool, bool>,
 
     #[serde(skip_serializing_if = "std::collections::HashMap::is_empty")]


### PR DESCRIPTION
Evidently they are legal in Protobuf, though no Google Cloud service
uses them. ProtoJSON requires converting the `bool` to strings when
used as map keys.

Related to #2328
