### PR TITLE
feat(storage-control): add new PRPCs

### DIFF
--- a/src/storage-control/src/client.rs
+++ b/src/storage-control/src/client.rs
@@ -559,6 +559,48 @@ impl StorageControl {
         self.control.list_anywhere_caches()
     }
 
+    /// Returns the Project scoped singleton IntelligenceConfig resource.
+    pub fn get_project_intelligence_config(
+        &self,
+    ) -> super::builder::storage_control::GetProjectIntelligenceConfig {
+        self.control.get_project_intelligence_config()
+    }
+
+    /// Updates the Project scoped singleton IntelligenceConfig resource.
+    pub fn update_project_intelligence_config(
+        &self,
+    ) -> super::builder::storage_control::UpdateProjectIntelligenceConfig {
+        self.control.update_project_intelligence_config()
+    }
+
+    /// Returns the Folder scoped singleton IntelligenceConfig resource.
+    pub fn get_folder_intelligence_config(
+        &self,
+    ) -> super::builder::storage_control::GetFolderIntelligenceConfig {
+        self.control.get_folder_intelligence_config()
+    }
+
+    /// Updates the Folder scoped singleton IntelligenceConfig resource.
+    pub fn update_folder_intelligence_config(
+        &self,
+    ) -> super::builder::storage_control::UpdateFolderIntelligenceConfig {
+        self.control.update_folder_intelligence_config()
+    }
+
+    /// Returns the Organization scoped singleton IntelligenceConfig resource.
+    pub fn get_organization_intelligence_config(
+        &self,
+    ) -> super::builder::storage_control::GetOrganizationIntelligenceConfig {
+        self.control.get_organization_intelligence_config()
+    }
+
+    /// Updates the Organization scoped singleton IntelligenceConfig resource.
+    pub fn update_organization_intelligence_config(
+        &self,
+    ) -> super::builder::storage_control::UpdateOrganizationIntelligenceConfig {
+        self.control.update_organization_intelligence_config()
+    }
+
     /// Provides the [Operations][google.longrunning.Operations] service functionality in this service.
     ///
     /// [google.longrunning.Operations]: longrunning::client::Operations

--- a/src/storage-control/src/stub.rs
+++ b/src/storage-control/src/stub.rs
@@ -400,6 +400,72 @@ pub trait StorageControl: std::fmt::Debug + Send + Sync {
         gaxi::unimplemented::unimplemented_stub()
     }
 
+    /// Implements [super::client::StorageControl::get_project_intelligence_config].
+    fn get_project_intelligence_config(
+        &self,
+        _req: crate::model::GetProjectIntelligenceConfigRequest,
+        _options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > + Send {
+        gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::StorageControl::update_project_intelligence_config].
+    fn update_project_intelligence_config(
+        &self,
+        _req: crate::model::UpdateProjectIntelligenceConfigRequest,
+        _options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > + Send {
+        gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::StorageControl::get_folder_intelligence_config].
+    fn get_folder_intelligence_config(
+        &self,
+        _req: crate::model::GetFolderIntelligenceConfigRequest,
+        _options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > + Send {
+        gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::StorageControl::update_folder_intelligence_config].
+    fn update_folder_intelligence_config(
+        &self,
+        _req: crate::model::UpdateFolderIntelligenceConfigRequest,
+        _options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > + Send {
+        gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::StorageControl::get_organization_intelligence_config].
+    fn get_organization_intelligence_config(
+        &self,
+        _req: crate::model::GetOrganizationIntelligenceConfigRequest,
+        _options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > + Send {
+        gaxi::unimplemented::unimplemented_stub()
+    }
+
+    /// Implements [super::client::StorageControl::update_organization_intelligence_config].
+    fn update_organization_intelligence_config(
+        &self,
+        _req: crate::model::UpdateOrganizationIntelligenceConfigRequest,
+        _options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > + Send {
+        gaxi::unimplemented::unimplemented_stub()
+    }
+
     /// Implements [super::client::StorageControl::get_operation].
     fn get_operation(
         &self,
@@ -738,6 +804,66 @@ where
         Output = crate::Result<gax::response::Response<crate::model::ListAnywhereCachesResponse>>,
     > {
         T::list_anywhere_caches(self, req, options)
+    }
+
+    fn get_project_intelligence_config(
+        &self,
+        req: crate::model::GetProjectIntelligenceConfigRequest,
+        options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > {
+        T::get_project_intelligence_config(self, req, options)
+    }
+
+    fn update_project_intelligence_config(
+        &self,
+        req: crate::model::UpdateProjectIntelligenceConfigRequest,
+        options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > {
+        T::update_project_intelligence_config(self, req, options)
+    }
+
+    fn get_folder_intelligence_config(
+        &self,
+        req: crate::model::GetFolderIntelligenceConfigRequest,
+        options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > {
+        T::get_folder_intelligence_config(self, req, options)
+    }
+
+    fn update_folder_intelligence_config(
+        &self,
+        req: crate::model::UpdateFolderIntelligenceConfigRequest,
+        options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > {
+        T::update_folder_intelligence_config(self, req, options)
+    }
+
+    fn get_organization_intelligence_config(
+        &self,
+        req: crate::model::GetOrganizationIntelligenceConfigRequest,
+        options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > {
+        T::get_organization_intelligence_config(self, req, options)
+    }
+
+    fn update_organization_intelligence_config(
+        &self,
+        req: crate::model::UpdateOrganizationIntelligenceConfigRequest,
+        options: gax::options::RequestOptions,
+    ) -> impl std::future::Future<
+        Output = crate::Result<gax::response::Response<crate::model::IntelligenceConfig>>,
+    > {
+        T::update_organization_intelligence_config(self, req, options)
     }
 
     fn get_operation(

--- a/src/storage-control/tests/mocking.rs
+++ b/src/storage-control/tests/mocking.rs
@@ -55,6 +55,12 @@ mod test {
             async fn resume_anywhere_cache( &self, _req: gcs::model::ResumeAnywhereCacheRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::AnywhereCache>>;
             async fn get_anywhere_cache( &self, _req: gcs::model::GetAnywhereCacheRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::AnywhereCache>>;
             async fn list_anywhere_caches( &self, _req: gcs::model::ListAnywhereCachesRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::ListAnywhereCachesResponse>>;
+            async fn get_folder_intelligence_config( &self, _req: gcs::model::GetFolderIntelligenceConfigRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::IntelligenceConfig>>;
+            async fn update_folder_intelligence_config( &self, _req: gcs::model::UpdateFolderIntelligenceConfigRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::IntelligenceConfig>>;
+            async fn get_project_intelligence_config( &self, _req: gcs::model::GetProjectIntelligenceConfigRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::IntelligenceConfig>>;
+            async fn update_project_intelligence_config( &self, _req: gcs::model::UpdateProjectIntelligenceConfigRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::IntelligenceConfig>>;
+            async fn get_organization_intelligence_config( &self, _req: gcs::model::GetOrganizationIntelligenceConfigRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::IntelligenceConfig>>;
+            async fn update_organization_intelligence_config( &self, _req: gcs::model::UpdateOrganizationIntelligenceConfigRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<gcs::model::IntelligenceConfig>>;
             async fn get_operation( &self, _req: longrunning::model::GetOperationRequest, _options: gax::options::RequestOptions) -> gax::Result<gax::response::Response<longrunning::model::Operation>>;
         }
     }
@@ -200,6 +206,30 @@ mod test {
             .times(1)
             .in_sequence(&mut seq)
             .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
+        mock.expect_get_folder_intelligence_config()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
+        mock.expect_update_folder_intelligence_config()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
+        mock.expect_get_project_intelligence_config()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
+        mock.expect_update_project_intelligence_config()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
+        mock.expect_get_organization_intelligence_config()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
+        mock.expect_update_organization_intelligence_config()
+            .times(1)
+            .in_sequence(&mut seq)
+            .returning(|_, _| Err(gax::error::Error::other("simulated failure")));
         mock.expect_get_operation()
             .times(1)
             .in_sequence(&mut seq)
@@ -246,6 +276,36 @@ mod test {
         let _ = client.resume_anywhere_cache().send().await.unwrap_err();
         let _ = client.get_anywhere_cache().send().await.unwrap_err();
         let _ = client.list_anywhere_caches().send().await.unwrap_err();
+        let _ = client
+            .get_folder_intelligence_config()
+            .send()
+            .await
+            .unwrap_err();
+        let _ = client
+            .update_folder_intelligence_config()
+            .send()
+            .await
+            .unwrap_err();
+        let _ = client
+            .get_project_intelligence_config()
+            .send()
+            .await
+            .unwrap_err();
+        let _ = client
+            .update_project_intelligence_config()
+            .send()
+            .await
+            .unwrap_err();
+        let _ = client
+            .get_organization_intelligence_config()
+            .send()
+            .await
+            .unwrap_err();
+        let _ = client
+            .update_organization_intelligence_config()
+            .send()
+            .await
+            .unwrap_err();
         let _ = client.get_operation().send().await.unwrap_err();
     }
 
@@ -304,6 +364,12 @@ mod test {
             resume_anywhere_cache,
             get_anywhere_cache,
             list_anywhere_caches,
+            get_folder_intelligence_config,
+            update_folder_intelligence_config,
+            get_project_intelligence_config,
+            update_project_intelligence_config,
+            get_organization_intelligence_config,
+            update_organization_intelligence_config,
             get_operation
         );
     }


### PR DESCRIPTION
This is an easy command to see what is missing from the handwritten surface:

```
git grep -ho "super::builder::storage_control::[A-Za-z]*[^ :]" | sort | uniq -c | grep 2
```
```
      2 super::builder::storage_control::GetFolderIntelligenceConfig
      2 super::builder::storage_control::GetOrganizationIntelligenceConfig
      2 super::builder::storage_control::GetProjectIntelligenceConfig
      2 super::builder::storage_control::UpdateFolderIntelligenceConfig
      2 super::builder::storage_control::UpdateOrganizationIntelligenceConfig
      2 super::builder::storage_control::UpdateProjectIntelligenceConfig
```

We expect the builders to be referenced three times: twice in generated code, and once from the veneer client.