### PR TITLE
impl(wkt): better validation for `Any`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4632,6 +4632,7 @@ dependencies = [
  "test-case",
  "thiserror",
  "time",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -310,7 +310,8 @@ tonic              = { default-features = false, version = "0.13", features = ["
 tonic-build        = { default-features = false, version = "0.13" }
 tracing            = { default-features = false, version = "0.1", features = ["attributes"] }
 tracing-subscriber = { default-features = false, version = "0.3" }
-# Test packags
+url                = { default-features = false, version = "2" }
+# Test packages
 anyhow         = { default-features = false, version = "1" }
 axum           = { default-features = false, version = "0.8" }
 httptest       = { default-features = false, version = "0.16.3" }
@@ -325,7 +326,6 @@ tempfile       = { default-features = false, version = "3" }
 test-case      = { default-features = false, version = "3" }
 tokio-stream   = { default-features = false, version = "0.1" }
 tokio-test     = { default-features = false, version = "0.4" }
-url            = { default-features = false, version = "2" }
 num-bigint-dig = { default-features = false, version = "0.8" }
 
 # Local packages used as dependencies

--- a/src/wkt/Cargo.toml
+++ b/src/wkt/Cargo.toml
@@ -48,6 +48,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 thiserror.workspace  = true
 time                 = { workspace = true, features = ["formatting", "parsing"] }
+url.workspace        = true
 
 [dev-dependencies]
 anyhow.workspace    = true

--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -249,28 +249,20 @@ impl<'de> serde::de::Deserialize<'de> for Any {
             None => Err(D::Error::missing_field("@type")),
             Some(Value::String(s)) if validate_type_url(s) => Ok(Any(value)),
             Some(Value::String(s)) => Err(D::Error::invalid_value(Unexpected::Str(s), &EXPECTED)),
-            Some(Value::Null) => Err(D::Error::invalid_type(
-                Unexpected::Other("JSON null"),
-                &EXPECTED,
-            )),
-            Some(Value::Object(_)) => Err(D::Error::invalid_type(
-                Unexpected::Other("JSON object"),
-                &EXPECTED,
-            )),
-            Some(Value::Array(_)) => Err(D::Error::invalid_type(
-                Unexpected::Other("JSON array"),
-                &EXPECTED,
-            )),
-            Some(Value::Number(_)) => Err(D::Error::invalid_type(
-                Unexpected::Other("JSON number"),
-                &EXPECTED,
-            )),
-            Some(Value::Bool(_)) => Err(D::Error::invalid_type(
-                Unexpected::Other("JSON boolean"),
-                &EXPECTED,
-            )),
+            Some(Value::Null) => Err(type_field_invalid_type("JSON null")),
+            Some(Value::Object(_)) => Err(type_field_invalid_type("JSON object")),
+            Some(Value::Array(_)) => Err(type_field_invalid_type("JSON array")),
+            Some(Value::Number(_)) => Err(type_field_invalid_type("JSON number")),
+            Some(Value::Bool(_)) => Err(type_field_invalid_type("JSON boolean")),
         }
     }
+}
+
+fn type_field_invalid_type<E>(reason: &str) -> E
+where
+    E: serde::de::Error,
+{
+    E::invalid_type(Unexpected::Other(reason), &EXPECTED)
 }
 
 fn validate_type_url(type_url: &str) -> bool {

--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -289,7 +289,7 @@ fn is_protobuf_id(path: &str) -> bool {
 
 fn is_identifier(id: &str) -> bool {
     !id.is_empty()
-        && id.chars().all(|c: char| c.is_alphanumeric())
+        && id.chars().all(|c: char| c.is_alphanumeric() || c == '_')
         && !id.starts_with(|c: char| c.is_ascii_digit())
 }
 
@@ -364,6 +364,17 @@ mod test {
         let d = any.to_msg::<Duration>()?;
         assert_eq!(d, Duration::clamp(60, 0));
         Ok(())
+    }
+
+    #[test_case(json!({"@type": "type.googleapis.com/foo"}))]
+    #[test_case(json!({"@type": "type.googleapis.com/foo_bar"}))]
+    #[test_case(json!({"@type": "type.googleapis.com/foo_bar.baz"}))]
+    #[test_case(json!({"@type": "type.googleapis.com/foo_bar.baz.Message"}))]
+    #[test_case(json!({"@type": "type.googleapis.com/foo_bar.baz.Message3"}))]
+    #[test_case(json!({"@type": "type.googleapis.com/foo2_bar.baz.Message3"}))]
+    fn deserialize_any_success(input: Value) {
+        let any = serde_json::from_value::<Any>(input.clone());
+        assert!(any.is_ok(), "{any:?} from {input:?}");
     }
 
     #[test_case(json!({"value": "7"}))]

--- a/src/wkt/src/any.rs
+++ b/src/wkt/src/any.rs
@@ -246,7 +246,7 @@ impl<'de> serde::de::Deserialize<'de> for Any {
         use serde_json::Value;
         let value = ValueMap::deserialize(deserializer)?;
         match value.get("@type") {
-            None => Err(D::Error::missing_field("@type")),
+            None => Ok(Any(value)),
             Some(Value::String(s)) if validate_type_url(s) => Ok(Any(value)),
             Some(Value::String(s)) => Err(D::Error::invalid_value(Unexpected::Str(s), &EXPECTED)),
             Some(Value::Null) => Err(type_field_invalid_type("JSON null")),
@@ -366,6 +366,7 @@ mod test {
         Ok(())
     }
 
+    #[test_case(json!({"value": "7"}))]
     #[test_case(json!({"@type": "type.googleapis.com/foo"}))]
     #[test_case(json!({"@type": "type.googleapis.com/foo_bar"}))]
     #[test_case(json!({"@type": "type.googleapis.com/foo_bar.baz"}))]
@@ -377,7 +378,6 @@ mod test {
         assert!(any.is_ok(), "{any:?} from {input:?}");
     }
 
-    #[test_case(json!({"value": "7"}))]
     #[test_case(json!({"@type": "", "value": "7"}))]
     #[test_case(json!({"@type": "type.googleapis.com/", "value": "7"}))]
     #[test_case(json!({"@type": "/google.protobuf.Duration", "value": "7"}))]


### PR DESCRIPTION
To pass the ProtoJSON conformance test we need to reject some invalid
values in the `@type` field.

Fixes #2326
